### PR TITLE
fix: wrap idea description in matching card border

### DIFF
--- a/src/app/(main)/ideas/[id]/page.tsx
+++ b/src/app/(main)/ideas/[id]/page.tsx
@@ -448,7 +448,7 @@ export default async function IdeaDetailPage({ params }: PageProps) {
       )}
 
       {/* ══ Description (promoted to top of content) ═══════ */}
-      <div className="mt-6">
+      <div className="mt-4 rounded-xl border border-border bg-card p-4 sm:p-5">
         <InlineIdeaBody
           ideaId={idea.id}
           description={idea.description}

--- a/src/components/ideas/inline-idea-body.tsx
+++ b/src/components/ideas/inline-idea-body.tsx
@@ -99,11 +99,11 @@ export function InlineIdeaBody({
   }
 
   return (
-    <>
+    <div className="space-y-4">
       {/* GitHub URL */}
       {isAuthor ? (
         editingGithubUrl ? (
-          <div className="mt-4">
+          <div>
             <Input
               value={githubUrl}
               onChange={(e) => setGithubUrl(e.target.value)}
@@ -115,7 +115,7 @@ export function InlineIdeaBody({
             />
           </div>
         ) : githubUrl ? (
-          <div className="mt-4 group/github inline-flex items-center gap-2">
+          <div className="group/github inline-flex items-center gap-2">
             <a
               href={githubUrl}
               target="_blank"
@@ -136,7 +136,7 @@ export function InlineIdeaBody({
         ) : (
           <button
             onClick={startEditingGithub}
-            className="mt-4 inline-flex items-center gap-2 rounded-lg border border-dashed border-border px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-primary hover:text-foreground"
+            className="inline-flex items-center gap-2 rounded-lg border border-dashed border-border px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-primary hover:text-foreground"
           >
             <Github className="h-4 w-4" />
             <Plus className="h-3 w-3" />
@@ -149,7 +149,7 @@ export function InlineIdeaBody({
             href={initialGithubUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-4 inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-primary hover:text-foreground"
+            className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-primary hover:text-foreground"
           >
             <Github className="h-4 w-4" />
             View Repository
@@ -188,6 +188,6 @@ export function InlineIdeaBody({
           <Markdown>{initialDescription}</Markdown>
         </div>
       )}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Wrapped the idea description section in a `rounded-xl border bg-card` card to visually match the hero card above it
- Removed redundant `mt-4` margins from GitHub URL elements (card padding handles spacing)
- Added `space-y-4` wrapper in `InlineIdeaBody` for consistent internal spacing

## Test plan
- [ ] View an idea detail page — description section should have a card border matching the hero card
- [ ] Check GitHub URL button alignment inside the new card
- [ ] Verify mobile responsiveness (padding switches from `p-4` to `sm:p-5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)