### PR TITLE
debug: add logging to OAuth route handlers

### DIFF
--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -10,65 +10,83 @@ function getServiceClient() {
 }
 
 export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const clientId = url.searchParams.get("client_id");
-  const redirectUri = url.searchParams.get("redirect_uri");
-  const codeChallenge = url.searchParams.get("code_challenge");
-  const codeChallengeMethod = url.searchParams.get("code_challenge_method");
-  const state = url.searchParams.get("state");
-  const scope = url.searchParams.get("scope") || "";
+  console.log("[oauth/authorize] GET handler invoked");
+  try {
+    const url = new URL(request.url);
+    const clientId = url.searchParams.get("client_id");
+    const redirectUri = url.searchParams.get("redirect_uri");
+    const codeChallenge = url.searchParams.get("code_challenge");
+    const codeChallengeMethod = url.searchParams.get("code_challenge_method");
+    const state = url.searchParams.get("state");
+    const scope = url.searchParams.get("scope") || "";
 
-  if (!clientId || !redirectUri || !codeChallenge || !state) {
+    console.log("[oauth/authorize] Params:", JSON.stringify({ clientId, redirectUri: redirectUri?.substring(0, 50), codeChallenge: !!codeChallenge, state: !!state, scope }));
+
+    if (!clientId || !redirectUri || !codeChallenge || !state) {
+      console.log("[oauth/authorize] Missing required params");
+      return NextResponse.json(
+        { error: "invalid_request", error_description: "Missing required parameters: client_id, redirect_uri, code_challenge, state" },
+        { status: 400 }
+      );
+    }
+
+    if (codeChallengeMethod && codeChallengeMethod !== "S256") {
+      console.log("[oauth/authorize] Invalid code_challenge_method:", codeChallengeMethod);
+      return NextResponse.json(
+        { error: "invalid_request", error_description: "Only S256 code_challenge_method is supported" },
+        { status: 400 }
+      );
+    }
+
+    // Validate client_id and redirect_uri
+    console.log("[oauth/authorize] Looking up client...");
+    const supabase = getServiceClient();
+    const { data: client, error } = await supabase
+      .from("mcp_oauth_clients")
+      .select("client_id, redirect_uris")
+      .eq("client_id", clientId)
+      .maybeSingle();
+
+    if (error || !client) {
+      console.log("[oauth/authorize] Client lookup failed:", error?.message || "not found");
+      return NextResponse.json(
+        { error: "invalid_client", error_description: "Unknown client_id" },
+        { status: 400 }
+      );
+    }
+
+    if (!client.redirect_uris.includes(redirectUri)) {
+      console.log("[oauth/authorize] redirect_uri not registered");
+      return NextResponse.json(
+        { error: "invalid_request", error_description: "redirect_uri not registered for this client" },
+        { status: 400 }
+      );
+    }
+
+    // Redirect to the consent/login page with all OAuth params
+    if (!process.env.NEXT_PUBLIC_APP_URL) {
+      console.error("[oauth/authorize] NEXT_PUBLIC_APP_URL not configured");
+      return NextResponse.json(
+        { error: "server_error", error_description: "NEXT_PUBLIC_APP_URL is not configured" },
+        { status: 500 }
+      );
+    }
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL;
+    const loginUrl = new URL(`${baseUrl}/oauth/authorize`);
+    loginUrl.searchParams.set("client_id", clientId);
+    loginUrl.searchParams.set("redirect_uri", redirectUri);
+    loginUrl.searchParams.set("code_challenge", codeChallenge);
+    loginUrl.searchParams.set("code_challenge_method", codeChallengeMethod || "S256");
+    loginUrl.searchParams.set("state", state);
+    loginUrl.searchParams.set("scope", scope);
+
+    console.log("[oauth/authorize] Redirecting to consent page");
+    return NextResponse.redirect(loginUrl.toString());
+  } catch (err) {
+    console.error("[oauth/authorize] Unhandled error:", err instanceof Error ? { message: err.message, stack: err.stack, name: err.name } : err);
     return NextResponse.json(
-      { error: "invalid_request", error_description: "Missing required parameters: client_id, redirect_uri, code_challenge, state" },
-      { status: 400 }
-    );
-  }
-
-  if (codeChallengeMethod && codeChallengeMethod !== "S256") {
-    return NextResponse.json(
-      { error: "invalid_request", error_description: "Only S256 code_challenge_method is supported" },
-      { status: 400 }
-    );
-  }
-
-  // Validate client_id and redirect_uri
-  const supabase = getServiceClient();
-  const { data: client, error } = await supabase
-    .from("mcp_oauth_clients")
-    .select("client_id, redirect_uris")
-    .eq("client_id", clientId)
-    .maybeSingle();
-
-  if (error || !client) {
-    return NextResponse.json(
-      { error: "invalid_client", error_description: "Unknown client_id" },
-      { status: 400 }
-    );
-  }
-
-  if (!client.redirect_uris.includes(redirectUri)) {
-    return NextResponse.json(
-      { error: "invalid_request", error_description: "redirect_uri not registered for this client" },
-      { status: 400 }
-    );
-  }
-
-  // Redirect to the consent/login page with all OAuth params
-  if (!process.env.NEXT_PUBLIC_APP_URL) {
-    return NextResponse.json(
-      { error: "server_error", error_description: "NEXT_PUBLIC_APP_URL is not configured" },
+      { error: "server_error", error_description: "Internal server error" },
       { status: 500 }
     );
   }
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL;
-  const loginUrl = new URL(`${baseUrl}/oauth/authorize`);
-  loginUrl.searchParams.set("client_id", clientId);
-  loginUrl.searchParams.set("redirect_uri", redirectUri);
-  loginUrl.searchParams.set("code_challenge", codeChallenge);
-  loginUrl.searchParams.set("code_challenge_method", codeChallengeMethod || "S256");
-  loginUrl.searchParams.set("state", state);
-  loginUrl.searchParams.set("scope", scope);
-
-  return NextResponse.redirect(loginUrl.toString());
 }

