### PR TITLE
ci: node-pty cross-platform probe matrix (spike 966c7d8f RQ1)

### DIFF
--- a/.github/workflows/pty-probe.yml
+++ b/.github/workflows/pty-probe.yml
@@ -1,0 +1,113 @@
+name: PTY Probe
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "scripts/pty-load-test/**"
+      - ".github/workflows/pty-probe.yml"
+  pull_request:
+    paths:
+      - "scripts/pty-load-test/**"
+      - ".github/workflows/pty-probe.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pty-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: probe (${{ matrix.label }})
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: win-conpty
+            runner: windows-latest
+            container: ""
+            arch: x64
+          - label: linux-glibc
+            runner: ubuntu-latest
+            container: ""
+            arch: x64
+          - label: linux-musl
+            runner: ubuntu-latest
+            container: node:20-alpine
+            arch: x64
+          - label: macos-x64
+            runner: macos-13
+            container: ""
+            arch: x64
+          - label: macos-arm64
+            runner: macos-14
+            container: ""
+            arch: arm64
+    steps:
+      # Alpine ships without git; actions/checkout@v4 needs it. Install before checkout
+      # so the musl row produces a real node-pty verdict instead of a harness error.
+      - name: Install git (Alpine, pre-checkout)
+        if: ${{ matrix.container == 'node:20-alpine' }}
+        run: apk add --no-cache git
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build toolchain (Alpine)
+        if: ${{ matrix.container == 'node:20-alpine' }}
+        run: apk add --no-cache python3 make g++ bash
+
+      - name: Setup Node 20
+        if: ${{ matrix.container == '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install node-pty (capture log)
+        shell: bash
+        working-directory: scripts/pty-load-test
+        run: npm install --no-audit --no-fund --loglevel verbose > install.log 2>&1 || (cat install.log; exit 1)
+
+      - name: Run probe
+        shell: bash
+        working-directory: scripts/pty-load-test
+        run: node load-test.mjs --install-log install.log --label "${{ matrix.label }}" --out "result-${{ matrix.label }}.txt"
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pty-${{ matrix.label }}
+          path: |
+            scripts/pty-load-test/result-${{ matrix.label }}.txt
+            scripts/pty-load-test/install.log
+          retention-days: 14
+
+  summarize:
+    name: summarize
+    needs: probe
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Download probe results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pty-*
+          merge-multiple: true
+          path: results
+
+      - name: Summarize and gate
+        run: node scripts/pty-load-test/summarize.mjs --dir results

--- a/scripts/pty-load-test/.gitignore
+++ b/scripts/pty-load-test/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+install.log
+result-*.txt
+package-lock.json

--- a/scripts/pty-load-test/load-test.mjs
+++ b/scripts/pty-load-test/load-test.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+// Isolated node-pty probe for spike 966c7d8f RQ1.
+//
+// Determines, per runner, whether node-pty installed via a prebuilt binary
+// (CLEAN) or fell back to a local node-gyp compile (FALLBACK), and whether a
+// live PTY can actually be spawned. Emits one machine-parseable result line.
+//
+// Exit code: 0 for any verdict (CLEAN / FALLBACK / FAIL). Non-zero ONLY on a
+// harness error (cannot read the install log, or node-pty import throws before
+// a spawn was attempted). The pass/fail GATE lives in summarize.mjs.
+
+import { readFileSync, existsSync, readdirSync, statSync, appendFileSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// arg parsing
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--install-log") out.installLog = argv[++i];
+    else if (a === "--label") out.label = argv[++i];
+    else if (a === "--out") out.out = argv[++i];
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const label = args.label || "unknown";
+
+function harnessError(msg) {
+  process.stderr.write(`pty-load-test harness error: ${msg}\n`);
+  process.exit(2);
+}
+
+if (!args.installLog) harnessError("missing --install-log <path>");
+if (!args.out) harnessError("missing --out <path>");
+
+// ---------------------------------------------------------------------------
+// platform / arch / libc detection
+// ---------------------------------------------------------------------------
+const platform = process.platform;
+const arch = process.arch;
+
+function detectLibc() {
+  if (platform !== "linux") return "n/a";
+  try {
+    const header = process.report.getReport().header;
+    // glibcVersionRuntime present => glibc; absent on linux => musl (Alpine).
+    return header && header.glibcVersionRuntime ? "glibc" : "musl";
+  } catch {
+    return "unknown";
+  }
+}
+const libc = detectLibc();
+
+// ---------------------------------------------------------------------------
+// Signal A — install-log forensics
+// ---------------------------------------------------------------------------
+// Match ONLY true-execution evidence that a compiler / node-gyp actually ran.
+// NOT the bare "node-gyp rebuild" string: node-pty 1.1.0's install script is
+// literally `node scripts/prebuild.js || node-gyp rebuild`, and npm's verbose
+// log echoes that command definition verbatim even when prebuild.js succeeds
+// and node-gyp never runs. The markers below appear only on a real compile.
+const COMPILE_MARKERS = [
+  "gyp info spawn",
+  "gyp info ok",
+  "CXX(",
+  "clang++ ",
+  "clang ",
+  "cc1plus",
+  "cl.exe",
+  "c++ -o",
+  "make: entering",
+  ".target.mk",
+  "creating library", // MSVC linker line
+];
+
+function computeSignalA(logPath) {
+  let raw;
+  try {
+    raw = readFileSync(logPath, "utf8");
+  } catch (err) {
+    harnessError(`cannot read install log at ${logPath}: ${err.message}`);
+  }
+  const hay = raw.toLowerCase();
+  const compiled = COMPILE_MARKERS.some((m) => hay.includes(m.toLowerCase()));
+  // Binary signal: real compiler ran ⇒ FALLBACK; a successful install with no
+  // compile evidence means the prebuilt path was taken ⇒ CLEAN.
+  return compiled ? "FALLBACK" : "CLEAN";
+}
+const signalA = computeSignalA(args.installLog);
+
+// ---------------------------------------------------------------------------
+// Signal B — artifact inspection of node_modules/node-pty
+// ---------------------------------------------------------------------------
+const PTY_DIR = join(process.cwd(), "node_modules", "node-pty");
+
+function walkForNode(dir) {
+  // returns list of absolute paths to *.node files under dir (recursive)
+  const found = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      found.push(...walkForNode(full));
+    } else if (e.isFile() && e.name.endsWith(".node")) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function computeSignalB() {
+  const buildRelease = join(PTY_DIR, "build", "Release");
+  const prebuildsDir = join(PTY_DIR, "prebuilds", `${platform}-${arch}`);
+
+  const buildNodes = walkForNode(buildRelease);
+  const prebuildNodes = walkForNode(prebuildsDir);
+  const hasBuild = buildNodes.length > 0;
+  const hasPrebuild = prebuildNodes.length > 0;
+
+  if (hasBuild) return { signalB: "FALLBACK", buildNodes, prebuildNodes };
+  if (hasPrebuild) return { signalB: "CLEAN", buildNodes, prebuildNodes };
+  return { signalB: "MISSING", buildNodes, prebuildNodes };
+}
+const { signalB, buildNodes, prebuildNodes } = computeSignalB();
+
+// ---------------------------------------------------------------------------
+// macOS spawn-helper chmod fix
+// ---------------------------------------------------------------------------
+if (platform === "darwin") {
+  const candidates = [];
+  const buildRelease = join(PTY_DIR, "build", "Release");
+  const prebuildsRoot = join(PTY_DIR, "prebuilds");
+  for (const root of [buildRelease, prebuildsRoot]) {
+    function findHelper(dir) {
+      let entries;
+      try {
+        entries = readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        const full = join(dir, e.name);
+        if (e.isDirectory()) findHelper(full);
+        else if (e.isFile() && e.name === "spawn-helper") candidates.push(full);
+      }
+    }
+    findHelper(root);
+  }
+  for (const helper of candidates) {
+    try {
+      chmodSync(helper, 0o755);
+    } catch {
+      // best-effort; ignore
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Live spawn
+// ---------------------------------------------------------------------------
+// Signal B (on-disk artifacts) is the authoritative determinant of origin;
+// Signal A (log forensics) corroborates. node-pty ships prebuilts under
+// prebuilds/<plat-arch>/ and only creates build/Release/*.node when it compiles.
+function reconcile(spawn) {
+  if (spawn !== "OK") {
+    return { result: "FAIL", reason: spawnFailReason(spawn) };
+  }
+  if (signalB === "FALLBACK") {
+    // A real compile produced on-disk artifacts — authoritative, regardless of A.
+    return {
+      result: "FALLBACK",
+      reason: "build/Release/*.node present (real compile produced on-disk artifacts); live PTY spawned and echoed PTYOK",
+    };
+  }
+  if (signalB === "CLEAN") {
+    if (signalA === "FALLBACK") {
+      // Prebuilt present yet the log shows a real compile ran too — genuine
+      // disagreement; fall back conservatively.
+      return {
+        result: "FALLBACK",
+        reason: "prebuilt binary present but install log shows a real compile ran (genuine disagreement A=FALLBACK/B=CLEAN); conservative FALLBACK; live PTY spawned and echoed PTYOK",
+      };
+    }
+    return {
+      result: "CLEAN",
+      reason: "prebuilt binary used (prebuilds/<plat-arch>/*.node present, no build/); no compiler lines in install log; live PTY spawned and echoed PTYOK",
+    };
+  }
+  // signalB === "MISSING": no .node located on disk — lean on A + spawn.
+  if (signalA === "FALLBACK") {
+    return {
+      result: "FALLBACK",
+      reason: "no .node artifact located on disk but install log shows a real compile ran; live PTY spawned and echoed PTYOK",
+    };
+  }
+  return {
+    result: "CLEAN",
+    reason: "no .node artifact located on disk and no compiler lines in install log (indeterminate origin); live PTY spawned and echoed PTYOK",
+  };
+}
+
+function spawnFailReason(spawn) {
+  if (spawn === "TIMEOUT") return "live PTY spawn timed out after 10s (no PTYOK / no exit)";
+  return "live PTY spawn did not produce PTYOK with exitCode 0";
+}
+
+function emit(result, spawn, reason) {
+  const safeReason = String(reason).replace(/"/g, "'").replace(/[\r\n]+/g, " ");
+  const line = `result=${result} label=${label} platform=${platform} arch=${arch} libc=${libc} signalA=${signalA} signalB=${signalB} spawn=${spawn} reason="${safeReason}"`;
+  process.stdout.write(line + "\n");
+  try {
+    writeFileSync(args.out, line + "\n");
+  } catch (err) {
+    process.stderr.write(`warning: could not write --out ${args.out}: ${err.message}\n`);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    try {
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, line + "\n");
+    } catch {
+      // non-fatal
+    }
+  }
+  return line;
+}
+
+async function main() {
+  let pty;
+  try {
+    pty = await import("node-pty");
+  } catch (err) {
+    // import threw before any spawn => harness error per spec
+    harnessError(`failed to import node-pty: ${err && err.message ? err.message : err}`);
+    return;
+  }
+
+  const spawnFn = pty.spawn || (pty.default && pty.default.spawn);
+  if (typeof spawnFn !== "function") {
+    harnessError("node-pty imported but no spawn() export found");
+    return;
+  }
+
+  let data = "";
+  let settled = false;
+  let timer;
+
+  const spawnResult = await new Promise((resolve) => {
+    let child;
+    try {
+      child = spawnFn(
+        process.execPath,
+        ["-e", "process.stdout.write('PTYOK')"],
+        { name: "xterm-color", cols: 80, rows: 24, cwd: process.cwd(), env: process.env }
+      );
+    } catch (err) {
+      resolve({ spawn: "FAIL", err });
+      return;
+    }
+
+    timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        child.kill();
+      } catch {
+        // ignore
+      }
+      resolve({ spawn: "TIMEOUT" });
+    }, 10000);
+
+    child.onData((d) => {
+      data += d;
+    });
+
+    child.onExit(({ exitCode }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const ok = data.includes("PTYOK") && exitCode === 0;
+      resolve({ spawn: ok ? "OK" : "FAIL", exitCode });
+    });
+  });
+
+  const spawn = spawnResult.spawn;
+  const { result, reason } = reconcile(spawn);
+  emit(result, spawn, reason);
+  // Verdict exit code is always 0 here; gate lives in summarize.mjs.
+  process.exit(0);
+}
+
+main().catch((err) => {
+  // Anything unexpected after import counts as a harness error.
+  harnessError(`unexpected: ${err && err.stack ? err.stack : err}`);
+});

--- a/scripts/pty-load-test/package.json
+++ b/scripts/pty-load-test/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pty-load-test",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Isolated node-pty probe for spike 966c7d8f RQ1 — verifies prebuilt vs node-gyp fallback and live PTY spawn across runners. No app dependencies.",
+  "dependencies": {
+    "node-pty": "1.1.0"
+  }
+}

--- a/scripts/pty-load-test/summarize.mjs
+++ b/scripts/pty-load-test/summarize.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Aggregates result-*.txt probe outputs into a markdown table and applies the
+// RQ1 verdict gate for spike 966c7d8f.
+//
+// Exit code: 0 => PASS (all expected labels present, none FAIL).
+//            1 => BLOCKED (an expected label is missing, or any row FAIL).
+
+import { readFileSync, readdirSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--dir") out.dir = argv[++i];
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.dir) {
+  process.stderr.write("summarize: missing --dir <dir>\n");
+  process.exit(2);
+}
+
+const EXPECTED_LABELS = ["win-conpty", "linux-glibc", "linux-musl", "macos-x64", "macos-arm64"];
+const PRIMARY_LABELS = ["win-conpty", "macos-arm64"]; // RQ1 primaries
+
+// ---------------------------------------------------------------------------
+// parse key=value line (values may be quoted)
+// ---------------------------------------------------------------------------
+function parseLine(line) {
+  const row = {};
+  // match key=value where value is "quoted" or unquoted (no spaces)
+  const re = /(\w+)=("([^"]*)"|(\S+))/g;
+  let m;
+  while ((m = re.exec(line)) !== null) {
+    row[m[1]] = m[3] !== undefined ? m[3] : m[4];
+  }
+  return row;
+}
+
+function loadRows(dir) {
+  let files;
+  try {
+    files = readdirSync(dir);
+  } catch (err) {
+    process.stderr.write(`summarize: cannot read --dir ${dir}: ${err.message}\n`);
+    process.exit(2);
+  }
+  const resultFiles = files.filter((f) => /^result-.*\.txt$/.test(f));
+  const rows = [];
+  for (const f of resultFiles) {
+    let content;
+    try {
+      content = readFileSync(join(dir, f), "utf8");
+    } catch {
+      continue;
+    }
+    const line = content.split(/\r?\n/).find((l) => l.includes("result="));
+    if (!line) continue;
+    const row = parseLine(line);
+    if (row.result) rows.push(row);
+  }
+  return rows;
+}
+
+const rows = loadRows(args.dir);
+
+// ---------------------------------------------------------------------------
+// render markdown table
+// ---------------------------------------------------------------------------
+function renderTable(rows) {
+  const header = "| Platform | Label | libc | Signal A | Signal B | Spawn | Result |";
+  const sep = "| --- | --- | --- | --- | --- | --- | --- |";
+  const lines = [header, sep];
+  // stable ordering: by expected label order, then any extras
+  const order = (lbl) => {
+    const i = EXPECTED_LABELS.indexOf(lbl);
+    return i === -1 ? EXPECTED_LABELS.length : i;
+  };
+  const sorted = [...rows].sort((a, b) => order(a.label) - order(b.label));
+  for (const r of sorted) {
+    lines.push(
+      `| ${r.platform || "?"} | ${r.label || "?"} | ${r.libc || "?"} | ${r.signalA || "?"} | ${r.signalB || "?"} | ${r.spawn || "?"} | ${r.result || "?"} |`
+    );
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// gate
+// ---------------------------------------------------------------------------
+const presentLabels = new Set(rows.map((r) => r.label));
+const missing = EXPECTED_LABELS.filter((l) => !presentLabels.has(l));
+const failed = rows.filter((r) => r.result === "FAIL").map((r) => r.label || "?");
+
+const out = [];
+out.push("## node-pty probe — RQ1 (spike 966c7d8f)");
+out.push("");
+out.push(renderTable(rows));
+out.push("");
+
+let exitCode = 0;
+if (missing.length > 0) {
+  out.push(`**BLOCKED** — missing required runner result(s): ${missing.join(", ")}`);
+  exitCode = 1;
+}
+if (failed.length > 0) {
+  out.push(`**BLOCKED** — live PTY spawn FAILED on: ${failed.join(", ")}`);
+  exitCode = 1;
+}
+if (exitCode === 0) {
+  out.push("**PASS** — all expected runners reported, every row is CLEAN or FALLBACK (none FAIL).");
+}
+
+// RQ1 primaries note
+const primaryStatus = PRIMARY_LABELS.map((p) => {
+  if (!presentLabels.has(p)) return `${p}=MISSING`;
+  const row = rows.find((r) => r.label === p);
+  return `${p}=${row ? row.result : "?"}`;
+}).join(", ");
+out.push("");
+out.push(`RQ1 primaries (must be present and not FAIL): ${primaryStatus}`);
+
+const report = out.join("\n");
+process.stdout.write(report + "\n");
+if (process.env.GITHUB_STEP_SUMMARY) {
+  try {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, report + "\n");
+  } catch {
+    // non-fatal
+  }
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
## What
Adds a **node-pty cross-platform probe** — the P0 gate (`18e7f260`) for the "display local Claude Code in-app" feature, settling **RQ1** of spike `966c7d8f`: does a node-pty bridge install **with no compiler** on a clean machine across every target OS/arch?

The spike could only test macOS arm64 locally. This runs the question empirically across the full matrix in CI.

## How
- `scripts/pty-load-test/` — an **isolated** probe package (pins only `node-pty@1.1.0`; never touches the app dep tree or bundle).
- `.github/workflows/pty-probe.yml` — a 5-row matrix (`fail-fast:false`): **windows-latest (ConPTY)**, ubuntu glibc, `node:20-alpine` (musl), macos-13 (x64), macos-14 (arm64).
- Each job **dual-detects** how node-pty got its binary: install-log forensics for *real-compile* evidence **and** on-disk inspection (`build/Release/*.node` = compiled vs `prebuilds/<plat-arch>/` = prebuilt, the authoritative signal), then a **live PTY spawn**.
- `summarize.mjs` collates a 5-row **CLEAN / FALLBACK / FAIL** table to the run summary and is the single gate: all CLEAN/FALLBACK → **PASS**; any FAIL or missing row → **BLOCKED** (a Windows ConPTY FAIL flips the spike to BLOCKED).

## The point
GitHub runners ship compilers, so "install succeeded" proves nothing — the probe detects *how* it installed. Expected: macOS/Windows CLEAN (prebuilt), Linux glibc/musl likely **FALLBACK** (node-pty 1.1.0 ships no Linux prebuilds → compiles). This PR exists to confirm that empirically, especially **musl** (the headline unknown) and **Windows ConPTY** (a primary).

## Safety
Additive CI only — no app / build / Vercel / Supabase / secret / migration impact. `workflow_dispatch` + paths-scoped push/PR triggers (no per-commit cost). Rollback = delete the files. Dry-run on darwin-arm64 reports CLEAN; gate verified both ways locally.

**Watch the `summarize` job's step summary on this PR for the 5-platform verdict.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)