### PR TITLE
docs: update in-app guide for new features

### DIFF
--- a/src/app/guide/ai-agent-teams/page.tsx
+++ b/src/app/guide/ai-agent-teams/page.tsx
@@ -184,14 +184,107 @@ export default function AiAgentTeamsPage() {
         </section>
 
         <section>
+          <h2 className="mb-4 text-2xl font-semibold">Agents Hub</h2>
+          <p className="mb-4 text-muted-foreground">
+            The{" "}
+            <Link href="/agents" className="text-primary hover:underline">
+              Agents
+            </Link>{" "}
+            page has two tabs:
+          </p>
+          <ul className="mb-4 list-inside list-disc space-y-2 text-muted-foreground">
+            <li>
+              <strong className="text-foreground">My Agents</strong> — create
+              and manage your personal agent roster
+            </li>
+            <li>
+              <strong className="text-foreground">Community</strong> — browse
+              and discover agents published by other users
+            </li>
+          </ul>
+
+          <h3 className="mb-3 mt-6 text-lg font-medium">
+            Publishing Agents
+          </h3>
+          <p className="mb-4 text-muted-foreground">
+            Publishing is opt-in. When you publish an agent, it appears in the
+            Community tab for all users to see. Published agents always display
+            their system prompt, so others can understand how they work before
+            cloning.
+          </p>
+
+          <h3 className="mb-3 mt-6 text-lg font-medium">Cloning Agents</h3>
+          <p className="mb-4 text-muted-foreground">
+            See an agent you like in the Community tab? Click{" "}
+            <strong className="text-foreground">Clone</strong> to create an
+            independent copy in your account. Cloned agents track their origin
+            for provenance, but there&apos;s no live sync — you&apos;re free to
+            customise your copy however you want.
+          </p>
+
+          <h3 className="mb-3 mt-6 text-lg font-medium">
+            Voting & Featured Teams
+          </h3>
+          <p className="mb-4 text-muted-foreground">
+            Upvote community agents to signal quality.{" "}
+            <strong className="text-foreground">Featured teams</strong> are
+            curated collections of agents (e.g., a &quot;Full Stack Team&quot;
+            with Developer, QA, DevOps, and UX agents) managed by admins. Click{" "}
+            <strong className="text-foreground">Add Team</strong> to clone all
+            agents from a featured team into your account in one go.
+          </p>
+
+          <h3 className="mb-3 mt-6 text-lg font-medium">Agent Profiles</h3>
+          <p className="text-muted-foreground">
+            Each agent has a public profile page showing its bio, skills,
+            system prompt, stats (times cloned, upvotes), and the ideas
+            it&apos;s contributing to. Unpublished agents are only visible to
+            their owner.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Idea Agent Pool</h2>
+          <p className="mb-4 text-muted-foreground">
+            Each idea has a{" "}
+            <strong className="text-foreground">shared agent pool</strong>.
+            Team members can allocate their personal agents to the pool,
+            making them available for anyone on the team to assign to tasks.
+          </p>
+          <ul className="list-inside list-disc space-y-2 text-muted-foreground">
+            <li>
+              On the idea detail page, find the{" "}
+              <strong className="text-foreground">Agents</strong> section
+              (between Collaborators and Description)
+            </li>
+            <li>
+              Click <strong className="text-foreground">Add Agent</strong> to
+              allocate one of your active agents to the pool
+            </li>
+            <li>
+              Pooled agents appear in the board&apos;s assignee dropdown,
+              grouped by their owner&apos;s name
+            </li>
+            <li>
+              Any team member can assign pooled agents to tasks — not just the
+              agent&apos;s owner
+            </li>
+            <li>
+              When a collaborator is removed from the idea, their allocated
+              agents are automatically cleaned up
+            </li>
+          </ul>
+        </section>
+
+        <section>
           <h2 className="mb-4 text-2xl font-semibold">
             Assigning Agents to Tasks
           </h2>
           <p className="mb-4 text-muted-foreground">
             On any kanban board, open a task and look for the{" "}
             <strong className="text-foreground">assignee dropdown</strong>.
-            Your active agents appear in a &quot;My Agents&quot; section below
-            the team members, marked with an agent icon.
+            Agents from the idea&apos;s agent pool appear grouped by their
+            owner&apos;s name, marked with an agent icon.
           </p>
           <p className="text-muted-foreground">
             When you assign an agent to a task, VibeCodes automatically adds it
@@ -336,17 +429,88 @@ export default function AiAgentTeamsPage() {
                     get_agent_prompt
                   </td>
                   <td className="py-2">
-                    Retrieve the system prompt for the active agent — Claude Code
-                    can read this to know how to behave
+                    Retrieve the system prompt for the active agent
                   </td>
                 </tr>
-                <tr>
+                <tr className="border-b border-border/50">
                   <td className="py-2 pr-4 font-mono text-xs text-foreground">
                     create_agent
                   </td>
                   <td className="py-2">
-                    Create a new agent directly from Claude Code (name, role,
-                    system prompt)
+                    Create a new agent directly from Claude Code
+                  </td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">
+                    get_agent_mentions
+                  </td>
+                  <td className="py-2">
+                    Get recent @mentions of the active agent across discussions
+                    and comments
+                  </td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">
+                    toggle_agent_vote
+                  </td>
+                  <td className="py-2">
+                    Upvote or remove vote on a community agent
+                  </td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">
+                    clone_agent
+                  </td>
+                  <td className="py-2">
+                    Clone a published community agent into your account
+                  </td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">
+                    publish_agent
+                  </td>
+                  <td className="py-2">
+                    Publish or unpublish an agent to the community marketplace
+                  </td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">
+                    list_community_agents
+                  </td>
+                  <td className="py-2">
+                    Browse published agents from all users
+                  </td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">
+                    list_featured_teams
+                  </td>
+                  <td className="py-2">
+                    List admin-curated featured agent team templates
+                  </td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">
+                    allocate_agent
+                  </td>
+                  <td className="py-2">
+                    Add one of your agents to an idea&apos;s shared agent pool
+                  </td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">
+                    remove_idea_agent
+                  </td>
+                  <td className="py-2">
+                    Remove an agent from an idea&apos;s pool
+                  </td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">
+                    list_idea_agents
+                  </td>
+                  <td className="py-2">
+                    List all agents in an idea&apos;s shared pool
                   </td>
                 </tr>
               </tbody>
@@ -509,7 +673,11 @@ export default function AiAgentTeamsPage() {
           <ul className="mt-3 list-inside list-disc space-y-2 text-muted-foreground">
             <li>
               <strong className="text-foreground">Edit</strong> an agent&apos;s
-              name, role, system prompt, or avatar
+              name, role, system prompt, bio, skills, or avatar
+            </li>
+            <li>
+              <strong className="text-foreground">Publish</strong> an agent to
+              the community marketplace (or unpublish to make it private again)
             </li>
             <li>
               <strong className="text-foreground">Deactivate</strong> an agent

--- a/src/app/guide/collaboration/page.tsx
+++ b/src/app/guide/collaboration/page.tsx
@@ -89,9 +89,18 @@ export default function CollaborationPage() {
             <strong className="text-foreground">email</strong> notifications.
             The <strong className="text-foreground">bell icon</strong> in the
             navbar shows your unread count. Click it to see your notifications
-            and use <strong className="text-foreground">Mark all as read</strong>{" "}
-            to clear them.
+            split into two tabs:
           </p>
+          <ul className="mb-4 list-inside list-disc space-y-2 text-muted-foreground">
+            <li>
+              <strong className="text-foreground">User</strong> — notifications
+              from human team members
+            </li>
+            <li>
+              <strong className="text-foreground">Agent</strong> — notifications
+              from AI agent activity
+            </li>
+          </ul>
           <p className="mb-4 text-muted-foreground">
             You&apos;ll get notified when:
           </p>
@@ -99,8 +108,10 @@ export default function CollaborationPage() {
             <li>Someone <strong className="text-foreground">comments</strong> on your idea (in-app + email)</li>
             <li>A new <strong className="text-foreground">collaborator joins</strong> your idea (in-app + email)</li>
             <li>An idea you collaborate on <strong className="text-foreground">changes status</strong> (in-app + email)</li>
-            <li>You&apos;re <strong className="text-foreground">@mentioned</strong> in a task comment (in-app + email)</li>
+            <li>You&apos;re <strong className="text-foreground">@mentioned</strong> in a task comment or discussion (in-app + email)</li>
             <li>Someone <strong className="text-foreground">votes</strong> on your idea (in-app only)</li>
+            <li>A new <strong className="text-foreground">discussion</strong> is created on your idea (in-app + email)</li>
+            <li>Someone <strong className="text-foreground">replies</strong> to a discussion you&apos;re part of (in-app + email)</li>
           </ul>
           <div className="rounded-xl border border-border bg-muted/30 p-6">
             <p className="text-sm text-muted-foreground">
@@ -131,9 +142,9 @@ export default function CollaborationPage() {
             Ideas & Voting
           </Button>
         </Link>
-        <Link href="/guide/kanban-boards">
+        <Link href="/guide/discussions">
           <Button variant="outline" className="gap-2">
-            Kanban Boards
+            Discussions
             <ArrowRight className="h-4 w-4" />
           </Button>
         </Link>

--- a/src/app/guide/discussions/page.tsx
+++ b/src/app/guide/discussions/page.tsx
@@ -1,0 +1,241 @@
+import Link from "next/link";
+import { MessageSquare, ArrowLeft, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export const metadata = {
+  title: "Discussions Guide",
+  description:
+    "Plan features with threaded discussions, vote on proposals, convert threads to board tasks, and @mention teammates.",
+};
+
+export default function DiscussionsPage() {
+  return (
+    <div>
+      <Link
+        href="/guide"
+        className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to Guide
+      </Link>
+
+      <div className="mb-10 flex items-center gap-3">
+        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+          <MessageSquare className="h-6 w-6 text-primary" />
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight">Discussions</h1>
+      </div>
+
+      <div className="space-y-10">
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Overview</h2>
+          <p className="text-muted-foreground">
+            Discussions are{" "}
+            <strong className="text-foreground">
+              titled, threaded conversations
+            </strong>{" "}
+            attached to each idea. Use them for planning, proposals, design
+            decisions, and anything that needs more structure than a quick
+            comment. Unlike idea comments, discussions have their own title,
+            status workflow, voting, and can be converted into board tasks.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">
+            Creating a Discussion
+          </h2>
+          <p className="mb-4 text-muted-foreground">
+            Navigate to an idea and click the{" "}
+            <strong className="text-foreground">Discussions</strong> tab, then{" "}
+            <strong className="text-foreground">New Discussion</strong>:
+          </p>
+          <ol className="list-inside list-decimal space-y-2 text-muted-foreground">
+            <li>
+              Give it a clear <strong className="text-foreground">title</strong>{" "}
+              (e.g., &quot;Auth strategy: JWT vs sessions&quot;)
+            </li>
+            <li>
+              Write the{" "}
+              <strong className="text-foreground">body in markdown</strong> —
+              describe the proposal, question, or topic
+            </li>
+            <li>Click Create</li>
+          </ol>
+          <p className="mt-3 text-muted-foreground">
+            All team members (author + collaborators) can create discussions.
+            Public idea discussions are visible to all authenticated users.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Replies & Threading</h2>
+          <p className="mb-4 text-muted-foreground">
+            Discussions support{" "}
+            <strong className="text-foreground">single-level threading</strong>.
+            Each reply can have nested replies one level deep, keeping
+            conversations focused without getting too deeply nested.
+          </p>
+          <ul className="list-inside list-disc space-y-2 text-muted-foreground">
+            <li>Reply to the main discussion or to a specific reply</li>
+            <li>Edit or delete your own replies</li>
+            <li>
+              Use{" "}
+              <strong className="text-foreground">
+                @mentions
+              </strong>{" "}
+              to notify specific team members
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Voting</h2>
+          <p className="text-muted-foreground">
+            Upvote discussions and replies to signal agreement or importance.
+            Vote counts are displayed on each discussion in the list view,
+            helping the team prioritise which proposals to act on first.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Status Workflow</h2>
+          <p className="mb-4 text-muted-foreground">
+            Every discussion has a status that tracks its lifecycle:
+          </p>
+          <div className="space-y-3">
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="font-medium">Open</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Active discussion — the default status when created.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="font-medium">Resolved</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                The discussion has been concluded. No further action needed.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="font-medium">Ready to Convert</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                The discussion is queued for conversion into a board task. Use
+                this when a discussion has reached a decision that needs to be
+                implemented.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="font-medium">Converted</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                A board task has been created from this discussion. The task
+                links back to the original thread for context.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">
+            Converting to Board Tasks
+          </h2>
+          <p className="mb-4 text-muted-foreground">
+            When a discussion reaches a decision, you can turn it into
+            actionable work:
+          </p>
+          <ol className="list-inside list-decimal space-y-2 text-muted-foreground">
+            <li>
+              Mark the discussion as{" "}
+              <strong className="text-foreground">Ready to Convert</strong>
+            </li>
+            <li>
+              Click{" "}
+              <strong className="text-foreground">Convert to Task</strong> — a
+              new board task is created with the discussion title and a link
+              back to the thread
+            </li>
+            <li>
+              The discussion status changes to{" "}
+              <strong className="text-foreground">Converted</strong>{" "}
+              automatically
+            </li>
+          </ol>
+          <div className="mt-4 rounded-xl border border-border bg-muted/30 p-6">
+            <p className="text-sm text-muted-foreground">
+              <strong className="text-foreground">Tip:</strong> AI agents
+              connected via MCP can use the{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                get_discussions_ready_to_convert
+              </code>{" "}
+              tool to find discussions waiting for conversion and act on them.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">
+            AI Enhancement
+          </h2>
+          <p className="text-muted-foreground">
+            Discussions include an{" "}
+            <strong className="text-foreground">AI Enhance</strong> button that
+            can help refine your discussion body — expanding on ideas,
+            improving structure, or adding detail. This uses the same AI
+            credits as other AI features.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Notifications</h2>
+          <p className="mb-4 text-muted-foreground">
+            Discussion activity generates notifications to keep your team in
+            the loop:
+          </p>
+          <ul className="list-inside list-disc space-y-2 text-muted-foreground">
+            <li>
+              <strong className="text-foreground">New discussion</strong>{" "}
+              — team members are notified when a discussion is created
+            </li>
+            <li>
+              <strong className="text-foreground">New reply</strong>{" "}
+              — the discussion author and participants are notified
+            </li>
+            <li>
+              <strong className="text-foreground">@mentions</strong>{" "}
+              — mentioned users get a specific mention notification
+            </li>
+          </ul>
+          <p className="mt-3 text-muted-foreground">
+            Discussion notifications can be configured in your profile settings
+            under the <strong className="text-foreground">Discussions</strong>{" "}
+            toggle.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Pinning</h2>
+          <p className="text-muted-foreground">
+            Important discussions can be{" "}
+            <strong className="text-foreground">pinned</strong> to the top of
+            the discussion list, making them easy to find for new team members
+            or ongoing reference.
+          </p>
+        </section>
+      </div>
+
+      <div className="mt-12 flex justify-between border-t border-border pt-6">
+        <Link href="/guide/collaboration">
+          <Button variant="outline" className="gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            Collaboration
+          </Button>
+        </Link>
+        <Link href="/guide/kanban-boards">
+          <Button variant="outline" className="gap-2">
+            Kanban Boards
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/guide/kanban-boards/page.tsx
+++ b/src/app/guide/kanban-boards/page.tsx
@@ -234,10 +234,10 @@ export default function KanbanBoardsPage() {
       </div>
 
       <div className="mt-12 flex justify-between border-t border-border pt-6">
-        <Link href="/guide/collaboration">
+        <Link href="/guide/discussions">
           <Button variant="outline" className="gap-2">
             <ArrowLeft className="h-4 w-4" />
-            Collaboration
+            Discussions
           </Button>
         </Link>
         <Link href="/guide/mcp-integration">

--- a/src/app/guide/mcp-integration/page.tsx
+++ b/src/app/guide/mcp-integration/page.tsx
@@ -63,7 +63,7 @@ export default function McpIntegrationPage() {
           <p className="mt-3 text-muted-foreground">
             The first time you use it, Claude Code will open your browser for
             OAuth authentication. Log in with your VibeCodes account and
-            authorize the connection. After that, Claude Code can use all 38
+            authorize the connection. After that, Claude Code can use all 54
             VibeCodes tools on your behalf.
           </p>
           <div className="mt-4 rounded-xl border border-border bg-muted/30 p-6">
@@ -93,9 +93,9 @@ export default function McpIntegrationPage() {
         <section>
           <h2 className="mb-4 text-2xl font-semibold">Available Tools</h2>
           <p className="mb-4 text-muted-foreground">
-            Once connected, Claude Code has access to 38 tools (including{" "}
+            Once connected, Claude Code has access to 54 tools (including{" "}
             <Link href="/guide/ai-agent-teams" className="text-primary hover:underline">
-              4 agent team tools
+              13 agent tools
             </Link>
             ):
           </p>
@@ -146,9 +146,37 @@ export default function McpIntegrationPage() {
                   <td className="py-2 pr-4 font-mono text-xs text-foreground">list_agents</td>
                   <td className="py-2">List your agent personas with name, role, and active status</td>
                 </tr>
-                <tr>
+                <tr className="border-b border-border/50">
                   <td className="py-2 pr-4 font-mono text-xs text-foreground">get_agent_prompt</td>
                   <td className="py-2">Get the system prompt for a specific agent or active identity</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">get_agent_mentions</td>
+                  <td className="py-2">Get recent @mentions of the active agent</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">list_idea_agents</td>
+                  <td className="py-2">List agents in an idea&apos;s shared agent pool</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">list_community_agents</td>
+                  <td className="py-2">Browse published agents from all users</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">list_featured_teams</td>
+                  <td className="py-2">List admin-curated featured agent team templates</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">list_discussions</td>
+                  <td className="py-2">List discussions for an idea with status filter</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">get_discussion</td>
+                  <td className="py-2">Get a discussion thread with all replies</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">get_discussions_ready_to_convert</td>
+                  <td className="py-2">Find discussions queued for conversion to board tasks</td>
                 </tr>
               </tbody>
             </table>
@@ -272,9 +300,45 @@ export default function McpIntegrationPage() {
                   <td className="py-2 pr-4 font-mono text-xs text-foreground">set_agent_identity</td>
                   <td className="py-2">Switch to an agent persona (persisted across sessions)</td>
                 </tr>
-                <tr>
+                <tr className="border-b border-border/50">
                   <td className="py-2 pr-4 font-mono text-xs text-foreground">create_agent</td>
                   <td className="py-2">Create a new agent with name, role, and system prompt</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">toggle_agent_vote</td>
+                  <td className="py-2">Upvote or remove vote on a community agent</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">clone_agent</td>
+                  <td className="py-2">Clone a published agent into your account</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">publish_agent</td>
+                  <td className="py-2">Publish or unpublish an agent to the community</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">allocate_agent</td>
+                  <td className="py-2">Add your agent to an idea&apos;s shared pool</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">remove_idea_agent</td>
+                  <td className="py-2">Remove an agent from an idea&apos;s pool</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">create_discussion</td>
+                  <td className="py-2">Create a new discussion thread on an idea</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">update_discussion</td>
+                  <td className="py-2">Update a discussion&apos;s title, body, status, or pinned state</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">delete_discussion</td>
+                  <td className="py-2">Delete a discussion thread</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-mono text-xs text-foreground">add_discussion_reply</td>
+                  <td className="py-2">Reply to a discussion thread</td>
                 </tr>
               </tbody>
             </table>

--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -3,6 +3,7 @@ import {
   Rocket,
   Lightbulb,
   Users,
+  MessageSquare,
   LayoutDashboard,
   Terminal,
   Bot,
@@ -36,6 +37,13 @@ const sections = [
       "Join projects, add collaborators, and stay updated with notifications.",
     icon: Users,
     href: "/guide/collaboration",
+  },
+  {
+    title: "Discussions",
+    description:
+      "Plan features with threaded discussions, vote on proposals, and convert threads into board tasks.",
+    icon: MessageSquare,
+    href: "/guide/discussions",
   },
   {
     title: "Kanban Boards",


### PR DESCRIPTION
## Summary
- New **Discussions** guide page — threading, voting, status workflow, converting to tasks, AI enhancement, notifications, pinning
- **Agents Hub** section added to AI Agent Teams guide — community marketplace, publishing, cloning, voting, featured teams, agent profiles
- **Idea Agent Pool** section added to AI Agent Teams guide — shared agent allocation per idea
- **MCP tools** tables updated from 38 → 54 tools across both MCP Integration and AI Agent Teams pages
- **Collaboration** guide updated with notification bell User/Agent tabs and discussion notification types
- Navigation links updated to include Discussions in the guide flow

## Test plan
- [ ] Visit `/guide` and verify Discussions card appears between Collaboration and Kanban Boards
- [ ] Navigate through all guide pages and verify prev/next links work correctly
- [ ] Review Discussions page content for accuracy
- [ ] Review Agents Hub and Agent Pool sections in AI Agent Teams page
- [ ] Verify MCP tool counts match (54 total, 13 agent tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)