### PR TITLE
fix: Add issues write permission to E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,10 @@ on:
     branches: [master, develop]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- The GitHub Actions token needs explicit `issues: write` permission to create issues on E2E failure
- Without it, the `github-script` step fails with "Resource not accessible by integration"
- Also required for the new board task creation step

## Test plan
- [ ] E2E workflow runs without "Resource not accessible by integration" error
- [ ] On test failure, GitHub issue is created and board task appears in To Do

🤖 Generated with [Claude Code](https://claude.com/claude-code)