### PR TITLE
hotfix: Mobile overflow & DnD vertical auto-scroll

### DIFF
--- a/src/components/profile/bot-management.tsx
+++ b/src/components/profile/bot-management.tsx
@@ -52,7 +52,7 @@ export function BotManagement({ bots }: BotManagementProps) {
             return (
               <div
                 key={bot.id}
-                className={`flex items-start gap-3 rounded-lg border p-3 ${
+                className={`flex items-start gap-3 overflow-hidden rounded-lg border p-3 ${
                   bot.is_active ? "border-border" : "border-border/50 opacity-60"
                 }`}
               >
@@ -63,12 +63,12 @@ export function BotManagement({ bots }: BotManagementProps) {
                   </AvatarFallback>
                 </Avatar>
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
                     <span className="font-medium text-sm truncate">
                       {bot.name}
                     </span>
                     {bot.role && (
-                      <Badge variant="secondary" className="text-[10px] shrink-0">
+                      <Badge variant="secondary" className="text-[10px] shrink-0 max-w-[120px] truncate">
                         {bot.role}
                       </Badge>
                     )}


### PR DESCRIPTION
## Summary
Cherry-pick of a05bd60 to master as a hotfix:

- **Agents page mobile overflow**: Add `overflow-hidden` to agent cards and `min-w-0` to header row to prevent horizontal overflow on mobile viewports; truncate long role badges at 120px
- **DnD vertical auto-scroll**: Extend `useEdgeScroll` to scroll column task lists vertically when the pointer approaches the top/bottom edges during drag operations

## Test plan
- [ ] Verify agents page renders without horizontal scrollbar on mobile
- [ ] Drag a board task near the top/bottom edge and confirm the board auto-scrolls vertically

🤖 Generated with [Claude Code](https://claude.ai/code)