### PR TITLE
feat: add priority levels to board tasks (low, medium, high, urgent)

### DIFF
--- a/e2e/board/board-priority.spec.ts
+++ b/e2e/board/board-priority.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from "../fixtures/auth";
+import {
+  createTestIdea,
+  createTestBoardWithTasks,
+  cleanupTestData,
+} from "../fixtures/test-data";
+import { supabaseAdmin } from "../fixtures/supabase-admin";
+
+async function getUserId(fullName: string): Promise<string> {
+  const { data } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("full_name", fullName)
+    .single();
+  if (!data) throw new Error(`Test user not found: ${fullName}`);
+  return data.id;
+}
+
+test.describe("Board Task Priority", () => {
+  let userAId: string;
+  let ideaId: string;
+  let tasks: Array<{ id: string; title: string }>;
+
+  test.beforeAll(async () => {
+    userAId = await getUserId("Test User A");
+
+    const idea = await createTestIdea(userAId, {
+      title: "[E2E] Priority Board Test Idea",
+      description: "[E2E] Idea for testing task priority features.",
+      tags: ["e2e-test", "priority"],
+    });
+    ideaId = idea.id;
+
+    const board = await createTestBoardWithTasks(ideaId, 3);
+    tasks = board.tasks;
+  });
+
+  test.afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  test("new tasks default to medium priority dot on card", async ({
+    userAPage,
+  }) => {
+    await userAPage.goto(`/ideas/${ideaId}/board`);
+
+    const taskCard = userAPage.locator(
+      `[data-testid="task-card-${tasks[0].id}"]`
+    );
+    await expect(taskCard).toBeVisible({ timeout: 15_000 });
+
+    // The priority dot is a span with bg-yellow-600/40 (medium default)
+    const priorityDot = taskCard.locator("span.rounded-full.bg-yellow-600\\/40");
+    await expect(priorityDot).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("change priority from task detail dialog", async ({ userAPage }) => {
+    const taskId = tasks[1].id;
+
+    await userAPage.goto(`/ideas/${ideaId}/board`);
+
+    // Open task detail
+    const taskCard = userAPage.locator(`[data-testid="task-card-${taskId}"]`);
+    await expect(taskCard).toBeVisible({ timeout: 15_000 });
+    await taskCard.click();
+
+    const dialog = userAPage.getByRole("dialog").first();
+    await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+    // Verify the Priority label is visible
+    await expect(dialog.getByText("Priority")).toBeVisible({ timeout: 5_000 });
+
+    // The priority select trigger should show "Medium" by default
+    const priorityTrigger = dialog
+      .locator('[role="combobox"]')
+      .filter({ hasText: "Medium" });
+    await expect(priorityTrigger).toBeVisible({ timeout: 5_000 });
+
+    // Open the priority select
+    await priorityTrigger.click();
+
+    // Select "High" from the dropdown
+    const highOption = userAPage.getByRole("option", { name: "High" });
+    await expect(highOption).toBeVisible({ timeout: 5_000 });
+    await highOption.click();
+
+    // The trigger should now show "High"
+    await expect(
+      dialog.locator('[role="combobox"]').filter({ hasText: "High" })
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Wait for server save
+    await userAPage.waitForTimeout(1000);
+
+    // Close dialog
+    await userAPage.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+
+    // The card should now show the orange dot (high priority)
+    const updatedCard = userAPage.locator(
+      `[data-testid="task-card-${taskId}"]`
+    );
+    await expect(updatedCard).toBeVisible({ timeout: 15_000 });
+    const highDot = updatedCard.locator("span.rounded-full.bg-orange-500");
+    await expect(highDot).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("change priority to urgent and verify red dot on card", async ({
+    userAPage,
+  }) => {
+    const taskId = tasks[2].id;
+
+    await userAPage.goto(`/ideas/${ideaId}/board`);
+
+    // Open task detail
+    const taskCard = userAPage.locator(`[data-testid="task-card-${taskId}"]`);
+    await expect(taskCard).toBeVisible({ timeout: 15_000 });
+    await taskCard.click();
+
+    const dialog = userAPage.getByRole("dialog").first();
+    await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+    // Open the priority select (currently Medium)
+    const priorityTrigger = dialog
+      .locator('[role="combobox"]')
+      .filter({ hasText: "Medium" });
+    await expect(priorityTrigger).toBeVisible({ timeout: 5_000 });
+    await priorityTrigger.click();
+
+    // Select "Urgent"
+    const urgentOption = userAPage.getByRole("option", { name: "Urgent" });
+    await expect(urgentOption).toBeVisible({ timeout: 5_000 });
+    await urgentOption.click();
+
+    // The trigger should now show "Urgent"
+    await expect(
+      dialog.locator('[role="combobox"]').filter({ hasText: "Urgent" })
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Wait for server save
+    await userAPage.waitForTimeout(1000);
+
+    // Close dialog
+    await userAPage.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+
+    // The card should now show the red dot (urgent priority)
+    const updatedCard = userAPage.locator(
+      `[data-testid="task-card-${taskId}"]`
+    );
+    await expect(updatedCard).toBeVisible({ timeout: 15_000 });
+    const urgentDot = updatedCard.locator("span.rounded-full.bg-red-500");
+    await expect(urgentDot).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("priority persists after page reload", async ({ userAPage }) => {
+    const taskId = tasks[1].id;
+
+    // Set priority to "low" directly in DB for a clean test
+    await supabaseAdmin
+      .from("board_tasks")
+      .update({ priority: "low" })
+      .eq("id", taskId);
+
+    await userAPage.goto(`/ideas/${ideaId}/board`);
+
+    // The card should show the zinc dot (low priority)
+    const taskCard = userAPage.locator(`[data-testid="task-card-${taskId}"]`);
+    await expect(taskCard).toBeVisible({ timeout: 15_000 });
+    const lowDot = taskCard.locator("span.rounded-full.bg-zinc-500");
+    await expect(lowDot).toBeVisible({ timeout: 10_000 });
+
+    // Open detail dialog and verify the select shows "Low"
+    await taskCard.click();
+    const dialog = userAPage.getByRole("dialog").first();
+    await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+    await expect(
+      dialog.locator('[role="combobox"]').filter({ hasText: "Low" })
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/mcp-server/src/tools/board-write.ts
+++ b/mcp-server/src/tools/board-write.ts
@@ -43,6 +43,10 @@ export const createTaskSchema = z.object({
     .uuid()
     .optional()
     .describe("Link task back to a source discussion (for converted discussions)"),
+  priority: z
+    .enum(["low", "medium", "high", "urgent"])
+    .optional()
+    .describe("Task priority (default: medium)"),
 });
 
 export async function createTask(ctx: McpContext, params: z.infer<typeof createTaskSchema>) {
@@ -58,6 +62,7 @@ export async function createTask(ctx: McpContext, params: z.infer<typeof createT
       assignee_id: params.assignee_id ?? null,
       due_date: params.due_date ?? null,
       discussion_id: params.discussion_id ?? null,
+      ...(params.priority && { priority: params.priority }),
       position,
     })
     .select("id, title, column_id, position")
@@ -104,13 +109,17 @@ export const updateTaskSchema = z.object({
     .optional()
     .describe("New due date (null to clear)"),
   archived: z.boolean().optional().describe("Archive or unarchive the task"),
+  priority: z
+    .enum(["low", "medium", "high", "urgent"])
+    .optional()
+    .describe("New priority level"),
 });
 
 export async function updateTask(ctx: McpContext, params: z.infer<typeof updateTaskSchema>) {
   // Fetch current task for activity diffs
   const { data: current } = await ctx.supabase
     .from("board_tasks")
-    .select("title, description, assignee_id, due_date, archived")
+    .select("title, description, assignee_id, due_date, archived, priority")
     .eq("id", params.task_id)
     .single();
 
@@ -122,6 +131,7 @@ export async function updateTask(ctx: McpContext, params: z.infer<typeof updateT
   if (params.assignee_id !== undefined) updates.assignee_id = params.assignee_id;
   if (params.due_date !== undefined) updates.due_date = params.due_date;
   if (params.archived !== undefined) updates.archived = params.archived;
+  if (params.priority !== undefined) updates.priority = params.priority;
 
   if (Object.keys(updates).length === 0) {
     return { success: true, message: "No changes to apply" };
@@ -177,6 +187,12 @@ export async function updateTask(ctx: McpContext, params: z.infer<typeof updateT
       params.idea_id,
       params.archived ? "archived" : "unarchived"
     );
+  }
+  if (params.priority !== undefined && params.priority !== current.priority) {
+    await logActivity(ctx, params.task_id, params.idea_id, "priority_changed", {
+      from: current.priority,
+      to: params.priority,
+    });
   }
 
   return { success: true, task };

--- a/src/actions/board.ts
+++ b/src/actions/board.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { DEFAULT_BOARD_COLUMNS, POSITION_GAP } from "@/lib/constants";
-import { validateTitle, validateOptionalDescription, validateLabelName, validateLabelColor, validateComment } from "@/lib/validation";
+import { validateTitle, validateOptionalDescription, validateLabelName, validateLabelColor, validateComment, validatePriority } from "@/lib/validation";
 
 export async function initializeBoardColumns(ideaId: string) {
   const supabase = await createClient();
@@ -159,7 +159,8 @@ export async function createBoardTask(
   columnId: string,
   title: string,
   description?: string,
-  assigneeId?: string
+  assigneeId?: string,
+  priority?: string
 ) {
   const supabase = await createClient();
   const {
@@ -170,6 +171,7 @@ export async function createBoardTask(
 
   title = validateTitle(title);
   description = validateOptionalDescription(description ?? null) ?? undefined;
+  const validatedPriority = priority ? validatePriority(priority) : undefined;
 
   // Get max position in this column
   const { data: tasks } = await supabase
@@ -190,6 +192,7 @@ export async function createBoardTask(
       description: description || null,
       assignee_id: assigneeId || null,
       position: maxPos + POSITION_GAP,
+      ...(validatedPriority && { priority: validatedPriority }),
     })
     .select("id")
     .single();
@@ -210,6 +213,7 @@ export async function updateBoardTask(
     assignee_id?: string | null;
     due_date?: string | null;
     archived?: boolean;
+    priority?: string;
   }
 ) {
   const supabase = await createClient();
@@ -225,10 +229,14 @@ export async function updateBoardTask(
   if (updates.description !== undefined) {
     updates.description = validateOptionalDescription(updates.description ?? null);
   }
+  const validatedUpdates: Record<string, unknown> = { ...updates };
+  if (updates.priority !== undefined) {
+    validatedUpdates.priority = validatePriority(updates.priority);
+  }
 
   const { error } = await supabase
     .from("board_tasks")
-    .update(updates)
+    .update(validatedUpdates)
     .eq("id", taskId)
     .eq("idea_id", ideaId);
 

--- a/src/components/board/board-task-card.tsx
+++ b/src/components/board/board-task-card.tsx
@@ -24,6 +24,7 @@ import { LabelPicker } from "./label-picker";
 import { DueDateBadge } from "./due-date-badge";
 import { createClient } from "@/lib/supabase/client";
 import { TaskAutoOpenContext } from "./kanban-board";
+import { PRIORITY_CONFIG } from "@/lib/priority";
 import type { BoardTaskWithAssignee, BoardLabel, TaskWorkflowStepWithAgent, User } from "@/types";
 
 const TaskDetailDialog = dynamic(() => import("./task-detail-dialog").then((m) => m.TaskDetailDialog), { ssr: false });
@@ -288,8 +289,12 @@ export const BoardTaskCard = memo(function BoardTaskCard({
               </div>
             )}
 
-            <p className="text-sm font-medium leading-snug">
-              {highlightQuery ? <HighlightedText text={task.title} query={highlightQuery} /> : task.title}
+            <p className="text-sm font-medium leading-snug flex items-start gap-1.5">
+              <span
+                className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${PRIORITY_CONFIG[task.priority as keyof typeof PRIORITY_CONFIG]?.dot ?? PRIORITY_CONFIG.medium.dot}`}
+                title={`${PRIORITY_CONFIG[task.priority as keyof typeof PRIORITY_CONFIG]?.label ?? "Medium"} priority`}
+              />
+              <span>{highlightQuery ? <HighlightedText text={task.title} query={highlightQuery} /> : task.title}</span>
             </p>
 
             {task.description && (

--- a/src/components/board/task-detail-dialog.tsx
+++ b/src/components/board/task-detail-dialog.tsx
@@ -27,6 +27,9 @@ import { enhanceTaskDescription } from "@/actions/ai";
 import { useBoardOps } from "./board-context";
 import { createClient } from "@/lib/supabase/client";
 import { logTaskActivity } from "@/lib/activity";
+import { PRIORITY_CONFIG, PRIORITY_OPTIONS } from "@/lib/priority";
+import type { TaskPriority } from "@/lib/priority";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useBotRoles } from "@/components/bot-roles-context";
 import { getRoleColor } from "@/lib/agent-colors";
 import { getInitials } from "@/lib/utils";
@@ -109,6 +112,7 @@ export function TaskDetailDialog({
   const [isArchived, setIsArchived] = useState(task.archived);
 
   const [localAssigneeId, setLocalAssigneeId] = useState<string | null>(task.assignee_id);
+  const [localPriority, setLocalPriority] = useState<TaskPriority>(task.priority as TaskPriority);
 
   // Sync state when task prop changes (including external updates via Realtime/MCP)
   const [lastTaskId, setLastTaskId] = useState(task.id);
@@ -116,12 +120,14 @@ export function TaskDetailDialog({
   const [lastTaskTitle, setLastTaskTitle] = useState(task.title);
   const [lastTaskAssigneeId, setLastTaskAssigneeId] = useState(task.assignee_id);
   const [lastTaskArchived, setLastTaskArchived] = useState(task.archived);
+  const [lastTaskPriority, setLastTaskPriority] = useState(task.priority);
 
   if (task.id !== lastTaskId) {
     // Different task — full reset
     setTitle(task.title);
     setDescription(task.description ?? "");
     setLocalAssigneeId(task.assignee_id);
+    setLocalPriority(task.priority as TaskPriority);
     setIsArchived(task.archived);
     setEditingDescription(false);
     setLastTaskId(task.id);
@@ -129,6 +135,7 @@ export function TaskDetailDialog({
     setLastTaskTitle(task.title);
     setLastTaskAssigneeId(task.assignee_id);
     setLastTaskArchived(task.archived);
+    setLastTaskPriority(task.priority);
   } else {
     // Same task — sync fields changed externally (only if user isn't actively editing)
     if (task.description !== lastTaskDesc && !editingDescription) {
@@ -146,6 +153,10 @@ export function TaskDetailDialog({
     if (task.archived !== lastTaskArchived) {
       setIsArchived(task.archived);
       setLastTaskArchived(task.archived);
+    }
+    if (task.priority !== lastTaskPriority) {
+      setLocalPriority(task.priority as TaskPriority);
+      setLastTaskPriority(task.priority);
     }
   }
 
@@ -317,6 +328,23 @@ export function TaskDetailDialog({
     } catch {
       toast.error("Failed to update assignee");
       setLocalAssigneeId(task.assignee_id);
+    }
+  }
+
+  async function handlePriorityChange(value: string) {
+    const prev = localPriority;
+    const next = value as TaskPriority;
+    setLocalPriority(next);
+
+    try {
+      await updateBoardTask(task.id, ideaId, { priority: next });
+      logTaskActivity(task.id, ideaId, currentUserId, "priority_changed", {
+        from: prev,
+        to: next,
+      });
+    } catch {
+      toast.error("Failed to update priority");
+      setLocalPriority(prev);
     }
   }
 
@@ -619,6 +647,43 @@ export function TaskDetailDialog({
                         dueDate={task.due_date}
                         currentUserId={currentUserId}
                       />
+                    )}
+                  </div>
+                </div>
+
+                <div className="space-y-1.5">
+                  <span className="text-sm font-medium">Priority</span>
+                  <div className="flex items-center gap-2">
+                    {isReadOnly ? (
+                      <div className="flex items-center gap-1.5">
+                        <span className={`h-2 w-2 rounded-full ${PRIORITY_CONFIG[localPriority]?.dot ?? PRIORITY_CONFIG.medium.dot}`} />
+                        <span className="text-xs">
+                          {PRIORITY_CONFIG[localPriority]?.label ?? "Medium"}
+                        </span>
+                      </div>
+                    ) : (
+                      <Select value={localPriority} onValueChange={handlePriorityChange}>
+                        <SelectTrigger className="h-8 w-32 text-xs">
+                          <SelectValue placeholder="Set priority">
+                            {PRIORITY_CONFIG[localPriority] && (
+                              <div className="flex items-center gap-2">
+                                <span className={`h-2 w-2 rounded-full ${PRIORITY_CONFIG[localPriority].dot}`} />
+                                {PRIORITY_CONFIG[localPriority].label}
+                              </div>
+                            )}
+                          </SelectValue>
+                        </SelectTrigger>
+                        <SelectContent>
+                          {PRIORITY_OPTIONS.map(([key, config]) => (
+                            <SelectItem key={key} value={key}>
+                              <div className="flex items-center gap-2">
+                                <span className={`h-1.5 w-1.5 rounded-full ${config.dot}`} />
+                                {config.label}
+                              </div>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     )}
                   </div>
                 </div>

--- a/src/components/board/task-edit-dialog.tsx
+++ b/src/components/board/task-edit-dialog.tsx
@@ -233,6 +233,7 @@ export function TaskEditDialog({
       attachment_count: 0,
       cover_image_path: null,
       comment_count: 0,
+      priority: "medium",
       discussion_id: null,
     };
 

--- a/src/lib/priority.ts
+++ b/src/lib/priority.ts
@@ -1,0 +1,13 @@
+export const PRIORITY_CONFIG = {
+  urgent: { label: "Urgent", color: "text-red-500", dot: "bg-red-500" },
+  high: { label: "High", color: "text-orange-500", dot: "bg-orange-500" },
+  medium: { label: "Medium", color: "text-yellow-600", dot: "bg-yellow-600/40" },
+  low: { label: "Low", color: "text-zinc-500", dot: "bg-zinc-500" },
+} as const;
+
+export type TaskPriority = keyof typeof PRIORITY_CONFIG;
+
+export const PRIORITY_OPTIONS = Object.entries(PRIORITY_CONFIG) as [
+  TaskPriority,
+  (typeof PRIORITY_CONFIG)[TaskPriority],
+][];

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -25,6 +25,9 @@ const VALID_LABEL_COLORS = [
   "rose", "zinc",
 ];
 
+const VALID_PRIORITIES = ["low", "medium", "high", "urgent"] as const;
+export type TaskPriority = (typeof VALID_PRIORITIES)[number];
+
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const GITHUB_URL_PATTERN = /^https:\/\/github\.com\/.+/;
@@ -97,6 +100,15 @@ export function validateTags(tagsRaw: string): string[] {
     }
   }
   return tags;
+}
+
+export function validatePriority(priority: string): TaskPriority {
+  if (!VALID_PRIORITIES.includes(priority as TaskPriority)) {
+    throw new ValidationError(
+      `Invalid priority: must be one of ${VALID_PRIORITIES.join(", ")}`,
+    );
+  }
+  return priority as TaskPriority;
 }
 
 export function validateLabelColor(color: string): string {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -356,6 +356,7 @@ export type Database = {
           attachment_count: number;
           comment_count: number;
           cover_image_path: string | null;
+          priority: "low" | "medium" | "high" | "urgent";
           discussion_id: string | null;
           created_at: string;
           updated_at: string;
@@ -375,6 +376,7 @@ export type Database = {
           attachment_count?: number;
           comment_count?: number;
           cover_image_path?: string | null;
+          priority?: "low" | "medium" | "high" | "urgent";
           discussion_id?: string | null;
           created_at?: string;
           updated_at?: string;
@@ -394,6 +396,7 @@ export type Database = {
           attachment_count?: number;
           comment_count?: number;
           cover_image_path?: string | null;
+          priority?: "low" | "medium" | "high" | "urgent";
           discussion_id?: string | null;
           created_at?: string;
           updated_at?: string;

--- a/supabase/migrations/00072_board_task_priority.sql
+++ b/supabase/migrations/00072_board_task_priority.sql
@@ -1,0 +1,7 @@
+-- Add priority column to board_tasks
+-- Four levels: low, medium, high, urgent (default: medium)
+-- Using text + CHECK constraint (not enum) for easier future extensibility
+
+ALTER TABLE board_tasks
+ADD COLUMN priority text NOT NULL DEFAULT 'medium'
+CONSTRAINT board_tasks_priority_check CHECK (priority IN ('low', 'medium', 'high', 'urgent'));


### PR DESCRIPTION
Add a priority field to board tasks with colour-coded dot indicators on task cards and a Select dropdown in the task detail dialog. Includes database migration, server action + MCP tool updates, validation, and E2E tests.

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

-

## Test plan

<!-- How did you verify this works? -->

- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] Tested manually in browser
- [ ] New tests added (if applicable)

## Screenshots

<!-- If there are UI changes, add before/after screenshots. -->
