### PR TITLE
fix: add missing e2e/fixtures/constants.ts

### DIFF
--- a/e2e/fixtures/constants.ts
+++ b/e2e/fixtures/constants.ts
@@ -1,0 +1,1 @@
+export const EXPECT_TIMEOUT = 15_000;


### PR DESCRIPTION
## Summary
- Adds the missing `e2e/fixtures/constants.ts` file that exports `EXPECT_TIMEOUT` (15s)
- Every E2E spec imports this but the file was never committed, causing all CI runs to fail

## Test plan
- [ ] E2E CI passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)