--- a/src/app/api/oauth/code/route.ts
+++ b/src/app/api/oauth/code/route.ts
@@ -10,7 +10,9 @@ function getServiceClient() {
 }
 
 export async function POST(request: Request) {
+  console.log("[oauth/code] POST handler invoked");
   try {
+    console.log("[oauth/code] Parsing request body...");
     const body = await request.json();
     const {
       code,
@@ -23,7 +25,14 @@ export async function POST(request: Request) {
       supabase_refresh_token,
     } = body;
 
+    console.log("[oauth/code] Fields present:", JSON.stringify({
+      code: !!code, client_id: !!client_id, redirect_uri: !!redirect_uri,
+      code_challenge: !!code_challenge, supabase_access_token: !!supabase_access_token,
+      supabase_refresh_token: !!supabase_refresh_token,
+    }));
+
     if (!code || !client_id || !redirect_uri || !code_challenge || !supabase_access_token || !supabase_refresh_token) {
+      console.log("[oauth/code] Missing required fields");
       return NextResponse.json(
         { error: "Missing required fields" },
         { status: 400 }
@@ -31,10 +40,12 @@ export async function POST(request: Request) {
     }
 
     // Verify the access token to get the user ID
+    console.log("[oauth/code] Verifying access token...");
     const supabase = getServiceClient();
     const { data: { user }, error: userError } = await supabase.auth.getUser(supabase_access_token);
 
     if (userError || !user) {
+      console.log("[oauth/code] Token verification failed:", userError?.message);
       return NextResponse.json(
         { error: "Invalid access token" },
         { status: 401 }
@@ -42,6 +53,7 @@ export async function POST(request: Request) {
     }
 
     // Store the authorization code
+    console.log("[oauth/code] Storing authorization code for user:", user.id);
     const { error } = await supabase
       .from("mcp_oauth_codes")
       .insert({
@@ -57,14 +69,17 @@ export async function POST(request: Request) {
       });
 
     if (error) {
+      console.error("[oauth/code] Insert error:", error.message, error.code, error.details);
       return NextResponse.json(
         { error: "Failed to store authorization code" },
         { status: 500 }
       );
     }
 
+    console.log("[oauth/code] Success");
     return NextResponse.json({ success: true });
-  } catch {
+  } catch (err) {
+    console.error("[oauth/code] Unhandled error:", err instanceof Error ? { message: err.message, stack: err.stack, name: err.name } : err);
     return NextResponse.json(
       { error: "Invalid request body" },
       { status: 400 }

--- a/src/app/api/oauth/register/route.ts
+++ b/src/app/api/oauth/register/route.ts
@@ -11,11 +11,15 @@ function getServiceClient() {
 }
 
 export async function POST(request: Request) {
+  console.log("[oauth/register] POST handler invoked");
   try {
+    console.log("[oauth/register] Parsing request body...");
     const body = await request.json();
+    console.log("[oauth/register] Body parsed:", JSON.stringify(body));
     const { redirect_uris, client_name } = body;
 
     if (!redirect_uris || !Array.isArray(redirect_uris) || redirect_uris.length === 0) {
+      console.log("[oauth/register] Invalid redirect_uris:", redirect_uris);
       return NextResponse.json(
         { error: "invalid_client_metadata", error_description: "redirect_uris is required" },
         { status: 400 }
@@ -23,8 +27,10 @@ export async function POST(request: Request) {
     }
 
     const clientSecret = crypto.randomBytes(32).toString("hex");
+    console.log("[oauth/register] Creating Supabase client...");
     const supabase = getServiceClient();
 
+    console.log("[oauth/register] Inserting OAuth client...");
     const { data, error } = await supabase
       .from("mcp_oauth_clients")
       .insert({
@@ -36,12 +42,14 @@ export async function POST(request: Request) {
       .single();
 
     if (error) {
+      console.error("[oauth/register] Supabase insert error:", error.message, error.code, error.details);
       return NextResponse.json(
         { error: "server_error", error_description: error.message },
         { status: 500 }
       );
     }
 
+    console.log("[oauth/register] Success, client_id:", data.client_id);
     return NextResponse.json({
       client_id: data.client_id,
       client_secret: clientSecret,
@@ -49,7 +57,8 @@ export async function POST(request: Request) {
       client_name: client_name || undefined,
       token_endpoint_auth_method: "client_secret_post",
     }, { status: 201 });
-  } catch {
+  } catch (err) {
+    console.error("[oauth/register] Unhandled error:", err instanceof Error ? { message: err.message, stack: err.stack, name: err.name } : err);
     return NextResponse.json(
       { error: "invalid_request", error_description: "Invalid JSON body" },
       { status: 400 }

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -19,21 +19,32 @@ function sha256(input: string): Buffer {
 }
 
 export async function POST(request: Request) {
-  const body = await request.formData();
-  const grantType = body.get("grant_type") as string;
+  console.log("[oauth/token] POST handler invoked");
+  try {
+    const body = await request.formData();
+    const grantType = body.get("grant_type") as string;
+    console.log("[oauth/token] grant_type:", grantType);
 
-  if (grantType === "authorization_code") {
-    return handleAuthorizationCode(body);
+    if (grantType === "authorization_code") {
+      return await handleAuthorizationCode(body);
+    }
+
+    if (grantType === "refresh_token") {
+      return await handleRefreshToken(body);
+    }
+
+    console.log("[oauth/token] Unsupported grant_type:", grantType);
+    return NextResponse.json(
+      { error: "unsupported_grant_type", error_description: "Supported: authorization_code, refresh_token" },
+      { status: 400 }
+    );
+  } catch (err) {
+    console.error("[oauth/token] Unhandled error:", err instanceof Error ? { message: err.message, stack: err.stack, name: err.name } : err);
+    return NextResponse.json(
+      { error: "server_error", error_description: "Internal server error" },
+      { status: 500 }
+    );
   }
-
-  if (grantType === "refresh_token") {
-    return handleRefreshToken(body);
-  }
-
-  return NextResponse.json(
-    { error: "unsupported_grant_type", error_description: "Supported: authorization_code, refresh_token" },
-    { status: 400 }
-  );
 }
 
 async function handleAuthorizationCode(body: FormData) {
@@ -42,7 +53,10 @@ async function handleAuthorizationCode(body: FormData) {
   const clientId = body.get("client_id") as string;
   const redirectUri = body.get("redirect_uri") as string;
 
+  console.log("[oauth/token] authorization_code flow, client_id:", clientId, "has_code:", !!code, "has_verifier:", !!codeVerifier);
+
   if (!code || !codeVerifier || !clientId) {
+    console.log("[oauth/token] Missing required params");
     return NextResponse.json(
       { error: "invalid_request", error_description: "Missing required parameters" },
       { status: 400 }
@@ -52,6 +66,7 @@ async function handleAuthorizationCode(body: FormData) {
   const supabase = getServiceClient();
 
   // Look up the authorization code
+  console.log("[oauth/token] Looking up authorization code...");
   const { data: authCode, error } = await supabase
     .from("mcp_oauth_codes")
     .select("*")
@@ -59,6 +74,7 @@ async function handleAuthorizationCode(body: FormData) {
     .maybeSingle();
 
   if (error || !authCode) {
+    console.log("[oauth/token] Code lookup failed:", error?.message || "not found");
     return NextResponse.json(
       { error: "invalid_grant", error_description: "Invalid authorization code" },
       { status: 400 }
@@ -67,6 +83,7 @@ async function handleAuthorizationCode(body: FormData) {
 
   // Check not expired
   if (new Date(authCode.expires_at) < new Date()) {
+    console.log("[oauth/token] Code expired at:", authCode.expires_at);
     return NextResponse.json(
       { error: "invalid_grant", error_description: "Authorization code expired" },
       { status: 400 }
@@ -75,6 +92,7 @@ async function handleAuthorizationCode(body: FormData) {
 
   // Check not used
   if (authCode.used) {
+    console.log("[oauth/token] Code already used");
     return NextResponse.json(
       { error: "invalid_grant", error_description: "Authorization code already used" },
       { status: 400 }
@@ -83,6 +101,7 @@ async function handleAuthorizationCode(body: FormData) {
 
   // Verify client_id matches
   if (authCode.client_id !== clientId) {
+    console.log("[oauth/token] client_id mismatch:", authCode.client_id, "!==", clientId);
     return NextResponse.json(
       { error: "invalid_grant", error_description: "client_id mismatch" },
       { status: 400 }
@@ -91,6 +110,7 @@ async function handleAuthorizationCode(body: FormData) {
 
   // Verify redirect_uri if stored
   if (redirectUri && authCode.redirect_uri !== redirectUri) {
+    console.log("[oauth/token] redirect_uri mismatch");
     return NextResponse.json(
       { error: "invalid_grant", error_description: "redirect_uri mismatch" },
       { status: 400 }
@@ -100,6 +120,7 @@ async function handleAuthorizationCode(body: FormData) {
   // Verify PKCE: SHA256(code_verifier) === code_challenge
   const computedChallenge = base64URLEncode(sha256(codeVerifier));
   if (computedChallenge !== authCode.code_challenge) {
+    console.log("[oauth/token] PKCE verification failed");
     return NextResponse.json(
       { error: "invalid_grant", error_description: "PKCE verification failed" },
       { status: 400 }
@@ -107,6 +128,7 @@ async function handleAuthorizationCode(body: FormData) {
   }
 
   // Mark as used
+  console.log("[oauth/token] Marking code as used...");
   await supabase
     .from("mcp_oauth_codes")
     .update({ used: true })
@@ -114,6 +136,7 @@ async function handleAuthorizationCode(body: FormData) {
 
   // Refresh the session to get fresh tokens with full TTL
   // (the stored tokens may already be partially expired)
+  console.log("[oauth/token] Refreshing Supabase session...");
   const anonClient = createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
@@ -124,12 +147,14 @@ async function handleAuthorizationCode(body: FormData) {
   });
 
   if (refreshError || !refreshed.session) {
+    console.error("[oauth/token] Session refresh failed:", refreshError?.message);
     return NextResponse.json(
       { error: "invalid_grant", error_description: "Session expired — please re-authenticate" },
       { status: 400 }
     );
   }
 
+  console.log("[oauth/token] authorization_code flow complete");
   return NextResponse.json({
     access_token: refreshed.session.access_token,
     token_type: "bearer",
@@ -143,7 +168,10 @@ async function handleRefreshToken(body: FormData) {
   const refreshToken = body.get("refresh_token") as string;
   const clientId = body.get("client_id") as string;
 
+  console.log("[oauth/token] refresh_token flow, client_id:", clientId, "has_token:", !!refreshToken);
+
   if (!refreshToken || !clientId) {
+    console.log("[oauth/token] Missing refresh_token or client_id");
     return NextResponse.json(
       { error: "invalid_request", error_description: "Missing refresh_token or client_id" },
       { status: 400 }
@@ -151,6 +179,7 @@ async function handleRefreshToken(body: FormData) {
   }
 
   // Verify client exists
+  console.log("[oauth/token] Verifying client...");
   const supabase = getServiceClient();
   const { data: client } = await supabase
     .from("mcp_oauth_clients")
@@ -159,6 +188,7 @@ async function handleRefreshToken(body: FormData) {
     .maybeSingle();
 
   if (!client) {
+    console.log("[oauth/token] Unknown client_id:", clientId);
     return NextResponse.json(
       { error: "invalid_client", error_description: "Unknown client_id" },
       { status: 400 }
@@ -166,6 +196,7 @@ async function handleRefreshToken(body: FormData) {
   }
 
   // Use Supabase to refresh the session
+  console.log("[oauth/token] Refreshing Supabase session...");
   const anonClient = createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
@@ -176,12 +207,14 @@ async function handleRefreshToken(body: FormData) {
   });
 
   if (error || !session.session) {
+    console.error("[oauth/token] Refresh failed:", error?.message);
     return NextResponse.json(
       { error: "invalid_grant", error_description: "Failed to refresh session" },
       { status: 400 }
     );
   }
 
+  console.log("[oauth/token] refresh_token flow complete");
   return NextResponse.json({
     access_token: session.session.access_token,
     token_type: "bearer",


### PR DESCRIPTION
## Summary
- Adds `console.log`/`console.error` debug logging to all 4 OAuth route handlers (`register`, `authorize`, `code`, `token`) to diagnose intermittent "No response returned from route handler" errors on Vercel
- Wraps `/api/oauth/authorize` and `/api/oauth/token` in try/catch — both were previously unprotected, which is a likely root cause of the intermittent failures
- Adds `await` to sub-handler calls in token route to prevent unhandled sync throws

## Test plan
- [ ] Deploy to staging and trigger OAuth flows via MCP client
- [ ] Monitor Vercel logs for `[oauth/*]` prefixed entries
- [ ] Confirm the intermittent error is either caught by the new try/catch or visible in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)