### PR TITLE
fix: inline CORS handler for oauth-protected-resource endpoint

### DIFF
--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,7 +1,11 @@
-import {
-  protectedResourceHandler,
-  metadataCorsOptionsRequestHandler,
-} from "mcp-handler";
+import { protectedResourceHandler } from "mcp-handler";
+import { NextResponse } from "next/server";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "*",
+};
 
 const handler = protectedResourceHandler({
   authServerUrls: [
@@ -9,6 +13,8 @@ const handler = protectedResourceHandler({
   ],
 });
 
-const corsHandler = metadataCorsOptionsRequestHandler();
+export { handler as GET };
 
-export { handler as GET, corsHandler as OPTIONS };
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}


### PR DESCRIPTION
## Summary
- Replaces `metadataCorsOptionsRequestHandler()` from mcp-handler with inlined CORS handler in `.well-known/oauth-protected-resource`
- Fixes intermittent 500 "No response is returned" errors on Vercel cold starts that break MCP OAuth discovery
- Same fix already applied to `oauth-authorization-server` in f478f4e but was missed for this endpoint

## Test plan
- [ ] Verify remote MCP connection via Claude Code `/mcp` command
- [ ] Confirm `.well-known/oauth-protected-resource` returns valid JSON with CORS headers
- [ ] Confirm OPTIONS preflight returns 204

🤖 Generated with [Claude Code](https://claude.com/claude-code)