### PR TITLE
fix: Improve mobile drag-and-drop on kanban board

### DIFF
--- a/src/components/board/board-column.tsx
+++ b/src/components/board/board-column.tsx
@@ -44,6 +44,7 @@ interface BoardColumnProps {
   hasApiKey?: boolean;
   ideaDescription?: string;
   isReadOnly?: boolean;
+  isCompact?: boolean;
 }
 
 export const BoardColumn = memo(function BoardColumn({
@@ -61,6 +62,7 @@ export const BoardColumn = memo(function BoardColumn({
   hasApiKey = false,
   ideaDescription = "",
   isReadOnly = false,
+  isCompact = false,
 }: BoardColumnProps) {
   const [addTaskOpen, setAddTaskOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
@@ -136,9 +138,9 @@ export const BoardColumn = memo(function BoardColumn({
         ref={setNodeRef}
         style={style}
         data-testid={`column-${column.id}`}
-        className={`flex max-h-full min-w-[280px] max-w-[320px] shrink-0 snap-start flex-col rounded-lg border border-border bg-muted/50 ${
-          isOver ? "ring-2 ring-primary/50" : ""
-        } ${isDragging ? "opacity-50" : ""}`}
+        className={`flex max-h-full shrink-0 snap-start flex-col rounded-lg border border-border bg-muted/50 ${
+          isCompact ? "min-w-[180px] max-w-[200px]" : "min-w-[280px] max-w-[320px]"
+        } ${isOver ? "ring-2 ring-primary/50" : ""} ${isDragging ? "opacity-50" : ""}`}
       >
         {/* Column header */}
         <div className="flex items-center justify-between border-b border-border px-3 py-2">


### PR DESCRIPTION
## Summary

- Replace twitchy auto-scroll with Jira-style **dwell-based edge scroll** (350ms dwell, one column at a time, 500ms between steps)
- **Compact columns** during touch drags — columns shrink from 280-320px to 180-200px so more drop targets are visible on mobile
- **Visual edge-zone indicators** appear during touch drags showing where to hover to scroll
- **Target column name** shown in drag overlay for clear drop feedback
- Improved collision detection to bridge 16px gaps between columns
- Fixed TouchSensor tolerance/delay for more reliable touch activation
- Disabled dnd-kit built-in autoScroll to prevent dual-scroll conflicts
- Multiple ref cleanup and edge-case fixes found during code review

## Changes

- kanban-board.tsx — new useDwellEdgeScroll hook, improved collision detection, compact mode, overlay feedback, ref cleanup
- board-column.tsx — isCompact prop for narrower columns during drag

## Test plan

- [ ] On mobile (or Chrome DevTools mobile emulation), long-press a task card to initiate drag
- [ ] Drag to a different visible column — task should drop cleanly
- [ ] Drag to the edge of the screen — after 350ms hold, board should scroll one column
- [ ] Drag back and forth between columns — task should not get stuck
- [ ] Verify columns shrink during touch drag and expand back after drop
- [ ] Verify target column name appears in drag overlay when crossing columns
- [ ] Verify desktop mouse drag still works normally (no compact mode, no edge indicators)
- [ ] Verify no console errors during drag operations

Generated with [Claude Code](https://claude.com/claude-code)