### PR TITLE
feat: in-app local Claude Code terminal (P1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,13 @@ NOTIFICATION_WEBHOOK_SECRET=your-webhook-secret-here
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 TERMINAL_SESSION_SECRET=your-terminal-session-secret-here
 
+# In-app terminal dock (browser leg) — OFF by default. Set to exactly "true" to
+# render the collapsible terminal dock on idea boards (team members only).
+NEXT_PUBLIC_TERMINAL_ENABLED=false
+# WebSocket base URL of the terminal relay the browser dock attaches to.
+# Defaults to the local wrangler dev relay when unset.
+NEXT_PUBLIC_TERMINAL_RELAY_URL=ws://127.0.0.1:8787
+
 # Cloudflare Turnstile CAPTCHA (optional — signup spam protection)
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key-here
 TURNSTILE_SECRET_KEY=your-turnstile-secret-key-here

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,13 @@ API_KEY_ENCRYPTION_KEY=your-64-char-hex-string-here
 # Used to verify requests from Supabase pg_net webhook
 NOTIFICATION_WEBHOOK_SECRET=your-webhook-secret-here
 
+# In-app terminal session token secret (HMAC-SHA256 signing key)
+# Used by /api/terminal/session to mint short-lived owner-bound relay tokens.
+# The SAME value must be set on the Cloudflare relay (wrangler .dev.vars locally,
+# or `wrangler secret put TERMINAL_SESSION_SECRET` in prod) so tokens verify.
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+TERMINAL_SESSION_SECRET=your-terminal-session-secret-here
+
 # Cloudflare Turnstile CAPTCHA (optional — signup spam protection)
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key-here
 TURNSTILE_SECRET_KEY=your-turnstile-secret-key-here

--- a/docs/in-app-terminal-design.html
+++ b/docs/in-app-terminal-design.html
@@ -1,0 +1,835 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>In-App Local Claude Code Terminal — UX Design (Compass) · Rev 2</title>
+<style>
+  :root {
+    --bg: #0a0a0b;
+    --panel: #141417;
+    --panel-2: #1c1c21;
+    --panel-3: #232329;
+    --border: #2a2a31;
+    --border-2: #3a3a44;
+    --text: #e6e6ea;
+    --muted: #9a9aa6;
+    --muted-2: #6f6f7a;
+    --accent: #7dd3fc;
+    --emerald: #34d399;
+    --amber: #fbbf24;
+    --rose: #fb7185;
+    --violet: #a78bfa;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    line-height: 1.55; font-size: 15px;
+  }
+  .wrap { max-width: 1020px; margin: 0 auto; padding: 48px 28px 120px; }
+  header.doc { border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 32px; }
+  .kicker { color: var(--accent); font-size: 12px; letter-spacing: .14em; text-transform: uppercase; font-weight: 700; }
+  h1 { font-size: 30px; margin: 8px 0 6px; }
+  h2 { font-size: 21px; margin: 52px 0 14px; padding-top: 16px; border-top: 1px solid var(--border); }
+  h3 { font-size: 16px; margin: 28px 0 10px; color: var(--accent); }
+  p { color: var(--text); }
+  .sub { color: var(--muted); }
+  a { color: var(--accent); }
+  .persona { display: inline-block; background: var(--panel-2); border: 1px solid var(--border); border-radius: 999px; padding: 4px 12px; font-size: 12px; color: var(--violet); margin-right: 8px; }
+  code, .mono { font-family: var(--mono); font-size: 13px; }
+  code.inline { background: var(--panel-2); border: 1px solid var(--border); border-radius: 5px; padding: 1px 6px; color: var(--accent); }
+  pre { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 16px 18px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.5; color: #d6e7f0; }
+
+  .cite { background: linear-gradient(90deg, rgba(167,139,250,.08), transparent); border-left: 3px solid var(--violet); border-radius: 0 8px 8px 0; padding: 14px 18px; margin: 16px 0; font-size: 14px; }
+  .cite b { color: var(--violet); }
+  .rationale { background: linear-gradient(90deg, rgba(125,211,252,.07), transparent); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 12px 16px; margin: 14px 0 22px; font-size: 13.5px; color: var(--muted); }
+  .rationale b { color: var(--text); }
+  .rationale .law { color: var(--accent); font-weight: 600; }
+
+  .changed { background: linear-gradient(90deg, rgba(251,191,36,.10), transparent); border: 1px solid rgba(251,191,36,.4); border-radius: 12px; padding: 18px 22px; margin: 18px 0; }
+  .changed h3 { margin-top: 0; color: var(--amber); }
+  .changed ul { margin: 8px 0 0; padding-left: 18px; }
+  .changed li { margin: 7px 0; font-size: 14px; color: var(--text); }
+  .changed li b { color: var(--amber); }
+
+  .reco { background: linear-gradient(90deg, rgba(52,211,153,.10), transparent); border: 1px solid rgba(52,211,153,.4); border-radius: 12px; padding: 18px 22px; margin: 18px 0; }
+  .reco h3 { margin-top: 0; color: var(--emerald); }
+  .reco .pick { display:inline-block; background: rgba(52,211,153,.16); border:1px solid rgba(52,211,153,.5); color: var(--emerald); border-radius: 6px; padding: 2px 9px; font-size: 12px; font-weight: 700; margin-left: 6px; }
+  .alt { color: var(--muted); font-size: 13.5px; border-left: 2px solid var(--border-2); padding-left: 14px; margin-top: 12px; }
+
+  /* ── Mock chrome ── */
+  .browser { border: 1px solid var(--border); border-radius: 12px; overflow: hidden; margin: 14px 0; background: var(--panel); box-shadow: 0 8px 30px rgba(0,0,0,.4); }
+  .chrome-bar { display:flex; align-items:center; gap:8px; background: var(--panel-2); border-bottom: 1px solid var(--border); padding: 9px 14px; }
+  .dot { width:11px; height:11px; border-radius:50%; }
+  .dot.r{background:#fb7185}.dot.y{background:#fbbf24}.dot.g{background:#34d399}
+  .urlbar { flex:1; margin-left:8px; background: var(--bg); border:1px solid var(--border); border-radius:6px; padding:3px 10px; font-family:var(--mono); font-size:11.5px; color:var(--muted); }
+
+  /* ── Board chrome (hero) ── */
+  .boardtop { display:flex; align-items:center; gap:12px; padding:11px 16px; background:var(--panel); border-bottom:1px solid var(--border); }
+  .boardtop .crumb { font-size:13px; color:var(--muted); }
+  .boardtop .crumb b { color:var(--text); }
+  .boardtop .spacer { flex:1; }
+  .avatarstack { display:flex; }
+  .avatarstack span { width:24px; height:24px; border-radius:50%; border:2px solid var(--panel); margin-left:-7px; font-size:10px; display:flex; align-items:center; justify-content:center; font-weight:700; color:#06222e; }
+  .kanban { display:flex; gap:12px; padding:14px 16px; background:#0d0d10; overflow:hidden; }
+  .col { flex:1; min-width:0; }
+  .col h4 { margin:0 0 9px; font-size:12px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--muted); display:flex; align-items:center; gap:7px; }
+  .col h4 .count { background:var(--panel-3); border:1px solid var(--border); color:var(--muted); border-radius:999px; padding:0 7px; font-size:11px; }
+  .tcard { background:var(--panel-2); border:1px solid var(--border); border-radius:9px; padding:10px 11px; margin-bottom:9px; }
+  .tcard .ttl { font-size:13px; color:var(--text); line-height:1.4; }
+  .tcard .meta { display:flex; align-items:center; gap:6px; margin-top:8px; }
+  .chip { font-size:10.5px; font-weight:700; border-radius:5px; padding:1px 7px; letter-spacing:.02em; }
+  .chip.cyan{ color:var(--accent); background:rgba(125,211,252,.12); border:1px solid rgba(125,211,252,.4);}
+  .chip.violet{ color:var(--violet); background:rgba(167,139,250,.12); border:1px solid rgba(167,139,250,.4);}
+  .chip.amber{ color:var(--amber); background:rgba(251,191,36,.12); border:1px solid rgba(251,191,36,.4);}
+  .chip.emerald{ color:var(--emerald); background:rgba(52,211,153,.12); border:1px solid rgba(52,211,153,.4);}
+  .tcard .mini-av { width:19px; height:19px; border-radius:50%; font-size:9px; display:flex; align-items:center; justify-content:center; font-weight:700; color:#06222e; margin-left:auto; }
+
+  /* slim docked terminal tab (collapsed) */
+  .dockbar { display:flex; align-items:center; gap:10px; background:var(--panel-2); border-top:1px solid var(--border-2); padding:7px 14px; }
+  .dockbar .lbl { display:inline-flex; align-items:center; gap:8px; font-size:12.5px; font-weight:600; color:var(--text); }
+  .dockbar .spacer { flex:1; }
+
+  /* ── Terminal panel ── */
+  .term { background:#0c0c0e; border-top: 1px solid var(--border-2); }
+  .term-header { display:flex; align-items:center; gap:10px; background: var(--panel-2); border-bottom:1px solid var(--border); padding: 8px 12px; flex-wrap: wrap; }
+  .statepill { display:inline-flex; align-items:center; gap:6px; border-radius:7px; padding:4px 10px; font-size:12.5px; font-weight:600; border:1px solid var(--border-2); background: var(--panel-3); }
+  .statepill .ic { font-size:12px; line-height:1; }
+  .statepill.connected { color: var(--emerald); border-color: rgba(52,211,153,.5); background: rgba(52,211,153,.10); }
+  .statepill.connecting { color: var(--amber); border-color: rgba(251,191,36,.5); background: rgba(251,191,36,.10); }
+  .statepill.waiting { color: var(--accent); border-color: rgba(125,211,252,.5); background: rgba(125,211,252,.10); }
+  .statepill.disconnected { color: var(--muted); border-color: var(--border-2); background: var(--panel-3); }
+  .statepill.ended { color: var(--muted); border-color: var(--border-2); background: var(--panel-3); }
+  .statepill.error { color: var(--rose); border-color: rgba(251,113,133,.55); background: rgba(251,113,133,.10); }
+  .slowtag { display:inline-flex; align-items:center; gap:4px; font-size:10.5px; font-weight:700; color:var(--amber); background:rgba(251,191,36,.10); border:1px solid rgba(251,191,36,.45); border-radius:5px; padding:2px 6px; }
+  .hostinfo { font-family: var(--mono); font-size: 12px; color: var(--muted); display:flex; align-items:center; gap:6px; }
+  .hostinfo .sep { color: var(--muted-2); }
+  .ro-badge { display:inline-flex; align-items:center; gap:5px; font-size:11.5px; font-weight:700; color: var(--violet); background: rgba(167,139,250,.12); border:1px solid rgba(167,139,250,.55); border-radius:6px; padding:3px 9px; letter-spacing:.02em; }
+  .spacer { flex:1; }
+  .tctrls { display:flex; align-items:center; gap:6px; }
+  .ibtn { display:inline-flex; align-items:center; gap:5px; height:30px; min-width:30px; justify-content:center; padding:0 9px; border-radius:7px; border:1px solid var(--border-2); background: var(--panel-3); color: var(--text); font-size:12.5px; cursor:pointer; }
+  .ibtn:hover { background: #2c2c34; }
+  .ibtn.danger { color: var(--rose); border-color: rgba(251,113,133,.45); }
+  .ibtn.danger:hover { background: rgba(251,113,133,.12); }
+  .ibtn.toggle-on { color: var(--violet); border-color: rgba(167,139,250,.55); background: rgba(167,139,250,.12); }
+  .ibtn:focus-visible, .btn:focus-visible, .tin:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .resize-grip { height:6px; background:repeating-linear-gradient(90deg,var(--border-2) 0 10px,transparent 10px 20px); opacity:.5; cursor:ns-resize; }
+
+  .xterm { font-family: var(--mono); font-size: 12.5px; line-height: 1.5; padding: 16px 18px; color: #cfd8df; min-height: 230px; white-space: pre-wrap; }
+  .xterm .c-cyan { color: #7dd3fc; }
+  .xterm .c-green { color: #34d399; }
+  .xterm .c-dim { color: #6f6f7a; }
+  .xterm .c-amber { color: #fbbf24; }
+  .xterm .c-violet { color: #a78bfa; }
+  .xterm .c-white { color: #e6e6ea; }
+  .xterm .bullet { color:#34d399; }
+  .cursor { display:inline-block; width:8px; height:15px; background:#cfd8df; vertical-align:-2px; animation: blink 1.1s steps(1) infinite; }
+  @keyframes blink { 50% { opacity: 0; } }
+
+  .term-input { display:flex; align-items:center; gap:8px; border-top:1px solid var(--border); background: var(--panel); padding:8px 12px; }
+  .term-input .prompt { color: var(--emerald); font-family:var(--mono); font-size:12.5px; }
+  .tin { flex:1; background: var(--bg); border:1px solid var(--border-2); border-radius:7px; padding:6px 10px; color: var(--text); font-family:var(--mono); font-size:12.5px; }
+  .tin::placeholder { color: var(--muted-2); }
+  .input-note { font-size:11.5px; color: var(--muted); padding:6px 12px; background: rgba(167,139,250,.06); border-top:1px solid var(--border); }
+  .input-note b { color: var(--violet); }
+
+  /* centered state overlays inside terminal body */
+  .overlay { min-height: 230px; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; padding: 28px; gap:12px; }
+  .overlay .big { font-size: 30px; line-height:1; }
+  .overlay .ttl { font-size: 16px; font-weight: 700; }
+  .overlay .ttl.green { color: var(--emerald); } .overlay .ttl.amber{color:var(--amber);} .overlay .ttl.rose{color:var(--rose);} .overlay .ttl.cyan{color:var(--accent);} .overlay .ttl.muted{color:var(--muted);} .overlay .ttl.violet{color:var(--violet);}
+  .overlay .msg { color: var(--muted); font-size:13.5px; max-width: 460px; }
+  .codebox { font-family: var(--mono); font-size: 28px; letter-spacing: .14em; font-weight: 700; color: var(--accent); background: var(--bg); border: 1px dashed var(--border-2); border-radius: 10px; padding: 12px 22px; }
+  .btn { display:inline-flex; align-items:center; gap:7px; height:36px; padding:0 18px; border-radius:8px; font-size:13.5px; font-weight:600; cursor:pointer; border:1px solid transparent; }
+  .btn.lg { height:42px; padding:0 22px; font-size:14.5px; }
+  .btn.primary { background: var(--accent); color:#06222e; }
+  .btn.emerald { background: var(--emerald); color:#04231a; }
+  .btn.ghost { background: var(--panel-3); color: var(--text); border-color: var(--border-2); }
+  .btn.danger { background: rgba(251,113,133,.12); color: var(--rose); border:1px solid rgba(251,113,133,.5); }
+  .btnrow { display:flex; gap:10px; flex-wrap:wrap; justify-content:center; }
+  .adv { font-size:12px; color:var(--muted-2); margin-top:4px; }
+  .adv summary { cursor:pointer; color:var(--muted); }
+  .adv summary:hover { color:var(--text); }
+
+  /* OS prompt mock */
+  .osprompt { max-width:360px; margin:14px auto; background:#232327; border:1px solid #3a3a40; border-radius:14px; box-shadow:0 18px 50px rgba(0,0,0,.6); overflow:hidden; }
+  .osprompt .body { padding:22px 22px 16px; text-align:center; }
+  .osprompt .ic { width:52px; height:52px; border-radius:12px; margin:0 auto 12px; display:flex; align-items:center; justify-content:center; font-size:26px; background:linear-gradient(180deg,#3b3b42,#26262b); border:1px solid #45454d; }
+  .osprompt .t { font-size:14.5px; font-weight:700; color:#f2f2f5; }
+  .osprompt .d { font-size:12.5px; color:#b8b8c0; margin-top:6px; line-height:1.5; }
+  .osprompt .actions { display:flex; border-top:1px solid #3a3a40; }
+  .osprompt .actions button { flex:1; background:transparent; border:0; padding:11px; font-size:13.5px; color:var(--accent); cursor:pointer; }
+  .osprompt .actions button.cancel { color:#b8b8c0; border-right:1px solid #3a3a40; }
+  .osprompt .actions button.primary { font-weight:700; }
+
+  /* state index grid */
+  .grid { display:grid; grid-template-columns: 1fr 1fr; gap:14px; margin:16px 0; }
+  @media (max-width:760px){ .grid { grid-template-columns: 1fr; } }
+  .state { border:1px solid var(--border); border-radius:12px; padding:14px 16px; background: var(--panel); }
+  .state .tag { font-size:11px; font-weight:700; letter-spacing:.06em; text-transform:uppercase; display:flex; align-items:center; gap:6px; }
+  .state.ok{border-color:rgba(52,211,153,.4)} .state.ok .tag{color:var(--emerald)}
+  .state.wait{border-color:rgba(125,211,252,.4)} .state.wait .tag{color:var(--accent)}
+  .state.warn{border-color:rgba(251,191,36,.4)} .state.warn .tag{color:var(--amber)}
+  .state.err{border-color:rgba(251,113,133,.45)} .state.err .tag{color:var(--rose)}
+  .state.kill{border-color:rgba(167,139,250,.45)} .state.kill .tag{color:var(--violet)}
+  .state.neutral .tag{color:var(--muted)}
+  .state p { font-size:13px; color:var(--muted); margin:8px 0 0; }
+  .state .next { color: var(--emerald); font-weight:600; }
+
+  table { width:100%; border-collapse:collapse; margin:14px 0; font-size:13.5px; }
+  th,td { text-align:left; padding:9px 12px; border-bottom:1px solid var(--border); vertical-align:top; }
+  th { color:var(--muted); font-weight:600; font-size:12px; text-transform:uppercase; letter-spacing:.05em; }
+  td code { color: var(--accent); }
+
+  /* flow */
+  .flow { display:flex; flex-direction:column; margin:18px 0; }
+  .step { display:flex; gap:14px; }
+  .step .num { flex:0 0 34px; height:34px; border-radius:50%; background:var(--panel-2); border:1px solid var(--border); display:flex; align-items:center; justify-content:center; font-weight:700; font-size:13px; color:var(--accent); }
+  .step .body { flex:1; background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:11px 16px; margin-bottom:10px; }
+  .step .body .t { font-weight:600; }
+  .step .body .d { color:var(--muted); font-size:13px; margin-top:2px; }
+  .connector { margin:-6px 0 4px 16px; color:var(--border-2); font-size:18px; line-height:1; }
+
+  /* horizontal mini-flow strip */
+  .strip { display:flex; align-items:stretch; gap:0; margin:16px 0; flex-wrap:wrap; }
+  .strip .s { flex:1; min-width:150px; background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:12px 14px; position:relative; }
+  .strip .s .k { font-size:11px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--accent); }
+  .strip .s .h { font-size:13.5px; font-weight:600; margin-top:4px; }
+  .strip .s .b { font-size:12px; color:var(--muted); margin-top:3px; }
+  .strip .arrow { display:flex; align-items:center; color:var(--border-2); font-size:20px; padding:0 6px; }
+  .strip .s .once { position:absolute; top:-9px; right:10px; font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--amber); background:rgba(251,191,36,.12); border:1px solid rgba(251,191,36,.45); border-radius:5px; padding:1px 6px; }
+  .strip .s .every { position:absolute; top:-9px; right:10px; font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--emerald); background:rgba(52,211,153,.12); border:1px solid rgba(52,211,153,.45); border-radius:5px; padding:1px 6px; }
+  @media (max-width:680px){ .strip .arrow{ transform:rotate(90deg); padding:4px 0; width:100%; justify-content:center;} .strip .s{ flex:1 1 100%; } }
+
+  .label { display:inline-block; font-size:11px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; color:var(--muted); background:var(--panel-2); border:1px solid var(--border); border-radius:6px; padding:3px 10px; margin-bottom:10px; }
+  .toc { columns:2; gap:24px; font-size:13.5px; color:var(--muted); }
+  @media (max-width:680px){ .toc{columns:1;} }
+  .toc a { display:block; padding:3px 0; }
+  ul.tight { margin:8px 0 0; padding-left:18px; }
+  ul.tight li { margin:5px 0; font-size:13.5px; color:var(--muted); }
+  ul.tight li b { color: var(--text); }
+  .splitbtn { display:inline-flex; }
+  .splitbtn .main { background: var(--accent); border:1px solid var(--accent); border-right:0; border-radius:8px 0 0 8px; color:#06222e; height:34px; display:flex; align-items:center; gap:7px; padding:0 14px; font-size:13.5px; font-weight:700; }
+  .splitbtn .caret { background: var(--accent); border:1px solid var(--accent); border-radius:0 8px 8px 0; color:#06222e; height:34px; display:flex; align-items:center; padding:0 9px; }
+  .hero-cap { font-size:12px; color:var(--muted-2); text-align:center; margin:4px 0 0; }
+
+  /* ── Launch Claude Code "where should it run?" menu ── */
+  .launchmenu { width: 340px; max-width:100%; background: var(--panel); border:1px solid var(--border-2); border-radius:12px; box-shadow:0 18px 50px rgba(0,0,0,.6); overflow:hidden; }
+  .launchmenu .lm-head { font-size:11px; font-weight:700; letter-spacing:.06em; text-transform:uppercase; color:var(--muted); padding:11px 14px 7px; }
+  .launchmenu .lm-item { display:flex; gap:11px; align-items:flex-start; width:100%; text-align:left; background:transparent; border:0; border-top:1px solid var(--border); padding:12px 14px; min-height:44px; cursor:pointer; color:var(--text); }
+  .launchmenu .lm-item:hover { background: var(--panel-2); }
+  .launchmenu .lm-item:focus-visible { outline:2px solid var(--accent); outline-offset:-2px; }
+  .launchmenu .lm-ic { font-size:18px; line-height:1.2; flex:0 0 auto; }
+  .launchmenu .lm-txt { display:flex; flex-direction:column; gap:2px; }
+  .launchmenu .lm-txt .lm-ttl { font-size:13.5px; font-weight:700; display:flex; align-items:center; gap:7px; }
+  .launchmenu .lm-sub { font-size:11.5px; color:var(--muted); line-height:1.45; }
+  .launchmenu .lm-tag { font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; padding:1px 6px; border-radius:5px; }
+  .launchmenu .lm-tag.today { color:var(--emerald); background:rgba(52,211,153,.12); border:1px solid rgba(52,211,153,.45); }
+  .launchmenu .lm-tag.beta { color:var(--violet); background:rgba(167,139,250,.12); border:1px solid rgba(167,139,250,.5); }
+  .launchmenu .lm-foot { font-size:11px; color:var(--muted-2); padding:9px 14px; border-top:1px solid var(--border); background:var(--panel-2); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="doc">
+  <div class="kicker">UX Design · Step 2 · In-App Local Claude Code Terminal · Revision 2 · P1</div>
+  <h1>“In the browser” — a new way to run the same Launch Claude Code button</h1>
+  <p class="sub">
+    <span class="persona">Compass · UX Designer</span>
+    This is <b>not a new button</b>. The existing <b>Launch Claude Code</b> control on your idea board now asks
+    <b>where</b> Claude should run — you pick one: <b>“In a terminal window”</b> (on your own computer — exactly how it
+    works today, nothing to install) or <b>“In the browser”</b> (new). Pick <b>In the browser</b> and — the first time only —
+    you install a small <b>VibeCodes desktop helper</b>; the OS asks “Open VibeCodes?”, the helper starts
+    <code class="inline">claude</code> on your machine, and the live session renders in a <b>terminal panel docked at the
+    bottom of the board</b> (VS Code convention). You run Claude in <i>one</i> place at a time — a terminal window
+    <i>or</i> the browser, never both. Opt-in, feature-flagged, owner-bound, <b>read-write with a read-only kill-switch</b>,
+    mac + Windows. <b>No command typing in the everyday path.</b>
+  </p>
+</header>
+
+<div class="changed">
+  <h3>⟳ What changed in this revision</h3>
+  <p style="margin:2px 0 0; font-size:13.5px; color:var(--muted);">Sent back at the Design-Review gate. The fixes:</p>
+  <ul>
+    <li><b>One entry point, not two.</b> Launch is now a <b>mode of the existing “Launch Claude Code” button</b> — terminal window (today) vs in the browser (new) — <b>pick one</b>; the helper install is only needed for the in-browser mode. No second, parallel “Launch terminal” button anywhere (§1–§2).</li>
+    <li><b>Launch is a button, not a pasted command.</b> Choosing <b>In the browser</b> = install the helper app once → OS “Open VibeCodes?” → terminal appears. The old <code class="inline">npx</code> paste survives only behind an <b>Advanced</b> disclosure (§2–§3).</li>
+    <li><b>Pairing is automatic on the same machine.</b> The <code class="inline">vibecodes://</code> deep link carries the signed session identity, so the common case has <b>no code to type</b>. The manual device-code is now just the labelled <b>cross-machine fallback</b> (§4).</li>
+    <li><b>New hero: the board mockup.</b> The terminal is shown docked on a real idea board — <b>collapsed</b> (slim bar) and <b>expanded</b> (live session) — at realistic proportions (§1).</li>
+    <li><b>End-to-end “how it works” strip</b> added: install once → click Launch → OS opens helper → terminal appears (§2).</li>
+    <li><b>Gap fixes folded in:</b> a distinct <b>“bridge belongs to another account”</b> owner-mismatch error; non-alarming <b>idle-timeout / max-duration</b> ended copy; a subtle <b>slow-connection</b> indicator on the Connected pill; and the <b>two independent clocks</b> (connect timeout vs session limits) called out (§6–§7).</li>
+    <li><b>The helper ships signed, notarized &amp; verified.</b> The first-run OS step now shows the <b>verified-developer</b> / <b>verified-publisher</b> experience, not the scary “unidentified developer” warning — plus an <b>“Is this safe?”</b> reassurance panel for non-coders (§3). <b>Code-signing + notarization is now a hard P1 requirement</b> (§3, gate).</li>
+  </ul>
+</div>
+
+<div class="cite">
+  <b>Building on Step 1 (Requirements).</b> The ProdOwner slice fixed: <b>single-attach</b> (one helper per session),
+  <b>opt-in + feature-flagged</b>, <b>owner-bound</b> (the session belongs to the authenticated human, not a bot identity),
+  <b>read-write with a read-only kill-switch</b>, and <b>mac + Windows</b>. The relay is opaque (no plaintext at the Cloudflare DO).
+  Two open questions went to UX: <b>Q2</b> pairing UX; <b>Q3</b> where the panel lives. Both are answered below and reflect the
+  reviewer’s direction: pairing should be <b>click-to-launch, auto-paired</b> for non-coders, with manual codes kept only as a fallback.
+</div>
+
+<div class="label">Contents</div>
+<nav class="toc">
+  <a href="#hero">1 · The board mockup — collapsed &amp; expanded (HERO)</a>
+  <a href="#how">2 · How it works, end to end — the “In the browser” path</a>
+  <a href="#firstrun">3 · First run — install the helper (signed &amp; verified trust step)</a>
+  <a href="#pair">4 · Pairing — automatic same-machine, manual fallback</a>
+  <a href="#gating">5 · Gating — flag-off / opt-in / first-run</a>
+  <a href="#panel">6 · Connected panel · slow-connection · two clocks</a>
+  <a href="#killswitch">7 · Read-only kill-switch</a>
+  <a href="#states">8 · All connection states (incl. owner-mismatch &amp; idle-timeout)</a>
+  <a href="#responsive">9 · Responsive — desktop vs 375px</a>
+  <a href="#a11y">10 · Accessibility &amp; review checklist</a>
+  <a href="#northstar">11 · North star — Option 3 (future, separate task)</a>
+</nav>
+
+<!-- ============================================================= -->
+<h2 id="hero">1 · The board mockup — the hero</h2>
+<p class="sub">Where it lives (Q3): a <b>collapsible terminal dock at the bottom of the idea board</b>, exactly the VS Code bottom-panel convention (Jakob’s Law). The board’s kanban columns and cards stay visible above it. Here it is in both resting states.</p>
+
+<h3>1a · Collapsed — a slim dock bar on the board</h3>
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/ideas/recipe-saver/board</span></div>
+  <!-- board top bar -->
+  <div class="boardtop">
+    <span class="crumb">Recipe Saver <span style="color:var(--muted-2)">/</span> <b>Board</b></span>
+    <span class="spacer"></span>
+    <span class="splitbtn"><span class="main">▸ Launch Claude Code</span><span class="caret" aria-label="Choose where Claude runs">▾</span></span>
+    <span class="avatarstack"><span style="background:#7dd3fc">NB</span><span style="background:#a78bfa">RC</span><span style="background:#34d399">AI</span></span>
+  </div>
+  <!-- kanban -->
+  <div class="kanban">
+    <div class="col">
+      <h4>To Do <span class="count">3</span></h4>
+      <div class="tcard"><div class="ttl">Add pagination to the recipe list</div><div class="meta"><span class="chip cyan">feature</span><span class="mini-av" style="background:#7dd3fc">NB</span></div></div>
+      <div class="tcard"><div class="ttl">Email when a saved recipe goes on sale</div><div class="meta"><span class="chip violet">idea</span></div></div>
+    </div>
+    <div class="col">
+      <h4>In Progress <span class="count">1</span></h4>
+      <div class="tcard"><div class="ttl">Import recipes from a URL</div><div class="meta"><span class="chip amber">in progress</span><span class="mini-av" style="background:#a78bfa">AI</span></div></div>
+    </div>
+    <div class="col">
+      <h4>Verify <span class="count">2</span></h4>
+      <div class="tcard"><div class="ttl">Fix blurry recipe photos on mobile</div><div class="meta"><span class="chip emerald">verify</span></div></div>
+    </div>
+    <div class="col">
+      <h4>Done <span class="count">8</span></h4>
+      <div class="tcard"><div class="ttl">Sign in with Google</div><div class="meta"><span class="chip emerald">done</span></div></div>
+    </div>
+  </div>
+  <!-- collapsed terminal dock -->
+  <div class="dockbar">
+    <span class="lbl"><span style="color:var(--emerald)">●</span> Terminal <span style="color:var(--muted-2)">·</span> <span class="hostinfo" style="font-size:11.5px;">Nick’s MacBook Pro · session a3f9</span></span>
+    <span class="spacer"></span>
+    <span class="statepill connected" style="font-size:11px; padding:3px 8px;"><span class="ic">●</span> Connected</span>
+    <button class="ibtn" style="height:26px;" aria-label="Expand terminal panel">⌃ Expand</button>
+  </div>
+</div>
+<div class="hero-cap">Collapsed: the dock is a one-line bar pinned under the board. A coloured dot + “Connected” pill tell you it’s live at a glance; “Expand” opens it.</div>
+<div class="rationale"><b>The dock never steals the board.</b> Collapsed, it’s a ~36px bar — the kanban stays the focus. The live status rides on the bar itself (icon + text, never colour alone) so you don’t have to expand it to know the agent is connected. This is the <span class="law">Jakob’s Law</span> bet: anyone who’s used VS Code’s bottom panel already knows this control.</div>
+
+<h3>1a-ii · The “Launch Claude Code” menu — pick where Claude runs</h3>
+<p class="sub">Clicking the caret on the <b>existing</b> Launch Claude Code button opens a small menu. It’s a <b>pick-one</b> choice — Claude runs in <i>one</i> place at a time. Nothing auto-runs; the user chooses. The in-browser option carries a <b>Beta</b> tag and a one-line note that it needs the helper the first time.</p>
+<div class="launchmenu" role="menu" aria-label="Where should Claude Code run?">
+  <div class="lm-head">Where should Claude run?</div>
+  <button class="lm-item" role="menuitem">
+    <span class="lm-ic" aria-hidden="true">🖥️</span>
+    <span class="lm-txt">
+      <span class="lm-ttl">In a terminal window <span class="lm-tag today">Today</span></span>
+      <span class="lm-sub">On your own computer — exactly how it works now. Nothing to install.</span>
+    </span>
+  </button>
+  <button class="lm-item" role="menuitem">
+    <span class="lm-ic" aria-hidden="true">🌐</span>
+    <span class="lm-txt">
+      <span class="lm-ttl">In the browser <span class="lm-tag beta">Beta</span></span>
+      <span class="lm-sub">A live terminal docked on this board. First time only: installs a small one-time helper.</span>
+    </span>
+  </button>
+  <div class="lm-foot">You run Claude in one place at a time — terminal window <b>or</b> browser, never both.</div>
+</div>
+<div class="hero-cap" style="text-align:left;">One control, two destinations. “In a terminal window” is the unchanged deep-link / copy-command path most users already know; “In the browser” is the new docked terminal this doc designs.</div>
+<div class="rationale"><b>Additive, not disruptive.</b> Existing users who only ever want a terminal window keep doing exactly that — same button, default behaviour, <b>zero new install</b>. The in-browser terminal is a purely <i>opt-in extra destination</i> reached through the same affordance, so we never sprout a second parallel “Launch terminal” button competing with the original. <span class="law">Hick’s Law</span>: one button, one clearly-scoped two-item menu, labelled by outcome (“in a terminal window” / “in the browser”), not by mechanism. The helper-install step (§3) is reached <b>only</b> down the “In the browser” path — pick the terminal-window option and you’ll never see it.</div>
+
+<h3>1b · Expanded — the live terminal docked under the board</h3>
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/ideas/recipe-saver/board</span></div>
+  <div class="boardtop">
+    <span class="crumb">Recipe Saver <span style="color:var(--muted-2)">/</span> <b>Board</b></span>
+    <span class="spacer"></span>
+    <span class="splitbtn"><span class="main">▸ Launch Claude Code</span><span class="caret" aria-label="Choose where Claude runs">▾</span></span>
+    <span class="avatarstack"><span style="background:#7dd3fc">NB</span><span style="background:#a78bfa">RC</span><span style="background:#34d399">AI</span></span>
+  </div>
+  <!-- compressed kanban peeking above -->
+  <div class="kanban" style="padding:10px 16px;">
+    <div class="col"><h4>To Do <span class="count">3</span></h4><div class="tcard" style="padding:8px 10px;"><div class="ttl" style="font-size:12px;">Add pagination to the recipe list</div></div></div>
+    <div class="col"><h4>In Progress <span class="count">1</span></h4><div class="tcard" style="padding:8px 10px; border-color:rgba(251,191,36,.4);"><div class="ttl" style="font-size:12px;">Import recipes from a URL</div></div></div>
+    <div class="col"><h4>Verify <span class="count">2</span></h4></div>
+    <div class="col"><h4>Done <span class="count">8</span></h4></div>
+  </div>
+  <!-- resize grip -->
+  <div class="resize-grip" title="Drag to resize"></div>
+  <!-- terminal -->
+  <div class="term">
+    <div class="term-header">
+      <span class="statepill connected"><span class="ic">●</span> Connected</span>
+      <span class="hostinfo">Nick’s MacBook Pro <span class="sep">·</span> ~/projects/recipe-saver <span class="sep">·</span> session a3f9</span>
+      <span class="spacer"></span>
+      <div class="tctrls">
+        <button class="ibtn" aria-label="Switch to read-only">🔒 Read-only</button>
+        <button class="ibtn" aria-label="Fullscreen the terminal">⛶</button>
+        <button class="ibtn" aria-label="Collapse terminal panel">⌄</button>
+        <button class="ibtn danger" aria-label="End session">⏻ End</button>
+      </div>
+    </div>
+    <div class="xterm"><span class="c-violet"> ▐▛███▜▌</span>   <span class="c-white">Claude Code</span> <span class="c-dim">v2.1 · model: claude-opus-4-8</span>
+<span class="c-violet">▝▜█████▛▘</span>  <span class="c-dim">connected to</span> <span class="c-cyan">vibecodes</span> <span class="c-dim">(MCP) · 83 tools · cwd ~/projects/recipe-saver</span>
+<span class="c-violet">  ▘▘ ▝▝ </span>
+
+<span class="bullet">●</span> I’ll pick up the top task on your board.
+
+<span class="bullet">●</span> <span class="c-cyan">get_board</span> <span class="c-dim">(idea_id 7f3a…)</span>
+  <span class="c-dim">⎿ To Do (3) · In Progress (1) · Verify (2)</span>
+
+<span class="bullet">●</span> Claiming <span class="c-white">“Add pagination to the recipe list”</span> → <span class="c-amber">In Progress</span>
+
+<span class="bullet">●</span> <span class="c-cyan">Edit</span> src/components/recipe-list.tsx
+  <span class="c-green">⎿ +28 -4 · added usePagination() + page controls</span>
+
+<span class="c-dim">Run the tests before you commit, then move it to Verify.</span>
+<span class="c-green">›</span> npm run test <span class="cursor"></span></div>
+    <div class="term-input">
+      <span class="prompt">›</span>
+      <input class="tin" placeholder="Type to steer the agent — Enter to send · Esc clears" aria-label="Send keystrokes to the session">
+      <button class="ibtn" aria-label="Send">↩</button>
+    </div>
+  </div>
+</div>
+<div class="hero-cap">Expanded: bottom panel ≈40% of the board height, drag-handle to resize, fullscreen + collapse + End in the header. The kanban stays visible above so you never lose board context.</div>
+<div class="rationale"><b>This is the picture the reviewer asked for.</b> The terminal is a resizable bottom dock, not a separate page or a modal — the board breathes above it. Header reads left→right as <b>state · identity · controls</b>, controls ordered safest→most destructive with <b>End</b> pinned far right and danger-tinted (<span class="law">Fitts’s Law</span>). The xterm uses real Claude Code TUI grammar (the <code class="inline">●</code> tool lines, <code class="inline">⎿</code> results) so density is judged honestly.</div>
+
+<!-- ============================================================= -->
+<h2 id="how">2 · How it works, end to end (the “In the browser” path)</h2>
+<p class="sub">This is the flow for the <b>“In the browser”</b> choice only. Pick <b>“In a terminal window”</b> instead and none of this happens — that option is unchanged from today and needs no helper. For in-browser: a non-coder never types a command, and the helper installs once. <span class="law">Hick’s Law</span> — one decision per step.</p>
+
+<div class="strip">
+  <div class="s"><span class="every">every time</span><div class="k">Step 1</div><div class="h">Launch Claude Code → <b>In the browser</b></div><div class="b">Open the existing button’s menu, pick the in-browser option.</div></div>
+  <div class="arrow">→</div>
+  <div class="s"><span class="once">first time only</span><div class="k">Step 2</div><div class="h">Install the helper</div><div class="b">Only on the in-browser path. Download &amp; open <code class="inline">VibeCodes Bridge</code>, approve once. Skipped on every later launch.</div></div>
+  <div class="arrow">→</div>
+  <div class="s"><span class="every">every time</span><div class="k">Step 3</div><div class="h">OS asks “Open VibeCodes?”</div><div class="b">Click <b>Open</b>. The helper starts <code class="inline">claude</code>.</div></div>
+  <div class="arrow">→</div>
+  <div class="s"><span class="every">every time</span><div class="k">Step 4</div><div class="h">Terminal appears</div><div class="b">The dock pairs itself and goes live. Drive or watch.</div></div>
+</div>
+<div class="rationale"><b>Two zones: a first-time setup (amber) and the everyday loop (emerald).</b> The install (Step 2) sits <b>inside the in-browser branch only</b> and fires once — pick the terminal-window option and it never appears at all. After that, the daily in-browser experience is Steps 1, 3, 4 — three clicks, zero commands. The deep link from Step 1 carries the signed session identity, so Step 4 pairs <b>without a code</b> in the common (same-machine) case.</div>
+
+<h3>2a · The launch flow in detail</h3>
+<div class="flow">
+  <div class="step"><div class="num">1</div><div class="body"><div class="t">Open <b>Launch Claude Code</b> → choose <b>In the browser</b></div><div class="d">The existing accent-filled split-button in the board toolbar; its caret opens the two-item menu (§1a-ii). Choosing <b>In the browser</b> opens the dock to <b>Connecting…</b> immediately so the click feels acknowledged. (Choosing <b>In a terminal window</b> runs today’s unchanged deep-link / copy-command flow and stops here — no dock, no helper.)</div></div></div>
+  <div class="connector">│</div>
+  <div class="step"><div class="num">2</div><div class="body"><div class="t">Browser opens <code>vibecodes://launch?session=…&amp;idea=…&amp;sig=…</code></div><div class="d">A signed deep link the installed helper is registered to handle. It carries the session id, the idea scope, and a short-lived signature — this is what makes pairing automatic.</div></div></div>
+  <div class="connector">│</div>
+  <div class="step"><div class="num">3</div><div class="body"><div class="t">OS shows “Open VibeCodes?”</div><div class="d">The familiar macOS/Windows “open this app?” confirmation. One click on <b>Open</b>. (A “Always allow” checkbox removes even this after the first time.)</div></div></div>
+  <div class="connector">│</div>
+  <div class="step"><div class="num">4</div><div class="body"><div class="t">Helper starts <code>claude</code> in your project &amp; opens the relay</div><div class="d">The helper validates the signature against your signed-in session, launches Claude Code in the idea’s folder, and attaches to the opaque relay. Dock → <b>Connected</b>.</div></div></div>
+  <div class="connector">│</div>
+  <div class="step"><div class="num">5</div><div class="body"><div class="t">Drive or watch</div><div class="d">Live xterm.js stream + keystroke input. Read-only kill-switch one tap away; End session far right.</div></div></div>
+</div>
+
+<details class="adv" style="margin:8px 0 18px;">
+  <summary>Advanced ▾ — run the bridge by hand (power users / unusual setups)</summary>
+  <div style="margin-top:10px; padding:12px 14px; background:var(--panel); border:1px solid var(--border); border-radius:10px;">
+    <p class="sub" style="margin:0 0 8px; font-size:13px;">Prefer not to install the helper, or running on a box without it? Start the bridge manually and pair with a code (§4b):</p>
+    <span class="mono" style="background:var(--bg); border:1px solid var(--border-2); border-radius:8px; padding:8px 12px; display:inline-flex; gap:10px; align-items:center; font-size:12.5px;">npx vibecodes-bridge <button class="ibtn" style="height:24px;" aria-label="Copy command">⧉ Copy</button></span>
+  </div>
+</details>
+<div class="rationale"><b>The old paste path isn’t deleted — it’s demoted.</b> Keeping <code class="inline">npx vibecodes-bridge</code> behind an <b>Advanced</b> disclosure preserves the universal/cross-machine escape hatch (and power users’ trust) without putting a command in a non-coder’s face. <span class="law">Progressive disclosure</span> — the default path has zero commands; the command is one click away for the few who want it.</div>
+
+<!-- ============================================================= -->
+<h2 id="firstrun">3 · First run — install the helper (signed, notarized &amp; verified)</h2>
+<p class="sub"><b>This step is reached only when the user picks “In the browser.”</b> The “In a terminal window” choice never lands here — it needs no helper. On the very first <i>in-browser</i> launch there’s no helper to open yet; we catch that and walk the user through a normal download → install → trust flow. Because the helper is <b>code-signed and notarized</b>, the OS shows a calm <b>verified-developer</b> confirmation — there’s still one click the first time, but it reads as safe and routine, not a scary “unidentified developer” warning. We’re honest that the click exists; we just make sure it’s the trustworthy version of it.</p>
+
+<h3>3a · No helper detected → install prompt in the dock</h3>
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/ideas/recipe-saver/board</span></div>
+  <div class="term">
+    <div class="term-header">
+      <span class="statepill waiting"><span class="ic">◴</span> Set up once</span>
+      <span class="spacer"></span>
+      <button class="ibtn" aria-label="Collapse panel">⌄</button>
+    </div>
+    <div class="overlay">
+      <div class="big">🖥️</div>
+      <div class="ttl cyan">Install the VibeCodes helper — one time</div>
+      <div class="msg">A small app that lets this panel start and mirror Claude Code on your computer. After this, launching is one click. It runs only when you ask it to, and everything stays on your machine — we relay just the screen.</div>
+      <div class="btnrow">
+        <button class="btn primary lg">⬇ Download for macOS</button>
+        <button class="btn ghost">Windows</button>
+      </div>
+      <div class="msg" style="font-size:12px; color:var(--muted-2);">~6 MB · opens <b>VibeCodes Bridge.dmg</b> · <a href="#">What does the helper do?</a></div>
+    </div>
+  </div>
+</div>
+
+<!-- Is this safe? reassurance callout -->
+<div role="note" aria-label="Is this safe?" style="background:linear-gradient(90deg, rgba(52,211,153,.09), transparent); border:1px solid rgba(52,211,153,.4); border-radius:12px; padding:16px 20px; margin:16px 0 6px;">
+  <div style="display:flex; align-items:center; gap:10px;">
+    <span aria-hidden="true" style="font-size:20px; line-height:1;">🛡️</span>
+    <span style="font-size:15px; font-weight:700; color:var(--emerald);">Is this safe? Yes — here’s why</span>
+  </div>
+  <ul class="tight" style="margin-top:10px;">
+    <li><b>The OS confirms it’s really us.</b> The helper is <b>signed and notarized by Apple</b> on Mac (and <b>code-signed</b> on Windows), so your computer checks it for malware and shows <b>VibeCodes</b> as a verified developer — not “unknown”.</li>
+    <li><b>It only comes from vibecodes.co.uk.</b> You download it straight from the site you’re already signed into — nowhere else.</li>
+    <li><b>It’s open-source.</b> Anyone — including you — can read exactly what it does. Nothing hidden.</li>
+    <li><b>It does one thing.</b> It runs Claude Code on your computer and streams the terminal to your board. It <b>never sees your passwords</b>, and it only runs when you click Launch.</li>
+  </ul>
+</div>
+<div class="hero-cap" style="text-align:left;">Recognition over recall: the cautious user gets the four answers they need — who made it, where it came from, can I inspect it, what it touches — before they click anything.</div>
+
+<h3>3b · After install → the OS trust step (calm, verified — not scary)</h3>
+<p class="sub" style="margin-top:6px;">First time the helper opens, macOS/Windows asks the user to confirm. Because we’re signed + notarized, that confirmation shows <b>VibeCodes as a verified developer / publisher</b> and says the app was malware-scanned — a routine “Open?” box, not a red “can’t be opened” warning. We pre-warn the user so it isn’t a surprise and tell them exactly which button to click.</p>
+<div class="grid">
+  <!-- macOS: verified developer -->
+  <div>
+    <div class="label">macOS · Gatekeeper</div>
+    <div class="osprompt" role="dialog" aria-label="macOS open confirmation — verified developer" style="margin:0 auto;">
+      <div class="body">
+        <div class="ic">🧭</div>
+        <div style="display:inline-flex; align-items:center; gap:6px; margin-bottom:8px; font-size:11.5px; font-weight:700; color:#34d399; background:rgba(52,211,153,.14); border:1px solid rgba(52,211,153,.5); border-radius:999px; padding:3px 10px;"><span aria-hidden="true">✓</span> Verified developer</div>
+        <div class="t">Open “VibeCodes”?</div>
+        <div class="d">“VibeCodes” is from a verified developer. Apple checked it for malicious software and none was detected.</div>
+        <div class="d" style="margin-top:6px; color:#9a9aa6;">VibeCodes Bridge.dmg — downloaded from vibecodes.co.uk.</div>
+      </div>
+      <div class="actions">
+        <button class="cancel">Cancel</button>
+        <button class="primary">Open</button>
+      </div>
+    </div>
+  </div>
+  <!-- Windows: verified publisher -->
+  <div>
+    <div class="label">Windows · User Account Control</div>
+    <div class="osprompt" role="dialog" aria-label="Windows User Account Control — verified publisher" style="margin:0 auto;">
+      <div class="body" style="text-align:left;">
+        <div class="ic" style="margin:0 0 12px;">🛡️</div>
+        <div class="t">Do you want to allow this app to make changes to your device?</div>
+        <div class="d" style="margin-top:8px;"><b style="color:#f2f2f5;">VibeCodes Bridge</b></div>
+        <div class="d" style="display:inline-flex; align-items:center; gap:6px; margin-top:6px; color:#34d399; font-weight:700;"><span aria-hidden="true">✓</span> Verified publisher: VibeCodes</div>
+        <div class="d" style="margin-top:4px;">File origin: Downloaded from the Internet (vibecodes.co.uk)</div>
+      </div>
+      <div class="actions">
+        <button class="cancel">No</button>
+        <button class="primary">Yes</button>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="hero-cap">Both OSes name <b>VibeCodes</b> as a verified developer / publisher and say it was scanned — so the right button (<b>Open</b> / <b>Yes</b>) reads as the safe, obvious one. It only happens the first time.</div>
+<div class="rationale"><b>Signed + notarized is what turns the OS prompt from a scare into a reassurance.</b> An <i>unsigned</i> app triggers the red “unidentified developer / cannot be opened” path — the moment most non-coders abandon. A properly <b>code-signed and notarized</b> helper instead gets the calm “verified developer” box: the OS itself vouches that the app is really from VibeCodes and is malware-free. We still forewarn it — “Your Mac/PC will ask once; it’ll say VibeCodes is a verified developer — click <b>Open</b>” — so the system’s own trust signal does the reassuring. <b>This is why code-signing + notarization is a hard P1 requirement: no unidentified-developer warning, ever.</b></div>
+
+<h3>3c · Everyday launch (helper already installed &amp; trusted)</h3>
+<p class="sub" style="margin-top:6px;">From the second time on, choosing <b>Launch Claude Code → In the browser</b> shows only the lightweight “Open VibeCodes?” confirmation (or nothing, if the user ticked “Always allow”). This is the steady state for ~99% of in-browser launches.</p>
+<div class="osprompt" role="dialog" aria-label="Open app confirmation">
+  <div class="body">
+    <div class="ic">🧭</div>
+    <div class="t">Open “VibeCodes”?</div>
+    <div class="d">vibecodes.co.uk wants to open the VibeCodes Bridge helper.</div>
+    <label style="display:flex; gap:7px; align-items:center; justify-content:center; margin-top:12px; font-size:12px; color:#b8b8c0;"><input type="checkbox" checked> Always allow vibecodes.co.uk to open this</label>
+  </div>
+  <div class="actions">
+    <button class="cancel">Cancel</button>
+    <button class="primary">Open</button>
+  </div>
+</div>
+
+<!-- ============================================================= -->
+<h2 id="pair">4 · Pairing — automatic on the same machine, manual fallback for cross-machine</h2>
+
+<h3>4a · Same machine (the default) — no code, ever</h3>
+<p class="sub">When the helper runs on the same computer as the browser, the signed <code class="inline">vibecodes://</code> deep link <i>is</i> the pairing. The session id and signature travel in the link; the helper redeems them against the signed-in session. The user sees <b>Connecting…</b> → <b>Connected</b> with no code field.</p>
+<div class="strip">
+  <div class="s"><div class="k">click</div><div class="h">Launch Claude Code → In the browser</div><div class="b">Dock → Connecting…</div></div>
+  <div class="arrow">→</div>
+  <div class="s"><div class="k">os</div><div class="h">Open VibeCodes?</div><div class="b">Helper validates the signed link</div></div>
+  <div class="arrow">→</div>
+  <div class="s"><div class="k">auto</div><div class="h">Bound to you</div><div class="b">Signature ↔ your session = owner-bound, no typing</div></div>
+  <div class="arrow">→</div>
+  <div class="s"><div class="k">live</div><div class="h">Connected</div><div class="b">Stream opens</div></div>
+</div>
+<div class="rationale"><b>The deep link replaces the code in the common case.</b> Because the link is signed and redeemed inside the authenticated session, owner-binding is automatic and unambiguous — the helper proves it was launched by <i>this</i> logged-in human. <span class="law">Recognition over recall</span> taken to its limit: nothing to recall at all.</div>
+
+<h3>4b · Cross-machine fallback (labelled) — bridge on a different/remote box</h3>
+<p class="sub">If the bridge runs somewhere the browser can’t deep-link to — an SSH box, a headless dev VM, a second laptop, or you’re viewing on your phone — there’s no scheme handler to catch the link. We fall back to the well-worn <b>device code</b> (the <code class="inline">gh auth login</code> / <code class="inline">tv.youtube.com</code> pattern). This path is reached via <b>Advanced → Connect a remote machine</b>, not the default.</p>
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/ideas/recipe-saver/board</span></div>
+  <div class="term">
+    <div class="term-header">
+      <span class="statepill waiting"><span class="ic">◴</span> Waiting to pair</span>
+      <span class="hostinfo"><span class="sep">·</span> remote machine</span>
+      <span class="spacer"></span>
+      <button class="ibtn" aria-label="Collapse panel">⌄</button>
+    </div>
+    <div class="overlay">
+      <div class="ttl cyan">Connect a remote machine</div>
+      <div class="msg">On the other machine, run <code class="inline">npx vibecodes-bridge</code>. It prints a code — enter it here. (For your own computer, just pick <b>Launch Claude Code → In the browser</b> — no code needed.)</div>
+      <div style="display:flex; gap:8px; align-items:center;">
+        <input class="tin" style="width:170px; text-align:center; letter-spacing:.14em; text-transform:uppercase;" placeholder="QFRT-8316" aria-label="Pairing code">
+        <button class="btn primary">Pair</button>
+      </div>
+      <div class="msg" style="font-size:12px;">Single-use · expires 9:42 · binds to <b>nicholasmball@gmail.com</b></div>
+    </div>
+  </div>
+</div>
+<pre>$ npx vibecodes-bridge
+<span style="color:#7dd3fc">vibecodes-bridge</span> v0.1.0  ·  host: dev-vm-london
+
+  ◆ Pair this session — enter on your board’s Terminal panel (expires 10:00):
+
+        ┌──────────────┐
+        │   <span style="color:#34d399">QFRT - 8316</span>   │
+        └──────────────┘
+
+  ⠿ Waiting for you to pair…  (relay: connected · read-write)</pre>
+<div class="rationale"><b>The manual code earns its keep as a fallback, not the front door.</b> It’s the only thing that works when there’s no local scheme handler — so we keep it, label it for what it is (“remote machine”), and reassure same-machine users they’ll never need it. The footer still names the bound account and the single-use/expiry facts, so even the fallback makes owner-binding <i>visible</i> at the moment of consent.</div>
+
+<!-- ============================================================= -->
+<h2 id="gating">5 · Gating — flag-off / opt-in / first-run</h2>
+<p class="sub">Same board toolbar location for everyone; what renders depends on flag + opt-in + history.</p>
+
+<h3>5a · Flag OFF — in-browser option absent (terminal window unchanged)</h3>
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/ideas/recipe-saver/board</span></div>
+  <div class="boardtop">
+    <span class="crumb">Recipe Saver <span style="color:var(--muted-2)">/</span> <b>Board</b></span>
+    <span class="spacer"></span>
+    <span class="splitbtn"><span class="main">▸ Launch Claude Code</span><span class="caret" aria-label="Open in a terminal window">▾</span></span>
+    <span class="avatarstack"><span style="background:#7dd3fc">NB</span><span style="background:#a78bfa">RC</span></span>
+  </div>
+  <div class="kanban" style="padding:10px 16px;"><div class="col"><h4>To Do <span class="count">3</span></h4></div><div class="col"><h4>In Progress <span class="count">1</span></h4></div><div class="col"><h4>Verify <span class="count">2</span></h4></div><div class="col"><h4>Done <span class="count">8</span></h4></div></div>
+</div>
+<div class="rationale"><b>Honest absence — but only of the new option.</b> The flag gates the <i>in-browser terminal</i>, not the whole button. Flag off → the existing <b>Launch Claude Code</b> control still works exactly as today (terminal window), and the <b>“In the browser”</b> menu item is simply <b>not rendered</b> — no disabled ghost, no “coming soon” teaser (which would violate “no disabled buttons without a what’s-needed note”). With the flag off the menu collapses to its single original action, so existing users see no change at all.</div>
+
+<h3>5b · Flag ON, not yet enabled — the opt-in moment</h3>
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/ideas/recipe-saver/board</span></div>
+  <div class="term">
+    <div class="term-header">
+      <span class="statepill disconnected"><span class="ic">○</span> Terminal · off</span>
+      <span class="spacer"></span>
+      <button class="ibtn" aria-label="Collapse panel">⌄</button>
+    </div>
+    <div class="overlay">
+      <div class="big">🖥️</div>
+      <div class="ttl cyan">Watch your local Claude Code in the browser</div>
+      <div class="msg">Click one button on your board and this panel mirrors the live session on your computer — read the agent’s work as it happens, or type to steer it. It stays on your machine; we only relay the screen. <b>You can flip to read-only any time.</b></div>
+      <div class="btnrow">
+        <button class="btn primary">Enable terminal for me</button>
+        <button class="btn ghost">How it works ↗</button>
+      </div>
+      <div class="msg" style="font-size:12px; color:var(--muted-2);">Opt-in · single session · bound to your account · turn off anytime in Settings</div>
+    </div>
+  </div>
+</div>
+<div class="rationale"><b>Opt-in is a deliberate, informed choice.</b> One primary action, one secondary (<span class="law">Hick’s Law</span>). The copy answers the three questions a cautious user asks — <i>where does my code go, who can attach, how do I stop it</i> — and states the read-only promise up front.</div>
+
+<h3>5c · Enabled, helper installed, nothing launched yet — first-run resting state</h3>
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/ideas/recipe-saver/board</span></div>
+  <div class="term">
+    <div class="term-header">
+      <span class="statepill disconnected"><span class="ic">○</span> Terminal · idle</span>
+      <span class="spacer"></span>
+      <button class="ibtn" aria-label="Collapse panel">⌄</button>
+    </div>
+    <div class="overlay">
+      <div class="ttl green" style="font-size:16px;">Ready when you are</div>
+      <div class="msg">You picked <b>In the browser</b>. Click <b>Launch in browser</b> to start Claude Code on <b>Nick’s MacBook Pro</b> and mirror it here. Your Mac will ask to open VibeCodes — click <b>Open</b>.</div>
+      <button class="btn primary lg">▸ Launch in browser</button>
+      <div class="msg" style="font-size:12px;"><a href="#">Run in a terminal window instead</a> · <a href="#">Connect a different / remote machine</a> · <a href="#">Advanced ↗</a></div>
+    </div>
+  </div>
+</div>
+<div class="rationale"><b>First-run is a launch pad, not an empty box.</b> This is the dock <i>after</i> the user has chosen <b>In the browser</b>; the big <b>Launch in browser</b> button is the only thing a non-coder needs, with an escape hatch back to the unchanged terminal-window option and the cross-machine + advanced paths as quiet links beneath. We forewarn the OS prompt right in the helper text so Step 3 isn’t a surprise. <span class="law">Information scent</span> — the button text matches exactly what they’ll click and what happens next.</div>
+
+<!-- ============================================================= -->
+<h2 id="panel">6 · Connected panel · slow connection · two clocks</h2>
+<p class="sub">The connected hero is shown at §1b. Two refinements the reviewer asked for: a subtle <b>slow-connection</b> indicator, and acknowledging the <b>two independent clocks</b>.</p>
+
+<h3>6a · Slow connection — a subtle pill annotation, not an alarm</h3>
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/ideas/recipe-saver/board</span></div>
+  <div class="term">
+    <div class="term-header">
+      <span class="statepill connected"><span class="ic">●</span> Connected</span>
+      <span class="slowtag" title="Higher than usual latency">🐢 Slow connection</span>
+      <span class="hostinfo">Nick’s MacBook Pro <span class="sep">·</span> session a3f9</span>
+      <span class="spacer"></span>
+      <div class="tctrls">
+        <button class="ibtn" aria-label="Switch to read-only">🔒 Read-only</button>
+        <button class="ibtn danger" aria-label="End session">⏻ End</button>
+      </div>
+    </div>
+    <div class="xterm" style="min-height:120px;"><span class="bullet">●</span> <span class="c-cyan">Bash</span> npm run test
+  <span class="c-dim">⎿ running… (output a little behind)</span><span class="cursor"></span></div>
+    <div class="input-note" style="color:var(--amber); background:rgba(251,191,36,.06);">🐢 <b style="color:var(--amber);">Slow connection.</b> Keystrokes and updates may lag a second or two. The session is fine — this is just your network. Typing still works.</div>
+  </div>
+</div>
+<div class="rationale"><b>Slow ≠ broken.</b> Still <b>Connected</b> (green), with an amber <code class="inline">🐢 Slow connection</code> annotation <i>beside</i> the pill — icon + text + colour, never colour alone. It explains the lag and reassures that input still works, so a non-coder doesn’t mistake latency for a crash and yank the session. It only escalates to “Reconnecting…” if the stream actually drops.</div>
+
+<h3>6b · Two independent clocks</h3>
+<table>
+  <tr><th>Clock</th><th>What it times</th><th>Where it shows</th><th>On expiry</th></tr>
+  <tr><td><b>Connect timeout</b></td><td>How long we’ll wait for the relay to come up after Launch (≈30s).</td><td>Only during <b>Connecting…</b>.</td><td>→ <b>Error</b> “Couldn’t reach your machine” + Retry.</td></tr>
+  <tr><td><b>Session limits</b></td><td>Idle timeout (≈30 min no activity) and a max-duration safety cap (≈8 h), enforced by the bridge.</td><td>Only while <b>Connected</b> (a quiet “idle 26:10” hint appears as it nears).</td><td>→ <b>Session ended</b> with the specific reason (§8).</td></tr>
+</table>
+<div class="rationale"><b>Naming the two clocks prevents a whole class of confusion.</b> A timeout while <i>connecting</i> means “we never reached your machine” (network/helper problem → retry). A timeout while <i>connected</i> means “we ended a long-idle session on purpose” (expected, safe → relaunch). They look different, read differently, and never share copy — so the user always knows whether something broke or simply expired.</div>
+
+<!-- ============================================================= -->
+<h2 id="killswitch">7 · Read-only kill-switch</h2>
+<p class="sub">The safety control the requirements name. One tap freezes input; the live view keeps streaming so you never lose sight of the agent.</p>
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/ideas/recipe-saver/board</span></div>
+  <div class="term">
+    <div class="term-header">
+      <span class="statepill connected"><span class="ic">●</span> Connected</span>
+      <span class="ro-badge">🔒 Read-only</span>
+      <span class="hostinfo">Nick’s MacBook Pro <span class="sep">·</span> session a3f9</span>
+      <span class="spacer"></span>
+      <div class="tctrls">
+        <button class="ibtn toggle-on" aria-pressed="true" aria-label="Read-only is on — click to allow input">🔒 Read-only · on</button>
+        <button class="ibtn" aria-label="Fullscreen">⛶</button>
+        <button class="ibtn danger" aria-label="End session">⏻ End</button>
+      </div>
+    </div>
+    <div class="xterm"><span class="bullet">●</span> <span class="c-cyan">Bash</span> npm run test
+  <span class="c-green">⎿ ✓ 142 passed</span> <span class="c-dim">(3.1s)</span>
+
+<span class="bullet">●</span> Tests pass. Ready to commit and move the task to Verify.
+<span class="c-dim">  (waiting — input is frozen)</span><span class="cursor"></span></div>
+    <div class="input-note">🔒 <b>Read-only is on.</b> You’re watching live; the agent can’t receive keystrokes from here. <a href="#">Allow input</a> to steer again.</div>
+  </div>
+</div>
+<div class="rationale">
+  <b>The kill-switch is signalled three ways — never colour alone.</b> (1) a <span style="color:var(--violet)">violet</span> <code class="inline">🔒 Read-only</code> badge in the header, (2) the toggle showing <code class="inline">aria-pressed="true"</code> + “on”, and (3) the input bar <b>replaced</b> by an explanatory note (not merely disabled — a disabled box with no reason violates the persona rule). Flipping back is one click. Critically, <b>the stream keeps flowing in read-only</b> — freezing input must never mean going blind. Violet keeps it distinct from the green “Connected” state, so “connected” and “read-only” read as two independent facts.
+</div>
+
+<!-- ============================================================= -->
+<h2 id="states">8 · All connection states</h2>
+<p class="sub">Every state is distinct, labelled, and carries icon + text + actionable next step. A terminal that only handles “connected” is unshippable.</p>
+<div class="grid">
+  <div class="state wait"><div class="tag">◴ Waiting to pair</div><p>Cross-machine fallback only — bridge started, code not yet entered. (Same-machine launch skips straight to Connecting.)</p><p class="next">→ Enter the code from the remote machine, or just use Launch on your own computer.</p></div>
+  <div class="state warn"><div class="tag">◐ Connecting…</div><p>Launch clicked / code accepted; relay handshaking. Animated indicator, no input bar yet. <b>Connect-timeout clock</b> runs (≈30s) → Error.</p><p class="next">→ Click Open in the OS prompt; otherwise just wait. Cancel reverts to idle.</p></div>
+  <div class="state ok"><div class="tag">● Connected</div><p>Live stream + read-write input (or read-only if killed). May carry a 🐢 slow-connection note (§6a). The hero state.</p><p class="next">→ Watch, or type to steer.</p></div>
+  <div class="state neutral"><div class="tag">◌ Disconnected — reconnecting</div><p>Bridge dropped (laptop slept, Wi-Fi blip). Auto-reconnect with backoff; last screen dimmed + held, not cleared.</p><p class="next">→ Auto-retrying (2s, 4s, 8s…). “Reconnect now” + “End session” available.</p></div>
+  <div class="state neutral"><div class="tag">◾ Session ended</div><p>Clean stop — End pressed, bridge exited (<code>Ctrl-C</code>), <b>or a session-limit clock fired</b> (idle / max-duration). Reason named; scrollback frozen + readable.</p><p class="next">→ “Launch again” reopens the flow.</p></div>
+  <div class="state err"><div class="tag">✕ Error</div><p>Connect timed out, helper not found, version mismatch, relay rejected, or <b>owner mismatch</b>. Names the cause + a fix.</p><p class="next">→ Specific recovery (retry / install helper / update / sign in as owner).</p></div>
+</div>
+
+<h3>8a · Connecting</h3>
+<div class="browser"><div class="term"><div class="term-header"><span class="statepill connecting"><span class="ic">◐</span> Connecting…</span><span class="hostinfo">Nick’s MacBook Pro <span class="sep">·</span> opening relay</span><span class="spacer"></span><button class="ibtn">Cancel</button></div><div class="overlay"><div class="big" style="color:var(--amber)">◐</div><div class="ttl amber">Starting Claude Code on your Mac…</div><div class="msg">If your Mac asks, click <b>Open</b>. Then we open the encrypted stream — usually instant. <span style="color:var(--muted-2)">(waiting up to 30s)</span></div></div></div></div>
+
+<h3>8b · Disconnected — auto-reconnecting (recovery)</h3>
+<div class="browser"><div class="term"><div class="term-header"><span class="statepill disconnected"><span class="ic">◌</span> Reconnecting…</span><span class="hostinfo">Nick’s MacBook Pro <span class="sep">·</span> retry in 4s</span><span class="spacer"></span><div class="tctrls"><button class="ibtn">↻ Reconnect now</button><button class="ibtn danger">⏻ End</button></div></div>
+  <div class="xterm" style="opacity:.45; min-height:110px;"><span class="bullet">●</span> <span class="c-cyan">Edit</span> src/components/recipe-list.tsx
+  <span class="c-green">⎿ +28 -4</span>
+<span class="c-dim">— connection lost · last frame held —</span></div>
+  <div class="input-note">◌ <b>Lost the connection.</b> Your machine may have slept or dropped Wi-Fi. Retrying automatically (next in 4s). Nothing is lost — the agent keeps running locally; we’ll re-attach to it.</div>
+</div></div>
+<div class="rationale"><b>A drop is recoverable, and the UI says so.</b> The last frame is <b>dimmed and held</b>, not wiped — losing the relay must not look like losing the work. Copy reassures the agent keeps running locally. Auto-backoff + a manual “Reconnect now” gives passive and active recovery; the header counts down so the wait feels bounded.</div>
+
+<h3>8c · Session ended — clean stop vs idle/max-duration (distinct, non-alarming copy)</h3>
+<div class="grid">
+  <div class="browser" style="margin:0;"><div class="term"><div class="term-header"><span class="statepill ended"><span class="ic">◾</span> Session ended</span><span class="spacer"></span><button class="ibtn">⌄</button></div><div class="overlay"><div class="big" style="color:var(--muted)">◾</div><div class="ttl muted">You ended the session</div><div class="msg">Claude Code on <b>Nick’s MacBook Pro</b> stopped. Scrollback is kept below.</div><button class="btn primary">▸ Launch again</button></div></div></div>
+  <div class="browser" style="margin:0;"><div class="term"><div class="term-header"><span class="statepill ended"><span class="ic">◾</span> Session ended</span><span class="spacer"></span><button class="ibtn">⌄</button></div><div class="overlay"><div class="big" style="color:var(--muted)">⏱</div><div class="ttl muted">Ended after 30 min idle</div><div class="msg">No activity for a while, so we closed the session to keep things tidy and safe. Nothing went wrong. Your work on your machine is untouched.</div><button class="btn primary">▸ Launch again</button></div></div></div>
+</div>
+<div class="rationale"><b>Idle/max-duration endings are calm and explicitly “nothing went wrong.”</b> Same grey <code class="inline">◾ Session ended</code> family, but the headline names the <i>reason</i> — “Ended after 30 min idle” (or “Reached the 8-hour limit”) — with a clock glyph, not an error glyph, and reassuring copy. It must never read like a crash; it’s a safety timeout doing its job. One forward action: <b>Launch again</b>.</div>
+
+<h3>8d · Error — incl. the owner-mismatch case</h3>
+<div class="grid">
+  <div class="browser" style="margin:0;"><div class="term"><div class="term-header"><span class="statepill error"><span class="ic">✕</span> Error</span><span class="spacer"></span><button class="ibtn">⌄</button></div><div class="overlay"><div class="big" style="color:var(--rose)">✕</div><div class="ttl rose">Couldn’t reach your machine</div><div class="msg">We waited 30s but the helper didn’t connect. Is <b>VibeCodes Bridge</b> installed and allowed to open?</div><div class="btnrow"><button class="btn primary">↻ Try again</button><button class="btn ghost">Reinstall helper ↗</button></div></div></div></div>
+  <div class="browser" style="margin:0;"><div class="term"><div class="term-header"><span class="statepill error"><span class="ic">✕</span> Owner mismatch</span><span class="spacer"></span><button class="ibtn">⌄</button></div><div class="overlay"><div class="big" style="color:var(--rose)">🔐</div><div class="ttl rose">This bridge belongs to another account</div><div class="msg">The bridge on <b>dev-vm-london</b> was started by <b>rosa@…</b>, not your account. For safety, a bridge only attaches to the person who launched it.</div><div class="btnrow"><button class="btn ghost">Switch account ↗</button><button class="btn ghost">Start your own bridge</button></div></div></div></div>
+</div>
+<div class="rationale"><b>Owner mismatch is its own first-class error, not a generic failure.</b> When a redeemed code (or a relay attach) belongs to a different human, we say so plainly — “This bridge belongs to another account” — name who started it, and explain the rule (a bridge attaches only to its launcher). The recovery isn’t “retry” (that can’t help); it’s <b>switch account</b> or <b>start your own bridge</b>. This makes the owner-binding requirement legible at exactly the moment it bites. <b>Ended ≠ Error:</b> a clean/idle stop is calm grey with one forward action; an error is rose, names the specific cause, and hands over the exact fix.</div>
+
+<!-- ============================================================= -->
+<h2 id="responsive">9 · Responsive — desktop vs 375px</h2>
+<h3>9a · Desktop (≥768px)</h3>
+<p class="sub">Full dock as shown in §1b — a bottom panel ~40% of the board height, drag-to-resize via the grip, fullscreen toggle, persistent input bar. Header controls sit in one row; identity truncates middle-out (<code class="inline">Nick’s MacBook Pro · ~/pro…/recipe-saver · a3f9</code>) so the state pill + End never get pushed off.</p>
+
+<h3>9b · 375px mobile — the honest call: <b>read-only, view-first</b></h3>
+<div style="max-width:340px; margin:14px 0;">
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">…/recipe-saver/board</span></div>
+  <div class="term">
+    <div class="term-header" style="gap:6px;">
+      <span class="statepill connected" style="font-size:11.5px; padding:3px 7px;"><span class="ic">●</span> Connected</span>
+      <span class="ro-badge" style="font-size:10px; padding:2px 6px;">🔒 Read-only</span>
+      <span class="spacer"></span>
+      <button class="ibtn danger" style="height:44px; padding:0 10px;" aria-label="End session">⏻</button>
+    </div>
+    <div class="xterm" style="font-size:11px; min-height:140px; padding:12px;"><span class="bullet">●</span> <span class="c-cyan">Edit</span> recipe-list.tsx
+  <span class="c-green">⎿ +28 -4</span>
+
+<span class="bullet">●</span> <span class="c-cyan">Bash</span> npm run test
+  <span class="c-green">⎿ ✓ 142 passed</span>
+
+<span class="c-dim">watching live…</span><span class="cursor"></span></div>
+    <div class="input-note" style="font-size:11px;">📱 <b>Read-only on mobile.</b> Driving a terminal needs a keyboard + width. <a href="#">Open on desktop</a> to type — or use the kill-switch &amp; End here.</div>
+  </div>
+</div>
+</div>
+<div class="rationale">
+  <b>The honest call: a phone can <i>watch</i> but shouldn’t <i>drive</i>.</b> A full xterm with a soft-keyboard, escape sequences, and arrow-key navigation is genuinely bad UX — pretending otherwise fails the “does it work at 375px?” test dishonestly. So below 768px the panel is <b>read-only by default</b>: the live stream stays, and the two <b>safety</b> controls that matter on the go — the read-only kill-switch (already engaged) and <b>End</b> (a ≥44px target) — remain; keystroke input hides behind an honest note pointing to desktop. <b>Safety controls are never desktop-only</b> — you must be able to stop a runaway agent from your phone.
+</div>
+
+<!-- ============================================================= -->
+<h2 id="a11y">10 · Accessibility &amp; review checklist</h2>
+<table>
+  <tr><th>Concern</th><th>How this design handles it</th></tr>
+  <tr><td>Never colour alone</td><td>Every state = icon + text + colour. Connected (● green text), Slow (🐢 amber tag + text), Read-only (🔒 violet badge + “on” + aria-pressed), Owner mismatch (🔐 rose + named account), Idle-ended (⏱ grey + reason). Colour-blind safe.</td></tr>
+  <tr><td>Contrast (WCAG AA)</td><td>Body text <code>#e6e6ea</code> on <code>#0c0c0e</code> ≈ 15:1. State pills use ≥4.5:1 text; muted <code>#9a9aa6</code> meta clears 4.5:1 at 12px.</td></tr>
+  <tr><td>Keyboard</td><td>Tab order: state → controls → xterm → input. xterm.js focusable with a live region for screen readers; <code>Esc</code> moves focus out of the terminal trap back to the header.</td></tr>
+  <tr><td>OS prompt forewarned</td><td>The native “Open VibeCodes?” / Gatekeeper dialog is announced in-app before it appears, with the exact button to click — no surprise system modal for non-coders. Because the helper is signed + notarized, it’s the calm <b>verified-developer / verified-publisher</b> prompt, never the red “unidentified developer” one. The verified state is shown icon + text (✓ + “Verified”), not colour alone.</td></tr>
+  <tr><td>Visible labels</td><td>The (fallback) pairing code field has a visible label, not just a placeholder. All icon-only header buttons carry <code>aria-label</code>; End also shows its text on desktop.</td></tr>
+  <tr><td>Touch targets</td><td>Header buttons ≥30px desktop; on mobile the kill-switch + End are ≥44px (Fitts’s Law).</td></tr>
+  <tr><td>No modals for inline content</td><td>Launch, pairing, errors, read-only all render inside the dock. The only modals are the OS’s own app-open prompts, which we don’t control.</td></tr>
+  <tr><td>Focus states</td><td>2px accent outline + 2px offset on every interactive element (<code>:focus-visible</code>).</td></tr>
+  <tr><td>Reduced motion</td><td>Connecting spinner + cursor blink respect <code>prefers-reduced-motion</code> (static fallback) — honoured in build.</td></tr>
+</table>
+
+<!-- ============================================================= -->
+<h2 id="northstar">11 · North star — Option 3 (future, separate task)</h2>
+<div class="reco">
+  <h3>Option 3 · Always-on background helper <span class="pick">FUTURE · own task</span></h3>
+  <p style="margin:6px 0 0;">The endgame is <b>zero clicks</b>: a tiny background helper that’s already running and signed in, so choosing <b>Launch Claude Code → In the browser</b> attaches instantly with <i>no</i> OS prompt at all — the deep link goes straight to a listening local agent. That’s the consumer-grade ideal.</p>
+  <ul class="tight">
+    <li><b>P1 ships Option 2</b> (this doc): install once, click Launch, one OS confirm. It’s the honest, shippable middle — real one-click feel without a always-resident background process to design, secure, auto-update, and earn trust for.</li>
+    <li><b>Option 3 is tracked as its own task</b> — it adds a login-item/agent lifecycle, background-permission story, and auto-update channel that deserve their own design + security review. Building Option 2 first doesn’t block it; Option 3 layers onto the same signed deep-link + relay.</li>
+  </ul>
+  <div class="alt"><b>Progression:</b> Option 1 (paste a command, now demoted to Advanced) → <b>Option 2 (P1: install once + Launch button)</b> → Option 3 (always-on, zero clicks). Each step removes friction without changing the underlying signed-link + opaque-relay model.</div>
+</div>
+
+<div class="reco" style="margin-top:26px;">
+  <h3>Design-Review gate — what to sign off</h3>
+  <ul class="tight">
+    <li><b>Launch model:</b> Approve making in-browser a <b>mode of the existing “Launch Claude Code” button</b> — a pick-one menu (“In a terminal window” = today, unchanged / “In the browser” = new, install-once helper), never a second parallel button — as the P1 primary path (npx demoted to Advanced)?</li>
+    <li><b>Pairing:</b> Approve <b>automatic same-machine pairing via signed <code>vibecodes://</code> deep link</b>, with the manual device-code kept only as the labelled cross-machine fallback?</li>
+    <li><b>Home (Q3):</b> Approve the <b>per-idea board terminal dock</b> (collapsible bottom panel) as the P1 home?</li>
+    <li><b>OS trust step:</b> Approve <b>forewarning the OS “Open VibeCodes?” prompt</b> honestly in-app rather than hiding it?</li>
+    <li><b>Signing (hard requirement):</b> Confirm <b>code-signing + notarization is a hard P1 requirement</b> — the helper must show the verified-developer / verified-publisher prompt, with <b>no “unidentified developer” warning</b> ever reaching a user?</li>
+    <li><b>Kill-switch:</b> Approve read-only that <b>freezes input but keeps the stream live</b>, badged three ways?</li>
+    <li><b>Mobile:</b> Approve <b>read-only-on-mobile</b> with safety controls retained, driving redirected to desktop?</li>
+    <li><b>Flag-off:</b> Approve <b>not rendering</b> the entry point when the flag is off?</li>
+    <li><b>Gap fixes:</b> Approve the distinct <b>owner-mismatch</b> error, <b>idle/max-duration</b> ended copy, <b>slow-connection</b> indicator, and the <b>two-clocks</b> model?</li>
+  </ul>
+</div>
+
+<p class="sub" style="margin-top:40px; font-size:12.5px; color:var(--muted-2);">Compass · UX Design · Step 2 of the Feature Development workflow · Revision 2 · single self-contained doc, no app source modified.</p>
+
+</div>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@supabase/supabase-js": "^2.95.3",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "ai": "^6.0.86",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -8093,6 +8095,21 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -15087,7 +15104,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@supabase/supabase-js": "^2.95.3",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "ai": "^6.0.86",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/(main)/ideas/[id]/board/page.tsx
+++ b/src/app/(main)/ideas/[id]/board/page.tsx
@@ -12,6 +12,8 @@ import { BoardRealtime } from "@/components/board/board-realtime";
 import { GuestBoardBanner } from "@/components/board/guest-board-banner";
 import { BoardPageTabs } from "@/components/board/board-page-tabs";
 import { KitAppliedToast } from "@/components/board/kit-applied-toast";
+import { TerminalDock } from "@/components/board/terminal-dock";
+import { isTerminalEnabled } from "@/lib/terminal/connection";
 import { McpConnectionBanner } from "@/components/shared/mcp-connection-banner";
 import { computeIdeaHealth } from "@/lib/idea-health";
 import { WORKFLOW_AI_ADJUDICATION_TIMEOUT_MS } from "@/lib/workflow-suggestion-constants";
@@ -356,6 +358,12 @@ export default async function BoardPage({ params, searchParams }: PageProps) {
         />
       </BoardPageTabs>
       <KitAppliedToast />
+
+      {/* In-app local Claude Code terminal — OFF by default (NEXT_PUBLIC_TERMINAL_ENABLED),
+          team-members only. Renders nothing when the flag is off → board unchanged. */}
+      {isTerminalEnabled() && isTeamMember && (
+        <TerminalDock ideaId={id} ideaTitle={idea.title} />
+      )}
     </div>
   );
 }

--- a/src/app/api/terminal/session/route.ts
+++ b/src/app/api/terminal/session/route.ts
@@ -1,0 +1,92 @@
+// Terminal session token minting — SLICE 2 (auth + ownership).
+//
+// Mints the short-lived, owner-bound tokens the in-app terminal relay requires.
+// The authenticated VibeCodes user gets a token PER LEG (browser + bridge) for one
+// session id; both carry the same `sub` so the relay can prove the two legs belong
+// to the same human and refuse a cross-user attach.
+//
+// Signing lives in the SHARED module (terminal/shared/session-token.mjs) so the
+// exact same code verifies on the Cloudflare relay. The secret comes from the
+// TERMINAL_SESSION_SECRET env var — never hard-coded.
+
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+// One shared implementation of the token scheme — also imported by the relay.
+import { mintSessionTokens } from "../../../../../terminal/shared/session-token.mjs";
+
+const BodySchema = z.object({
+  ideaId: z.string().uuid(),
+});
+
+export async function POST(req: Request) {
+  try {
+    const secret = process.env.TERMINAL_SESSION_SECRET;
+    if (!secret) {
+      logger.error("Terminal session mint failed: TERMINAL_SESSION_SECRET not configured");
+      return Response.json({ error: "Terminal sessions are not configured" }, { status: 503 });
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return Response.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const parsed = BodySchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
+    const { ideaId } = parsed.data;
+
+    // Only a member of the idea (author or collaborator) may open a terminal on it.
+    const { data: idea } = await supabase
+      .from("ideas")
+      .select("id, author_id")
+      .eq("id", ideaId)
+      .maybeSingle();
+    if (!idea) {
+      return Response.json({ error: "Idea not found" }, { status: 404 });
+    }
+    if (idea.author_id !== user.id) {
+      const { data: collab } = await supabase
+        .from("collaborators")
+        .select("id")
+        .eq("idea_id", ideaId)
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!collab) {
+        return Response.json(
+          { error: "Only team members can open a terminal for this idea" },
+          { status: 403 },
+        );
+      }
+    }
+
+    const tokens = await mintSessionTokens({ sub: user.id, idea: ideaId, secret });
+
+    logger.info("Minted terminal session tokens", {
+      userId: user.id,
+      ideaId,
+      sid: tokens.sid,
+      exp: tokens.exp,
+    });
+
+    // Return both leg tokens + the session id. The browser token is for the in-app
+    // panel; the bridge token is handed to the local helper (slice 3 wiring).
+    return Response.json({
+      sessionId: tokens.sid,
+      ideaId: tokens.idea,
+      expiresAt: tokens.exp,
+      browserToken: tokens.browser,
+      bridgeToken: tokens.bridge,
+    });
+  } catch (err) {
+    logger.error("Terminal session mint error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return Response.json({ error: "An unexpected error occurred" }, { status: 500 });
+  }
+}

--- a/src/app/download/terminal-helper/route.ts
+++ b/src/app/download/terminal-helper/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+// Stable, public download endpoint for the in-app terminal's macOS helper.
+// The signed + notarized installer is hosted as a GitHub Release asset (public
+// CDN); this route 302-redirects to it so the app can link to a clean, stable
+// path (`/download/terminal-helper`) and we can bump the target per release
+// without touching the UI. Bump the tag/filename below when publishing a new
+// helper build. Apple Silicon (arm64) only for now — Intel/x64 is a follow-up.
+const HELPER_DMG_URL =
+  "https://github.com/vibecodes-org/vibe-coding-ideas/releases/download/terminal-helper-v0.1.0/VibeCodes-0.1.0-arm64.dmg";
+
+export function GET() {
+  return NextResponse.redirect(HELPER_DMG_URL, 302);
+}

--- a/src/components/board/launch-claude-code-button.tsx
+++ b/src/components/board/launch-claude-code-button.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { Terminal, ChevronDown, Copy, FolderCog, FolderPlus, ExternalLink } from "lucide-react";
+import { Terminal, ChevronDown, Copy, FolderCog, FolderPlus, ExternalLink, Globe } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -29,6 +29,8 @@ import {
   DEFAULT_NEW_PROJECT_PARENT,
 } from "@/lib/launch-claude-code";
 import { LaunchPathDialog } from "./launch-path-dialog";
+import { isTerminalEnabled } from "@/lib/terminal/connection";
+import { isBrowserLaunchAvailable, requestBrowserLaunch } from "@/lib/terminal/launch-mode";
 
 const APP_URL =
   process.env.NEXT_PUBLIC_APP_URL?.replace(/\/+$/, "") || "https://vibecodes.co.uk";
@@ -296,6 +298,18 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
     void copyCommand(resolveState());
   }, [resolveState, copyCommand]);
 
+  // The in-browser destination only exists behind the terminal flag. When the flag
+  // is OFF this is false, so the menu collapses to exactly today's single
+  // terminal-window action — the existing behaviour is completely untouched.
+  // Picking "In the browser" asks the board's terminal dock (a page-level sibling)
+  // to open + auto-launch via the vibecodes:// deep link; it does NOT also run the
+  // terminal-window flow — Claude runs in one place at a time.
+  const browserLaunchAvailable = isBrowserLaunchAvailable(isTerminalEnabled());
+  const handleLaunchInBrowser = useCallback(() => {
+    posthog?.capture("launch_claude_code_clicked", { method: "in_browser" });
+    requestBrowserLaunch();
+  }, [posthog]);
+
   const openDialog = useCallback((mode: LaunchMode, launch: boolean) => {
     setPendingLaunch(launch);
     setDialogMode(mode);
@@ -402,10 +416,40 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-72">
-            <DropdownMenuItem onSelect={handleLaunch}>
-              <Terminal className="mr-2 h-4 w-4" />
-              Open in Claude Code
-            </DropdownMenuItem>
+            {browserLaunchAvailable ? (
+              // Pick-one: where should Claude run? "In a terminal window" is today's
+              // unchanged behaviour; "In the browser" opens the docked terminal.
+              <>
+                <DropdownMenuItem onSelect={handleLaunch}>
+                  <Terminal className="mr-2 h-4 w-4" />
+                  <div className="flex flex-col">
+                    <span>In a terminal window</span>
+                    <span className="text-[11px] text-muted-foreground">
+                      On your computer — how it works today
+                    </span>
+                  </div>
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={handleLaunchInBrowser}>
+                  <Globe className="mr-2 h-4 w-4" />
+                  <div className="flex flex-col">
+                    <span className="inline-flex items-center gap-1.5">
+                      In the browser
+                      <span className="rounded bg-sky-500/15 px-1 text-[10px] font-semibold uppercase leading-tight tracking-wide text-sky-400">
+                        Beta
+                      </span>
+                    </span>
+                    <span className="text-[11px] text-muted-foreground">
+                      A live terminal docked on this board
+                    </span>
+                  </div>
+                </DropdownMenuItem>
+              </>
+            ) : (
+              <DropdownMenuItem onSelect={handleLaunch}>
+                <Terminal className="mr-2 h-4 w-4" />
+                Open in Claude Code
+              </DropdownMenuItem>
+            )}
             {effectiveTarget.source !== "none" && effectiveTarget.displayPath && (
               <>
                 <DropdownMenuSeparator />

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -59,8 +59,10 @@ import { buildLaunchDeepLink, redactDeepLinkToken } from "@/lib/terminal/deep-li
 import { subscribeBrowserLaunch } from "@/lib/terminal/launch-mode";
 
 // Where the dock points the user when no helper catches the vibecodes:// link.
-// Slice 7 (packaging) replaces this with the real signed-helper download.
-const HELPER_INSTALL_URL = "/guide";
+// Slice 7 ships the signed, notarized macOS helper (terminal/helper/) whose
+// install lives at this path. HOSTING TODO: publish the notarized .dmg there and
+// have this page link to it (see terminal/helper/BUILD-AND-SIGN.md → "Hosting").
+const HELPER_INSTALL_URL = "/download/terminal-helper";
 // How long to wait for the helper to attach before nudging "install it / Advanced".
 const HELPER_OPEN_TIMEOUT_MS = 6000;
 

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -34,6 +34,8 @@ import {
   Copy,
   Terminal as TerminalIcon,
   RotateCw,
+  Download,
+  ChevronRight,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -53,6 +55,17 @@ import {
   type TerminalConnectionState,
   type TerminalStatus,
 } from "@/lib/terminal/connection";
+import { buildLaunchDeepLink, redactDeepLinkToken } from "@/lib/terminal/deep-link";
+import { subscribeBrowserLaunch } from "@/lib/terminal/launch-mode";
+
+// Where the dock points the user when no helper catches the vibecodes:// link.
+// Slice 7 (packaging) replaces this with the real signed-helper download.
+const HELPER_INSTALL_URL = "/guide";
+// How long to wait for the helper to attach before nudging "install it / Advanced".
+const HELPER_OPEN_TIMEOUT_MS = 6000;
+
+/** Launch UI phase for the same-machine deep-link auto-launch path. */
+type LaunchPhase = "idle" | "opening" | "helper-timeout";
 
 interface TerminalDockProps {
   ideaId: string;
@@ -116,12 +129,17 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
   const [readOnly, setReadOnly] = useState(false);
   const [pair, setPair] = useState<PairInfo | null>(null);
   const [xtermReady, setXtermReady] = useState(false);
+  // Same-machine auto-launch UI (the vibecodes:// deep-link path). "idle" = the
+  // manual cross-machine flow (copy a command); "opening"/"helper-timeout" = we
+  // fired a deep link and are waiting on the local helper.
+  const [launchPhase, setLaunchPhase] = useState<LaunchPhase>("idle");
 
   const wsRef = useRef<WebSocket | null>(null);
   const termRef = useRef<XTerm | null>(null);
   const fitRef = useRef<XFitAddon | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const connectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const helperTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastDimsRef = useRef<string>("");
 
   // Mirror live state into refs so the stable xterm onData handler reads current
@@ -228,6 +246,48 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
     }
   }, []);
 
+  const clearHelperTimer = useCallback(() => {
+    if (helperTimerRef.current) {
+      clearTimeout(helperTimerRef.current);
+      helperTimerRef.current = null;
+    }
+  }, []);
+
+  // Fire the signed vibecodes:// deep link so a same-machine helper attaches as the
+  // bridge leg with no copied command. The bridge token is a secret — it travels in
+  // the link but is NEVER logged (only the redacted form is). The OS routing of the
+  // scheme to the installed helper is slice 7 (packaging); here we just fire it and
+  // fall back to the Advanced manual command if nothing attaches.
+  const fireLaunchDeepLink = useCallback(
+    (sessionId: string, bridgeToken: string) => {
+      let link: string;
+      try {
+        link = buildLaunchDeepLink({ relay: relayBaseUrl(), session: sessionId, token: bridgeToken });
+      } catch (err) {
+        logger.error("Terminal deep-link build failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setLaunchPhase("helper-timeout");
+        return;
+      }
+      logger.info("Terminal firing launch deep link", { sessionId, url: redactDeepLinkToken(link) });
+      setLaunchPhase("opening");
+      try {
+        window.location.assign(link);
+      } catch {
+        // Some browsers throw synchronously on a blocked/unknown custom scheme.
+        setLaunchPhase("helper-timeout");
+        return;
+      }
+      // If the helper doesn't attach within a few seconds, nudge install / Advanced.
+      clearHelperTimer();
+      helperTimerRef.current = setTimeout(() => {
+        setLaunchPhase((p) => (p === "opening" ? "helper-timeout" : p));
+      }, HELPER_OPEN_TIMEOUT_MS);
+    },
+    [clearHelperTimer],
+  );
+
   const teardownSocket = useCallback(() => {
     clearConnectTimer();
     const ws = wsRef.current;
@@ -243,8 +303,14 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
   }, [clearConnectTimer]);
 
   // ── connect (browser leg) ───────────────────────────────────────────────────
-  const connect = useCallback(async () => {
+  // `autoLaunch` = the same-machine path: after minting, fire the vibecodes:// deep
+  // link so the local helper attaches automatically (no copied command). Without it
+  // (manual reconnect), we stay in the cross-machine "copy a command" flow.
+  const connect = useCallback(async (options?: { autoLaunch?: boolean }) => {
+    const autoLaunch = options?.autoLaunch ?? false;
     teardownSocket();
+    clearHelperTimer();
+    setLaunchPhase(autoLaunch ? "opening" : "idle");
     setExpanded(true);
     lastDimsRef.current = "";
     dispatch({ type: "connect" });
@@ -276,6 +342,9 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
     setPair({ sessionId: data.sessionId, bridgeToken: data.bridgeToken });
     termRef.current?.clear();
 
+    // Same-machine: hand the bridge token to the local helper via the deep link.
+    if (autoLaunch) fireLaunchDeepLink(data.sessionId, data.bridgeToken);
+
     const url = buildRelayUrl(relayBaseUrl(), data.sessionId, data.browserToken);
     let ws: WebSocket;
     try {
@@ -303,6 +372,10 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
       // BINARY = opaque PTY bytes → xterm. TEXT = control frame (none expected from
       // the bridge today); ignore so it never reaches the screen as garbage.
       if (typeof ev.data === "string") return;
+      // The helper attached and is streaming — the launch succeeded; drop the
+      // "opening helper / install it" nudge.
+      clearHelperTimer();
+      setLaunchPhase("idle");
       dispatch({ type: "data" });
       termRef.current?.write(new Uint8Array(ev.data as ArrayBuffer));
     };
@@ -315,10 +388,12 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
       wsRef.current = null;
       dispatch({ type: "closed", code: ev.code, reason: ev.reason });
     };
-  }, [ideaId, teardownSocket, clearConnectTimer]);
+  }, [ideaId, teardownSocket, clearConnectTimer, clearHelperTimer, fireLaunchDeepLink]);
 
   const endSession = useCallback(() => {
     dispatch({ type: "user-end" });
+    clearHelperTimer();
+    setLaunchPhase("idle");
     const ws = wsRef.current;
     if (ws) {
       try {
@@ -328,10 +403,22 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
       }
     }
     teardownSocket();
-  }, [teardownSocket]);
+  }, [teardownSocket, clearHelperTimer]);
 
   // Clean up the socket if the dock unmounts mid-session.
   useEffect(() => () => teardownSocket(), [teardownSocket]);
+
+  // Clear the helper-open timer on unmount.
+  useEffect(() => () => clearHelperTimer(), [clearHelperTimer]);
+
+  // The "In the browser" menu item (board toolbar) fires the launch bus; pick it up
+  // here and run the auto-launch (mint → open browser leg → fire deep link). Keeping
+  // the mint in ONE place (the dock) means the session — and its bridge token — is
+  // never created twice.
+  useEffect(() => {
+    if (!enabled) return;
+    return subscribeBrowserLaunch(() => void connect({ autoLaunch: true }));
+  }, [enabled, connect]);
 
   const copyBridgeCommand = useCallback(() => {
     if (!pair) return;
@@ -452,7 +539,8 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
               state={state}
               pair={pair}
               canLaunch={canLaunch}
-              onLaunch={() => void connect()}
+              launchPhase={launchPhase}
+              onLaunch={() => void connect({ autoLaunch: true })}
               onReconnect={() => void connect()}
               onCopyBridge={copyBridgeCommand}
             />
@@ -495,6 +583,7 @@ function StateOverlay({
   state,
   pair,
   canLaunch,
+  launchPhase,
   onLaunch,
   onReconnect,
   onCopyBridge,
@@ -502,6 +591,7 @@ function StateOverlay({
   state: TerminalConnectionState;
   pair: PairInfo | null;
   canLaunch: boolean;
+  launchPhase: LaunchPhase;
   onLaunch: () => void;
   onReconnect: () => void;
   onCopyBridge: () => void;
@@ -533,26 +623,67 @@ function StateOverlay({
 
       {state.status === "waiting-to-pair" && (
         <>
-          <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
-          <div className="text-base font-semibold text-sky-400">Waiting for your machine to attach</div>
-          <p className="max-w-md text-[13px] text-zinc-400">
-            The relay is up. Start a bridge on your computer for this session to go live.
-          </p>
-          {pair && (
-            <div className="flex flex-col items-center gap-1.5">
-              <code className="rounded-md border border-dashed border-zinc-700 bg-[#0a0a0b] px-3 py-1.5 font-mono text-sm tracking-wide text-sky-300">
-                session {pair.sessionId.slice(0, 8)}
-              </code>
-              <Button
-                variant="outline"
-                size="xs"
-                className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
-                onClick={onCopyBridge}
+          {launchPhase === "opening" && (
+            <>
+              <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
+              <div className="text-base font-semibold text-sky-400">Opening the VibeCodes helper…</div>
+              <p className="max-w-md text-[13px] text-zinc-400">
+                Your computer may ask to open VibeCodes — click <b className="text-zinc-200">Open</b>. The helper
+                starts Claude Code and attaches here automatically.
+              </p>
+            </>
+          )}
+
+          {launchPhase === "helper-timeout" && (
+            <>
+              <Download className="h-7 w-7 text-sky-400" />
+              <div className="text-base font-semibold text-sky-200">Don&apos;t have the helper?</div>
+              <p className="max-w-md text-[13px] text-zinc-400">
+                Nothing opened. Install the small VibeCodes helper once, then launch again — or pair another
+                machine by hand under Advanced.
+              </p>
+              <a
+                href={HELPER_INSTALL_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-md bg-sky-500 px-3 py-1.5 text-sm font-semibold text-sky-950 hover:bg-sky-400"
               >
-                <Copy className="h-3 w-3" /> Copy bridge command
-              </Button>
-              <span className="text-[11px] text-zinc-600">Single-use · expires ~5 min · bound to your account</span>
-            </div>
+                <Download className="h-4 w-4" /> Install the helper
+              </a>
+            </>
+          )}
+
+          {launchPhase === "idle" && (
+            <>
+              <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
+              <div className="text-base font-semibold text-sky-400">Waiting for your machine to attach</div>
+              <p className="max-w-md text-[13px] text-zinc-400">
+                The relay is up. Start a bridge on your computer for this session to go live.
+              </p>
+            </>
+          )}
+
+          {/* Advanced ▾ — cross-machine fallback: copy the manual bridge command. */}
+          {pair && (
+            <details className="mt-1 w-full max-w-md text-left">
+              <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-[12px] text-zinc-500 hover:text-zinc-300 [&::-webkit-details-marker]:hidden">
+                <ChevronRight className="h-3 w-3" /> Advanced — pair a remote machine by hand
+              </summary>
+              <div className="mt-2 flex flex-col items-start gap-1.5 rounded-md border border-zinc-800 bg-[#0a0a0b] px-3 py-2.5">
+                <code className="font-mono text-xs tracking-wide text-sky-300">
+                  session {pair.sessionId.slice(0, 8)}
+                </code>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+                  onClick={onCopyBridge}
+                >
+                  <Copy className="h-3 w-3" /> Copy bridge command
+                </Button>
+                <span className="text-[11px] text-zinc-600">Single-use · expires ~5 min · bound to your account</span>
+              </div>
+            </details>
           )}
         </>
       )}

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1,0 +1,650 @@
+"use client";
+
+// In-app local Claude Code terminal — the board bottom dock (SLICE 3, browser leg).
+//
+// Renders the collapsible VS Code-style terminal dock from the approved design
+// (docs/in-app-terminal-design.html) and wires it to the opaque Cloudflare relay
+// as the `browser` leg:
+//
+//   POST /api/terminal/session  →  { sessionId, browserToken, bridgeToken }
+//   WebSocket  <relay>/?session&role=browser&token  →  xterm.js
+//
+// The connection STATE MACHINE + close-code mapping + framing are pure and live in
+// src/lib/terminal/connection.ts (unit-tested); this component owns only the side
+// effects (fetch, socket, xterm, timers) and renders the six visible states.
+//
+// GATING: off by default. Renders nothing unless NEXT_PUBLIC_TERMINAL_ENABLED is
+// exactly "true" (checked here AND at the board page mount). xterm is imported
+// dynamically (client-only) so there is no SSR / window access at module load.
+
+import "@xterm/xterm/css/xterm.css";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import {
+  ChevronUp,
+  ChevronDown,
+  Circle,
+  CircleDot,
+  Loader2,
+  WifiOff,
+  Square,
+  CircleAlert,
+  Power,
+  Lock,
+  LockOpen,
+  Copy,
+  Terminal as TerminalIcon,
+  RotateCw,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { logger } from "@/lib/logger";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import type { FitAddon as XFitAddon } from "@xterm/addon-fit";
+import {
+  CONNECT_TIMEOUT_MS,
+  buildRelayUrl,
+  encodeResizeMessage,
+  initialConnectionState,
+  isInputEnabled,
+  isTerminalEnabled,
+  relayBaseUrl,
+  terminalReducer,
+  type TerminalConnectionState,
+  type TerminalStatus,
+} from "@/lib/terminal/connection";
+
+interface TerminalDockProps {
+  ideaId: string;
+  ideaTitle: string;
+}
+
+interface PairInfo {
+  sessionId: string;
+  bridgeToken: string;
+}
+
+interface StatusMeta {
+  label: string;
+  Icon: typeof Circle;
+  spin?: boolean;
+  className: string;
+}
+
+// Header pill — icon + text + colour (never colour alone), one per status.
+function statusMeta(state: TerminalConnectionState): StatusMeta {
+  switch (state.status) {
+    case "connected":
+      return { label: "Connected", Icon: CircleDot, className: "border-emerald-500/50 bg-emerald-500/10 text-emerald-400" };
+    case "connecting":
+      return { label: "Connecting…", Icon: Loader2, spin: true, className: "border-amber-500/50 bg-amber-500/10 text-amber-400" };
+    case "waiting-to-pair":
+      return { label: "Waiting to pair", Icon: Loader2, spin: true, className: "border-sky-500/50 bg-sky-500/10 text-sky-400" };
+    case "disconnected":
+      return { label: "Reconnecting…", Icon: WifiOff, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
+    case "session-ended":
+      return { label: "Session ended", Icon: Square, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
+    case "error":
+      return { label: state.errorKind === "owner-mismatch" ? "Owner mismatch" : "Error", Icon: CircleAlert, className: "border-rose-500/55 bg-rose-500/10 text-rose-400" };
+    default:
+      return { label: "Terminal · off", Icon: Circle, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
+  }
+}
+
+// A small dot for the collapsed bar that echoes the live state at a glance.
+function dotClass(status: TerminalStatus): string {
+  switch (status) {
+    case "connected":
+      return "text-emerald-400";
+    case "connecting":
+    case "waiting-to-pair":
+      return "text-amber-400";
+    case "error":
+      return "text-rose-400";
+    default:
+      return "text-zinc-500";
+  }
+}
+
+export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
+  // Defence-in-depth: also gated at the page mount. When off, render nothing —
+  // no dock, no entry point, board unchanged.
+  const enabled = isTerminalEnabled();
+
+  const [state, dispatch] = useReducer(terminalReducer, initialConnectionState);
+  const [expanded, setExpanded] = useState(false);
+  const [readOnly, setReadOnly] = useState(false);
+  const [pair, setPair] = useState<PairInfo | null>(null);
+  const [xtermReady, setXtermReady] = useState(false);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const termRef = useRef<XTerm | null>(null);
+  const fitRef = useRef<XFitAddon | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const connectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastDimsRef = useRef<string>("");
+
+  // Mirror live state into refs so the stable xterm onData handler reads current
+  // values without re-binding on every render.
+  const statusRef = useRef(state.status);
+  const readOnlyRef = useRef(readOnly);
+  statusRef.current = state.status;
+  readOnlyRef.current = readOnly;
+
+  // ── lazy, client-only xterm init ────────────────────────────────────────────
+  useEffect(() => {
+    if (!enabled) return;
+    let disposed = false;
+    let term: XTerm | null = null;
+
+    (async () => {
+      const [{ Terminal }, { FitAddon }] = await Promise.all([
+        import("@xterm/xterm"),
+        import("@xterm/addon-fit"),
+      ]);
+      if (disposed || !containerRef.current) return;
+
+      term = new Terminal({
+        convertEol: false,
+        cursorBlink: true,
+        fontFamily: 'ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace',
+        fontSize: 12.5,
+        theme: { background: "#0c0c0e", foreground: "#cfd8df", cursor: "#cfd8df" },
+        scrollback: 5000,
+      });
+      const fit = new FitAddon();
+      term.loadAddon(fit);
+      term.open(containerRef.current);
+      try {
+        fit.fit();
+      } catch {
+        /* container may be 0-size while collapsed — refit on expand */
+      }
+
+      // Keystrokes → relay (binary). Guarded by the pure input-enabled predicate so
+      // read-only / non-connected states never reach the PTY.
+      term.onData((data) => {
+        if (statusRef.current !== "connected" || readOnlyRef.current) return;
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(new TextEncoder().encode(data));
+        }
+      });
+
+      termRef.current = term;
+      fitRef.current = fit;
+      setXtermReady(true);
+    })().catch((err) => {
+      logger.error("Terminal xterm init failed", { error: err instanceof Error ? err.message : String(err) });
+    });
+
+    return () => {
+      disposed = true;
+      term?.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+    };
+  }, [enabled]);
+
+  // Fit + emit a resize control frame (TEXT) matching the bridge's framing.
+  const sendResize = useCallback(() => {
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit) return;
+    try {
+      fit.fit();
+    } catch {
+      return;
+    }
+    const msg = encodeResizeMessage(term.cols, term.rows);
+    if (!msg) return;
+    const key = `${term.cols}x${term.rows}`;
+    if (key === lastDimsRef.current) return;
+    lastDimsRef.current = key;
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) ws.send(msg);
+  }, []);
+
+  // Refit on container resize and whenever the dock expands.
+  useEffect(() => {
+    if (!xtermReady || !containerRef.current) return;
+    const ro = new ResizeObserver(() => sendResize());
+    ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, [xtermReady, sendResize]);
+
+  useEffect(() => {
+    if (expanded) {
+      // Next paint, once the body has non-zero size.
+      const id = window.requestAnimationFrame(() => sendResize());
+      return () => window.cancelAnimationFrame(id);
+    }
+  }, [expanded, sendResize]);
+
+  const clearConnectTimer = useCallback(() => {
+    if (connectTimerRef.current) {
+      clearTimeout(connectTimerRef.current);
+      connectTimerRef.current = null;
+    }
+  }, []);
+
+  const teardownSocket = useCallback(() => {
+    clearConnectTimer();
+    const ws = wsRef.current;
+    wsRef.current = null;
+    if (ws) {
+      ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+    }
+  }, [clearConnectTimer]);
+
+  // ── connect (browser leg) ───────────────────────────────────────────────────
+  const connect = useCallback(async () => {
+    teardownSocket();
+    setExpanded(true);
+    lastDimsRef.current = "";
+    dispatch({ type: "connect" });
+
+    let data: { sessionId: string; browserToken: string; bridgeToken: string };
+    try {
+      const res = await fetch("/api/terminal/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ideaId }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error || `Session request failed (${res.status})`);
+      }
+      data = await res.json();
+    } catch (err) {
+      logger.error("Terminal session mint failed (client)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      dispatch({ type: "session-mint-failed" });
+      toast.error("Couldn't start a terminal session", {
+        description: err instanceof Error ? err.message : undefined,
+      });
+      return;
+    }
+
+    dispatch({ type: "session-created", sessionId: data.sessionId });
+    setPair({ sessionId: data.sessionId, bridgeToken: data.bridgeToken });
+    termRef.current?.clear();
+
+    const url = buildRelayUrl(relayBaseUrl(), data.sessionId, data.browserToken);
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+    } catch (err) {
+      logger.error("Terminal relay socket open failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      dispatch({ type: "closed", code: 1006 });
+      return;
+    }
+    ws.binaryType = "arraybuffer";
+    wsRef.current = ws;
+
+    connectTimerRef.current = setTimeout(() => {
+      dispatch({ type: "connect-timeout" });
+      teardownSocket();
+    }, CONNECT_TIMEOUT_MS);
+
+    ws.onopen = () => {
+      clearConnectTimer();
+      dispatch({ type: "relay-open" });
+    };
+    ws.onmessage = (ev) => {
+      // BINARY = opaque PTY bytes → xterm. TEXT = control frame (none expected from
+      // the bridge today); ignore so it never reaches the screen as garbage.
+      if (typeof ev.data === "string") return;
+      dispatch({ type: "data" });
+      termRef.current?.write(new Uint8Array(ev.data as ArrayBuffer));
+    };
+    ws.onerror = () => {
+      // A 'close' with the real code follows; just log metadata here.
+      logger.warn("Terminal relay socket error", { sessionId: data.sessionId });
+    };
+    ws.onclose = (ev) => {
+      clearConnectTimer();
+      wsRef.current = null;
+      dispatch({ type: "closed", code: ev.code, reason: ev.reason });
+    };
+  }, [ideaId, teardownSocket, clearConnectTimer]);
+
+  const endSession = useCallback(() => {
+    dispatch({ type: "user-end" });
+    const ws = wsRef.current;
+    if (ws) {
+      try {
+        ws.close(1000, "user-end");
+      } catch {
+        /* already closing */
+      }
+    }
+    teardownSocket();
+  }, [teardownSocket]);
+
+  // Clean up the socket if the dock unmounts mid-session.
+  useEffect(() => () => teardownSocket(), [teardownSocket]);
+
+  const copyBridgeCommand = useCallback(() => {
+    if (!pair) return;
+    const cmd = `RELAY_URL=${relayBaseUrl()} SESSION_ID=${pair.sessionId} BRIDGE_TOKEN=${pair.bridgeToken} node terminal/bridge/src/index.js --cmd bash`;
+    navigator.clipboard
+      .writeText(cmd)
+      .then(() => toast.success("Bridge command copied"))
+      .catch(() => toast.error("Couldn't copy the command"));
+  }, [pair]);
+
+  if (!enabled) return null;
+
+  const meta = statusMeta(state);
+  const inputEnabled = isInputEnabled(state, readOnly);
+  const showStream = state.status === "connected" || state.status === "disconnected";
+  const canLaunch =
+    state.status === "idle" ||
+    state.status === "error" ||
+    state.status === "session-ended" ||
+    state.status === "disconnected";
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-zinc-700 bg-[#141417] text-zinc-200 shadow-[0_-8px_30px_rgba(0,0,0,0.4)]">
+      {/* Collapsed dock bar — always visible */}
+      <div className="flex items-center gap-2.5 px-3 py-1.5">
+        <span className="inline-flex items-center gap-2 text-xs font-semibold">
+          <Circle className={cn("h-2.5 w-2.5 fill-current", dotClass(state.status))} />
+          <TerminalIcon className="h-3.5 w-3.5 text-zinc-400" />
+          <span className="hidden sm:inline">Terminal</span>
+          {pair && (
+            <span className="hidden font-mono text-[11px] font-normal text-zinc-500 md:inline">
+              · session {pair.sessionId.slice(0, 8)}
+            </span>
+          )}
+        </span>
+        <span className="ml-auto inline-flex items-center" />
+        <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-semibold", meta.className)}>
+          <meta.Icon className={cn("h-3 w-3", meta.spin && "animate-spin")} />
+          {meta.label}
+        </span>
+        <Button
+          variant="ghost"
+          size="xs"
+          className="text-zinc-300 hover:text-zinc-100"
+          onClick={() => setExpanded((e) => !e)}
+          aria-label={expanded ? "Collapse terminal panel" : "Expand terminal panel"}
+          aria-expanded={expanded}
+        >
+          {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronUp className="h-3.5 w-3.5" />}
+          <span className="hidden sm:inline">{expanded ? "Collapse" : "Expand"}</span>
+        </Button>
+      </div>
+
+      {/* Expanded body — kept mounted (hidden when collapsed) so the xterm instance
+          and its scrollback survive collapse/expand and live bytes are never lost. */}
+      <div className={cn("border-t border-zinc-800 bg-[#0c0c0e]", !expanded && "hidden")}>
+        {/* Header: state · identity · controls (safest → most destructive) */}
+        <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 bg-[#141417] px-3 py-2">
+          <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold", meta.className)}>
+            <meta.Icon className={cn("h-3 w-3", meta.spin && "animate-spin")} />
+            {meta.label}
+          </span>
+          {readOnly && state.status === "connected" && (
+            <span className="inline-flex items-center gap-1.5 rounded-md border border-violet-500/55 bg-violet-500/10 px-2 py-1 text-[11px] font-bold text-violet-300">
+              <Lock className="h-3 w-3" /> Read-only
+            </span>
+          )}
+          <span className="hidden font-mono text-xs text-zinc-500 sm:inline">
+            {ideaTitle}
+            {pair && <span className="text-zinc-600"> · session {pair.sessionId.slice(0, 8)}</span>}
+          </span>
+          <span className="ml-auto inline-flex items-center gap-1.5">
+            {showStream && (
+              <Button
+                variant="outline"
+                size="xs"
+                className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+                onClick={() => setReadOnly((r) => !r)}
+                aria-pressed={readOnly}
+                aria-label={readOnly ? "Read-only is on — click to allow input" : "Switch to read-only"}
+              >
+                {readOnly ? <Lock className="h-3 w-3" /> : <LockOpen className="h-3 w-3" />}
+                {readOnly ? "Read-only · on" : "Read-only"}
+              </Button>
+            )}
+            {(showStream || state.status === "connecting" || state.status === "waiting-to-pair") && (
+              <Button
+                variant="outline"
+                size="xs"
+                className="border-rose-500/45 bg-transparent text-rose-400 hover:bg-rose-500/10"
+                onClick={endSession}
+                aria-label="End session"
+              >
+                <Power className="h-3 w-3" /> End
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="text-zinc-300 hover:text-zinc-100"
+              onClick={() => setExpanded(false)}
+              aria-label="Collapse terminal panel"
+            >
+              <ChevronDown className="h-3.5 w-3.5" />
+            </Button>
+          </span>
+        </div>
+
+        {/* Terminal body — the xterm host plus a state overlay. The host stays
+            mounted under every state so scrollback is frozen + readable on end. */}
+        <div className="relative h-[38vh] min-h-[220px]">
+          <div
+            ref={containerRef}
+            className={cn("h-full w-full px-3 py-2", state.status === "disconnected" && "opacity-45")}
+          />
+          {!showStream && (
+            <StateOverlay
+              state={state}
+              pair={pair}
+              canLaunch={canLaunch}
+              onLaunch={() => void connect()}
+              onReconnect={() => void connect()}
+              onCopyBridge={copyBridgeCommand}
+            />
+          )}
+          {state.status === "disconnected" && (
+            <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
+              <WifiOff className="mr-1 inline h-3 w-3" />
+              <b>Lost the connection.</b> Your machine may have slept or dropped Wi-Fi. The agent keeps running locally.
+              <button className="ml-2 underline hover:text-amber-200" onClick={() => void connect()}>
+                Reconnect now
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Input affordance — read-write bar, or the read-only explanatory note. */}
+        {state.status === "connected" && (
+          inputEnabled ? (
+            <div className="flex items-center gap-2 border-t border-zinc-800 bg-[#141417] px-3 py-2 text-xs text-zinc-500">
+              <span className="font-mono text-emerald-400">›</span>
+              <span>Click the terminal and type to steer the agent. Enter sends.</span>
+            </div>
+          ) : (
+            <div className="border-t border-zinc-800 bg-violet-500/5 px-3 py-2 text-[11px] text-zinc-400">
+              <Lock className="mr-1 inline h-3 w-3 text-violet-300" />
+              <b className="text-violet-300">Read-only is on.</b> You&apos;re watching live; keystrokes are frozen.
+              <button className="ml-2 underline hover:text-zinc-200" onClick={() => setReadOnly(false)}>
+                Allow input
+              </button>
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── per-state centred overlays (icon + text + next step) ──────────────────────
+function StateOverlay({
+  state,
+  pair,
+  canLaunch,
+  onLaunch,
+  onReconnect,
+  onCopyBridge,
+}: {
+  state: TerminalConnectionState;
+  pair: PairInfo | null;
+  canLaunch: boolean;
+  onLaunch: () => void;
+  onReconnect: () => void;
+  onCopyBridge: () => void;
+}) {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-[#0c0c0e]/95 px-6 text-center">
+      {state.status === "idle" && (
+        <>
+          <TerminalIcon className="h-7 w-7 text-emerald-400" />
+          <div className="text-base font-semibold text-emerald-400">Ready when you are</div>
+          <p className="max-w-md text-[13px] text-zinc-400">
+            Start Claude Code on your machine and mirror it here. Your code stays on your computer — we only relay the screen.
+          </p>
+          <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onLaunch}>
+            <TerminalIcon className="h-4 w-4" /> Launch in browser
+          </Button>
+        </>
+      )}
+
+      {state.status === "connecting" && (
+        <>
+          <Loader2 className="h-7 w-7 animate-spin text-amber-400" />
+          <div className="text-base font-semibold text-amber-400">Starting your session…</div>
+          <p className="max-w-md text-[13px] text-zinc-400">
+            Opening the encrypted relay — usually instant. <span className="text-zinc-600">(waiting up to 30s)</span>
+          </p>
+        </>
+      )}
+
+      {state.status === "waiting-to-pair" && (
+        <>
+          <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
+          <div className="text-base font-semibold text-sky-400">Waiting for your machine to attach</div>
+          <p className="max-w-md text-[13px] text-zinc-400">
+            The relay is up. Start a bridge on your computer for this session to go live.
+          </p>
+          {pair && (
+            <div className="flex flex-col items-center gap-1.5">
+              <code className="rounded-md border border-dashed border-zinc-700 bg-[#0a0a0b] px-3 py-1.5 font-mono text-sm tracking-wide text-sky-300">
+                session {pair.sessionId.slice(0, 8)}
+              </code>
+              <Button
+                variant="outline"
+                size="xs"
+                className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+                onClick={onCopyBridge}
+              >
+                <Copy className="h-3 w-3" /> Copy bridge command
+              </Button>
+              <span className="text-[11px] text-zinc-600">Single-use · expires ~5 min · bound to your account</span>
+            </div>
+          )}
+        </>
+      )}
+
+      {state.status === "session-ended" && (
+        <>
+          <Square className="h-7 w-7 text-zinc-400" />
+          <div className="text-base font-semibold text-zinc-300">{endedTitle(state)}</div>
+          <p className="max-w-md text-[13px] text-zinc-400">{endedMessage(state)}</p>
+          <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onLaunch}>
+            <TerminalIcon className="h-4 w-4" /> Launch again
+          </Button>
+        </>
+      )}
+
+      {state.status === "error" && (
+        <>
+          <CircleAlert className="h-7 w-7 text-rose-400" />
+          <div className="text-base font-semibold text-rose-400">{errorTitle(state)}</div>
+          <p className="max-w-md text-[13px] text-zinc-400">{errorMessage(state)}</p>
+          {canLaunch && state.errorKind !== "owner-mismatch" && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+              onClick={onReconnect}
+            >
+              <RotateCw className="h-3.5 w-3.5" /> Try again
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function endedTitle(state: TerminalConnectionState): string {
+  switch (state.endedReason) {
+    case "user":
+      return "You ended the session";
+    case "idle":
+      return "Ended after being idle";
+    case "max-duration":
+      return "Reached the session time limit";
+    default:
+      return "Session ended";
+  }
+}
+
+function endedMessage(state: TerminalConnectionState): string {
+  switch (state.endedReason) {
+    case "idle":
+    case "max-duration":
+      return "We closed the session to keep things tidy and safe. Nothing went wrong — your work on your machine is untouched.";
+    default:
+      return "Claude Code on your machine stopped. The scrollback above is kept.";
+  }
+}
+
+function errorTitle(state: TerminalConnectionState): string {
+  switch (state.errorKind) {
+    case "owner-mismatch":
+      return "This bridge belongs to another account";
+    case "bad-token":
+      return "Couldn't verify this session";
+    case "duplicate":
+      return "This session is already open elsewhere";
+    case "connect-timeout":
+    case "relay-unreachable":
+      return "Couldn't reach the relay";
+    case "session-mint-failed":
+      return "Couldn't start a session";
+    default:
+      return "Something went wrong";
+  }
+}
+
+function errorMessage(state: TerminalConnectionState): string {
+  switch (state.errorKind) {
+    case "owner-mismatch":
+      return "For safety, a bridge only attaches to the person who launched it. Start your own bridge, or sign in as the owning account.";
+    case "bad-token":
+      return "The session token was invalid or expired. Launch again to mint a fresh one.";
+    case "duplicate":
+      return "Another browser tab is already attached to this session. Close it, then launch again.";
+    case "connect-timeout":
+      return "We waited 30s but nothing connected. Is a bridge running and allowed to open?";
+    case "relay-unreachable":
+      return "The terminal relay didn't respond. Check it's running, then try again.";
+    case "session-mint-failed":
+      return "The session request failed. Check your connection and try again.";
+    default:
+      return "The terminal session failed. Try launching again.";
+  }
+}

--- a/src/lib/terminal/connection.test.ts
+++ b/src/lib/terminal/connection.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import {
+  RELAY_CLOSE,
+  initialConnectionState,
+  terminalReducer,
+  mapCloseCode,
+  isInputEnabled,
+  buildRelayUrl,
+  encodeResizeMessage,
+  type TerminalConnectionState,
+  type TerminalEvent,
+} from "./connection";
+
+// Helper: fold a sequence of events through the reducer from the initial state.
+function run(events: TerminalEvent[], start = initialConnectionState): TerminalConnectionState {
+  return events.reduce(terminalReducer, start);
+}
+
+describe("terminalReducer — happy path", () => {
+  it("starts idle", () => {
+    expect(initialConnectionState.status).toBe("idle");
+  });
+
+  it("connect → session-created → relay-open → data reaches connected", () => {
+    const s = run([
+      { type: "connect" },
+      { type: "session-created", sessionId: "a3f9" },
+      { type: "relay-open" },
+      { type: "data" },
+    ]);
+    expect(s.status).toBe("connected");
+    expect(s.sessionId).toBe("a3f9");
+    expect(s.errorKind).toBeNull();
+  });
+
+  it("relay-open before any bridge bytes is waiting-to-pair", () => {
+    const s = run([{ type: "connect" }, { type: "relay-open" }]);
+    expect(s.status).toBe("waiting-to-pair");
+  });
+
+  it("connect resets prior error/ended metadata", () => {
+    const errored = run([{ type: "connect" }, { type: "connect-timeout" }]);
+    expect(errored.status).toBe("error");
+    const reconnected = terminalReducer(errored, { type: "connect" });
+    expect(reconnected.status).toBe("connecting");
+    expect(reconnected.errorKind).toBeNull();
+    expect(reconnected.sessionId).toBeNull();
+  });
+});
+
+describe("terminalReducer — guards", () => {
+  it("session-created is ignored unless connecting", () => {
+    const connected = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+    const after = terminalReducer(connected, { type: "session-created", sessionId: "late" });
+    expect(after.sessionId).toBeNull();
+  });
+
+  it("relay-open is ignored unless connecting", () => {
+    const connected = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+    const after = terminalReducer(connected, { type: "relay-open" });
+    expect(after.status).toBe("connected");
+  });
+
+  it("data while connected is a no-op (same state)", () => {
+    const connected = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+    expect(terminalReducer(connected, { type: "data" })).toBe(connected);
+  });
+
+  it("connect-timeout after connected is ignored", () => {
+    const connected = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+    const after = terminalReducer(connected, { type: "connect-timeout" });
+    expect(after.status).toBe("connected");
+  });
+
+  it("connect-timeout during handshake → error", () => {
+    const s = run([{ type: "connect" }, { type: "relay-open" }, { type: "connect-timeout" }]);
+    expect(s.status).toBe("error");
+    expect(s.errorKind).toBe("connect-timeout");
+  });
+});
+
+describe("terminalReducer — ending & failures", () => {
+  it("user-end → session-ended with reason user", () => {
+    const s = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }, { type: "user-end" }]);
+    expect(s.status).toBe("session-ended");
+    expect(s.endedReason).toBe("user");
+  });
+
+  it("a close event after a user-end does not clobber session-ended", () => {
+    const ended = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }, { type: "user-end" }]);
+    const after = terminalReducer(ended, { type: "closed", code: 1000 });
+    expect(after.status).toBe("session-ended");
+    expect(after.endedReason).toBe("user");
+    expect(after.closeCode).toBe(1000);
+  });
+
+  it("session-mint-failed → error", () => {
+    const s = run([{ type: "connect" }, { type: "session-mint-failed" }]);
+    expect(s.status).toBe("error");
+    expect(s.errorKind).toBe("session-mint-failed");
+  });
+
+  it("reset returns to a fresh idle state", () => {
+    const s = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }, { type: "reset" }]);
+    expect(s).toEqual(initialConnectionState);
+  });
+});
+
+describe("mapCloseCode", () => {
+  it("4005 → owner-mismatch error", () => {
+    expect(mapCloseCode(RELAY_CLOSE.OWNER_MISMATCH, undefined, "waiting-to-pair")).toEqual({
+      status: "error",
+      errorKind: "owner-mismatch",
+      endedReason: null,
+    });
+  });
+
+  it("4006 → bad-token error", () => {
+    expect(mapCloseCode(RELAY_CLOSE.BAD_TOKEN, undefined, "connecting").errorKind).toBe("bad-token");
+  });
+
+  it("4001 / 4002 → duplicate error", () => {
+    expect(mapCloseCode(RELAY_CLOSE.DUP_BROWSER, undefined, "connected").errorKind).toBe("duplicate");
+    expect(mapCloseCode(RELAY_CLOSE.DUP_BRIDGE, undefined, "connected").errorKind).toBe("duplicate");
+  });
+
+  it("4004 peer-gone → disconnected (recoverable)", () => {
+    expect(mapCloseCode(RELAY_CLOSE.PEER_GONE, undefined, "connected").status).toBe("disconnected");
+  });
+
+  it("1000 → session-ended; reason text classifies idle / max-duration", () => {
+    expect(mapCloseCode(1000, undefined, "connected").endedReason).toBe("remote");
+    expect(mapCloseCode(1000, "idle timeout", "connected").endedReason).toBe("idle");
+    expect(mapCloseCode(1000, "max-duration", "connected").endedReason).toBe("max-duration");
+  });
+
+  it("abnormal close depends on prior status", () => {
+    // Never reached the machine while handshaking → error.
+    expect(mapCloseCode(1006, undefined, "connecting").errorKind).toBe("relay-unreachable");
+    // Dropped after a live stream → recoverable disconnect.
+    expect(mapCloseCode(1006, undefined, "connected").status).toBe("disconnected");
+  });
+
+  it("closed event flows through the reducer with the mapped state + closeCode", () => {
+    const live = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+    const owner = terminalReducer(live, { type: "closed", code: RELAY_CLOSE.OWNER_MISMATCH });
+    expect(owner.status).toBe("error");
+    expect(owner.errorKind).toBe("owner-mismatch");
+    expect(owner.closeCode).toBe(RELAY_CLOSE.OWNER_MISMATCH);
+  });
+});
+
+describe("isInputEnabled", () => {
+  const connected: TerminalConnectionState = run([
+    { type: "connect" },
+    { type: "relay-open" },
+    { type: "data" },
+  ]);
+
+  it("true only when connected and not read-only", () => {
+    expect(isInputEnabled(connected, false)).toBe(true);
+    expect(isInputEnabled(connected, true)).toBe(false);
+  });
+
+  it("false in every non-connected state", () => {
+    expect(isInputEnabled(initialConnectionState, false)).toBe(false);
+    const waiting = run([{ type: "connect" }, { type: "relay-open" }]);
+    expect(isInputEnabled(waiting, false)).toBe(false);
+  });
+});
+
+describe("buildRelayUrl", () => {
+  it("builds the browser-leg attach URL and trims trailing slashes", () => {
+    expect(buildRelayUrl("ws://127.0.0.1:8787/", "a3f9", "tok.sig")).toBe(
+      "ws://127.0.0.1:8787/?session=a3f9&role=browser&token=tok.sig",
+    );
+  });
+
+  it("URL-encodes the session id and token", () => {
+    const url = buildRelayUrl("wss://relay.example", "s/i d", "a+b/c=");
+    expect(url).toContain("session=s%2Fi%20d");
+    expect(url).toContain("token=a%2Bb%2Fc%3D");
+    expect(url).toContain("role=browser");
+  });
+});
+
+describe("encodeResizeMessage", () => {
+  it("produces the bridge's resize control frame", () => {
+    expect(encodeResizeMessage(120, 30)).toBe('{"type":"resize","cols":120,"rows":30}');
+  });
+
+  it("rejects non-sane dimensions", () => {
+    expect(encodeResizeMessage(0, 30)).toBeNull();
+    expect(encodeResizeMessage(120, -1)).toBeNull();
+    expect(encodeResizeMessage(1.5, 30)).toBeNull();
+    expect(encodeResizeMessage(120, 99999)).toBeNull();
+  });
+});

--- a/src/lib/terminal/connection.test.ts
+++ b/src/lib/terminal/connection.test.ts
@@ -134,6 +134,19 @@ describe("mapCloseCode", () => {
     expect(mapCloseCode(1000, "max-duration", "connected").endedReason).toBe("max-duration");
   });
 
+  // Lock-step with terminal/relay/src/pairing.js → idleCloseReason / maxCloseReason
+  // (and the Node stand-in). These are the EXACT default strings the relay emits on
+  // a lifecycle close; if those builders change, this must move with them.
+  it("classifies the relay's actual lifecycle close reasons (slice 6)", () => {
+    const idle = mapCloseCode(1000, "idle-timeout: ended after 30 min idle", "connected");
+    expect(idle.status).toBe("session-ended");
+    expect(idle.endedReason).toBe("idle");
+
+    const max = mapCloseCode(1000, "max-duration: session reached its 4 hour limit", "connected");
+    expect(max.status).toBe("session-ended");
+    expect(max.endedReason).toBe("max-duration");
+  });
+
   it("abnormal close depends on prior status", () => {
     // Never reached the machine while handshaking → error.
     expect(mapCloseCode(1006, undefined, "connecting").errorKind).toBe("relay-unreachable");

--- a/src/lib/terminal/connection.ts
+++ b/src/lib/terminal/connection.ts
@@ -1,0 +1,233 @@
+// In-app terminal — pure connection logic (SLICE 3, browser leg).
+//
+// The browser-side terminal dock attaches to the opaque Cloudflare relay as the
+// `browser` leg and mirrors the bridge's PTY. This module holds the LOAD-BEARING,
+// side-effect-free pieces so they can be unit-tested in isolation:
+//
+//   - the connection STATE MACHINE (reducer over a small event set),
+//   - the relay close-code → state MAPPING (incl. the owner-mismatch / bad-token
+//     cases from relay codes 4005 / 4006 / 4001),
+//   - the relay attach URL builder + the resize control-frame framing (which must
+//     match the bridge's framing in terminal/bridge/src/framing.js),
+//   - the feature flag + relay base-url readers.
+//
+// xterm DOM rendering lives in the component; everything here is testable without
+// a DOM, a socket, or React.
+
+/** How long we wait for the relay handshake before declaring an error (≈30s). */
+export const CONNECT_TIMEOUT_MS = 30_000;
+
+/** Default dev relay (overridable via NEXT_PUBLIC_TERMINAL_RELAY_URL). */
+export const DEFAULT_RELAY_URL = "ws://127.0.0.1:8787";
+
+// Relay close codes (application-private range). These MUST stay in sync with
+// terminal/relay/src/pairing.js → CLOSE. Duplicated (not imported) because the
+// relay module is plain .mjs outside the app's TS build graph; the test pins the
+// values so a drift is caught.
+export const RELAY_CLOSE = Object.freeze({
+  DUP_BROWSER: 4001,
+  DUP_BRIDGE: 4002,
+  PEER_GONE: 4004,
+  OWNER_MISMATCH: 4005,
+  BAD_TOKEN: 4006,
+});
+
+export type TerminalStatus =
+  | "idle"
+  | "connecting"
+  | "waiting-to-pair"
+  | "connected"
+  | "disconnected"
+  | "session-ended"
+  | "error";
+
+export type TerminalErrorKind =
+  | "owner-mismatch"
+  | "bad-token"
+  | "duplicate"
+  | "connect-timeout"
+  | "relay-unreachable"
+  | "session-mint-failed"
+  | "unknown";
+
+export type EndedReason = "user" | "remote" | "idle" | "max-duration";
+
+export interface TerminalConnectionState {
+  status: TerminalStatus;
+  sessionId: string | null;
+  errorKind: TerminalErrorKind | null;
+  endedReason: EndedReason | null;
+  /** The WebSocket close code that produced the current state (when applicable). */
+  closeCode: number | null;
+}
+
+export type TerminalEvent =
+  | { type: "connect" }
+  | { type: "session-created"; sessionId: string }
+  | { type: "session-mint-failed" }
+  | { type: "relay-open" }
+  | { type: "data" }
+  | { type: "user-end" }
+  | { type: "connect-timeout" }
+  | { type: "closed"; code: number; reason?: string }
+  | { type: "reset" };
+
+export const initialConnectionState: TerminalConnectionState = {
+  status: "idle",
+  sessionId: null,
+  errorKind: null,
+  endedReason: null,
+  closeCode: null,
+};
+
+/** A status that means "we are mid-handshake, no bridge stream yet". */
+function isHandshaking(status: TerminalStatus): boolean {
+  return status === "connecting" || status === "waiting-to-pair";
+}
+
+/**
+ * Map a relay/WebSocket close into the resulting connection state. Pure so the
+ * close-code policy is unit-tested independently of the socket.
+ *
+ * `priorStatus` disambiguates the generic/abnormal codes: an abnormal close while
+ * still handshaking means "we never reached your machine" (error), whereas the
+ * same code after a live stream means "the link dropped" (recoverable disconnect).
+ */
+export function mapCloseCode(
+  code: number,
+  reason: string | undefined,
+  priorStatus: TerminalStatus,
+): Pick<TerminalConnectionState, "status" | "errorKind" | "endedReason"> {
+  switch (code) {
+    case RELAY_CLOSE.OWNER_MISMATCH:
+      return { status: "error", errorKind: "owner-mismatch", endedReason: null };
+    case RELAY_CLOSE.BAD_TOKEN:
+      return { status: "error", errorKind: "bad-token", endedReason: null };
+    case RELAY_CLOSE.DUP_BROWSER:
+    case RELAY_CLOSE.DUP_BRIDGE:
+      return { status: "error", errorKind: "duplicate", endedReason: null };
+    case RELAY_CLOSE.PEER_GONE:
+      // The bridge leg went away. Could be a clean exit or a drop — the relay
+      // can't tell us which, so treat it as a (recoverable) disconnect.
+      return { status: "disconnected", errorKind: null, endedReason: null };
+    case 1000:
+      // Normal closure — a clean session end. Parse the reason for the calm
+      // idle / max-duration copy when the bridge supplied it.
+      return { status: "session-ended", errorKind: null, endedReason: parseEndedReason(reason) };
+    default:
+      // 1005 (no status), 1006 (abnormal) and anything unexpected.
+      if (isHandshaking(priorStatus)) {
+        return { status: "error", errorKind: "relay-unreachable", endedReason: null };
+      }
+      return { status: "disconnected", errorKind: null, endedReason: null };
+  }
+}
+
+/** Best-effort reason classification from a close-frame reason string. */
+function parseEndedReason(reason: string | undefined): EndedReason {
+  const r = (reason ?? "").toLowerCase();
+  if (r.includes("idle")) return "idle";
+  if (r.includes("max")) return "max-duration";
+  return "remote";
+}
+
+/**
+ * The connection state machine. Pure: `(state, event) => state`. Drives the dock's
+ * six visible states; the component owns the side effects (fetch, socket, timers)
+ * and feeds their outcomes back in as events.
+ */
+export function terminalReducer(
+  state: TerminalConnectionState,
+  event: TerminalEvent,
+): TerminalConnectionState {
+  switch (event.type) {
+    case "connect":
+      // Fresh attempt — clear any prior error/ended metadata.
+      return { status: "connecting", sessionId: null, errorKind: null, endedReason: null, closeCode: null };
+
+    case "session-created":
+      // Only meaningful while we're opening a session; ignore stray late arrivals.
+      if (state.status !== "connecting") return state;
+      return { ...state, sessionId: event.sessionId };
+
+    case "session-mint-failed":
+      return { ...state, status: "error", errorKind: "session-mint-failed", closeCode: null };
+
+    case "relay-open":
+      // Relay reached; the bridge may not have attached yet → waiting-to-pair.
+      if (state.status !== "connecting") return state;
+      return { ...state, status: "waiting-to-pair", errorKind: null, endedReason: null };
+
+    case "data":
+      // First (or any) bytes from the bridge prove it's attached and streaming.
+      if (state.status === "connected") return state;
+      if (state.status === "waiting-to-pair" || state.status === "disconnected" || state.status === "connecting") {
+        return { ...state, status: "connected", errorKind: null, endedReason: null, closeCode: null };
+      }
+      return state;
+
+    case "user-end":
+      return { ...state, status: "session-ended", endedReason: "user", errorKind: null };
+
+    case "connect-timeout":
+      // Only the connect clock — irrelevant once a stream is live.
+      if (!isHandshaking(state.status)) return state;
+      return { ...state, status: "error", errorKind: "connect-timeout", closeCode: null };
+
+    case "closed": {
+      // A user-initiated end already produced the terminal state; the socket's own
+      // close event must not clobber it back to a generic disconnect.
+      if (state.status === "session-ended") return { ...state, closeCode: event.code };
+      const mapped = mapCloseCode(event.code, event.reason, state.status);
+      return { ...state, ...mapped, closeCode: event.code };
+    }
+
+    case "reset":
+      return { ...initialConnectionState };
+
+    default:
+      return state;
+  }
+}
+
+/** Whether keystroke input should be sent (connected + not read-only). */
+export function isInputEnabled(state: TerminalConnectionState, readOnly: boolean): boolean {
+  return state.status === "connected" && !readOnly;
+}
+
+/**
+ * Build the relay `browser`-leg attach URL. Mirrors the bridge's URL shape
+ * (`/?session=<sid>&role=<leg>&token=<jwt>`) — see terminal/bridge/src/index.js.
+ */
+export function buildRelayUrl(baseUrl: string, sessionId: string, browserToken: string): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  return (
+    `${base}/?session=${encodeURIComponent(sessionId)}` +
+    `&role=browser&token=${encodeURIComponent(browserToken)}`
+  );
+}
+
+/**
+ * Encode a resize control frame. Sent as a TEXT WebSocket frame; the bridge
+ * distinguishes TEXT (control) from BINARY (data) and applies pty.resize. Must
+ * match terminal/bridge/src/framing.js → encodeResize / parseControlMessage.
+ * Returns null for non-sane dimensions (so the caller skips the send).
+ */
+export function encodeResizeMessage(cols: number, rows: number): string | null {
+  if (!isValidDim(cols) || !isValidDim(rows)) return null;
+  return JSON.stringify({ type: "resize", cols, rows });
+}
+
+function isValidDim(n: number): boolean {
+  return Number.isInteger(n) && n > 0 && n <= 1000;
+}
+
+/** Feature flag — OFF unless NEXT_PUBLIC_TERMINAL_ENABLED is exactly "true". */
+export function isTerminalEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_TERMINAL_ENABLED === "true";
+}
+
+/** Relay base URL (public env), defaulting to the local dev relay. */
+export function relayBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_TERMINAL_RELAY_URL || DEFAULT_RELAY_URL;
+}

--- a/src/lib/terminal/connection.ts
+++ b/src/lib/terminal/connection.ts
@@ -123,7 +123,16 @@ export function mapCloseCode(
   }
 }
 
-/** Best-effort reason classification from a close-frame reason string. */
+/**
+ * Best-effort reason classification from a close-frame reason string.
+ *
+ * LOCK-STEP: the relay ends idle / max-duration sessions with code 1000 and a
+ * reason built by terminal/relay/src/pairing.js → idleCloseReason / maxCloseReason
+ * (shared by the Cloudflare DO and the Node stand-in). Those strings always contain
+ * the substring "idle" / "max" respectively, which is exactly what this matches.
+ * Keep the builders and this classifier in step — connection.test.ts pins the
+ * default strings.
+ */
 function parseEndedReason(reason: string | undefined): EndedReason {
   const r = (reason ?? "").toLowerCase();
   if (r.includes("idle")) return "idle";

--- a/src/lib/terminal/deep-link.test.ts
+++ b/src/lib/terminal/deep-link.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildLaunchDeepLink,
+  redactDeepLinkToken,
+  LAUNCH_SCHEME,
+  LAUNCH_HOST,
+} from "./deep-link";
+// The bridge/helper PARSES with the shared .mjs. Importing it here pins the two
+// implementations together: a link this (TS) module builds MUST parse back to the
+// same fields with the shared parser, or this test fails — catching any drift.
+import { parseLaunchDeepLink } from "../../../terminal/shared/deep-link.mjs";
+
+const SAMPLE = {
+  relay: "ws://127.0.0.1:8787",
+  session: "11111111-2222-3333-4444-555555555555",
+  // A realistic two-part HMAC token with reserved-ish chars to prove encoding.
+  token: "eyJzdWIiOiJ1c2VyIn0.aBcD-_eFgH+/=signaturebytes",
+  cwd: "/Users/nick/projects/my idea",
+};
+
+describe("buildLaunchDeepLink", () => {
+  it("builds a vibecodes://launch URL with encoded params", () => {
+    const url = buildLaunchDeepLink(SAMPLE);
+    expect(url.startsWith(`${LAUNCH_SCHEME}://${LAUNCH_HOST}?`)).toBe(true);
+    // Reserved characters in relay/token/cwd are percent-encoded, never raw.
+    expect(url).toContain(`relay=${encodeURIComponent(SAMPLE.relay)}`);
+    expect(url).toContain(`token=${encodeURIComponent(SAMPLE.token)}`);
+    expect(url).toContain(`cwd=${encodeURIComponent(SAMPLE.cwd)}`);
+    expect(url).not.toContain(" "); // the space in cwd must be encoded
+  });
+
+  it("omits cwd entirely when absent", () => {
+    const url = buildLaunchDeepLink({ relay: SAMPLE.relay, session: SAMPLE.session, token: SAMPLE.token });
+    expect(url).not.toContain("cwd=");
+  });
+
+  it("throws when a required field is missing", () => {
+    expect(() => buildLaunchDeepLink({ relay: "", session: "s", token: "t" })).toThrow();
+    expect(() => buildLaunchDeepLink({ relay: "r", session: "", token: "t" })).toThrow();
+    expect(() => buildLaunchDeepLink({ relay: "r", session: "s", token: "" })).toThrow();
+  });
+
+  it("round-trips through the shared parser the helper uses (build ⇄ parse)", () => {
+    const url = buildLaunchDeepLink(SAMPLE);
+    const parsed = parseLaunchDeepLink(url);
+    expect(parsed).toEqual(SAMPLE);
+  });
+
+  it("round-trips without cwd", () => {
+    const noCwd = { relay: SAMPLE.relay, session: SAMPLE.session, token: SAMPLE.token };
+    const parsed = parseLaunchDeepLink(buildLaunchDeepLink(noCwd));
+    expect(parsed).toEqual(noCwd);
+  });
+});
+
+describe("redactDeepLinkToken", () => {
+  it("replaces the token value with *** and never leaks the secret", () => {
+    const url = buildLaunchDeepLink(SAMPLE);
+    const redacted = redactDeepLinkToken(url);
+    expect(redacted).toContain("token=***");
+    // The raw token (and its url-encoded form) must NOT appear anywhere in the log line.
+    expect(redacted).not.toContain(SAMPLE.token);
+    expect(redacted).not.toContain(encodeURIComponent(SAMPLE.token));
+    // Non-secret params survive for debugging.
+    expect(redacted).toContain(`session=${SAMPLE.session}`);
+  });
+});

--- a/src/lib/terminal/deep-link.ts
+++ b/src/lib/terminal/deep-link.ts
@@ -1,0 +1,54 @@
+// In-app terminal — `vibecodes://launch?…` deep-link builder (SLICE 4, app side).
+//
+// The TYPED mirror of terminal/shared/deep-link.mjs. The app picks "In the browser",
+// mints a session, and fires this link; the OS routes it to the installed helper
+// (slice 7) which parses the IDENTICAL string back via the shared .mjs and attaches
+// as the bridge leg. The two implementations are kept in lock-step by a drift test
+// (deep-link.test.ts) that builds with THIS module and parses with the shared one —
+// mirroring how connection.ts duplicates the relay close codes for the same reason
+// (the .mjs is outside the app's TS build graph).
+//
+// `token` here is the app-minted, HMAC-signed BRIDGE-role token — the launch's only
+// credential (the relay verifies it). It is a SECRET: never log a raw link, always
+// redactDeepLinkToken() first.
+
+/** Custom URL scheme the packaged helper registers (slice 7 OS bit). */
+export const LAUNCH_SCHEME = "vibecodes";
+/** The single action this scheme exposes today: `vibecodes://launch?…`. */
+export const LAUNCH_HOST = "launch";
+
+export interface LaunchDeepLinkParams {
+  /** Relay base ws URL the helper should dial out to. */
+  relay: string;
+  /** Relay session id (sid) both legs pair on. */
+  session: string;
+  /** App-minted, HMAC-signed BRIDGE-role token (secret — keep out of logs). */
+  token: string;
+  /** Optional working directory for the spawned `claude`. */
+  cwd?: string;
+}
+
+/**
+ * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…]` deep link.
+ * Throws when a required field is missing so a malformed link is never fired.
+ */
+export function buildLaunchDeepLink({ relay, session, token, cwd }: LaunchDeepLinkParams): string {
+  if (!relay || !session || !token) {
+    throw new Error("buildLaunchDeepLink requires relay, session and token");
+  }
+  const parts = [
+    `relay=${encodeURIComponent(relay)}`,
+    `session=${encodeURIComponent(session)}`,
+    `token=${encodeURIComponent(token)}`,
+  ];
+  if (cwd) parts.push(`cwd=${encodeURIComponent(cwd)}`);
+  return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
+}
+
+/**
+ * Redact the `token` value from a launch link so it is safe to log. Replaces the
+ * value with `***` while keeping the rest intact for debugging.
+ */
+export function redactDeepLinkToken(url: string): string {
+  return url.replace(/([?&]token=)[^&]*/g, "$1***");
+}

--- a/src/lib/terminal/launch-mode.test.ts
+++ b/src/lib/terminal/launch-mode.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { launchModeOptions, isBrowserLaunchAvailable } from "./launch-mode";
+
+describe("launchModeOptions", () => {
+  it("flag OFF → only the terminal-window mode (in-browser item not rendered)", () => {
+    expect(launchModeOptions(false)).toEqual(["terminal-window"]);
+    expect(isBrowserLaunchAvailable(false)).toBe(false);
+  });
+
+  it("flag ON → terminal-window (default, first) then browser", () => {
+    const opts = launchModeOptions(true);
+    expect(opts).toEqual(["terminal-window", "browser"]);
+    // terminal-window is always present and always first — the existing default
+    // action is never moved or removed by enabling the flag.
+    expect(opts[0]).toBe("terminal-window");
+    expect(isBrowserLaunchAvailable(true)).toBe(true);
+  });
+});

--- a/src/lib/terminal/launch-mode.ts
+++ b/src/lib/terminal/launch-mode.ts
@@ -1,0 +1,51 @@
+// In-app terminal — launch-mode selection + cross-component launch bus (SLICE 4).
+//
+// "Launch Claude Code" is a PICK-ONE control: Claude runs in exactly one place at a
+// time. This module owns the pure decision of WHICH modes the menu offers (gated on
+// the terminal flag) plus a tiny SSR-safe event bus so the toolbar's menu item can
+// ask the board's terminal dock (a separate, page-level component) to open in the
+// browser. Keeping the selection logic pure makes it unit-testable without React.
+
+/** The two destinations Claude can run in. "terminal-window" = today's behaviour. */
+export type LaunchTarget = "terminal-window" | "browser";
+
+/**
+ * The launch modes the menu should offer, in display order.
+ *
+ *  - flag OFF → only "terminal-window" (the in-browser item is simply NOT rendered;
+ *    the control looks and behaves exactly as it does today).
+ *  - flag ON  → "terminal-window" (default, first) then "browser" (Beta).
+ *
+ * "terminal-window" is ALWAYS present and ALWAYS first, so the existing default
+ * action is never moved or removed by enabling the flag.
+ */
+export function launchModeOptions(terminalEnabled: boolean): LaunchTarget[] {
+  return terminalEnabled ? ["terminal-window", "browser"] : ["terminal-window"];
+}
+
+/** Whether the in-browser destination should appear in the menu. */
+export function isBrowserLaunchAvailable(terminalEnabled: boolean): boolean {
+  return launchModeOptions(terminalEnabled).includes("browser");
+}
+
+// ── launch bus ────────────────────────────────────────────────────────────────
+// The "In the browser" menu item lives in the board toolbar; the terminal dock that
+// mints the session + fires the deep link is a sibling at the bottom of the board.
+// A scoped CustomEvent lets the former trigger the latter without restructuring the
+// page or minting a session twice. SSR-safe (no-ops without a window).
+
+const LAUNCH_EVENT = "vibecodes:terminal-browser-launch";
+
+/** Ask the board's terminal dock to open + auto-launch in the browser. */
+export function requestBrowserLaunch(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(LAUNCH_EVENT));
+}
+
+/** Subscribe to in-browser launch requests; returns an unsubscribe fn. SSR-safe. */
+export function subscribeBrowserLaunch(handler: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const listener = () => handler();
+  window.addEventListener(LAUNCH_EVENT, listener);
+  return () => window.removeEventListener(LAUNCH_EVENT, listener);
+}

--- a/terminal/.gitignore
+++ b/terminal/.gitignore
@@ -1,6 +1,8 @@
-# Slice-1 terminal area — kept isolated from the Next.js app build.
+# Terminal area — kept isolated from the Next.js app build.
 node_modules/
 # wrangler local dev state / cache
 .wrangler/
+# local relay secrets (TERMINAL_SESSION_SECRET) — NEVER commit
+.dev.vars
 # logs
 *.log

--- a/terminal/.gitignore
+++ b/terminal/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 .dev.vars
 # logs
 *.log
+# helper build output (electron-builder)
+helper/dist/

--- a/terminal/.gitignore
+++ b/terminal/.gitignore
@@ -1,0 +1,6 @@
+# Slice-1 terminal area — kept isolated from the Next.js app build.
+node_modules/
+# wrangler local dev state / cache
+.wrangler/
+# logs
+*.log

--- a/terminal/RUN.md
+++ b/terminal/RUN.md
@@ -1,0 +1,109 @@
+# Terminal — Slice 1: bridge ↔ relay ↔ browser round-trip
+
+This is **slice 1** of the in-app local Claude Code terminal: it proves the byte
+round-trip through a local relay. Nothing here is wired into the Next.js app yet.
+
+```
+ sentinel / claude --[node-pty PTY]--> BRIDGE --ws--> RELAY (CF DO) --ws--> BROWSER leg
+                                       (local Node)   (opaque forward)       (xterm.js)
+```
+
+- **`bridge/`** — Node process: runs a command in a `node-pty` PTY and pipes it
+  opaquely over an outbound WebSocket to the relay. Forwards PTY output → ws
+  (binary), ws → PTY stdin (binary), and resize control frames (text/JSON) →
+  `pty.resize`. On macOS it `chmod +x`'s node-pty's `spawn-helper` first.
+- **`relay/`** — Cloudflare Worker + Durable Object (one DO per `session`). Pairs
+  one `bridge` leg with one `browser` leg and forwards bytes verbatim, never
+  parsing stream content (metadata only). Enforces single-attach.
+- **`test/`** — automated round-trip proof, a plain-ws stand-in relay, a manual
+  xterm.js page, and unit tests.
+
+## Prerequisites
+
+```bash
+cd terminal/bridge && npm install   # node-pty + ws
+cd terminal/relay  && npm install   # wrangler (Cloudflare local dev)
+cd terminal/test   && npm install   # ws
+```
+
+## Run the automated proof (no Cloudflare needed)
+
+Uses the Node stand-in relay, which shares the exact pairing/single-attach logic
+with the real Durable Object. Fully hermetic, hard timeouts, exits non-zero on
+failure.
+
+```bash
+cd terminal/test && npm test          # roundtrip.test.mjs
+```
+
+Unit tests for the pure bits:
+
+```bash
+cd terminal/relay  && npm test        # pairing / single-attach state machine
+cd terminal/bridge && npm test        # framing (control vs data, resize)
+```
+
+## Verify against the REAL Cloudflare DO (`wrangler dev`, offline)
+
+Terminal 1 — start the relay (local workerd, no Cloudflare account):
+
+```bash
+cd terminal/relay && npx wrangler dev          # serves http://127.0.0.1:8787
+```
+
+Terminal 2 — run the same three assertions against it:
+
+```bash
+cd terminal/test && RELAY_URL=ws://127.0.0.1:8787 node verify-against-relay.mjs
+```
+
+## Manual visual check (xterm.js)
+
+With `wrangler dev` running, start a bridge on a chosen session, then open the page:
+
+```bash
+# Terminal 2 — bridge running a cheap interactive shell on session "a3f9"
+cd terminal/bridge && RELAY_URL=ws://127.0.0.1:8787 SESSION_ID=a3f9 node src/index.js --cmd "bash"
+
+# Terminal 3 — serve the page and open it
+cd terminal/test && python3 -m http.server 5500
+#   then open http://127.0.0.1:5500/page.html , set session = a3f9 , click Connect
+```
+
+Type in the page → it reaches the PTY → output streams back. Resize the window →
+the PTY resizes.
+
+## End-to-end with REAL `claude` (manual)
+
+The bridge defaults to running `claude`. Point it at a real project and attach
+the browser leg:
+
+```bash
+cd terminal/relay && npx wrangler dev                                  # terminal 1
+cd terminal/bridge && RELAY_URL=ws://127.0.0.1:8787 SESSION_ID=a3f9 \
+  node src/index.js --cwd ~/path/to/your/project                       # terminal 2 (runs `claude`)
+# open terminal/test/page.html , session = a3f9 , Connect                # terminal 3
+```
+
+> Automated tests deliberately use a cheap non-interactive sentinel command, not
+> interactive `claude`, so CI never hangs.
+
+## Bridge flags
+
+| flag | env | default | meaning |
+|---|---|---|---|
+| `--relay <ws-url>` | `RELAY_URL` | `ws://localhost:8787` | relay base URL |
+| `--session <id>` | `SESSION_ID` | random | session id to pair on |
+| `--cmd <command…>` | `BRIDGE_CMD` | `claude` | command to run in the PTY |
+| `--cwd <dir>` | `BRIDGE_CWD` | cwd | PTY working directory |
+| `--max-seconds <n>` | `BRIDGE_MAX_SECONDS` | `28800` | hard self-kill safety cap |
+| `--connect-timeout-ms <n>` | — | `30000` | fail if relay never opens |
+
+## Stubbed for later slices
+
+- **Auth / ownership** — the relay accepts any session id. See
+  `relay/src/pairing.js` → `// TODO(slice 2): validate app-minted session token +
+  owner binding` and the matching note in `relay/src/index.js`.
+- **In-app panel** (the board terminal dock), the **Launch Claude Code menu**,
+  the signed `vibecodes://` deep link, helper **code-signing/notarization**, and
+  **lifecycle limits** (idle / max-duration UI, reconnect) — all later slices.

--- a/terminal/RUN.md
+++ b/terminal/RUN.md
@@ -1,7 +1,9 @@
-# Terminal — Slice 1: bridge ↔ relay ↔ browser round-trip
+# Terminal — bridge ↔ relay ↔ browser (slices 1–2)
 
-This is **slice 1** of the in-app local Claude Code terminal: it proves the byte
-round-trip through a local relay. Nothing here is wired into the Next.js app yet.
+- **Slice 1** — the byte round-trip through a local relay.
+- **Slice 2** — **auth + ownership**: the VibeCodes app mints short-lived,
+  owner-bound session tokens; the relay verifies them and refuses any leg that
+  isn't the owning user. The in-app panel is still a later slice.
 
 ```
  sentinel / claude --[node-pty PTY]--> BRIDGE --ws--> RELAY (CF DO) --ws--> BROWSER leg
@@ -25,6 +27,38 @@ cd terminal/bridge && npm install   # node-pty + ws
 cd terminal/relay  && npm install   # wrangler (Cloudflare local dev)
 cd terminal/test   && npm install   # ws
 ```
+
+### Session token secret (slice 2)
+
+Both the app and the relay sign/verify with one shared secret,
+`TERMINAL_SESSION_SECRET` (HMAC-SHA256). It NEVER lives in code.
+
+- **App:** set `TERMINAL_SESSION_SECRET` in `.env.local` (see `.env.example`).
+- **Relay (local):** put it in `terminal/relay/.dev.vars` (gitignored), which
+  `wrangler dev` loads automatically:
+  ```
+  TERMINAL_SESSION_SECRET=<same-value-as-the-app>
+  ```
+- **Relay (prod):** `wrangler secret put TERMINAL_SESSION_SECRET`.
+
+## Auth model (slice 2)
+
+The app endpoint `POST /api/terminal/session` (authenticated VibeCodes user) mints
+**two** short-lived (~5 min) tokens for one session id — one per leg — via the
+shared module `terminal/shared/session-token.mjs`:
+
+```
+token = base64url(JSON{sub,sid,idea,role,iat,exp}) . base64url(HMAC-SHA256(payload, secret))
+```
+
+Both legs carry the same `sub` (Supabase user id) and `sid`. Each leg passes its
+token to the relay as the **`token` query param**
+(`/?session=<sid>&role=<bridge|browser>&token=<jwt>`). The relay (same shared
+`authorizeAttach`) verifies signature + expiry + that `sid`/`role` match, then
+**owner-binds** the session to `sub`: the bridge and browser legs must share the
+same `sub`, or the second leg is closed. Close codes: `4005` owner-mismatch,
+`4006` invalid/tampered/expired token (in addition to slice-1 `4001`/`4002`
+single-attach).
 
 ## Run the automated proof (no Cloudflare needed)
 
@@ -51,24 +85,41 @@ Terminal 1 — start the relay (local workerd, no Cloudflare account):
 cd terminal/relay && npx wrangler dev          # serves http://127.0.0.1:8787
 ```
 
-Terminal 2 — run the same three assertions against it:
+Terminal 2 — run the assertions against it (mints owner-bound tokens with the
+SAME secret as the relay's `.dev.vars`):
 
 ```bash
-cd terminal/test && RELAY_URL=ws://127.0.0.1:8787 node verify-against-relay.mjs
+cd terminal/test && TERMINAL_SESSION_SECRET=<same-as-.dev.vars> \
+  RELAY_URL=ws://127.0.0.1:8787 node verify-against-relay.mjs
 ```
+
+Proves: (a) PTY output reaches the browser, (b) keystroke round-trip, (c)
+single-attach, (d) owner-mismatch rejected (4005), (e) expired token rejected
+(4006) — all through the real Durable Object.
 
 ## Manual visual check (xterm.js)
 
-With `wrangler dev` running, start a bridge on a chosen session, then open the page:
+With `wrangler dev` running, mint a token pair, start a bridge with the bridge
+token, then open the page with the browser token:
 
 ```bash
+# Terminal 2 — mint owner-bound tokens for session "a3f9" (stands in for the app)
+cd terminal/test && TERMINAL_SESSION_SECRET=<same-as-.dev.vars> \
+  node mint-token.mjs --session a3f9        # prints bridgeToken + browserToken
+
 # Terminal 2 — bridge running a cheap interactive shell on session "a3f9"
-cd terminal/bridge && RELAY_URL=ws://127.0.0.1:8787 SESSION_ID=a3f9 node src/index.js --cmd "bash"
+cd terminal/bridge && RELAY_URL=ws://127.0.0.1:8787 SESSION_ID=a3f9 \
+  BRIDGE_TOKEN=<bridgeToken> node src/index.js --cmd "bash"
 
 # Terminal 3 — serve the page and open it
 cd terminal/test && python3 -m http.server 5500
-#   then open http://127.0.0.1:5500/page.html , set session = a3f9 , click Connect
+#   then open http://127.0.0.1:5500/page.html , set session = a3f9 ,
+#   paste the browserToken, click Connect
 ```
+
+> The `page.html` from slice 1 has no token field yet (the real token UI is the
+> slice-3 in-app panel). For a quick manual check, append `&token=<browserToken>`
+> to the ws URL it builds, or use `verify-against-relay.mjs` which is fully wired.
 
 Type in the page → it reaches the PTY → output streams back. Resize the window →
 the PTY resizes.
@@ -80,9 +131,10 @@ the browser leg:
 
 ```bash
 cd terminal/relay && npx wrangler dev                                  # terminal 1
+# mint a token pair (see above), then:
 cd terminal/bridge && RELAY_URL=ws://127.0.0.1:8787 SESSION_ID=a3f9 \
-  node src/index.js --cwd ~/path/to/your/project                       # terminal 2 (runs `claude`)
-# open terminal/test/page.html , session = a3f9 , Connect                # terminal 3
+  BRIDGE_TOKEN=<bridgeToken> node src/index.js --cwd ~/path/to/your/project   # terminal 2 (runs `claude`)
+# open the page with the browserToken (see note above)                  # terminal 3
 ```
 
 > Automated tests deliberately use a cheap non-interactive sentinel command, not
@@ -94,6 +146,7 @@ cd terminal/bridge && RELAY_URL=ws://127.0.0.1:8787 SESSION_ID=a3f9 \
 |---|---|---|---|
 | `--relay <ws-url>` | `RELAY_URL` | `ws://localhost:8787` | relay base URL |
 | `--session <id>` | `SESSION_ID` | random | session id to pair on |
+| `--token <jwt>` | `BRIDGE_TOKEN` | — | **required** app-minted `bridge`-role token |
 | `--cmd <command…>` | `BRIDGE_CMD` | `claude` | command to run in the PTY |
 | `--cwd <dir>` | `BRIDGE_CWD` | cwd | PTY working directory |
 | `--max-seconds <n>` | `BRIDGE_MAX_SECONDS` | `28800` | hard self-kill safety cap |
@@ -101,9 +154,6 @@ cd terminal/bridge && RELAY_URL=ws://127.0.0.1:8787 SESSION_ID=a3f9 \
 
 ## Stubbed for later slices
 
-- **Auth / ownership** — the relay accepts any session id. See
-  `relay/src/pairing.js` → `// TODO(slice 2): validate app-minted session token +
-  owner binding` and the matching note in `relay/src/index.js`.
 - **In-app panel** (the board terminal dock), the **Launch Claude Code menu**,
   the signed `vibecodes://` deep link, helper **code-signing/notarization**, and
   **lifecycle limits** (idle / max-duration UI, reconnect) — all later slices.

--- a/terminal/RUN.md
+++ b/terminal/RUN.md
@@ -152,8 +152,41 @@ cd terminal/bridge && RELAY_URL=ws://127.0.0.1:8787 SESSION_ID=a3f9 \
 | `--max-seconds <n>` | `BRIDGE_MAX_SECONDS` | `28800` | hard self-kill safety cap |
 | `--connect-timeout-ms <n>` | — | `30000` | fail if relay never opens |
 
+## Session lifecycle limits (slice 6)
+
+The relay now ends forgotten sessions itself. It uses the **WebSocket Hibernation
+API** (so an idle DO is evicted from memory and stops billing duration) plus DO
+**alarms** for two caps:
+
+- **idle** — no traffic for `TERMINAL_IDLE_MS` (default 30 min) → both legs close
+  `1000` with reason `idle-timeout: …`.
+- **max-duration** — total session age ≥ `TERMINAL_MAX_MS` (default 4 h) → both
+  legs close `1000` with reason `max-duration: …`.
+
+Both reasons are classified by the dock (`src/lib/terminal/connection.ts`) into the
+calm idle / max-duration copy. Override the caps via env (`[vars]` in
+`wrangler.toml`, or `--var KEY:VALUE` for a quick local run). The stand-in relay
+enforces the same caps with plain timers, so the lifecycle is testable hermetically:
+
+```bash
+cd terminal/test && node --test lifecycle.test.mjs     # idle + max, both legs, code 1000
+```
+
+Prove the REAL DO's idle alarm against `wrangler dev` (short idle for speed):
+
+```bash
+cd terminal/relay && npx wrangler dev --port 8787 --var TERMINAL_IDLE_MS:3000   # terminal 1
+cd terminal/test  && TERMINAL_SESSION_SECRET=<same-as-.dev.vars> \
+  RELAY_URL=ws://127.0.0.1:8787 EXPECT_IDLE_MS=3000 node verify-lifecycle.mjs    # terminal 2
+```
+
+The DO logs `session ended … why:idle-timeout` and closes both legs. Note: local
+`wrangler dev` does NOT forward server-initiated close frames to clients (known
+wrangler bug workers-sdk#1812/#10307); production delivers them. Deploy steps:
+`relay/DEPLOY.md`.
+
 ## Stubbed for later slices
 
-- **In-app panel** (the board terminal dock), the **Launch Claude Code menu**,
-  the signed `vibecodes://` deep link, helper **code-signing/notarization**, and
-  **lifecycle limits** (idle / max-duration UI, reconnect) — all later slices.
+- **Helper code-signing / notarization**, registering the **`vibecodes://`** URL
+  scheme with the OS, and the **real signed download** of the bridge helper
+  (slice 7) — still to come.

--- a/terminal/bridge/package-lock.json
+++ b/terminal/bridge/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "vibecodes-terminal-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vibecodes-terminal-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "node-pty": "^1.1.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "vibecodes-bridge": "src/index.js"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/terminal/bridge/package.json
+++ b/terminal/bridge/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vibecodes-terminal-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Local Node bridge: runs a command in a node-pty PTY and pipes it opaquely over an outbound WebSocket to the VibeCodes terminal relay. (Slice 1)",
+  "bin": {
+    "vibecodes-bridge": "src/index.js"
+  },
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "node-pty": "^1.1.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/terminal/bridge/src/framing.js
+++ b/terminal/bridge/src/framing.js
@@ -1,0 +1,64 @@
+// Framing convention between the BROWSER leg and the BRIDGE leg.
+//
+// The relay forwards every WebSocket frame verbatim and never parses it, so the
+// two ends agree on a tiny convention that rides *inside* the frames:
+//
+//   - BINARY frame  -> opaque terminal bytes (PTY stdout -> browser, and
+//                      keystrokes browser -> PTY stdin). Forwarded verbatim.
+//   - TEXT frame    -> a JSON control message, e.g. a resize:
+//                      {"type":"resize","cols":120,"rows":30}
+//
+// Keeping control messages as TEXT and data as BINARY lets the bridge tell them
+// apart with zero ambiguity (data is never accidentally parsed as JSON), while
+// the relay stays fully opaque to both.
+//
+// These helpers are pure so they can be unit-tested in isolation.
+
+/**
+ * Build the wire form of a resize control message (a JSON string sent as TEXT).
+ * @param {number} cols
+ * @param {number} rows
+ * @returns {string}
+ */
+export function encodeResize(cols, rows) {
+  return JSON.stringify({ type: "resize", cols, rows });
+}
+
+/**
+ * Parse a TEXT control message coming from the browser leg.
+ *
+ * Returns a normalized control object, or null if the text is not a valid /
+ * supported control message (the caller should then ignore it rather than
+ * treating it as terminal input — control frames must never reach the PTY).
+ *
+ * @param {string} text
+ * @returns {{type:"resize", cols:number, rows:number} | null}
+ */
+export function parseControlMessage(text) {
+  if (typeof text !== "string" || text.length === 0) return null;
+  let msg;
+  try {
+    msg = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!msg || typeof msg !== "object") return null;
+
+  if (msg.type === "resize") {
+    const cols = Number(msg.cols);
+    const rows = Number(msg.rows);
+    if (!isValidDim(cols) || !isValidDim(rows)) return null;
+    return { type: "resize", cols, rows };
+  }
+  return null;
+}
+
+/**
+ * A terminal dimension must be a positive, finite, sane integer. Guards the
+ * PTY against NaN / 0 / absurd values that could throw or destabilize it.
+ * @param {number} n
+ * @returns {boolean}
+ */
+export function isValidDim(n) {
+  return Number.isInteger(n) && n > 0 && n <= 1000;
+}

--- a/terminal/bridge/src/framing.test.js
+++ b/terminal/bridge/src/framing.test.js
@@ -1,0 +1,46 @@
+// Unit tests for the bridge<->browser framing helpers.
+// Run: cd terminal/bridge && node --test   (or: npm test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { encodeResize, parseControlMessage, isValidDim } from "./framing.js";
+
+test("encodeResize round-trips through parseControlMessage", () => {
+  const wire = encodeResize(120, 30);
+  assert.deepEqual(parseControlMessage(wire), { type: "resize", cols: 120, rows: 30 });
+});
+
+test("parseControlMessage rejects non-JSON (so raw terminal text is never parsed)", () => {
+  assert.equal(parseControlMessage("npm run test\n"), null);
+  assert.equal(parseControlMessage(""), null);
+  assert.equal(parseControlMessage("{not json"), null);
+});
+
+test("parseControlMessage rejects unknown control types", () => {
+  assert.equal(parseControlMessage(JSON.stringify({ type: "explode" })), null);
+});
+
+test("parseControlMessage rejects resize with bad dimensions", () => {
+  assert.equal(parseControlMessage(JSON.stringify({ type: "resize", cols: 0, rows: 24 })), null);
+  assert.equal(parseControlMessage(JSON.stringify({ type: "resize", cols: 80, rows: -1 })), null);
+  assert.equal(parseControlMessage(JSON.stringify({ type: "resize", cols: 80 })), null);
+  assert.equal(parseControlMessage(JSON.stringify({ type: "resize", cols: 99999, rows: 24 })), null);
+});
+
+test("parseControlMessage coerces numeric strings (xterm sometimes sends strings)", () => {
+  assert.deepEqual(parseControlMessage(JSON.stringify({ type: "resize", cols: "80", rows: "24" })), {
+    type: "resize",
+    cols: 80,
+    rows: 24,
+  });
+});
+
+test("isValidDim guards the PTY against insane values", () => {
+  assert.equal(isValidDim(80), true);
+  assert.equal(isValidDim(1), true);
+  assert.equal(isValidDim(1000), true);
+  assert.equal(isValidDim(0), false);
+  assert.equal(isValidDim(-5), false);
+  assert.equal(isValidDim(1001), false);
+  assert.equal(isValidDim(3.5), false);
+  assert.equal(isValidDim(NaN), false);
+});

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// VibeCodes Terminal Bridge — SLICE 1
+//
+// Runs a command in a node-pty pseudo-terminal on the local machine and pipes it,
+// opaquely, over an OUTBOUND WebSocket to the relay. The relay pairs this
+// `bridge` leg with a `browser` leg and forwards bytes both ways.
+//
+//   PTY stdout  --(binary frame)-->  ws  -->  relay  -->  browser
+//   browser     --(binary frame)-->  relay  -->  ws  -->  PTY stdin
+//   browser     --(text/JSON resize)->  relay -->  ws  -->  pty.resize()
+//
+// SLICE-1 SCOPE: prove the byte round-trip. Auth/ownership, the signed
+// vibecodes:// deep link, the in-app panel, lifecycle limits and signing are
+// later slices (see RUN.md / design doc).
+//
+// Usage:
+//   node src/index.js --relay ws://localhost:8787 --session abc123 --cmd "bash"
+//
+// Flags (env fallback in brackets):
+//   --relay   <ws-url>   relay base URL                 [RELAY_URL]   default ws://localhost:8787
+//   --session <id>       session id to pair on          [SESSION_ID]  default random
+//   --cmd     <command>  command to run in the PTY       [BRIDGE_CMD]  default "claude"
+//                        (everything after --cmd, or the env string, is shell-split)
+//   --cwd     <dir>      working directory               [BRIDGE_CWD]  default process.cwd()
+//   --max-seconds <n>    hard self-kill safety cap       [BRIDGE_MAX_SECONDS] default 28800 (8h)
+//   --connect-timeout-ms <n>  fail if relay not open in time  [default 30000]
+
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import WebSocket from "ws";
+import { parseControlMessage } from "./framing.js";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── logging (metadata only — NEVER log stream content) ────────────────────────
+const t0 = Date.now();
+function log(level, msg, extra) {
+  const rec = { t: ((Date.now() - t0) / 1000).toFixed(2) + "s", level, comp: "bridge", msg, ...extra };
+  process.stderr.write(JSON.stringify(rec) + "\n");
+}
+
+// ── arg parsing ───────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--cmd") {
+      // everything after --cmd is the command + its args
+      out.cmd = argv.slice(i + 1).join(" ");
+      break;
+    } else if (a.startsWith("--")) {
+      out[a.slice(2)] = argv[++i];
+    } else {
+      out._.push(a);
+    }
+  }
+  return out;
+}
+
+// Minimal, dependency-free shell-ish splitter (handles "double" and 'single' quotes).
+function shellSplit(s) {
+  const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  const parts = [];
+  let m;
+  while ((m = re.exec(s)) !== null) parts.push(m[1] ?? m[2] ?? m[3]);
+  return parts;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const RELAY = args.relay || process.env.RELAY_URL || "ws://localhost:8787";
+const SESSION = args.session || process.env.SESSION_ID || `dev-${Math.random().toString(36).slice(2, 10)}`;
+const CMD = args.cmd || process.env.BRIDGE_CMD || "claude";
+const CWD = args.cwd || process.env.BRIDGE_CWD || process.cwd();
+const MAX_SECONDS = Number(args["max-seconds"] || process.env.BRIDGE_MAX_SECONDS || 28800);
+const CONNECT_TIMEOUT_MS = Number(args["connect-timeout-ms"] || 30000);
+
+const [file, ...cmdArgs] = shellSplit(CMD);
+
+// ── the known macOS spawn-helper fix ──────────────────────────────────────────
+// node-pty ships a `spawn-helper` binary under prebuilds/<platform>-<arch>/.
+// On macOS it can land without the executable bit (npm/tar quirks), which makes
+// pty.spawn throw EACCES. Re-assert +x before spawning. No-op elsewhere.
+function ensureSpawnHelperExecutable() {
+  if (process.platform !== "darwin") return;
+  try {
+    const ptyDir = path.dirname(require.resolve("node-pty"));
+    const pkgRoot = path.resolve(ptyDir, "..");
+    const plat = `${process.platform}-${process.arch}`;
+    const candidates = [
+      path.join(pkgRoot, "prebuilds", plat, "spawn-helper"),
+      path.join(pkgRoot, "build", "Release", "spawn-helper"),
+      path.join(pkgRoot, "build", "Debug", "spawn-helper"),
+    ];
+    for (const c of candidates) {
+      if (fs.existsSync(c)) {
+        fs.chmodSync(c, 0o755);
+        log("debug", "ensured spawn-helper executable", { path: c });
+      }
+    }
+  } catch (e) {
+    log("warn", "could not chmod spawn-helper (continuing)", { err: String(e?.message || e) });
+  }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+async function main() {
+  ensureSpawnHelperExecutable();
+
+  const pty = require("node-pty");
+
+  log("info", "spawning PTY", { file, args: cmdArgs, cwd: CWD });
+  let term;
+  try {
+    term = pty.spawn(file, cmdArgs, {
+      name: "xterm-color",
+      cols: 80,
+      rows: 24,
+      cwd: CWD,
+      env: { ...process.env, TERM: "xterm-color" },
+    });
+  } catch (e) {
+    log("error", "PTY spawn failed", { err: String(e?.message || e) });
+    process.exit(1);
+  }
+
+  const url = `${RELAY.replace(/\/$/, "")}/?session=${encodeURIComponent(SESSION)}&role=bridge`;
+  log("info", "connecting to relay", { url, host: os.hostname() });
+  const ws = new WebSocket(url);
+
+  let bytesOut = 0; // PTY -> ws
+  let bytesIn = 0; // ws -> PTY
+  let open = false;
+  let shuttingDown = false;
+
+  // Hard timeouts so nothing hangs.
+  const connectTimer = setTimeout(() => {
+    if (!open) {
+      log("error", "connect timeout — relay never opened", { ms: CONNECT_TIMEOUT_MS });
+      shutdown(1, "connect-timeout");
+    }
+  }, CONNECT_TIMEOUT_MS);
+
+  const maxTimer = setTimeout(() => {
+    log("warn", "max-duration cap reached — ending session", { seconds: MAX_SECONDS });
+    shutdown(0, "max-duration");
+  }, MAX_SECONDS * 1000);
+
+  function shutdown(code, why) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    clearTimeout(connectTimer);
+    clearTimeout(maxTimer);
+    log("info", "shutting down", { why, bytesOut, bytesIn });
+    try { ws.close(1000, why); } catch { /* ignore */ }
+    try { term.kill(); } catch { /* ignore */ }
+    // give sockets a tick to flush their close frame, then exit hard
+    setTimeout(() => process.exit(code), 200).unref();
+  }
+
+  // PTY -> relay (binary, verbatim). Buffer output produced before the relay
+  // WebSocket is open (e.g. the program's startup banner) and flush on open, so
+  // the first bytes are never lost to a connect race.
+  /** @type {Buffer[]} */
+  const preOpenBuffer = [];
+  term.onData((data) => {
+    const buf = Buffer.from(data, "utf8");
+    bytesOut += buf.length;
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(buf, { binary: true });
+    } else if (!shuttingDown) {
+      preOpenBuffer.push(buf);
+    }
+  });
+
+  term.onExit(({ exitCode, signal }) => {
+    log("info", "PTY exited", { exitCode, signal });
+    shutdown(0, "pty-exit");
+  });
+
+  // relay -> PTY
+  ws.on("message", (data, isBinary) => {
+    if (isBinary) {
+      // opaque keystroke bytes -> PTY stdin
+      bytesIn += data.length;
+      term.write(data.toString("utf8"));
+    } else {
+      // TEXT control frame (resize). Never written to the PTY as input.
+      const ctrl = parseControlMessage(data.toString("utf8"));
+      if (ctrl?.type === "resize") {
+        try {
+          term.resize(ctrl.cols, ctrl.rows);
+          log("debug", "resized PTY", { cols: ctrl.cols, rows: ctrl.rows });
+        } catch (e) {
+          log("warn", "resize failed", { err: String(e?.message || e) });
+        }
+      } else {
+        log("warn", "ignored unknown control frame");
+      }
+    }
+  });
+
+  ws.on("open", () => {
+    open = true;
+    clearTimeout(connectTimer);
+    log("info", "relay connected (bridge leg)", { session: SESSION });
+    // Flush any PTY output produced before the socket opened.
+    while (preOpenBuffer.length > 0) {
+      ws.send(preOpenBuffer.shift(), { binary: true });
+    }
+  });
+
+  ws.on("close", (code, reasonBuf) => {
+    const reason = reasonBuf?.toString?.() || "";
+    log("info", "relay closed", { code, reason });
+    shutdown(open ? 0 : 1, "ws-close");
+  });
+
+  ws.on("error", (e) => {
+    log("error", "relay ws error", { err: String(e?.message || e) });
+    // 'close' will follow; shutdown there.
+  });
+
+  // Clean teardown on Ctrl-C / kill.
+  for (const sig of ["SIGINT", "SIGTERM"]) {
+    process.on(sig, () => {
+      log("info", "received signal", { sig });
+      shutdown(0, sig);
+    });
+  }
+}
+
+main().catch((e) => {
+  log("error", "fatal", { err: String(e?.stack || e) });
+  process.exit(1);
+});

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -23,6 +23,12 @@
 //   --cmd     <command>  command to run in the PTY       [BRIDGE_CMD]  default "claude"
 //                        (everything after --cmd, or the env string, is shell-split)
 //   --cwd     <dir>      working directory               [BRIDGE_CWD]  default process.cwd()
+//   --launch-url <url>   a `vibecodes://launch?…` deep link [BRIDGE_LAUNCH_URL]
+//                        Parsed for relay/session/token/cwd — exactly what a packaged
+//                        helper's URL-scheme handler hands us (slice 7). It takes
+//                        precedence over the individual --relay/--session/--token/--cwd
+//                        flags. `--launch-url` MUST come before `--cmd` (which swallows
+//                        the rest of argv). Default spawned command stays "claude".
 //   --max-seconds <n>    hard self-kill safety cap       [BRIDGE_MAX_SECONDS] default 28800 (8h)
 //   --connect-timeout-ms <n>  fail if relay not open in time  [default 30000]
 
@@ -33,6 +39,7 @@ import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import WebSocket from "ws";
 import { parseControlMessage } from "./framing.js";
+import { parseLaunchDeepLink, redactDeepLinkToken } from "../../shared/deep-link.mjs";
 
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -72,11 +79,29 @@ function shellSplit(s) {
 }
 
 const args = parseArgs(process.argv.slice(2));
-const RELAY = args.relay || process.env.RELAY_URL || "ws://localhost:8787";
-const SESSION = args.session || process.env.SESSION_ID || `dev-${Math.random().toString(36).slice(2, 10)}`;
-const TOKEN = args.token || process.env.BRIDGE_TOKEN || "";
+
+// A `vibecodes://launch?…` deep link, when present, is the highest-precedence source
+// of relay/session/token/cwd — this is the same string a packaged helper's URL-scheme
+// handler will pass us (slice 7). Parse it ONCE; bail clearly if it's malformed.
+const LAUNCH_URL = args["launch-url"] || process.env.BRIDGE_LAUNCH_URL || "";
+let launched = null;
+if (LAUNCH_URL) {
+  launched = parseLaunchDeepLink(LAUNCH_URL);
+  if (!launched) {
+    log("error", "invalid --launch-url (not a vibecodes://launch link)", {
+      url: redactDeepLinkToken(LAUNCH_URL),
+    });
+    process.exit(1);
+  }
+  // Log the parsed link WITHOUT the token (never log secrets).
+  log("info", "using launch deep link", { url: redactDeepLinkToken(LAUNCH_URL) });
+}
+
+const RELAY = launched?.relay || args.relay || process.env.RELAY_URL || "ws://localhost:8787";
+const SESSION = launched?.session || args.session || process.env.SESSION_ID || `dev-${Math.random().toString(36).slice(2, 10)}`;
+const TOKEN = launched?.token || args.token || process.env.BRIDGE_TOKEN || "";
 const CMD = args.cmd || process.env.BRIDGE_CMD || "claude";
-const CWD = args.cwd || process.env.BRIDGE_CWD || process.cwd();
+const CWD = launched?.cwd || args.cwd || process.env.BRIDGE_CWD || process.cwd();
 const MAX_SECONDS = Number(args["max-seconds"] || process.env.BRIDGE_MAX_SECONDS || 28800);
 const CONNECT_TIMEOUT_MS = Number(args["connect-timeout-ms"] || 30000);
 

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -19,6 +19,7 @@
 // Flags (env fallback in brackets):
 //   --relay   <ws-url>   relay base URL                 [RELAY_URL]   default ws://localhost:8787
 //   --session <id>       session id to pair on          [SESSION_ID]  default random
+//   --token   <jwt>      app-minted bridge-role token    [BRIDGE_TOKEN] (required by the relay)
 //   --cmd     <command>  command to run in the PTY       [BRIDGE_CMD]  default "claude"
 //                        (everything after --cmd, or the env string, is shell-split)
 //   --cwd     <dir>      working directory               [BRIDGE_CWD]  default process.cwd()
@@ -73,6 +74,7 @@ function shellSplit(s) {
 const args = parseArgs(process.argv.slice(2));
 const RELAY = args.relay || process.env.RELAY_URL || "ws://localhost:8787";
 const SESSION = args.session || process.env.SESSION_ID || `dev-${Math.random().toString(36).slice(2, 10)}`;
+const TOKEN = args.token || process.env.BRIDGE_TOKEN || "";
 const CMD = args.cmd || process.env.BRIDGE_CMD || "claude";
 const CWD = args.cwd || process.env.BRIDGE_CWD || process.cwd();
 const MAX_SECONDS = Number(args["max-seconds"] || process.env.BRIDGE_MAX_SECONDS || 28800);
@@ -127,8 +129,17 @@ async function main() {
     process.exit(1);
   }
 
-  const url = `${RELAY.replace(/\/$/, "")}/?session=${encodeURIComponent(SESSION)}&role=bridge`;
-  log("info", "connecting to relay", { url, host: os.hostname() });
+  // The relay requires an app-minted `bridge`-role token (slice 2). It binds this
+  // leg to its owning user; the matching `browser` token must carry the same owner.
+  if (!TOKEN) {
+    log("error", "missing bridge token — set --token or BRIDGE_TOKEN (minted by the app)");
+    process.exit(1);
+  }
+  const url =
+    `${RELAY.replace(/\/$/, "")}/?session=${encodeURIComponent(SESSION)}` +
+    `&role=bridge&token=${encodeURIComponent(TOKEN)}`;
+  // Log the URL WITHOUT the token (never log secrets).
+  log("info", "connecting to relay", { url: url.replace(/token=[^&]*/, "token=***"), host: os.hostname() });
   const ws = new WebSocket(url);
 
   let bytesOut = 0; // PTY -> ws

--- a/terminal/helper/BUILD-AND-SIGN.md
+++ b/terminal/helper/BUILD-AND-SIGN.md
@@ -1,0 +1,170 @@
+# VibeCodes macOS helper — build, sign, notarize (slice 7)
+
+The helper is the **install-once** piece. It registers the `vibecodes://` URL
+scheme and, when the app fires a `vibecodes://launch?…` deep link, runs the
+existing **bridge** (`terminal/bridge`) — spawning `claude` in a node-pty PTY and
+connecting to the relay as the bridge leg. It is a thin, signable Electron wrapper
+around the bridge; **no bridge logic is duplicated** (it `fork`s the bridge with
+Electron-as-Node; node-pty 1.x is N-API, so its prebuilt binary loads unchanged).
+
+```
+vibecodes://launch?…  →  helper (this app)  →  fork bridge --launch-url
+                                                  │
+                          node-pty PTY (claude) ──┤
+                                                  └── ws → relay (bridge leg)
+```
+
+---
+
+## Why Electron (packaging choice)
+
+| Option | Download size | Signing/notarize reliability | Effort | Verdict |
+|---|---|---|---|---|
+| **Electron + electron-builder** | ~85–95 MB dmg (~240 MB installed) | **Highest** — one command does codesign + notarytool + staple; `open-url` Apple Event handled natively | Lowest | **Chosen** |
+| Node SEA in a minimal `.app` | ~70–90 MB | Risky — a bare Node `.app` has **no Cocoa run loop, so it cannot receive the `open-url` Apple Event** that macOS uses to deliver `vibecodes://` activations. Would need an Obj-C shim. | High | Rejected |
+| Tauri (Rust + Node sidecar) | ~10 MB shell | Good shell, but you still ship Node for node-pty + a Rust toolchain + sidecar IPC | Highest | Over-engineered |
+
+The decisive point is **URL-scheme delivery**: macOS hands `vibecodes://` launches
+to the running app as an Apple Event on its main event loop. Electron exposes this
+as `app.on("open-url")` for both cold and warm launches; a plain Node binary can't
+receive it without a native Cocoa shim. Electron also bundles Node + signs node-pty
++ notarizes in one step. The cost is bundle size (~90 MB download) — acceptable for
+a one-time install, and 65 MB lighter after we drop node-pty's win32 prebuilts.
+
+---
+
+## Prerequisites (one time)
+
+1. **Xcode Command Line Tools** (provides `codesign`, `notarytool`, `stapler`):
+   ```bash
+   xcode-select --install
+   ```
+2. **Apple Developer account** (individual is fine — you have this).
+3. **Developer ID Application certificate** — create + install into your login keychain:
+   - Xcode → Settings → Accounts → your Apple ID → *Manage Certificates* → **+** →
+     **Developer ID Application**. (Or create a CSR and download from
+     <https://developer.apple.com/account/resources/certificates>.)
+   - Confirm it's in the keychain:
+     ```bash
+     security find-identity -v -p codesigning   # look for "Developer ID Application: <Name> (TEAMID)"
+     ```
+4. **notarytool credentials** — either an app-specific password OR an App Store
+   Connect API key:
+   - **App-specific password:** <https://account.apple.com> → Sign-In & Security →
+     App-Specific Passwords → generate one (label it e.g. "notarytool").
+   - **API key (alternative):** App Store Connect → Users and Access → Integrations →
+     **+** → download the `.p8` (note the Key ID + Issuer ID).
+
+---
+
+## Build (signed + notarized)
+
+From `terminal/helper/`:
+
+```bash
+npm install            # electron + electron-builder (one time)
+
+# Identity: electron-builder auto-selects the Developer ID Application cert from
+# the keychain. To pin one explicitly, set CSC_NAME:
+export CSC_NAME="Developer ID Application: <Your Name> (<TEAMID>)"
+
+# notarytool credentials — pick ONE of the two blocks:
+
+# (A) app-specific password
+export APPLE_ID="you@example.com"
+export APPLE_APP_SPECIFIC_PASSWORD="abcd-efgh-ijkl-mnop"
+export APPLE_TEAM_ID="<TEAMID>"
+
+# (B) App Store Connect API key
+# export APPLE_API_KEY="/abs/path/AuthKey_XXXX.p8"
+# export APPLE_API_KEY_ID="XXXX"
+# export APPLE_API_ISSUER="aaaa-bbbb-cccc-dddd"
+
+npm run dist           # → dist/VibeCodes-0.1.0-arm64.dmg (+ x64, + .zip)
+```
+
+`electron-builder` (config in `electron-builder.yml`) will, in order:
+`@electron/rebuild` native deps → package → **codesign** every Mach-O (the app, the
+Electron Framework, `pty.node`, and `spawn-helper`) with the Developer ID cert under
+the **Hardened Runtime** + `entitlements.mac.plist` → **notarize** via `notarytool`
+(reads the env above) → **staple** the ticket. No credentials are written to disk.
+
+> **Entitlements** (`entitlements.mac.plist`) allow JIT, unsigned-executable-memory,
+> and `disable-library-validation` — the last is required so the hardened-runtime
+> process can load node-pty's `pty.node` and exec `spawn-helper`.
+
+### Verify the result
+
+```bash
+APP="dist/mac-arm64/VibeCodes.app"
+codesign --verify --deep --strict --verbose=2 "$APP"
+codesign -dvvv "$APP" 2>&1 | grep -E "Authority|TeamIdentifier|Runtime"
+spctl -a -vvv -t install "$APP"          # expect: "source=Notarized Developer ID"  "accepted"
+xcrun stapler validate "$APP"            # expect: "The validate action worked!"
+```
+
+A successful `spctl` "accepted / Notarized Developer ID" is what makes macOS show
+**"VibeCodes" with no unidentified-developer warning** on first open.
+
+---
+
+## Unsigned local build (no cert needed — proves the bundle)
+
+```bash
+npm run pack:unsigned    # CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --dir
+```
+
+Produces `dist/mac-arm64/VibeCodes.app` (unsigned). Use it to inspect the registered
+scheme and resource layout:
+
+```bash
+/usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes" \
+  dist/mac-arm64/VibeCodes.app/Contents/Info.plist
+```
+
+---
+
+## Prove the end-to-end chain (against the LIVE relay)
+
+`verify-helper-launch.mjs` mints owner-bound tokens with the relay's
+`TERMINAL_SESSION_SECRET` (read from `terminal/relay/.dev.vars`), attaches a browser
+leg to the **deployed** relay, then drives the helper with a real
+`vibecodes://launch?…` URL and asserts the byte round-trip.
+
+```bash
+# dev path (electron main.js)
+node verify-helper-launch.mjs
+
+# packaged path (the built .app's Resources bridge)
+HELPER_BIN="$PWD/dist/mac-arm64/VibeCodes.app/Contents/MacOS/VibeCodes" \
+  node verify-helper-launch.mjs
+```
+
+Both print `ALL ASSERTIONS PASSED`. (A non-interactive sentinel stands in for
+interactive `claude` via the bridge's `BRIDGE_CMD` env seam.)
+
+**What only a signed install can confirm:** registering the scheme with Launch
+Services so a *Finder/browser* click on `vibecodes://…` routes to the app (warm
+`open-url` Apple Event), and the Gatekeeper "verified developer" badge. The verify
+script delivers the URL on the command line — the same handler code, minus the OS
+Apple-Event delivery. After `npm run dist` + dragging the app to `/Applications`,
+confirm OS routing with:
+
+```bash
+open "vibecodes://launch?relay=...&session=...&token=...&cwd=..."
+```
+
+---
+
+## Hosting (wiring the download)
+
+The app's install button points at **`/download/terminal-helper`**
+(`HELPER_INSTALL_URL` in `src/components/board/terminal-dock.tsx`). To go live:
+
+1. Run `npm run dist` → upload `VibeCodes-<ver>-arm64.dmg` (and `-x64`, or a
+   `universal` dmg) to a public URL — e.g. Supabase Storage or a Vercel static
+   asset under `vibecodes.co.uk/download/`.
+2. Make `/download/terminal-helper` serve (or redirect to) that dmg, ideally with
+   light OS/arch detection. Until then the button 404s gracefully.
+
+Bump `version` in `package.json` for each release so artifact names don't collide.

--- a/terminal/helper/electron-builder.yml
+++ b/terminal/helper/electron-builder.yml
@@ -1,0 +1,75 @@
+# electron-builder config — VibeCodes macOS helper (slice 7).
+# Build:   npm run dist            (signed + notarized — needs Nick's cert + env)
+# Unsigned: npm run pack:unsigned  (proves the bundle/Info.plist locally, no cert)
+# See BUILD-AND-SIGN.md for the full runbook.
+
+appId: co.uk.vibecodes.helper
+productName: VibeCodes
+copyright: © VibeCodes
+
+directories:
+  output: dist
+  buildResources: build
+
+# Only the helper's own code goes inside app.asar. The reused bridge + shared
+# modules are shipped as extraResources (below) so node-pty's native binaries
+# stay executable on disk — you cannot exec a spawn-helper from inside an asar.
+files:
+  - main.js
+  - package.json
+
+extraResources:
+  - from: ../bridge
+    to: bridge
+    filter:
+      - "**/*"
+      - "!**/*.test.js"
+      - "!**/*.test.mjs"
+      - "!**/package-lock.json"
+      # node-pty ships prebuilts for every platform; the mac helper only needs
+      # darwin. Dropping the win32 ones trims ~65 MB of dead weight.
+      - "!**/node-pty/prebuilds/win32-*/**"
+  - from: ../shared
+    to: shared
+    filter:
+      - "**/*.mjs"
+      - "!**/*.test.mjs"
+
+# Emits Info.plist CFBundleURLTypes so the OS routes vibecodes:// to this app.
+protocols:
+  - name: VibeCodes Terminal Launch
+    schemes:
+      - vibecodes
+
+mac:
+  category: public.app-category.developer-tools
+  # Notarization requires the Hardened Runtime.
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: entitlements.mac.plist
+  entitlementsInherit: entitlements.mac.plist
+  # Sign with a "Developer ID Application" identity. electron-builder auto-selects
+  # it from the keychain; CSC_NAME / CSC_LINK env can pin a specific identity/cert.
+  # identity: "Developer ID Application: <Your Name> (<TEAMID>)"
+  # Notarize via notarytool. `true` makes electron-builder read either:
+  #   APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID, or
+  #   APPLE_API_KEY + APPLE_API_KEY_ID + APPLE_API_ISSUER  (App Store Connect key)
+  # and staples the ticket on success. No credentials live in this file.
+  notarize: true
+  target:
+    - target: dmg
+      arch:
+        - arm64
+        - x64
+    - target: zip
+      arch:
+        - arm64
+        - x64
+
+dmg:
+  title: ${productName}
+  artifactName: ${productName}-${version}-${arch}.${ext}
+
+# Universal build alternative (one binary for Intel + Apple Silicon) — bigger
+# download but a single artifact. Swap the per-arch targets above for:
+#   target: { target: dmg, arch: universal }

--- a/terminal/helper/entitlements.mac.plist
+++ b/terminal/helper/entitlements.mac.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Hardened Runtime entitlements required for an Electron + node-pty helper.
+       Notarization REQUIRES hardened runtime; these allowances let our signed
+       bundle do what it must without weakening it more than necessary. -->
+
+  <!-- Electron/V8 JIT. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+
+  <!-- Load node-pty's prebuilt native module (pty.node) and let it exec the
+       node-pty spawn-helper binary that creates the PTY. Without library
+       validation disabled, a hardened-runtime process refuses to load a .node
+       that isn't signed by the same Team ID toolchain. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+
+  <!-- The helper forks the bridge (Electron-as-Node), which spawns `claude` in
+       the PTY: child processes must inherit the runtime sandbox/signature. -->
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>

--- a/terminal/helper/main.js
+++ b/terminal/helper/main.js
@@ -1,0 +1,178 @@
+// VibeCodes macOS helper — SLICE 7 (the "install once" piece).
+//
+// A thin, installable, URL-scheme-registered wrapper around the existing
+// terminal/bridge. Its ONLY jobs:
+//
+//   1. Register the `vibecodes://` URL scheme so the OS routes the app's signed
+//      deep link here (Info.plist CFBundleURLTypes is emitted by electron-builder
+//      from `protocols` — see electron-builder.yml; we also call
+//      app.setAsDefaultProtocolClient at runtime for dev/registration).
+//   2. On `vibecodes://launch?relay&session&token[&cwd]`, run the EXISTING bridge
+//      logic with that URL as `--launch-url`. We do NOT re-implement the PTY/relay
+//      plumbing — we `fork` terminal/bridge/src/index.js using Electron-as-Node
+//      (ELECTRON_RUN_AS_NODE=1). node-pty 1.x is N-API (ABI-stable across Node and
+//      Electron) so its prebuilt pty.node loads unchanged; the bridge itself does
+//      the macOS spawn-helper chmod.
+//
+// Headless background helper: no window, no dock icon. It stays alive while a
+// bridge child is running and quits shortly after the last one exits, so it does
+// not linger as a resident process. A subsequent link just cold-launches it again.
+
+const { app } = require("electron");
+const { fork } = require("node:child_process");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+const LAUNCH_PREFIX = "vibecodes://";
+
+// ── where the reused bridge + shared modules live ────────────────────────────
+// Packaged: copied into the app bundle under Resources/ via electron-builder
+// `extraResources` (kept OUTSIDE app.asar so node-pty's native pty.node + the
+// spawn-helper binary stay executable on disk). Dev: straight from the repo.
+const BRIDGE_ENTRY = app.isPackaged
+  ? path.join(process.resourcesPath, "bridge", "src", "index.js")
+  : path.resolve(__dirname, "..", "bridge", "src", "index.js");
+
+const SHARED_DEEPLINK = app.isPackaged
+  ? path.join(process.resourcesPath, "shared", "deep-link.mjs")
+  : path.resolve(__dirname, "..", "shared", "deep-link.mjs");
+
+// ── logging (metadata only — NEVER log the deep-link token) ───────────────────
+const t0 = Date.now();
+function log(level, msg, extra) {
+  const rec = { t: ((Date.now() - t0) / 1000).toFixed(2) + "s", level, comp: "helper", msg, ...extra };
+  process.stderr.write(JSON.stringify(rec) + "\n");
+}
+
+// Lazily import the shared (ESM) parser/redactor once. Reused — not duplicated.
+let _shared = null;
+async function shared() {
+  if (!_shared) _shared = await import(pathToFileURL(SHARED_DEEPLINK).href);
+  return _shared;
+}
+
+// ── child-bridge bookkeeping + idle quit ─────────────────────────────────────
+const children = new Set();
+let quitTimer = null;
+const IDLE_QUIT_MS = 2000; // grace after the last bridge exits before we quit
+
+function scheduleQuitIfIdle() {
+  if (children.size > 0) {
+    if (quitTimer) { clearTimeout(quitTimer); quitTimer = null; }
+    return;
+  }
+  if (quitTimer) clearTimeout(quitTimer);
+  quitTimer = setTimeout(() => {
+    if (children.size === 0) {
+      log("info", "idle — no active sessions, quitting");
+      app.quit();
+    }
+  }, IDLE_QUIT_MS);
+  quitTimer.unref?.();
+}
+
+/**
+ * Hand a `vibecodes://launch?…` URL to the existing bridge. Validates with the
+ * SHARED parser first (so we never fork on garbage), then forks the bridge with
+ * `--launch-url`. The bridge re-parses the same string (single source of truth)
+ * and connects as the relay's bridge leg.
+ */
+async function handleLaunchUrl(rawUrl) {
+  const { parseLaunchDeepLink, redactDeepLinkToken } = await shared();
+  const parsed = parseLaunchDeepLink(rawUrl);
+  if (!parsed) {
+    log("warn", "ignoring non-launch / malformed vibecodes:// url", {
+      url: redactDeepLinkToken(rawUrl),
+    });
+    return;
+  }
+  log("info", "launching bridge for deep link", { url: redactDeepLinkToken(rawUrl) });
+
+  // ELECTRON_RUN_AS_NODE=1 → the forked process is plain Node (Electron's bundled
+  // runtime), so the bridge runs exactly as it does from the CLI. We pass our env
+  // through verbatim so test seams (e.g. BRIDGE_CMD) keep working; in production
+  // the bridge defaults the spawned command to `claude`.
+  const child = fork(BRIDGE_ENTRY, ["--launch-url", rawUrl], {
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  children.add(child);
+
+  // Surface the bridge's structured logs on our stderr (already token-redacted by
+  // the bridge). Never touch stream content.
+  const relay = (line) => { if (line.trim()) process.stderr.write(line.endsWith("\n") ? line : line + "\n"); };
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", relay);
+  child.stderr?.on("data", relay);
+
+  child.on("exit", (code, signal) => {
+    children.delete(child);
+    log("info", "bridge exited", { code, signal, active: children.size });
+    scheduleQuitIfIdle();
+  });
+  child.on("error", (err) => {
+    children.delete(child);
+    log("error", "bridge failed to start", { err: String(err?.message || err) });
+    scheduleQuitIfIdle();
+  });
+}
+
+// Pull a vibecodes:// link out of an argv array (cold launch on macOS dev /
+// Windows, and the second-instance forward).
+function urlFromArgv(argv) {
+  return argv.find((a) => typeof a === "string" && a.startsWith(LAUNCH_PREFIX));
+}
+
+// ── single-instance: forward a second click's URL to the running helper ──────
+const gotLock = app.requestSingleInstanceLock();
+if (!gotLock) {
+  app.quit();
+} else {
+  app.on("second-instance", (_event, argv) => {
+    const url = urlFromArgv(argv);
+    if (url) handleLaunchUrl(url);
+  });
+
+  // macOS delivers URL-scheme activations (cold AND warm) as an Apple Event that
+  // Electron surfaces here. URLs can arrive before `ready` — queue until then.
+  const pending = [];
+  let ready = false;
+  app.on("open-url", (event, url) => {
+    event.preventDefault();
+    if (ready) handleLaunchUrl(url);
+    else pending.push(url);
+  });
+
+  app.whenReady().then(() => {
+    ready = true;
+    app.dock?.hide(); // background helper — no dock icon
+    // Register the scheme. Packaged builds also declare it in Info.plist via
+    // electron-builder `protocols`; this runtime call covers dev + (re)registration.
+    if (app.isPackaged) {
+      app.setAsDefaultProtocolClient(LAUNCH_PREFIX.replace("://", ""));
+    } else {
+      // Dev: point the registration at this Electron + project dir.
+      app.setAsDefaultProtocolClient(LAUNCH_PREFIX.replace("://", ""), process.execPath, [
+        path.resolve(__dirname),
+      ]);
+    }
+
+    // Drain anything that arrived pre-ready, then a cold-launch argv URL (covers
+    // the dev/verify path where the link is passed on the command line).
+    for (const u of pending.splice(0)) handleLaunchUrl(u);
+    const argvUrl = urlFromArgv(process.argv);
+    if (argvUrl) handleLaunchUrl(argvUrl);
+
+    scheduleQuitIfIdle();
+  });
+
+  // We never open a window; keep the app alive on our own terms.
+  app.on("window-all-closed", () => { /* no-op: managed via scheduleQuitIfIdle */ });
+
+  app.on("before-quit", () => {
+    for (const child of children) {
+      try { child.kill(); } catch { /* ignore */ }
+    }
+  });
+}

--- a/terminal/helper/package-lock.json
+++ b/terminal/helper/package-lock.json
@@ -1,0 +1,5287 @@
+{
+  "name": "vibecodes-terminal-helper",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vibecodes-terminal-helper",
+      "version": "0.1.0",
+      "devDependencies": {
+        "electron": "^33.2.0",
+        "electron-builder": "^25.1.8"
+      }
+    },
+    "node_modules/@develar/schema-utils": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.0",
+        "ajv-keywords": "^3.4.1"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+      "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/asar/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+      "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.1.tgz",
+      "integrity": "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "compare-version": "^0.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.0.0",
+        "isbinaryfile": "^4.0.8",
+        "minimist": "^1.2.6",
+        "plist": "^3.0.5"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.js",
+        "electron-osx-sign": "bin/electron-osx-sign.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.1.tgz",
+      "integrity": "sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "chalk": "^4.0.0",
+        "debug": "^4.1.1",
+        "detect-libc": "^2.0.1",
+        "fs-extra": "^10.0.0",
+        "got": "^11.7.0",
+        "node-abi": "^3.45.0",
+        "node-api-version": "^0.2.0",
+        "node-gyp": "^9.0.0",
+        "ora": "^5.1.0",
+        "read-binary-file-arch": "^1.0.6",
+        "semver": "^7.3.5",
+        "tar": "^6.0.5",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz",
+      "integrity": "sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^3.2.7",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.3.1",
+        "dir-compare": "^4.2.0",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/fs-extra": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/plist": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/verror": {
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+      "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/7zip-bin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/app-builder-bin": {
+      "version": "5.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.10.tgz",
+      "integrity": "sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/app-builder-lib": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-25.1.8.tgz",
+      "integrity": "sha512-pCqe7dfsQFBABC1jeKZXQWhGcCPF3rPCXDdfqVKjIeWBcXzyC1iOWZdfFhGl+S9MyE/k//DFmC6FzuGAUudNDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@develar/schema-utils": "~2.6.5",
+        "@electron/notarize": "2.5.0",
+        "@electron/osx-sign": "1.3.1",
+        "@electron/rebuild": "3.6.1",
+        "@electron/universal": "2.0.1",
+        "@malept/flatpak-bundler": "^0.4.0",
+        "@types/fs-extra": "9.0.13",
+        "async-exit-hook": "^2.0.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chromium-pickle-js": "^0.2.0",
+        "config-file-ts": "0.2.8-rc1",
+        "debug": "^4.3.4",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
+        "ejs": "^3.1.8",
+        "electron-publish": "25.1.7",
+        "form-data": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "hosted-git-info": "^4.1.0",
+        "is-ci": "^3.0.0",
+        "isbinaryfile": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
+        "lazy-val": "^1.0.5",
+        "minimatch": "^10.0.0",
+        "resedit": "^1.7.0",
+        "sanitize-filename": "^1.6.3",
+        "semver": "^7.3.8",
+        "tar": "^6.1.12",
+        "temp-file": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "dmg-builder": "25.1.8",
+        "electron-builder-squirrel-windows": "25.1.8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bluebird-lst": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.5.5"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builder-util": {
+      "version": "25.1.7",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-25.1.7.tgz",
+      "integrity": "sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.6",
+        "7zip-bin": "~5.2.0",
+        "app-builder-bin": "5.0.0-alpha.10",
+        "bluebird-lst": "^1.0.9",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "is-ci": "^3.0.0",
+        "js-yaml": "^4.1.0",
+        "source-map-support": "^0.5.19",
+        "stat-mode": "^1.0.0",
+        "temp-file": "^3.4.0"
+      }
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.2.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
+      "integrity": "sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/builder-util/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/builder-util/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-file-ts": {
+      "version": "0.2.8-rc1",
+      "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.8-rc1.tgz",
+      "integrity": "sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.3.12",
+        "typescript": "^5.4.3"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-file-ts/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/dir-compare": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+      "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.5",
+        "p-limit": "^3.1.0 "
+      }
+    },
+    "node_modules/dir-compare/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-compare/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/dir-compare/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dmg-builder": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-25.1.8.tgz",
+      "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "fs-extra": "^10.1.0",
+        "iconv-lite": "^0.6.2",
+        "js-yaml": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "dmg-license": "^1.0.11"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/dmg-license": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.7",
+        "plist": "^3.0.4",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
+      },
+      "bin": {
+        "dmg-license": "bin/dmg-license.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron": {
+      "version": "33.4.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
+      "integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-builder": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-25.1.8.tgz",
+      "integrity": "sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "dmg-builder": "25.1.8",
+        "fs-extra": "^10.1.0",
+        "is-ci": "^3.0.0",
+        "lazy-val": "^1.0.5",
+        "simple-update-notifier": "2.0.0",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "electron-builder": "cli.js",
+        "install-app-deps": "install-app-deps.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-25.1.8.tgz",
+      "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "archiver": "^5.3.1",
+        "builder-util": "25.1.7",
+        "fs-extra": "^10.1.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-builder/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-publish": {
+      "version": "25.1.7",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz",
+      "integrity": "sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.11",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-publish/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-publish/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-publish/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-corefoundation": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "node-addon-api": "^1.6.3"
+      },
+      "engines": {
+        "node": "^8.11.2 || >=10"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.93.0.tgz",
+      "integrity": "sha512-Cu6yUpX5Iavugm8BeX7c0wgU9CvOqfd1yM6A1d2q2ZMjym7GjpASv2GdRcTq3Fx+Sb5OgBkEEpw4VnAbY6Y5RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-api-version/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^6.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^12.13 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/pe-library": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+      "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+      "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ssri": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/stat-mode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+      "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/temp-file": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+      "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "fs-extra": "^10.0.0"
+      }
+    },
+    "node_modules/temp-file/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/temp-file/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/temp-file/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  }
+}

--- a/terminal/helper/package.json
+++ b/terminal/helper/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vibecodes-terminal-helper",
+  "version": "0.1.0",
+  "private": true,
+  "description": "macOS helper app: registers the vibecodes:// URL scheme and runs the terminal bridge (node-pty PTY -> relay) on launch. A thin, installable, signable wrapper around terminal/bridge (no logic duplication).",
+  "author": "VibeCodes",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "verify": "node verify-helper-launch.mjs",
+    "pack:unsigned": "CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --dir -c electron-builder.yml",
+    "dist": "electron-builder -c electron-builder.yml"
+  },
+  "devDependencies": {
+    "electron": "^33.2.0",
+    "electron-builder": "^25.1.8"
+  }
+}

--- a/terminal/helper/verify-helper-launch.mjs
+++ b/terminal/helper/verify-helper-launch.mjs
@@ -1,0 +1,133 @@
+// Slice-7 proof: a real `vibecodes://launch?…` URL drives the HELPER → live relay.
+//
+// This exercises the exact production path the OS will trigger after the signed
+// install — minus the OS Apple-Event delivery (only a signed install can confirm
+// the "verified" Gatekeeper badge + Finder-delivered open-url). Here we hand the
+// link to the Electron helper on the command line (the same code path the helper's
+// cold-launch argv handler runs), and assert the round-trip through the LIVE relay.
+//
+//   helper (Electron) --fork--> bridge --node-pty PTY--> sentinel
+//        |                                                   |
+//        +--ws--> LIVE relay (Cloudflare DO) <--ws-- browser leg (this script)
+//
+// We mint owner-bound tokens with the SAME secret the deployed relay verifies with
+// (terminal/relay/.dev.vars → TERMINAL_SESSION_SECRET) and use a non-interactive
+// sentinel command (via the bridge's BRIDGE_CMD env seam) instead of interactive
+// `claude`, so the byte round-trip is deterministic.
+//
+// Usage:
+//   cd terminal/helper && npm install && node verify-helper-launch.mjs
+//   (override the relay with RELAY_URL=..., or the secret with TERMINAL_SESSION_SECRET=...)
+
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { mintSessionTokens } from "../shared/session-token.mjs";
+import { buildLaunchDeepLink, redactDeepLinkToken } from "../shared/deep-link.mjs";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, "..", "..");
+
+// ws + electron come from the bridge / helper node_modules respectively.
+const WebSocket = require(path.join(REPO, "terminal/bridge/node_modules/ws"));
+const electronBin = require(path.join(__dirname, "node_modules/electron")); // exports the binary path
+
+const MAIN = path.join(__dirname, "main.js");
+const SENTINEL = path.resolve(REPO, "terminal/test/sentinel-cmd.mjs");
+const RELAY_URL =
+  process.env.RELAY_URL || "wss://vibecodes-terminal-relay.nicholasmball.workers.dev";
+const HARD_TIMEOUT_MS = 30000;
+const session = `helper-verify-${Math.random().toString(36).slice(2, 8)}`;
+const owner = `helper-user-${Math.random().toString(36).slice(2, 8)}`;
+
+function readSecret() {
+  if (process.env.TERMINAL_SESSION_SECRET) return process.env.TERMINAL_SESSION_SECRET;
+  const devVars = path.resolve(REPO, "terminal/relay/.dev.vars");
+  const txt = fs.readFileSync(devVars, "utf8");
+  const m = txt.match(/^TERMINAL_SESSION_SECRET\s*=\s*(.+)\s*$/m);
+  if (!m) throw new Error("TERMINAL_SESSION_SECRET not found in terminal/relay/.dev.vars");
+  return m[1].trim().replace(/^['"]|['"]$/g, "");
+}
+
+function waitForText(getBuf, text, ms, label) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const iv = setInterval(() => {
+      if (getBuf().includes(text)) { clearInterval(iv); resolve(Date.now() - started); }
+      else if (Date.now() - started > ms) { clearInterval(iv); reject(new Error(`timeout waiting for ${label}`)); }
+    }, 25);
+  });
+}
+
+let helper, browser;
+function cleanup() {
+  try { browser?.terminate(); } catch { /* ignore */ }
+  if (helper && helper.exitCode === null) helper.kill("SIGKILL");
+}
+
+try {
+  const SECRET = readSecret();
+  console.log(`[verify] relay   = ${RELAY_URL}`);
+  console.log(`[verify] session = ${session}`);
+
+  const tokens = await mintSessionTokens({ sub: owner, idea: "helper-idea", sid: session, secret: SECRET });
+
+  // (1) Attach the browser leg to the LIVE relay and wait for it to open.
+  let browserBuf = "";
+  browser = new WebSocket(`${RELAY_URL}/?session=${session}&role=browser&token=${encodeURIComponent(tokens.browser)}`);
+  browser.on("message", (d) => { browserBuf += Buffer.isBuffer(d) ? d.toString("utf8") : String(d); });
+  await Promise.race([
+    once(browser, "open"),
+    new Promise((_, r) => setTimeout(() => r(new Error("browser open timeout")), 8000)),
+  ]);
+  console.log("[verify] browser leg connected to LIVE relay");
+
+  // (2) Build the real deep link and hand it to the HELPER on the command line
+  //     (same path the helper's cold-launch argv handler runs on a real OS click).
+  const launchUrl = buildLaunchDeepLink({
+    relay: RELAY_URL,
+    session,
+    token: tokens.bridge,
+    cwd: REPO,
+  });
+  console.log(`[verify] launch url = ${redactDeepLinkToken(launchUrl)}`);
+
+  // By default drive `electron main.js` (dev path). HELPER_BIN lets us instead
+  // drive the packaged .app binary, exercising the app.isPackaged Resources path.
+  const [bin, binArgs] = process.env.HELPER_BIN
+    ? [process.env.HELPER_BIN, [launchUrl]]
+    : [electronBin, [MAIN, launchUrl]];
+  helper = spawn(bin, binArgs, {
+    // Test seam: the bridge runs the sentinel instead of interactive `claude`.
+    env: {
+      ...process.env,
+      BRIDGE_CMD: `${process.execPath} ${SENTINEL}`,
+      ELECTRON_DISABLE_SECURITY_WARNINGS: "1",
+    },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+
+  // (3) The helper forks the bridge, which spawns the PTY and dials the live relay.
+  //     The browser leg should receive the sentinel's "READY" banner.
+  const tReady = await waitForText(() => browserBuf, "READY", HARD_TIMEOUT_MS, "PTY sentinel via helper");
+  console.log(`[verify] (a) PASS — helper -> bridge -> PTY -> LIVE relay -> browser saw "READY" in ${tReady}ms`);
+
+  // (4) Round-trip: browser -> relay -> PTY stdin -> sentinel echo -> back to browser.
+  const ping = `PING-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+  browserBuf = "";
+  browser.send(Buffer.from(ping + "\n", "utf8"), { binary: true });
+  const tEcho = await waitForText(() => browserBuf, ping, HARD_TIMEOUT_MS, "PTY echo");
+  console.log(`[verify] (b) PASS — full byte round-trip of ${ping} via the helper in ${tEcho}ms`);
+
+  console.log("[verify] ALL ASSERTIONS PASSED — vibecodes://launch drove the helper to the live relay");
+  cleanup();
+  setTimeout(() => process.exit(0), 200).unref();
+} catch (e) {
+  console.error("[verify] FAILED:", e.message);
+  cleanup();
+  setTimeout(() => process.exit(1), 200).unref();
+}

--- a/terminal/relay/DEPLOY.md
+++ b/terminal/relay/DEPLOY.md
@@ -1,0 +1,145 @@
+# Deploying the VibeCodes Terminal Relay (Cloudflare Worker + Durable Object)
+
+The relay is a tiny Cloudflare Worker backed by ONE Durable Object class
+(`TerminalRelay`). It opaquely forwards bytes between a `bridge` leg (the user's
+local machine) and a single `browser` leg (the in-app terminal). It uses the
+**WebSocket Hibernation API** (so an idle session stops billing duration) plus DO
+**alarms** for idle / max-duration limits.
+
+> You don't need any of this to develop locally — `npx wrangler dev` runs the real
+> Worker + DO offline. This doc is only for putting it on the public internet.
+
+## 0. Prerequisites
+
+- A **Cloudflare account** — create one at <https://dash.cloudflare.com/sign-up>.
+- The **Workers Paid plan ($5/mo)**. **Durable Objects are not available on the
+  free plan**, and this relay is entirely a Durable Object, so the Paid plan is
+  mandatory. Enable it under *Workers & Pages → Plans*.
+- Node 18+ locally. Wrangler is already a dev dependency of `terminal/relay`, so
+  you can use `npx wrangler …` (no global install needed). To install it globally
+  instead: `npm i -g wrangler`.
+
+## 1. Log in
+
+```bash
+cd terminal/relay
+npx wrangler login          # opens a browser to authorize wrangler against your account
+npx wrangler whoami         # confirm the account + email
+```
+
+If the machine has no browser (CI/SSH), create an API token instead
+(*My Profile → API Tokens → Edit Cloudflare Workers* template) and export it:
+
+```bash
+export CLOUDFLARE_API_TOKEN=<token>
+```
+
+## 2. Set the session secret (MUST match the app)
+
+The relay verifies app-minted session tokens with `TERMINAL_SESSION_SECRET`
+(HMAC-SHA256). It must be **byte-for-byte identical** to the value the VibeCodes
+app signs with (its `TERMINAL_SESSION_SECRET` env var). It is a **secret**, never
+committed and never placed in `wrangler.toml`:
+
+```bash
+npx wrangler secret put TERMINAL_SESSION_SECRET
+# paste the SAME value as the app's TERMINAL_SESSION_SECRET, then Enter
+```
+
+(The local-dev equivalent is `terminal/relay/.dev.vars`, which is gitignored and
+loaded automatically by `wrangler dev` — never used in production.)
+
+The idle / max-duration limits ship as plain `[vars]` in `wrangler.toml`
+(`TERMINAL_IDLE_MS = 1800000` / `TERMINAL_MAX_MS = 14400000` → 30 min / 4 h). Tune
+them there and re-`deploy`; they are not secrets. If absent, the DO falls back to
+the same defaults in code.
+
+## 3. Deploy
+
+```bash
+npx wrangler deploy
+```
+
+First deploy of a new DO class applies the `[[migrations]]` (`tag = "v1"`,
+`new_classes = ["TerminalRelay"]`) automatically. On success wrangler prints the
+public URL, e.g.:
+
+```
+https://vibecodes-terminal-relay.<your-subdomain>.workers.dev
+```
+
+Smoke-test it (the Worker answers a plain GET with 426 / `/healthz` with `ok`):
+
+```bash
+curl https://vibecodes-terminal-relay.<your-subdomain>.workers.dev/healthz   # → ok
+```
+
+WebSocket scheme: clients connect with **`wss://`** (TLS), not `https://`:
+
+```
+wss://vibecodes-terminal-relay.<your-subdomain>.workers.dev/?session=<id>&role=<bridge|browser>&token=<jwt>
+```
+
+### Optional: custom domain (`relay.vibecodes.co.uk`)
+
+If the `vibecodes.co.uk` zone is on this Cloudflare account, add a route in the
+dashboard (*Workers & Pages → vibecodes-terminal-relay → Settings → Domains &
+Routes → Add → Custom Domain*) for `relay.vibecodes.co.uk`. Cloudflare provisions
+the cert; the relay is then reachable at `wss://relay.vibecodes.co.uk/…`.
+
+## 4. Point the app at the relay
+
+Set the public env var in the VibeCodes app's **production (Vercel)** project so
+the in-app terminal dock attaches its `browser` leg to the deployed relay:
+
+```
+NEXT_PUBLIC_TERMINAL_RELAY_URL = wss://relay.vibecodes.co.uk
+#   (or) wss://vibecodes-terminal-relay.<your-subdomain>.workers.dev
+```
+
+Vercel → Project → Settings → Environment Variables → add for *Production* (and
+*Preview* if you want previews to use it), then redeploy. The app reads it via
+`relayBaseUrl()` in `src/lib/terminal/connection.ts` (default falls back to the
+local `ws://127.0.0.1:8787` for dev). The bridge helper receives the same URL
+inside the signed `vibecodes://launch?relay=…` deep link, so there is nothing else
+to configure on the bridge side.
+
+> Keep `TERMINAL_SESSION_SECRET` in sync across BOTH places (Vercel app env +
+> `wrangler secret`). A mismatch makes every leg fail token verification → the
+> relay closes with code `4006` and the dock shows the bad-token error.
+
+## 5. Operate
+
+Tail live logs (metadata only — the relay never logs stream content):
+
+```bash
+npx wrangler tail
+# or filter: npx wrangler tail --format pretty --status error
+```
+
+Roll back to the previous deployed version:
+
+```bash
+npx wrangler rollback                 # rolls back the latest deployment
+npx wrangler deployments list         # see versions / pick an id
+npx wrangler rollback <version-id>    # roll back to a specific version
+```
+
+> Durable Object **migrations** (the `[[migrations]]` block) cannot be rolled back
+> like code — `wrangler rollback` reverts the Worker script, not a class migration.
+> Since this relay only has `v1` (class creation), that's a non-issue today; if you
+> later rename/delete the DO class, add a new forward migration tag rather than
+> trying to undo one.
+
+## Notes / gotchas
+
+- **Local `wrangler dev` does not forward server-initiated WebSocket close frames
+  to clients** for hibernatable sockets (known wrangler/miniflare bug,
+  [workers-sdk #1812](https://github.com/cloudflare/workers-sdk/issues/1812) /
+  [#10307](https://github.com/cloudflare/workers-sdk/issues/10307)). The DO still
+  closes the session correctly server-side (visible in `wrangler dev` logs and
+  `wrangler tail`); production workerd delivers the close code/reason to clients as
+  expected. The hermetic Node stand-in test proves the client-observed close.
+- **One DO instance per session id** (`idFromName(session)`); legs for the same
+  session always land on the same instance, which is what makes pairing +
+  single-attach + owner-binding work.

--- a/terminal/relay/package-lock.json
+++ b/terminal/relay/package-lock.json
@@ -1,0 +1,1553 @@
+{
+  "name": "vibecodes-terminal-relay",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vibecodes-terminal-relay",
+      "version": "0.1.0",
+      "devDependencies": {
+        "wrangler": "^4.105.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260625.1.tgz",
+      "integrity": "sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260625.1.tgz",
+      "integrity": "sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260625.1.tgz",
+      "integrity": "sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260625.1.tgz",
+      "integrity": "sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260625.1.tgz",
+      "integrity": "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260625.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260625.0.tgz",
+      "integrity": "sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260625.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260625.1.tgz",
+      "integrity": "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260625.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260625.1",
+        "@cloudflare/workerd-linux-64": "1.20260625.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260625.1",
+        "@cloudflare/workerd-windows-64": "1.20260625.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.105.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.105.0.tgz",
+      "integrity": "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260625.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260625.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260625.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/terminal/relay/package.json
+++ b/terminal/relay/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vibecodes-terminal-relay",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Cloudflare Worker + Durable Object that opaquely relays bytes between a bridge leg and a single browser leg per session. (Slice 1)",
+  "scripts": {
+    "dev": "wrangler dev",
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "wrangler": "^4.105.0"
+  }
+}

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -17,6 +17,7 @@
 // identical rules.
 
 import { decideAttach, isValidSession, CLOSE } from "./pairing.js";
+import { authorizeAttach } from "../../shared/session-token.mjs";
 
 export default {
   /**
@@ -38,9 +39,11 @@ export default {
     }
 
     const session = url.searchParams.get("session");
-    // TODO(slice 2): validate app-minted session token + owner binding here —
-    // verify the signed vibecodes:// payload and bind to the authenticated human
-    // BEFORE routing to the DO, so an unauthorized leg never reaches a session.
+    // Cheap shape guard first (a malformed session id can't address a DO). FULL
+    // token verification + owner-binding happens inside the Durable Object on WS
+    // attach (see TerminalRelay.fetch) — that is where the per-session owner state
+    // lives, so both the signature/expiry check and the owner check are enforced
+    // in one place, by the same shared `authorizeAttach`.
     if (!isValidSession(session)) {
       return new Response(CLOSE.BAD_SESSION.reason, { status: 400 });
     }
@@ -64,6 +67,8 @@ export class TerminalRelay {
     this.bridge = null;
     /** @type {WebSocket|null} */
     this.browser = null;
+    /** @type {string|null} owning user id (`sub`) this session is bound to */
+    this.owner = null;
     this.bytes = { bridge: 0, browser: 0 };
   }
 
@@ -78,6 +83,7 @@ export class TerminalRelay {
     return {
       bridge: this.bridge !== null,
       browser: this.browser !== null,
+      owner: this.owner,
     };
   }
 
@@ -86,13 +92,30 @@ export class TerminalRelay {
     const url = new URL(request.url);
     const role = url.searchParams.get("role");
     const session = url.searchParams.get("session");
+    const token = url.searchParams.get("token");
 
     const pair = new WebSocketPair();
     const client = pair[0];
     const server = pair[1];
     server.accept();
 
-    const decision = decideAttach(this.attachState(), role);
+    // 1) Authenticate the leg: verify the app-minted token's signature + expiry and
+    //    that its `sid`/`role` claims match THIS connection. Never log the token.
+    const auth = await authorizeAttach({
+      token,
+      secret: this.env.TERMINAL_SESSION_SECRET,
+      session,
+      role,
+    });
+    if (!auth.ok) {
+      this.log("attach rejected (auth)", { session, role, reason: auth.reason, code: CLOSE.BAD_TOKEN.code });
+      server.close(CLOSE.BAD_TOKEN.code, CLOSE.BAD_TOKEN.reason);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    // 2) Owner-binding + single-attach (pure). Both legs of a session must carry the
+    //    same `sub`; a leg for a different user is rejected with OWNER_MISMATCH.
+    const decision = decideAttach(this.attachState(), role, auth.sub);
     if (!decision.ok) {
       this.log("attach rejected", { session, role, code: decision.code, reason: decision.reason });
       // Send the close on the accepted server socket so the client sees the code.
@@ -100,6 +123,7 @@ export class TerminalRelay {
       return new Response(null, { status: 101, webSocket: client });
     }
 
+    if (this.owner === null) this.owner = auth.sub;
     if (role === "bridge") this.bridge = server;
     else this.browser = server;
     this.log("attached", { session, role, ...this.attachState() });
@@ -136,6 +160,9 @@ export class TerminalRelay {
         if (role === "bridge") this.browser = null;
         else this.bridge = null;
       }
+      // Release the owner binding once the session is fully empty so the id can be
+      // cleanly re-established by an authorized owner.
+      if (this.bridge === null && this.browser === null) this.owner = null;
     };
 
     server.addEventListener("close", () => teardown("close"));

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -1,23 +1,49 @@
-// VibeCodes Terminal Relay — Cloudflare Worker + Durable Object — SLICE 1
+// VibeCodes Terminal Relay — Cloudflare Worker + Durable Object — SLICE 6
 //
 // One Durable Object instance per `session` id. It accepts two WebSocket legs —
 // `bridge` (the local machine) and `browser` (the in-app terminal) — pairs them,
 // and forwards bytes OPAQUELY in both directions. It never parses or logs stream
-// content; only metadata (session id, role, byte counts).
+// content; only metadata (session id, role).
 //
-// Enforces SINGLE-ATTACH: a 2nd browser (or 2nd bridge) for an already-attached
-// session is rejected with a clear close code/reason.
+// Enforces SINGLE-ATTACH and OWNER-BINDING: a 2nd browser/bridge is rejected, and
+// both legs must carry the same owner (`sub`).
 //
-// Connect with:  wss://<host>/?session=<id>&role=<bridge|browser>
+// SLICE 6 — WebSocket Hibernation + lifecycle timers:
+//   The DO uses the WebSocket HIBERNATION API (`state.acceptWebSocket` + the
+//   `webSocket*` handler methods) so it can be EVICTED FROM MEMORY between
+//   messages and stop billing duration while a session sits idle. Because instance
+//   fields don't survive eviction, all session state is reconstructed from durable
+//   sources on every wake-up:
+//     - per-socket identity → `ws.serializeAttachment({ role, sub })` + tags
+//       (`role:<role>`, `sub:<sub>`), read back via `getWebSockets(tag)` /
+//       `deserializeAttachment()`.
+//     - owner binding + lifecycle bookkeeping → `state.storage`.
+//   Idle / max-duration limits are enforced with DO ALARMS (also
+//   hibernation-compatible), so a forgotten session is closed cleanly instead of
+//   living forever.
+//
+// Connect with:  wss://<host>/?session=<id>&role=<bridge|browser>&token=<jwt>
 //
 // Run locally (offline, no Cloudflare account):  npx wrangler dev
 //
-// The pairing / single-attach decision logic lives in ./pairing.js and is shared
-// with the Node stand-in relay used by the automated test, so both enforce
-// identical rules.
+// The pairing / single-attach / lifecycle decision logic lives in ./pairing.js and
+// is shared with the Node stand-in relay used by the automated tests, so both
+// enforce identical rules.
 
-import { decideAttach, isValidSession, CLOSE } from "./pairing.js";
+import {
+  decideAttach,
+  isValidSession,
+  CLOSE,
+  DEFAULT_IDLE_MS,
+  DEFAULT_MAX_MS,
+  idleCloseReason,
+  maxCloseReason,
+  resolveMs,
+} from "./pairing.js";
 import { authorizeAttach } from "../../shared/session-token.mjs";
+
+/** Normal WebSocket closure code used for clean, server-initiated session ends. */
+const NORMAL_CLOSURE = 1000;
 
 export default {
   /**
@@ -41,9 +67,7 @@ export default {
     const session = url.searchParams.get("session");
     // Cheap shape guard first (a malformed session id can't address a DO). FULL
     // token verification + owner-binding happens inside the Durable Object on WS
-    // attach (see TerminalRelay.fetch) — that is where the per-session owner state
-    // lives, so both the signature/expiry check and the owner check are enforced
-    // in one place, by the same shared `authorizeAttach`.
+    // attach (see TerminalRelay.fetch).
     if (!isValidSession(session)) {
       return new Response(CLOSE.BAD_SESSION.reason, { status: 400 });
     }
@@ -63,13 +87,9 @@ export class TerminalRelay {
   constructor(state, env) {
     this.state = state;
     this.env = env;
-    /** @type {WebSocket|null} */
-    this.bridge = null;
-    /** @type {WebSocket|null} */
-    this.browser = null;
-    /** @type {string|null} owning user id (`sub`) this session is bound to */
-    this.owner = null;
-    this.bytes = { bridge: 0, browser: 0 };
+    // NOTE (hibernation): do NOT keep session state in instance fields — the DO
+    // can be evicted between messages. Live sockets + state.storage are the only
+    // durable sources, read on demand below.
   }
 
   /** @param {string} msg @param {object} [extra] */
@@ -78,13 +98,33 @@ export class TerminalRelay {
     console.log(JSON.stringify({ comp: "relay", msg, ...extra }));
   }
 
-  /** Current attachment state derived from live sockets (pure-logic input). */
-  attachState() {
-    return {
-      bridge: this.bridge !== null,
-      browser: this.browser !== null,
-      owner: this.owner,
-    };
+  /** Idle cap in ms (env override → default). */
+  idleMs() {
+    return resolveMs(this.env.TERMINAL_IDLE_MS, DEFAULT_IDLE_MS);
+  }
+
+  /** Max session age in ms (env override → default). */
+  maxMs() {
+    return resolveMs(this.env.TERMINAL_MAX_MS, DEFAULT_MAX_MS);
+  }
+
+  /** The live peer socket for the opposite role, or null. Tag-driven so it works post-hibernation. */
+  findPeer(role) {
+    const peerTag = role === "bridge" ? "role:browser" : "role:bridge";
+    return this.state.getWebSockets(peerTag)[0] ?? null;
+  }
+
+  /**
+   * Current attachment state, derived from the LIVE hibernatable sockets + the
+   * durable owner binding — the pure-logic input for decideAttach. This is how
+   * single-attach/owner survive eviction: we never trust instance memory.
+   * @returns {Promise<import("./pairing.js").AttachState>}
+   */
+  async computeAttachState() {
+    const bridge = this.state.getWebSockets("role:bridge").length > 0;
+    const browser = this.state.getWebSockets("role:browser").length > 0;
+    const owner = (await this.state.storage.get("owner")) ?? null;
+    return { bridge, browser, owner };
   }
 
   /** @param {Request} request */
@@ -97,7 +137,6 @@ export class TerminalRelay {
     const pair = new WebSocketPair();
     const client = pair[0];
     const server = pair[1];
-    server.accept();
 
     // 1) Authenticate the leg: verify the app-minted token's signature + expiry and
     //    that its `sid`/`role` claims match THIS connection. Never log the token.
@@ -109,65 +148,150 @@ export class TerminalRelay {
     });
     if (!auth.ok) {
       this.log("attach rejected (auth)", { session, role, reason: auth.reason, code: CLOSE.BAD_TOKEN.code });
+      // Reject with a close FRAME (not an HTTP error) so the client sees the code.
+      // A rejected leg never joins hibernation — plain accept + close.
+      server.accept();
       server.close(CLOSE.BAD_TOKEN.code, CLOSE.BAD_TOKEN.reason);
       return new Response(null, { status: 101, webSocket: client });
     }
 
-    // 2) Owner-binding + single-attach (pure). Both legs of a session must carry the
-    //    same `sub`; a leg for a different user is rejected with OWNER_MISMATCH.
-    const decision = decideAttach(this.attachState(), role, auth.sub);
+    // 2) Owner-binding + single-attach (pure), fed from LIVE sockets + durable owner.
+    const state = await this.computeAttachState();
+    const decision = decideAttach(state, role, auth.sub);
     if (!decision.ok) {
       this.log("attach rejected", { session, role, code: decision.code, reason: decision.reason });
-      // Send the close on the accepted server socket so the client sees the code.
+      server.accept();
       server.close(decision.code, decision.reason);
       return new Response(null, { status: 101, webSocket: client });
     }
 
-    if (this.owner === null) this.owner = auth.sub;
-    if (role === "bridge") this.bridge = server;
-    else this.browser = server;
-    this.log("attached", { session, role, ...this.attachState() });
+    // 3) Accept into HIBERNATION. Tag by role (+ sub) so the peer is findable and
+    //    single-attach is re-derivable after the DO is evicted from memory.
+    this.state.acceptWebSocket(server, [`role:${role}`, `sub:${auth.sub}`]);
+    // Per-socket identity that survives hibernation (read via deserializeAttachment).
+    server.serializeAttachment({ role, sub: auth.sub });
 
-    server.addEventListener("message", (event) => {
-      const peer = role === "bridge" ? this.browser : this.bridge;
-      const data = event.data;
-      // Count bytes for metadata; do NOT inspect content.
-      this.bytes[role] += typeof data === "string" ? data.length : data.byteLength;
-      if (peer) {
-        try {
-          peer.send(data); // verbatim, opaque
-        } catch (e) {
-          this.log("forward failed", { session, role, err: String(e) });
-        }
-      }
-      // If no peer yet, the frame is dropped — slice 1 has no buffering. The
-      // bridge's first PTY output may predate the browser attaching; the test
-      // orchestrates browser-first to avoid races, and real usage opens the
-      // browser dock to "Connecting…" before the bridge produces output.
-    });
+    // 4) Durable bookkeeping. Bind the owner on the first leg; stamp the session
+    //    start + activity and arm the idle/max alarm.
+    const now = Date.now();
+    if (state.owner === null) await this.state.storage.put("owner", auth.sub);
+    if ((await this.state.storage.get("sessionStartedAt")) == null) {
+      await this.state.storage.put("sessionStartedAt", now);
+    }
+    await this.state.storage.put("lastActivityAt", now);
+    await this.armAlarm(now);
 
-    const teardown = (why) => {
-      if (role === "bridge") this.bridge = null;
-      else this.browser = null;
-      this.log("detached", { session, role, why, bytes: this.bytes[role] });
-      // Tell the surviving peer its partner is gone, then drop it so the
-      // session can be cleanly re-established.
-      const peer = role === "bridge" ? this.browser : this.bridge;
-      if (peer) {
-        try {
-          peer.close(CLOSE.PEER_GONE.code, CLOSE.PEER_GONE.reason);
-        } catch { /* already closing */ }
-        if (role === "bridge") this.browser = null;
-        else this.bridge = null;
-      }
-      // Release the owner binding once the session is fully empty so the id can be
-      // cleanly re-established by an authorized owner.
-      if (this.bridge === null && this.browser === null) this.owner = null;
-    };
-
-    server.addEventListener("close", () => teardown("close"));
-    server.addEventListener("error", () => teardown("error"));
-
+    this.log("attached", { session, role, ...(await this.computeAttachState()) });
     return new Response(null, { status: 101, webSocket: client });
+  }
+
+  // ── Hibernation handlers (called by the runtime; the DO may have just woken) ──
+
+  /**
+   * @param {WebSocket} ws
+   * @param {string|ArrayBuffer} message
+   */
+  async webSocketMessage(ws, message) {
+    const att = ws.deserializeAttachment() || {};
+    const role = att.role;
+    if (role !== "bridge" && role !== "browser") return;
+
+    // Forward verbatim + opaque. Never inspect or log the payload.
+    const peer = this.findPeer(role);
+    if (peer) {
+      try {
+        peer.send(message);
+      } catch (e) {
+        this.log("forward failed", { role, err: String(e) });
+      }
+    }
+    // If no peer yet the frame is dropped (no buffering) — see slice-1 notes.
+
+    // Record activity + re-arm the idle/max alarm to the next deadline.
+    const now = Date.now();
+    await this.state.storage.put("lastActivityAt", now);
+    await this.armAlarm(now);
+  }
+
+  /**
+   * @param {WebSocket} ws @param {number} code @param {string} reason @param {boolean} wasClean
+   */
+  async webSocketClose(ws, code, reason, wasClean) {
+    await this.handleDetach(ws, "close", { code, wasClean });
+  }
+
+  /** @param {WebSocket} ws @param {unknown} error */
+  async webSocketError(ws, error) {
+    await this.handleDetach(ws, "error", { err: String(error) });
+  }
+
+  /**
+   * One leg went away. Tell the surviving peer (PEER_GONE) and drop it so the
+   * session id can be cleanly re-established, then release all session state.
+   * @param {WebSocket} ws @param {string} why @param {object} [extra]
+   */
+  async handleDetach(ws, why, extra = {}) {
+    let role = null;
+    try {
+      role = ws.deserializeAttachment()?.role ?? null;
+    } catch { /* attachment may be gone */ }
+    this.log("detached", { role, why, ...extra });
+
+    // Close the surviving peer (the closing socket may still appear in the list).
+    for (const peer of this.state.getWebSockets()) {
+      if (peer === ws) continue;
+      try {
+        peer.close(CLOSE.PEER_GONE.code, CLOSE.PEER_GONE.reason);
+      } catch { /* already closing */ }
+    }
+    // The session is now empty → release the owner binding + lifecycle state so a
+    // fresh authorized owner can re-establish the id.
+    await this.clearSessionState();
+  }
+
+  // ── Idle / max-duration via DO alarms ────────────────────────────────────────
+
+  /** Arm the alarm to the nearest of (idle deadline, max-duration deadline). */
+  async armAlarm(now) {
+    const started = (await this.state.storage.get("sessionStartedAt")) ?? now;
+    const next = Math.min(now + this.idleMs(), started + this.maxMs());
+    await this.state.storage.setAlarm(next);
+  }
+
+  /** Hibernation-compatible alarm: enforce the lifecycle caps or re-arm. */
+  async alarm() {
+    const now = Date.now();
+    const started = await this.state.storage.get("sessionStartedAt");
+    const last = await this.state.storage.get("lastActivityAt");
+
+    if (started != null && now - started >= this.maxMs()) {
+      this.log("session ended", { why: "max-duration", ageMs: now - started });
+      return this.endSession(maxCloseReason(this.maxMs()));
+    }
+    if (last != null && now - last >= this.idleMs()) {
+      this.log("session ended", { why: "idle-timeout", idleMs: now - last });
+      return this.endSession(idleCloseReason(this.idleMs()));
+    }
+    // Activity happened since the alarm was set (or no legs) → re-arm defensively.
+    if (started != null || last != null) {
+      const next = Math.min((last ?? now) + this.idleMs(), (started ?? now) + this.maxMs());
+      await this.state.storage.setAlarm(next);
+    }
+  }
+
+  /** Close BOTH legs with the normal code 1000 + lifecycle reason, then clear state. */
+  async endSession(reason) {
+    for (const ws of this.state.getWebSockets()) {
+      try {
+        ws.close(NORMAL_CLOSURE, reason);
+      } catch { /* already closing */ }
+    }
+    await this.clearSessionState();
+  }
+
+  /** Release owner binding + lifecycle bookkeeping + any pending alarm. */
+  async clearSessionState() {
+    await this.state.storage.delete(["owner", "sessionStartedAt", "lastActivityAt"]);
+    await this.state.storage.deleteAlarm();
   }
 }

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -1,0 +1,146 @@
+// VibeCodes Terminal Relay — Cloudflare Worker + Durable Object — SLICE 1
+//
+// One Durable Object instance per `session` id. It accepts two WebSocket legs —
+// `bridge` (the local machine) and `browser` (the in-app terminal) — pairs them,
+// and forwards bytes OPAQUELY in both directions. It never parses or logs stream
+// content; only metadata (session id, role, byte counts).
+//
+// Enforces SINGLE-ATTACH: a 2nd browser (or 2nd bridge) for an already-attached
+// session is rejected with a clear close code/reason.
+//
+// Connect with:  wss://<host>/?session=<id>&role=<bridge|browser>
+//
+// Run locally (offline, no Cloudflare account):  npx wrangler dev
+//
+// The pairing / single-attach decision logic lives in ./pairing.js and is shared
+// with the Node stand-in relay used by the automated test, so both enforce
+// identical rules.
+
+import { decideAttach, isValidSession, CLOSE } from "./pairing.js";
+
+export default {
+  /**
+   * @param {Request} request
+   * @param {{ TERMINAL_RELAY: DurableObjectNamespace }} env
+   */
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/healthz") {
+      return new Response("ok", { status: 200 });
+    }
+
+    if (request.headers.get("Upgrade") !== "websocket") {
+      return new Response(
+        "VibeCodes terminal relay. Connect a WebSocket: /?session=<id>&role=<bridge|browser>",
+        { status: 426 },
+      );
+    }
+
+    const session = url.searchParams.get("session");
+    // TODO(slice 2): validate app-minted session token + owner binding here —
+    // verify the signed vibecodes:// payload and bind to the authenticated human
+    // BEFORE routing to the DO, so an unauthorized leg never reaches a session.
+    if (!isValidSession(session)) {
+      return new Response(CLOSE.BAD_SESSION.reason, { status: 400 });
+    }
+
+    // Route every leg for a given session to the SAME Durable Object instance.
+    const id = env.TERMINAL_RELAY.idFromName(session);
+    const stub = env.TERMINAL_RELAY.get(id);
+    return stub.fetch(request);
+  },
+};
+
+export class TerminalRelay {
+  /**
+   * @param {DurableObjectState} state
+   * @param {Record<string, unknown>} env
+   */
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+    /** @type {WebSocket|null} */
+    this.bridge = null;
+    /** @type {WebSocket|null} */
+    this.browser = null;
+    this.bytes = { bridge: 0, browser: 0 };
+  }
+
+  /** @param {string} msg @param {object} [extra] */
+  log(msg, extra = {}) {
+    // Metadata only — never stream content.
+    console.log(JSON.stringify({ comp: "relay", msg, ...extra }));
+  }
+
+  /** Current attachment state derived from live sockets (pure-logic input). */
+  attachState() {
+    return {
+      bridge: this.bridge !== null,
+      browser: this.browser !== null,
+    };
+  }
+
+  /** @param {Request} request */
+  async fetch(request) {
+    const url = new URL(request.url);
+    const role = url.searchParams.get("role");
+    const session = url.searchParams.get("session");
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+    server.accept();
+
+    const decision = decideAttach(this.attachState(), role);
+    if (!decision.ok) {
+      this.log("attach rejected", { session, role, code: decision.code, reason: decision.reason });
+      // Send the close on the accepted server socket so the client sees the code.
+      server.close(decision.code, decision.reason);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    if (role === "bridge") this.bridge = server;
+    else this.browser = server;
+    this.log("attached", { session, role, ...this.attachState() });
+
+    server.addEventListener("message", (event) => {
+      const peer = role === "bridge" ? this.browser : this.bridge;
+      const data = event.data;
+      // Count bytes for metadata; do NOT inspect content.
+      this.bytes[role] += typeof data === "string" ? data.length : data.byteLength;
+      if (peer) {
+        try {
+          peer.send(data); // verbatim, opaque
+        } catch (e) {
+          this.log("forward failed", { session, role, err: String(e) });
+        }
+      }
+      // If no peer yet, the frame is dropped — slice 1 has no buffering. The
+      // bridge's first PTY output may predate the browser attaching; the test
+      // orchestrates browser-first to avoid races, and real usage opens the
+      // browser dock to "Connecting…" before the bridge produces output.
+    });
+
+    const teardown = (why) => {
+      if (role === "bridge") this.bridge = null;
+      else this.browser = null;
+      this.log("detached", { session, role, why, bytes: this.bytes[role] });
+      // Tell the surviving peer its partner is gone, then drop it so the
+      // session can be cleanly re-established.
+      const peer = role === "bridge" ? this.browser : this.bridge;
+      if (peer) {
+        try {
+          peer.close(CLOSE.PEER_GONE.code, CLOSE.PEER_GONE.reason);
+        } catch { /* already closing */ }
+        if (role === "bridge") this.browser = null;
+        else this.bridge = null;
+      }
+    };
+
+    server.addEventListener("close", () => teardown("close"));
+    server.addEventListener("error", () => teardown("error"));
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+}

--- a/terminal/relay/src/pairing.js
+++ b/terminal/relay/src/pairing.js
@@ -1,0 +1,100 @@
+// Pure pairing / single-attach state machine for the terminal relay.
+//
+// One relay "session" pairs exactly one `bridge` leg (the local machine running
+// the PTY) with exactly one `browser` leg (the in-app terminal). The relay is
+// OPAQUE: it never inspects stream bytes — it only tracks *which* legs are
+// attached so it can pair them and enforce single-attach. This module is the
+// decision logic, factored out so it can be unit-tested without workerd / ws.
+//
+// Shared by:
+//   - relay/src/index.js        (Cloudflare Worker + Durable Object)
+//   - test/standin-relay.mjs    (plain-ws Node stand-in used by the automated test)
+
+export const ROLES = Object.freeze(["bridge", "browser"]);
+
+// WebSocket close codes in the application-private range (4000-4999).
+export const CLOSE = Object.freeze({
+  BAD_ROLE: { code: 4000, reason: "invalid role (expected bridge|browser)" },
+  BAD_SESSION: { code: 4003, reason: "missing or invalid session id" },
+  DUP_BROWSER: { code: 4001, reason: "session already attached (single-attach)" },
+  DUP_BRIDGE: { code: 4002, reason: "bridge already attached for this session" },
+  PEER_GONE: { code: 4004, reason: "peer disconnected" },
+});
+
+/**
+ * @typedef {Object} AttachState
+ * @property {boolean} bridge  - a bridge leg is currently attached
+ * @property {boolean} browser - a browser leg is currently attached
+ */
+
+/** @returns {AttachState} a fresh, empty session attachment state */
+export function emptyState() {
+  return { bridge: false, browser: false };
+}
+
+/**
+ * Validate a session id. Slice-1 stub: accept any non-empty, reasonably-sized,
+ * URL-safe token. No ownership / signature checks yet.
+ *
+ * TODO(slice 2): validate app-minted session token + owner binding — verify the
+ * signed `vibecodes://` payload, bind the session to the authenticated human,
+ * and reject any leg whose owner does not match (the "owner mismatch" error).
+ *
+ * @param {unknown} session
+ * @returns {boolean}
+ */
+export function isValidSession(session) {
+  return (
+    typeof session === "string" &&
+    session.length >= 1 &&
+    session.length <= 128 &&
+    /^[A-Za-z0-9._-]+$/.test(session)
+  );
+}
+
+/**
+ * Decide whether an incoming leg may attach to a session.
+ *
+ * Pure: does not mutate `state`. The caller applies the attachment on `ok`.
+ *
+ * @param {AttachState} state - current attachment state for the session
+ * @param {string} role - "bridge" | "browser"
+ * @returns {{ok: true} | {ok: false, code: number, reason: string}}
+ */
+export function decideAttach(state, role) {
+  if (!ROLES.includes(role)) {
+    return { ok: false, ...CLOSE.BAD_ROLE };
+  }
+  if (role === "browser" && state.browser) {
+    return { ok: false, ...CLOSE.DUP_BROWSER };
+  }
+  if (role === "bridge" && state.bridge) {
+    return { ok: false, ...CLOSE.DUP_BRIDGE };
+  }
+  return { ok: true };
+}
+
+/**
+ * Apply an accepted attachment, returning a NEW state (does not mutate input).
+ * @param {AttachState} state
+ * @param {string} role
+ * @returns {AttachState}
+ */
+export function attach(state, role) {
+  return { ...state, [role]: true };
+}
+
+/**
+ * Apply a detachment, returning a NEW state (does not mutate input).
+ * @param {AttachState} state
+ * @param {string} role
+ * @returns {AttachState}
+ */
+export function detach(state, role) {
+  return { ...state, [role]: false };
+}
+
+/** The opposite role — used to pick the forwarding target. */
+export function peerRole(role) {
+  return role === "bridge" ? "browser" : "bridge";
+}

--- a/terminal/relay/src/pairing.js
+++ b/terminal/relay/src/pairing.js
@@ -19,17 +19,21 @@ export const CLOSE = Object.freeze({
   DUP_BROWSER: { code: 4001, reason: "session already attached (single-attach)" },
   DUP_BRIDGE: { code: 4002, reason: "bridge already attached for this session" },
   PEER_GONE: { code: 4004, reason: "peer disconnected" },
+  // SLICE 2 — auth + ownership:
+  OWNER_MISMATCH: { code: 4005, reason: "owner mismatch — token is for a different user" },
+  BAD_TOKEN: { code: 4006, reason: "invalid, tampered, or expired session token" },
 });
 
 /**
  * @typedef {Object} AttachState
- * @property {boolean} bridge  - a bridge leg is currently attached
- * @property {boolean} browser - a browser leg is currently attached
+ * @property {boolean} bridge       - a bridge leg is currently attached
+ * @property {boolean} browser      - a browser leg is currently attached
+ * @property {string|null} [owner]  - the `sub` this session is bound to (slice 2)
  */
 
 /** @returns {AttachState} a fresh, empty session attachment state */
 export function emptyState() {
-  return { bridge: false, browser: false };
+  return { bridge: false, browser: false, owner: null };
 }
 
 /**
@@ -57,13 +61,24 @@ export function isValidSession(session) {
  *
  * Pure: does not mutate `state`. The caller applies the attachment on `ok`.
  *
+ * Owner-binding (slice 2): when `sub` is supplied AND the session is already bound
+ * to a different owner, the leg is rejected with OWNER_MISMATCH — this is what stops
+ * user B from attaching to user A's session even with an otherwise-valid token. The
+ * owner check runs BEFORE single-attach so a cross-user attempt is reported as an
+ * ownership failure, not a duplicate. When `sub` is omitted (e.g. slice-1 callers /
+ * unit tests of the bare state machine) owner-binding is skipped.
+ *
  * @param {AttachState} state - current attachment state for the session
  * @param {string} role - "bridge" | "browser"
+ * @param {string} [sub] - the owner id carried by the (already token-verified) leg
  * @returns {{ok: true} | {ok: false, code: number, reason: string}}
  */
-export function decideAttach(state, role) {
+export function decideAttach(state, role, sub) {
   if (!ROLES.includes(role)) {
     return { ok: false, ...CLOSE.BAD_ROLE };
+  }
+  if (sub !== undefined && state.owner != null && state.owner !== sub) {
+    return { ok: false, ...CLOSE.OWNER_MISMATCH };
   }
   if (role === "browser" && state.browser) {
     return { ok: false, ...CLOSE.DUP_BROWSER };
@@ -76,22 +91,29 @@ export function decideAttach(state, role) {
 
 /**
  * Apply an accepted attachment, returning a NEW state (does not mutate input).
+ * Binds the session owner on the FIRST leg; later legs keep the established owner.
  * @param {AttachState} state
  * @param {string} role
+ * @param {string} [sub] - owner id to bind on the first leg
  * @returns {AttachState}
  */
-export function attach(state, role) {
-  return { ...state, [role]: true };
+export function attach(state, role, sub) {
+  const owner = state.owner != null ? state.owner : sub ?? null;
+  return { ...state, [role]: true, owner };
 }
 
 /**
- * Apply a detachment, returning a NEW state (does not mutate input).
+ * Apply a detachment, returning a NEW state (does not mutate input). When the last
+ * leg detaches, the owner binding is released so the session id can be cleanly
+ * re-established (by the same or a new authorized owner).
  * @param {AttachState} state
  * @param {string} role
  * @returns {AttachState}
  */
 export function detach(state, role) {
-  return { ...state, [role]: false };
+  const next = { ...state, [role]: false };
+  if (!next.bridge && !next.browser) next.owner = null;
+  return next;
 }
 
 /** The opposite role — used to pick the forwarding target. */

--- a/terminal/relay/src/pairing.js
+++ b/terminal/relay/src/pairing.js
@@ -120,3 +120,37 @@ export function detach(state, role) {
 export function peerRole(role) {
   return role === "bridge" ? "browser" : "bridge";
 }
+
+// ── Session lifecycle limits (slice 6) ────────────────────────────────────────
+//
+// Two server-side caps end a forgotten session cleanly so a DO can't live (and
+// bill) forever:
+//   - idle:         no traffic for IDLE_MS → close both legs.
+//   - max-duration: total session age ≥ MAX_MS → close both legs.
+// Both close with the NORMAL code 1000 + a reason string. The reason text is the
+// SINGLE SOURCE OF TRUTH the browser dock classifies on (see
+// src/lib/terminal/connection.ts → parseEndedReason): it looks for the substrings
+// "idle" / "max", so these builders and that classifier are in lock-step.
+
+/** Default idle cap: 30 minutes of no traffic. Overridable via env TERMINAL_IDLE_MS. */
+export const DEFAULT_IDLE_MS = 30 * 60 * 1000;
+/** Default hard cap on total session age: 4 hours. Overridable via env TERMINAL_MAX_MS. */
+export const DEFAULT_MAX_MS = 4 * 60 * 60 * 1000;
+
+/** Normal-closure reason for an idle-timeout end. MUST contain "idle". */
+export function idleCloseReason(idleMs = DEFAULT_IDLE_MS) {
+  const min = Math.max(1, Math.round(idleMs / 60_000));
+  return `idle-timeout: ended after ${min} min idle`;
+}
+
+/** Normal-closure reason for a max-duration end. MUST contain "max". */
+export function maxCloseReason(maxMs = DEFAULT_MAX_MS) {
+  const hours = Math.max(1, Math.round(maxMs / 3_600_000));
+  return `max-duration: session reached its ${hours} hour limit`;
+}
+
+/** Read a positive-millisecond override from an env-like bag, else the default. */
+export function resolveMs(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}

--- a/terminal/relay/src/pairing.test.js
+++ b/terminal/relay/src/pairing.test.js
@@ -1,0 +1,78 @@
+// Unit tests for the relay pairing / single-attach state machine.
+// Run: cd terminal/relay && node --test   (or: npm test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  emptyState,
+  isValidSession,
+  decideAttach,
+  attach,
+  detach,
+  peerRole,
+  CLOSE,
+} from "./pairing.js";
+
+test("empty session accepts a first bridge and a first browser", () => {
+  let s = emptyState();
+  assert.deepEqual(decideAttach(s, "bridge"), { ok: true });
+  s = attach(s, "bridge");
+  assert.deepEqual(decideAttach(s, "browser"), { ok: true });
+});
+
+test("single-attach: a 2nd browser is rejected with DUP_BROWSER", () => {
+  let s = emptyState();
+  s = attach(s, "browser");
+  const d = decideAttach(s, "browser");
+  assert.equal(d.ok, false);
+  assert.equal(d.code, CLOSE.DUP_BROWSER.code);
+  assert.equal(d.code, 4001);
+  assert.match(d.reason, /single-attach/);
+});
+
+test("a 2nd bridge is rejected with DUP_BRIDGE", () => {
+  let s = emptyState();
+  s = attach(s, "bridge");
+  const d = decideAttach(s, "bridge");
+  assert.equal(d.ok, false);
+  assert.equal(d.code, CLOSE.DUP_BRIDGE.code);
+  assert.equal(d.code, 4002);
+});
+
+test("an invalid role is rejected with BAD_ROLE", () => {
+  const d = decideAttach(emptyState(), "spectator");
+  assert.equal(d.ok, false);
+  assert.equal(d.code, CLOSE.BAD_ROLE.code);
+});
+
+test("after a browser detaches, a new browser may attach (re-pair)", () => {
+  let s = emptyState();
+  s = attach(s, "browser");
+  assert.equal(decideAttach(s, "browser").ok, false);
+  s = detach(s, "browser");
+  assert.deepEqual(decideAttach(s, "browser"), { ok: true });
+});
+
+test("attach/detach are pure — they do not mutate the input state", () => {
+  const s = emptyState();
+  const s2 = attach(s, "bridge");
+  assert.equal(s.bridge, false, "original state must be untouched");
+  assert.equal(s2.bridge, true);
+  const s3 = detach(s2, "bridge");
+  assert.equal(s2.bridge, true, "original state must be untouched");
+  assert.equal(s3.bridge, false);
+});
+
+test("peerRole returns the opposite leg", () => {
+  assert.equal(peerRole("bridge"), "browser");
+  assert.equal(peerRole("browser"), "bridge");
+});
+
+test("isValidSession accepts url-safe tokens and rejects junk", () => {
+  assert.equal(isValidSession("a3f9"), true);
+  assert.equal(isValidSession("dev-abc_123.4"), true);
+  assert.equal(isValidSession(""), false);
+  assert.equal(isValidSession("has space"), false);
+  assert.equal(isValidSession("has/slash"), false);
+  assert.equal(isValidSession(null), false);
+  assert.equal(isValidSession("x".repeat(129)), false);
+});

--- a/terminal/relay/src/pairing.test.js
+++ b/terminal/relay/src/pairing.test.js
@@ -67,6 +67,43 @@ test("peerRole returns the opposite leg", () => {
   assert.equal(peerRole("browser"), "bridge");
 });
 
+// ── owner-binding (slice 2) ──────────────────────────────────────────────────
+
+test("owner-binding: same-user bridge+browser pair is accepted", () => {
+  let s = emptyState();
+  assert.equal(decideAttach(s, "bridge", "user-A").ok, true);
+  s = attach(s, "bridge", "user-A");
+  assert.equal(s.owner, "user-A");
+  assert.equal(decideAttach(s, "browser", "user-A").ok, true);
+  s = attach(s, "browser", "user-A");
+  assert.equal(s.owner, "user-A", "owner stays bound to the first leg's user");
+});
+
+test("owner-binding: a different user is rejected with OWNER_MISMATCH (before single-attach)", () => {
+  let s = emptyState();
+  s = attach(s, "bridge", "user-A"); // session now owned by A, browser slot free
+  const d = decideAttach(s, "browser", "user-B");
+  assert.equal(d.ok, false);
+  assert.equal(d.code, CLOSE.OWNER_MISMATCH.code);
+  assert.equal(d.code, 4005);
+  assert.match(d.reason, /owner/);
+});
+
+test("owner-binding: releases the owner once the session is fully empty", () => {
+  let s = emptyState();
+  s = attach(s, "bridge", "user-A");
+  s = detach(s, "bridge");
+  assert.equal(s.owner, null, "owner released when no legs remain");
+  // a fresh, different owner may now claim the freed session id
+  assert.equal(decideAttach(s, "bridge", "user-B").ok, true);
+});
+
+test("owner-binding: omitting sub skips the owner check (slice-1 compatibility)", () => {
+  let s = attach(emptyState(), "bridge", "user-A");
+  // No sub passed → owner check is skipped, only single-attach applies.
+  assert.equal(decideAttach(s, "browser").ok, true);
+});
+
 test("isValidSession accepts url-safe tokens and rejects junk", () => {
   assert.equal(isValidSession("a3f9"), true);
   assert.equal(isValidSession("dev-abc_123.4"), true);

--- a/terminal/relay/wrangler.toml
+++ b/terminal/relay/wrangler.toml
@@ -22,11 +22,14 @@ compatibility_date = "2024-12-01"
 name = "TERMINAL_RELAY"
 class_name = "TerminalRelay"
 
-# DO classes must be declared in a migration (Durable Objects require the Workers
-# PAID plan — see DEPLOY.md).
+# DO classes must be declared in a migration. We use `new_sqlite_classes`
+# (SQLite-backed Durable Objects) — these run on the Cloudflare FREE plan, whereas
+# KV-backed `new_classes` requires the Workers Paid plan. Our storage usage
+# (state.storage put/get + alarms) and WebSocket Hibernation work identically on
+# the SQLite backend, so this is a drop-in. See DEPLOY.md.
 [[migrations]]
 tag = "v1"
-new_classes = ["TerminalRelay"]
+new_sqlite_classes = ["TerminalRelay"]
 
 # ── Session lifecycle limits (slice 6) ────────────────────────────────────────
 # Two server-side caps end a forgotten session cleanly so a DO can't live (and

--- a/terminal/relay/wrangler.toml
+++ b/terminal/relay/wrangler.toml
@@ -1,12 +1,20 @@
-# VibeCodes Terminal Relay — Cloudflare Worker + Durable Object (Slice 1)
+# VibeCodes Terminal Relay — Cloudflare Worker + Durable Object
 #
-# Run locally, offline (no Cloudflare account needed):
+# Opaquely relays bytes between a `bridge` leg (local machine) and a single
+# `browser` leg (the in-app terminal) per session id. See DEPLOY.md for the full
+# step-by-step deploy. Run locally, offline (no Cloudflare account needed):
+#
 #   cd terminal/relay && npx wrangler dev
-# Serves on http://localhost:8787 ; connect WebSockets at
-#   ws://localhost:8787/?session=<id>&role=<bridge|browser>
+#     → serves http://127.0.0.1:8787 ; connect WebSockets at
+#       ws://127.0.0.1:8787/?session=<id>&role=<bridge|browser>&token=<jwt>
 
 name = "vibecodes-terminal-relay"
 main = "src/index.js"
+
+# WebSocket HIBERNATION requirement: the DO uses state.acceptWebSocket() + the
+# webSocket* handler methods + storage alarms. No compat FLAG is needed — the
+# Hibernation API is on by default — but the compatibility_date must be recent
+# enough for the API to be present in the runtime. 2024-12-01 is comfortably so.
 compatibility_date = "2024-12-01"
 
 # One Durable Object class — TerminalRelay — bound as TERMINAL_RELAY.
@@ -14,7 +22,27 @@ compatibility_date = "2024-12-01"
 name = "TERMINAL_RELAY"
 class_name = "TerminalRelay"
 
-# DO classes must be declared in a migration.
+# DO classes must be declared in a migration (Durable Objects require the Workers
+# PAID plan — see DEPLOY.md).
 [[migrations]]
 tag = "v1"
 new_classes = ["TerminalRelay"]
+
+# ── Session lifecycle limits (slice 6) ────────────────────────────────────────
+# Two server-side caps end a forgotten session cleanly so a DO can't live (and
+# bill) forever. Both are read by the DO as env vars; the values below are the
+# production defaults and may be tuned WITHOUT a code change. The DO falls back to
+# the SAME defaults (30 min / 4 h) if these are absent, so they are documentation
+# as much as configuration.
+#   TERMINAL_IDLE_MS — close the session after this many ms of NO traffic.
+#   TERMINAL_MAX_MS  — hard cap on total session age, regardless of traffic.
+[vars]
+TERMINAL_IDLE_MS = "1800000"   # 30 minutes
+TERMINAL_MAX_MS  = "14400000"  # 4 hours
+
+# ── Secret (NOT set here — never commit it) ───────────────────────────────────
+# TERMINAL_SESSION_SECRET is the HMAC key the relay verifies app-minted session
+# tokens with. It MUST match the VibeCodes app's TERMINAL_SESSION_SECRET. Provide
+# it OUT OF BAND:
+#   - local dev:  terminal/relay/.dev.vars  (gitignored; loaded by `wrangler dev`)
+#   - production: `wrangler secret put TERMINAL_SESSION_SECRET`

--- a/terminal/relay/wrangler.toml
+++ b/terminal/relay/wrangler.toml
@@ -1,0 +1,20 @@
+# VibeCodes Terminal Relay — Cloudflare Worker + Durable Object (Slice 1)
+#
+# Run locally, offline (no Cloudflare account needed):
+#   cd terminal/relay && npx wrangler dev
+# Serves on http://localhost:8787 ; connect WebSockets at
+#   ws://localhost:8787/?session=<id>&role=<bridge|browser>
+
+name = "vibecodes-terminal-relay"
+main = "src/index.js"
+compatibility_date = "2024-12-01"
+
+# One Durable Object class — TerminalRelay — bound as TERMINAL_RELAY.
+[[durable_objects.bindings]]
+name = "TERMINAL_RELAY"
+class_name = "TerminalRelay"
+
+# DO classes must be declared in a migration.
+[[migrations]]
+tag = "v1"
+new_classes = ["TerminalRelay"]

--- a/terminal/shared/deep-link.mjs
+++ b/terminal/shared/deep-link.mjs
@@ -1,0 +1,94 @@
+// Shared terminal launch deep-link module — SLICE 4 (vibecodes:// auto-launch).
+//
+// ONE implementation of the `vibecodes://launch?…` URL scheme, imported by every
+// party that has to AGREE on its shape:
+//   - the VibeCodes app (src/lib/terminal/deep-link.ts)  — BUILDS the link (typed
+//     mirror; the app is TS and can't import this .mjs into its component tree
+//     cleanly, so it re-implements build/redact and a drift test pins the two).
+//   - the bridge (terminal/bridge/src/index.js)          — PARSES the link it is
+//     handed via `--launch-url` (exactly what a packaged helper's URL-scheme
+//     handler will call in slice 7).
+//   - the test harness (terminal/test/*.mjs)             — BUILDS + PARSES.
+//
+// The link carries everything the local helper needs to attach as the BRIDGE leg:
+//   relay   — relay base ws URL
+//   session — relay session id (sid)
+//   token   — the app-minted, HMAC-signed BRIDGE-role token (this IS the launch's
+//             credential; the relay verifies it, so no extra signature is needed)
+//   cwd     — optional working directory
+//
+// The `token` is a secret. NEVER log a raw link — use redactDeepLinkToken first.
+//
+// Pure + dependency-free (only the global WHATWG `URL`), so it runs unchanged in
+// Node (bridge) and is trivially unit-testable.
+
+/** Custom URL scheme the packaged helper registers (slice 7 OS bit). */
+export const LAUNCH_SCHEME = "vibecodes";
+/** The single action this scheme exposes today: `vibecodes://launch?…`. */
+export const LAUNCH_HOST = "launch";
+
+/**
+ * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…]` deep link.
+ *
+ * Uses encodeURIComponent so reserved characters in the relay URL / token survive
+ * the round-trip. `cwd` is omitted entirely when absent (no empty param). Throws
+ * when a required field is missing so a malformed link is never fired.
+ *
+ * @param {{ relay: string, session: string, token: string, cwd?: string }} params
+ * @returns {string}
+ */
+export function buildLaunchDeepLink({ relay, session, token, cwd } = {}) {
+  if (!relay || !session || !token) {
+    throw new Error("buildLaunchDeepLink requires relay, session and token");
+  }
+  const parts = [
+    `relay=${encodeURIComponent(relay)}`,
+    `session=${encodeURIComponent(session)}`,
+    `token=${encodeURIComponent(token)}`,
+  ];
+  if (cwd) parts.push(`cwd=${encodeURIComponent(cwd)}`);
+  return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
+}
+
+/**
+ * Parse a `vibecodes://launch?…` deep link into `{ relay, session, token, cwd }`,
+ * or null when it is not a well-formed launch link (wrong scheme/action, or any
+ * required field missing). This is exactly the logic a packaged helper's
+ * URL-scheme handler will run before connecting as the bridge leg.
+ *
+ * @param {unknown} url
+ * @returns {{ relay: string, session: string, token: string, cwd?: string } | null}
+ */
+export function parseLaunchDeepLink(url) {
+  if (typeof url !== "string" || url.length === 0) return null;
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== `${LAUNCH_SCHEME}:`) return null;
+  // For `scheme://launch?…` the action lands in `host`; tolerate `scheme:launch?…`
+  // (no authority) where it lands in `pathname` instead.
+  const action = parsed.host || parsed.pathname.replace(/^\/+/, "");
+  if (action !== LAUNCH_HOST) return null;
+
+  const relay = parsed.searchParams.get("relay");
+  const session = parsed.searchParams.get("session");
+  const token = parsed.searchParams.get("token");
+  const cwd = parsed.searchParams.get("cwd") || undefined;
+  if (!relay || !session || !token) return null;
+
+  return cwd ? { relay, session, token, cwd } : { relay, session, token };
+}
+
+/**
+ * Redact the `token` value from a launch link so it is safe to log. Replaces the
+ * value with `***` while keeping the rest intact for debugging.
+ *
+ * @param {unknown} url
+ * @returns {string}
+ */
+export function redactDeepLinkToken(url) {
+  return String(url).replace(/([?&]token=)[^&]*/g, "$1***");
+}

--- a/terminal/shared/package.json
+++ b/terminal/shared/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "vibecodes-terminal-shared",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Shared, dependency-free session-token scheme (HMAC-SHA256 over Web Crypto). Imported by the app, the relay, the bridge, and the tests so one implementation signs and verifies everywhere. (Slice 2)",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/terminal/shared/session-token.mjs
+++ b/terminal/shared/session-token.mjs
@@ -1,0 +1,192 @@
+// Shared terminal session-token module — SLICE 2 (auth + ownership).
+//
+// ONE implementation of the sign/verify code, imported by every party so the
+// exact same bytes are produced and checked everywhere:
+//   - the VibeCodes Next.js app  (src/app/api/terminal/session/route.ts) — MINTS tokens
+//   - the Cloudflare relay        (relay/src/index.js)                     — VERIFIES tokens
+//   - the Node stand-in relay     (test/standin-relay.mjs)                 — VERIFIES tokens
+//   - the test harness            (test/*.mjs)                             — MINTS tokens
+//
+// Design:
+//   A token is a compact, JWT-ish, two-part string:  <payloadB64url>.<sigB64url>
+//   payload  = JSON { sub, sid, idea, role, iat, exp }
+//   sig      = HMAC-SHA256( payloadB64url-bytes, secret )
+//
+// We deliberately use Web Crypto (`crypto.subtle`) and base64url helpers built on
+// `btoa`/`atob` only — NO node-only APIs (Buffer, node:crypto) — so the identical
+// module runs unchanged in the Cloudflare Worker runtime AND in Node. We do NOT
+// pull in a JWT library: the surface here is tiny and must run in workerd.
+//
+// The signing secret NEVER lives in code. It is read from the environment by each
+// caller (TERMINAL_SESSION_SECRET) and passed in. This module is pure crypto.
+
+/** @typedef {"bridge"|"browser"} Role */
+
+/**
+ * @typedef {Object} SessionClaims
+ * @property {string} sub  - Supabase user id (the owning human)
+ * @property {string} sid  - relay session id
+ * @property {string} idea - idea id this session belongs to
+ * @property {Role}   role - which leg this token authorizes
+ * @property {number} iat  - issued-at (unix seconds)
+ * @property {number} exp  - expiry (unix seconds)
+ */
+
+/** Default token lifetime: short-lived (5 minutes) — enough to open both legs. */
+export const DEFAULT_TTL_SECONDS = 300;
+
+const ROLES = Object.freeze(["bridge", "browser"]);
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+/** @param {Uint8Array} bytes @returns {string} base64url (no padding) */
+function bytesToBase64url(bytes) {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** @param {string} s base64url @returns {Uint8Array} */
+function base64urlToBytes(s) {
+  let b64 = s.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = b64.length % 4;
+  if (pad) b64 += "=".repeat(4 - pad);
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/** @param {string} secret @returns {Promise<CryptoKey>} */
+async function importKey(secret) {
+  if (typeof secret !== "string" || secret.length === 0) {
+    throw new Error("TERMINAL_SESSION_SECRET is missing or empty");
+  }
+  return crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+/**
+ * Sign a claims payload, producing `<payloadB64url>.<sigB64url>`.
+ * @param {SessionClaims} payload
+ * @param {string} secret
+ * @returns {Promise<string>}
+ */
+export async function signToken(payload, secret) {
+  const payloadB64 = bytesToBase64url(enc.encode(JSON.stringify(payload)));
+  const key = await importKey(secret);
+  const sig = new Uint8Array(await crypto.subtle.sign("HMAC", key, enc.encode(payloadB64)));
+  return `${payloadB64}.${bytesToBase64url(sig)}`;
+}
+
+/**
+ * Verify a token's signature and expiry. Constant-time signature check via
+ * `crypto.subtle.verify`. Does NOT check sid/role binding — see {@link authorizeAttach}.
+ *
+ * @param {unknown} token
+ * @param {string} secret
+ * @param {{ now?: number }} [opts] - `now` in unix seconds (defaults to wall clock)
+ * @returns {Promise<{ ok: true, claims: SessionClaims } | { ok: false, reason: string }>}
+ */
+export async function verifyToken(token, secret, opts = {}) {
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  if (typeof token !== "string" || token.length === 0) {
+    return { ok: false, reason: "missing token" };
+  }
+  if (token.length > 4096) return { ok: false, reason: "token too large" };
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot === token.length - 1) return { ok: false, reason: "malformed token" };
+  const payloadB64 = token.slice(0, dot);
+  const sigB64 = token.slice(dot + 1);
+
+  let sigBytes;
+  try {
+    sigBytes = base64urlToBytes(sigB64);
+  } catch {
+    return { ok: false, reason: "malformed signature" };
+  }
+
+  const key = await importKey(secret);
+  const valid = await crypto.subtle.verify("HMAC", key, sigBytes, enc.encode(payloadB64));
+  if (!valid) return { ok: false, reason: "bad signature" };
+
+  /** @type {SessionClaims} */
+  let claims;
+  try {
+    claims = JSON.parse(dec.decode(base64urlToBytes(payloadB64)));
+  } catch {
+    return { ok: false, reason: "malformed payload" };
+  }
+
+  if (typeof claims.iat !== "number" || typeof claims.exp !== "number") {
+    return { ok: false, reason: "missing iat/exp" };
+  }
+  if (now >= claims.exp) return { ok: false, reason: "expired" };
+  if (typeof claims.sub !== "string" || claims.sub.length === 0) {
+    return { ok: false, reason: "missing sub" };
+  }
+  if (typeof claims.sid !== "string" || claims.sid.length === 0) {
+    return { ok: false, reason: "missing sid" };
+  }
+  if (!ROLES.includes(claims.role)) return { ok: false, reason: "bad role" };
+
+  return { ok: true, claims };
+}
+
+/**
+ * Full attach authorization for a relay leg: verify signature + expiry, then bind
+ * the token to THIS connection by requiring `claims.sid` and `claims.role` to match
+ * the URL the leg connected on. Returns the owning `sub` for owner-binding.
+ *
+ * Shared by the Cloudflare relay and the Node stand-in so both enforce identically.
+ *
+ * @param {{ token: unknown, secret: string, session: unknown, role: unknown, now?: number }} args
+ * @returns {Promise<{ ok: true, sub: string, claims: SessionClaims } | { ok: false, reason: string }>}
+ */
+export async function authorizeAttach({ token, secret, session, role, now }) {
+  const res = await verifyToken(token, secret, { now });
+  if (!res.ok) return res;
+  const c = res.claims;
+  if (c.sid !== session) return { ok: false, reason: "sid mismatch" };
+  if (c.role !== role) return { ok: false, reason: "role mismatch" };
+  return { ok: true, sub: c.sub, claims: c };
+}
+
+/**
+ * Generate a fresh, URL-safe relay session id (matches the relay's isValidSession).
+ * @returns {string}
+ */
+export function newSessionId() {
+  return crypto.randomUUID();
+}
+
+/**
+ * Mint BOTH leg tokens (browser + bridge) for the same session/owner/idea. The app
+ * hands the `browser` token to the in-app panel and the `bridge` token to the local
+ * helper; both share one `sid` + `sub` so the relay can owner-bind the pair.
+ *
+ * @param {{ sub: string, idea: string, sid?: string, secret: string, ttlSeconds?: number, now?: number }} args
+ * @returns {Promise<{ sid: string, idea: string, sub: string, exp: number, browser: string, bridge: string }>}
+ */
+export async function mintSessionTokens({
+  sub,
+  idea,
+  sid = newSessionId(),
+  secret,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+  now = Math.floor(Date.now() / 1000),
+}) {
+  const exp = now + ttlSeconds;
+  /** @type {Omit<SessionClaims, "role">} */
+  const base = { sub, sid, idea, iat: now, exp };
+  const [browser, bridge] = await Promise.all([
+    signToken({ ...base, role: "browser" }, secret),
+    signToken({ ...base, role: "bridge" }, secret),
+  ]);
+  return { sid, idea, sub, exp, browser, bridge };
+}

--- a/terminal/shared/session-token.test.mjs
+++ b/terminal/shared/session-token.test.mjs
@@ -1,0 +1,108 @@
+// Unit tests for the shared terminal session-token module.
+// Run: cd terminal/shared && node --test   (or from terminal/test via npm test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  signToken,
+  verifyToken,
+  authorizeAttach,
+  mintSessionTokens,
+  newSessionId,
+  DEFAULT_TTL_SECONDS,
+} from "./session-token.mjs";
+
+const SECRET = "test-secret-do-not-ship";
+const NOW = 1_700_000_000; // fixed clock (unix seconds)
+
+function baseClaims(overrides = {}) {
+  return {
+    sub: "user-A",
+    sid: "sess-1",
+    idea: "idea-1",
+    role: "browser",
+    iat: NOW,
+    exp: NOW + DEFAULT_TTL_SECONDS,
+    ...overrides,
+  };
+}
+
+test("mint → verify happy path returns the original claims", async () => {
+  const token = await signToken(baseClaims(), SECRET);
+  const res = await verifyToken(token, SECRET, { now: NOW });
+  assert.equal(res.ok, true);
+  assert.deepEqual(res.claims, baseClaims());
+});
+
+test("expired token is rejected", async () => {
+  const token = await signToken(baseClaims({ exp: NOW + 60 }), SECRET);
+  // happy at NOW, expired one second after exp
+  assert.equal((await verifyToken(token, SECRET, { now: NOW })).ok, true);
+  const res = await verifyToken(token, SECRET, { now: NOW + 61 });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "expired");
+});
+
+test("tampered payload is rejected (bad signature)", async () => {
+  const token = await signToken(baseClaims(), SECRET);
+  const [payloadB64, sig] = token.split(".");
+  // Flip the payload to a different user but keep the original signature.
+  const forgedClaims = baseClaims({ sub: "user-EVIL" });
+  const forgedPayload = Buffer.from(JSON.stringify(forgedClaims))
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  assert.notEqual(forgedPayload, payloadB64);
+  const res = await verifyToken(`${forgedPayload}.${sig}`, SECRET, { now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "bad signature");
+});
+
+test("wrong secret is rejected (bad signature)", async () => {
+  const token = await signToken(baseClaims(), SECRET);
+  const res = await verifyToken(token, "a-different-secret", { now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "bad signature");
+});
+
+test("malformed tokens are rejected, never throw", async () => {
+  for (const bad of ["", "noseparator", ".", "a.", ".b", null, undefined, 42]) {
+    const res = await verifyToken(bad, SECRET, { now: NOW });
+    assert.equal(res.ok, false, `expected rejection for ${JSON.stringify(bad)}`);
+  }
+});
+
+test("authorizeAttach binds sid + role to the connection", async () => {
+  const token = await signToken(baseClaims({ role: "bridge" }), SECRET);
+  // correct sid + role
+  const ok = await authorizeAttach({ token, secret: SECRET, session: "sess-1", role: "bridge", now: NOW });
+  assert.equal(ok.ok, true);
+  assert.equal(ok.sub, "user-A");
+  // sid mismatch
+  const sidBad = await authorizeAttach({ token, secret: SECRET, session: "sess-OTHER", role: "bridge", now: NOW });
+  assert.equal(sidBad.ok, false);
+  assert.equal(sidBad.reason, "sid mismatch");
+  // role mismatch (bridge token presented on the browser leg)
+  const roleBad = await authorizeAttach({ token, secret: SECRET, session: "sess-1", role: "browser", now: NOW });
+  assert.equal(roleBad.ok, false);
+  assert.equal(roleBad.reason, "role mismatch");
+});
+
+test("mintSessionTokens mints both legs sharing one sid + sub", async () => {
+  const out = await mintSessionTokens({ sub: "user-A", idea: "idea-1", secret: SECRET, now: NOW });
+  assert.match(out.sid, /[0-9a-f-]{36}/);
+  assert.equal(out.exp, NOW + DEFAULT_TTL_SECONDS);
+  const b = await verifyToken(out.browser, SECRET, { now: NOW });
+  const g = await verifyToken(out.bridge, SECRET, { now: NOW });
+  assert.equal(b.ok, true);
+  assert.equal(g.ok, true);
+  assert.equal(b.claims.role, "browser");
+  assert.equal(g.claims.role, "bridge");
+  assert.equal(b.claims.sub, g.claims.sub);
+  assert.equal(b.claims.sid, g.claims.sid);
+});
+
+test("newSessionId produces a relay-safe id", () => {
+  const id = newSessionId();
+  assert.match(id, /^[A-Za-z0-9._-]+$/);
+});

--- a/terminal/test/deep-link.test.mjs
+++ b/terminal/test/deep-link.test.mjs
@@ -1,0 +1,61 @@
+// Unit tests for the shared vibecodes:// launch deep-link module — SLICE 4.
+//
+// Proves the build ⇄ parse round-trip the same-machine auto-launch relies on, and
+// that the bridge token is redactable for logs (never leaked).
+//
+// Run: cd terminal/test && node --test
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildLaunchDeepLink,
+  parseLaunchDeepLink,
+  redactDeepLinkToken,
+  LAUNCH_SCHEME,
+  LAUNCH_HOST,
+} from "../shared/deep-link.mjs";
+
+const SAMPLE = {
+  relay: "ws://127.0.0.1:8787",
+  session: "11111111-2222-3333-4444-555555555555",
+  token: "eyJzdWIiOiJ1c2VyIn0.aBcD-_eFgH+/=sigbytes",
+  cwd: "/Users/nick/projects/my idea",
+};
+
+test("build ⇄ parse round-trips with cwd", () => {
+  const url = buildLaunchDeepLink(SAMPLE);
+  assert.ok(url.startsWith(`${LAUNCH_SCHEME}://${LAUNCH_HOST}?`));
+  assert.deepEqual(parseLaunchDeepLink(url), SAMPLE);
+});
+
+test("build ⇄ parse round-trips without cwd", () => {
+  const noCwd = { relay: SAMPLE.relay, session: SAMPLE.session, token: SAMPLE.token };
+  assert.deepEqual(parseLaunchDeepLink(buildLaunchDeepLink(noCwd)), noCwd);
+});
+
+test("buildLaunchDeepLink throws on a missing required field", () => {
+  assert.throws(() => buildLaunchDeepLink({ relay: "", session: "s", token: "t" }));
+  assert.throws(() => buildLaunchDeepLink({ relay: "r", session: "", token: "t" }));
+  assert.throws(() => buildLaunchDeepLink({ relay: "r", session: "s", token: "" }));
+});
+
+test("parseLaunchDeepLink rejects a foreign scheme / wrong action / junk", () => {
+  assert.equal(parseLaunchDeepLink("claude-cli://open?q=hi"), null);
+  assert.equal(parseLaunchDeepLink(`${LAUNCH_SCHEME}://nope?relay=r&session=s&token=t`), null);
+  assert.equal(parseLaunchDeepLink("not a url"), null);
+  assert.equal(parseLaunchDeepLink(""), null);
+  assert.equal(parseLaunchDeepLink(null), null);
+});
+
+test("parseLaunchDeepLink returns null when a required param is absent", () => {
+  assert.equal(parseLaunchDeepLink(`${LAUNCH_SCHEME}://${LAUNCH_HOST}?relay=r&session=s`), null);
+});
+
+test("redactDeepLinkToken hides the token but keeps the rest", () => {
+  const url = buildLaunchDeepLink(SAMPLE);
+  const redacted = redactDeepLinkToken(url);
+  assert.match(redacted, /token=\*\*\*/);
+  assert.ok(!redacted.includes(SAMPLE.token), "raw token must not appear");
+  assert.ok(!redacted.includes(encodeURIComponent(SAMPLE.token)), "encoded token must not appear");
+  assert.ok(redacted.includes(`session=${SAMPLE.session}`), "non-secret params survive");
+});

--- a/terminal/test/lifecycle.test.mjs
+++ b/terminal/test/lifecycle.test.mjs
@@ -1,0 +1,91 @@
+// Session lifecycle limits — SLICE 6.
+//
+// Proves the idle + max-duration caps end a session cleanly and that BOTH legs are
+// closed with the NORMAL code 1000 and a reason the browser dock classifies as
+// "idle" / "max-duration" (see src/lib/terminal/connection.ts → parseEndedReason).
+//
+// Uses the Node stand-in relay (../test/standin-relay.mjs), which shares the exact
+// pairing + lifecycle reason logic with the real Cloudflare DO. The real DO's idle
+// close is additionally proven against `wrangler dev` via verify-lifecycle.mjs.
+//
+// Run: cd terminal/test && node --test lifecycle.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens } from "../shared/session-token.mjs";
+
+const SECRET = "lifecycle-test-secret";
+
+/** Open a leg and resolve once it's connected. */
+async function openLeg(relayUrl, session, role, token) {
+  const ws = new WebSocket(`${relayUrl}/?session=${session}&role=${role}&token=${encodeURIComponent(token)}`);
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${role} open timeout`)), 5000)),
+  ]);
+  return ws;
+}
+
+/** Wait for a close and resolve [code, reason]. */
+async function closeOf(ws, label) {
+  const [code, reasonBuf] = await Promise.race([
+    once(ws, "close"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${label} close timeout`)), 5000)),
+  ]);
+  return [code, reasonBuf ? reasonBuf.toString() : ""];
+}
+
+test("idle-timeout closes BOTH legs with code 1000 + an 'idle' reason", { timeout: 15000 }, async (t) => {
+  const session = `idle-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  // Tiny idle, large max → idle wins.
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, idleMs: 250, maxMs: 60_000 });
+  t.after(() => relay.close());
+
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-L", sid: session, secret: SECRET });
+  const browser = await openLeg(relay.url, session, "browser", tokens.browser);
+  const bridge = await openLeg(relay.url, session, "bridge", tokens.bridge);
+
+  // One message proves activity tracking (the idle clock starts from the LAST byte).
+  bridge.send(Buffer.from("READY\n", "utf8"), { binary: true });
+
+  const [bCode, bReason] = await closeOf(browser, "browser");
+  const [gCode, gReason] = await closeOf(bridge, "bridge");
+
+  assert.equal(bCode, 1000, "browser leg must close with normal code 1000");
+  assert.equal(gCode, 1000, "bridge leg must close with normal code 1000");
+  assert.match(bReason, /idle/, "browser close reason classifies as idle");
+  assert.match(gReason, /idle/, "bridge close reason classifies as idle");
+  console.log(`[idle] both legs closed 1000 reason=${JSON.stringify(bReason)}`);
+});
+
+test("max-duration closes BOTH legs with code 1000 + a 'max' reason", { timeout: 15000 }, async (t) => {
+  const session = `max-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  // Tiny max, large idle → max wins even though we keep sending traffic.
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, idleMs: 60_000, maxMs: 350 });
+  t.after(() => relay.close());
+
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-L", sid: session, secret: SECRET });
+  const browser = await openLeg(relay.url, session, "browser", tokens.browser);
+  const bridge = await openLeg(relay.url, session, "bridge", tokens.bridge);
+
+  // Keep traffic flowing so ONLY the max-duration cap can end the session.
+  const chatter = setInterval(() => {
+    try { bridge.send(Buffer.from(".", "utf8"), { binary: true }); } catch { /* closing */ }
+  }, 50);
+  t.after(() => clearInterval(chatter));
+
+  const [bCode, bReason] = await closeOf(browser, "browser");
+  const [gCode, gReason] = await closeOf(bridge, "bridge");
+  clearInterval(chatter);
+
+  assert.equal(bCode, 1000, "browser leg must close with normal code 1000");
+  assert.equal(gCode, 1000, "bridge leg must close with normal code 1000");
+  assert.match(bReason, /max/, "browser close reason classifies as max-duration");
+  assert.match(gReason, /max/, "bridge close reason classifies as max-duration");
+  console.log(`[max] both legs closed 1000 reason=${JSON.stringify(bReason)}`);
+});

--- a/terminal/test/mint-token.mjs
+++ b/terminal/test/mint-token.mjs
@@ -1,0 +1,42 @@
+// Mint owner-bound leg tokens for MANUAL relay testing (stands in for the app's
+// POST /api/terminal/session endpoint). Uses the shared token module + the same
+// TERMINAL_SESSION_SECRET the relay verifies with.
+//
+// Usage:
+//   TERMINAL_SESSION_SECRET=<secret> node mint-token.mjs --session a3f9 [--sub user-1] [--idea idea-1]
+//
+// Prints JSON: { sessionId, sub, idea, expiresAt, bridgeToken, browserToken }.
+// Hand BRIDGE_TOKEN=<bridgeToken> to the bridge and ?token=<browserToken> to the page.
+
+import { mintSessionTokens, newSessionId } from "../shared/session-token.mjs";
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : fallback;
+}
+
+const secret = process.env.TERMINAL_SESSION_SECRET;
+if (!secret) {
+  console.error("set TERMINAL_SESSION_SECRET (match the relay's .dev.vars)");
+  process.exit(2);
+}
+
+const sid = arg("session", newSessionId());
+const sub = arg("sub", "manual-user");
+const idea = arg("idea", "manual-idea");
+
+const tokens = await mintSessionTokens({ sub, idea, sid, secret });
+console.log(
+  JSON.stringify(
+    {
+      sessionId: tokens.sid,
+      sub: tokens.sub,
+      idea: tokens.idea,
+      expiresAt: tokens.exp,
+      bridgeToken: tokens.bridge,
+      browserToken: tokens.browser,
+    },
+    null,
+    2,
+  ),
+);

--- a/terminal/test/package-lock.json
+++ b/terminal/test/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "vibecodes-terminal-test",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vibecodes-terminal-test",
+      "version": "0.1.0",
+      "dependencies": {
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test roundtrip.test.mjs deep-link.test.mjs"
+    "test": "node --test roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "vibecodes-terminal-test",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
+  "scripts": {
+    "test": "node --test roundtrip.test.mjs"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  }
+}

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test roundtrip.test.mjs"
+    "test": "node --test roundtrip.test.mjs deep-link.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/page.html
+++ b/terminal/test/page.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>VibeCodes Terminal — Slice 1 manual check (browser leg)</title>
+<!-- xterm.js from CDN (manual visual check only — not part of the app build) -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css" />
+<style>
+  :root { --bg:#0a0a0b; --panel:#141417; --border:#2a2a31; --text:#e6e6ea; --muted:#9a9aa6; --accent:#7dd3fc; --emerald:#34d399; --rose:#fb7185; --amber:#fbbf24; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--text); font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+  .wrap { max-width:980px; margin:0 auto; padding:24px 20px 60px; }
+  h1 { font-size:18px; margin:0 0 4px; }
+  p.sub { color:var(--muted); font-size:13px; margin:0 0 16px; }
+  .bar { display:flex; gap:8px; align-items:center; flex-wrap:wrap; background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:10px 12px; margin-bottom:12px; }
+  .bar label { font-size:12px; color:var(--muted); }
+  .bar input { background:#0c0c0e; border:1px solid var(--border); border-radius:6px; color:var(--text); font-family:ui-monospace,Menlo,monospace; font-size:12px; padding:5px 8px; }
+  .bar button { background:var(--accent); color:#06222e; border:0; border-radius:6px; font-size:12.5px; font-weight:700; padding:6px 14px; cursor:pointer; }
+  .bar button.danger { background:rgba(251,113,133,.15); color:var(--rose); border:1px solid rgba(251,113,133,.5); }
+  .pill { font-size:12px; font-weight:700; border-radius:6px; padding:3px 10px; border:1px solid var(--border); }
+  .pill.connected { color:var(--emerald); border-color:rgba(52,211,153,.5); background:rgba(52,211,153,.1); }
+  .pill.connecting { color:var(--amber); border-color:rgba(251,191,36,.5); background:rgba(251,191,36,.1); }
+  .pill.closed { color:var(--rose); border-color:rgba(251,113,133,.5); background:rgba(251,113,133,.1); }
+  #term { background:#0c0c0e; border:1px solid var(--border); border-radius:10px; padding:8px; height:440px; }
+  code { color:var(--accent); font-family:ui-monospace,Menlo,monospace; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>VibeCodes Terminal — browser leg (slice 1 manual check)</h1>
+  <p class="sub">
+    This page is the <b>browser</b> leg. Start the relay (<code>npx wrangler dev</code> in <code>terminal/relay</code>)
+    and a bridge (see <code>RUN.md</code>) on the same session id, then Connect below. Everything you see is streamed
+    opaquely through the relay; keystrokes go back to the PTY. Resize is sent as a control frame.
+  </p>
+  <div class="bar">
+    <label>relay <input id="relay" value="ws://127.0.0.1:8787" size="22" /></label>
+    <label>session <input id="session" value="a3f9" size="10" /></label>
+    <button id="connect">Connect</button>
+    <button id="disconnect" class="danger">Disconnect</button>
+    <span id="status" class="pill closed">disconnected</span>
+  </div>
+  <div id="term"></div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+<script>
+  const term = new Terminal({ cursorBlink: true, fontFamily: "ui-monospace, Menlo, monospace", fontSize: 13, theme: { background: "#0c0c0e" } });
+  const fit = new FitAddon.FitAddon();
+  term.loadAddon(fit);
+  term.open(document.getElementById("term"));
+  fit.fit();
+
+  let ws = null;
+  const statusEl = document.getElementById("status");
+  function setStatus(cls, text) { statusEl.className = "pill " + cls; statusEl.textContent = text; }
+
+  function sendResize() {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      // TEXT control frame — opaque to the relay, interpreted by the bridge.
+      ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+    }
+  }
+
+  function connect() {
+    disconnect();
+    const relay = document.getElementById("relay").value.replace(/\/$/, "");
+    const session = encodeURIComponent(document.getElementById("session").value);
+    setStatus("connecting", "connecting…");
+    ws = new WebSocket(`${relay}/?session=${session}&role=browser`);
+    ws.binaryType = "arraybuffer";
+    ws.onopen = () => { setStatus("connected", "connected"); term.focus(); sendResize(); };
+    ws.onmessage = (ev) => {
+      // BINARY = terminal bytes (write verbatim to xterm).
+      if (ev.data instanceof ArrayBuffer) term.write(new Uint8Array(ev.data));
+      else term.write(ev.data);
+    };
+    ws.onclose = (ev) => setStatus("closed", `closed (${ev.code}${ev.reason ? " · " + ev.reason : ""})`);
+    ws.onerror = () => setStatus("closed", "error");
+  }
+
+  function disconnect() {
+    if (ws) { try { ws.close(1000, "user disconnect"); } catch {} ws = null; }
+  }
+
+  // Keystrokes -> BINARY frame -> relay -> PTY stdin.
+  term.onData((data) => {
+    if (ws && ws.readyState === WebSocket.OPEN) ws.send(new TextEncoder().encode(data));
+  });
+
+  window.addEventListener("resize", () => { fit.fit(); sendResize(); });
+  document.getElementById("connect").onclick = connect;
+  document.getElementById("disconnect").onclick = disconnect;
+</script>
+</body>
+</html>

--- a/terminal/test/roundtrip.test.mjs
+++ b/terminal/test/roundtrip.test.mjs
@@ -1,16 +1,20 @@
-// End-to-end round-trip proof — SLICE 1.
+// End-to-end round-trip + auth proof — SLICE 2.
 //
-// Wires up the real moving parts:
-//   sentinel-cmd  --[node-pty PTY]-->  BRIDGE  --ws-->  RELAY  --ws-->  BROWSER leg
+// Wires up the real moving parts WITH owner-bound tokens:
+//   sentinel-cmd  --[node-pty PTY]-->  BRIDGE  --ws(+token)-->  RELAY  --ws(+token)-->  BROWSER leg
 //
-// and asserts the three things slice 1 must prove:
+// and asserts everything slice 2 must prove:
 //   (a) the browser leg receives the bridge's PTY output (the READY sentinel),
 //   (b) bytes sent from the browser leg reach the PTY and echo back (round-trip),
-//   (c) a 2nd browser attach for the same session is rejected (single-attach).
+//   (c) a 2nd browser attach (same user, valid token) is rejected (single-attach),
+//   (d) a browser whose token is for a DIFFERENT user is rejected (owner-mismatch),
+//   (e) a browser with an EXPIRED token is rejected (bad/expired token).
 //
-// The relay here is the Node stand-in (../test/standin-relay.mjs), which shares
-// the exact pairing/single-attach logic with the Cloudflare DO. The real DO is
-// exercised manually with `npx wrangler dev` (see RUN.md).
+// Tokens are minted by the SHARED module (../shared/session-token.mjs) — the same
+// code the relay verifies with. The relay here is the Node stand-in
+// (../test/standin-relay.mjs), which shares the exact pairing/single-attach/owner
+// logic with the Cloudflare DO. The real DO is exercised manually with
+// `npx wrangler dev` (see RUN.md / verify-against-relay.mjs).
 //
 // Hard timeouts guard every wait; the process exits non-zero on any failure and
 // always tears down the bridge child + relay server.
@@ -25,11 +29,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import WebSocket from "ws";
 import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens, signToken } from "../shared/session-token.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const BRIDGE_ENTRY = path.resolve(__dirname, "../bridge/src/index.js");
 const SENTINEL = path.resolve(__dirname, "./sentinel-cmd.mjs");
 const HARD_TIMEOUT_MS = 20000;
+const SECRET = "roundtrip-test-secret";
 
 /** Resolve when `text` appears in accumulated browser-leg output, else reject. */
 function waitForText(getBuf, text, ms, label) {
@@ -47,8 +53,10 @@ function waitForText(getBuf, text, ms, label) {
   });
 }
 
-test("bridge <-> relay <-> browser round-trip + single-attach", { timeout: 60000 }, async (t) => {
+test("bridge <-> relay <-> browser round-trip + single-attach + owner-binding", { timeout: 60000 }, async (t) => {
   const session = `test-${Math.random().toString(36).slice(2, 8)}`;
+  const ownerA = "user-A-" + Math.random().toString(36).slice(2, 8);
+  const ownerB = "user-B-" + Math.random().toString(36).slice(2, 8);
   let relay;
   let bridge;
   let browser;
@@ -61,14 +69,18 @@ test("bridge <-> relay <-> browser round-trip + single-attach", { timeout: 60000
     if (relay) await relay.close();
   });
 
-  // 1) Start the stand-in relay.
-  relay = await startStandinRelay({ port: 0 });
+  // 0) Mint the owner-bound leg tokens (this is what the app's mint endpoint does).
+  const tokensA = await mintSessionTokens({ sub: ownerA, idea: "idea-X", sid: session, secret: SECRET });
+  console.log(`[test] minted owner-bound tokens for ${ownerA} on session ${session}`);
+
+  // 1) Start the stand-in relay WITH the same secret it must verify against.
+  relay = await startStandinRelay({ port: 0, secret: SECRET });
   console.log(`[test] relay listening at ${relay.url}`);
 
-  // 2) Connect the BROWSER leg FIRST so it is attached before the bridge's PTY
-  //    emits its banner (slice-1 relay has no buffering).
+  // 2) Connect the BROWSER leg FIRST (with its browser-role token) so it is attached
+  //    before the bridge's PTY emits its banner (the relay has no buffering).
   let browserBuf = "";
-  browser = new WebSocket(`${relay.url}/?session=${session}&role=browser`);
+  browser = new WebSocket(`${relay.url}/?session=${session}&role=browser&token=${encodeURIComponent(tokensA.browser)}`);
   browser.on("message", (data) => {
     browserBuf += Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
   });
@@ -76,14 +88,15 @@ test("bridge <-> relay <-> browser round-trip + single-attach", { timeout: 60000
     once(browser, "open"),
     new Promise((_, rej) => setTimeout(() => rej(new Error("browser ws open timeout")), 5000)),
   ]);
-  console.log("[test] browser leg connected");
+  console.log("[test] browser leg connected (authenticated)");
 
-  // 3) Start the BRIDGE leg, running the cheap sentinel command in a node-pty PTY.
+  // 3) Start the BRIDGE leg with its bridge-role token, running the cheap sentinel.
   bridge = spawn(process.execPath, [BRIDGE_ENTRY, "--cmd", `${process.execPath} ${SENTINEL}`], {
     env: {
       ...process.env,
       RELAY_URL: relay.url,
       SESSION_ID: session,
+      BRIDGE_TOKEN: tokensA.bridge,
       // keep timeouts short so a hang fails fast rather than dangling
       "BRIDGE_MAX_SECONDS": "60",
     },
@@ -102,19 +115,49 @@ test("bridge <-> relay <-> browser round-trip + single-attach", { timeout: 60000
   const tEcho = await waitForText(() => browserBuf, token, HARD_TIMEOUT_MS, "PTY echo");
   console.log(`[test] (b) PASS — browser->PTY->browser round-trip of ${token} in ${tEcho}ms`);
 
-  // (c) a 2nd browser attach for the same session is rejected (single-attach).
-  const second = new WebSocket(`${relay.url}/?session=${session}&role=browser`);
-  const [code, reasonBuf] = await Promise.race([
-    once(second, "close"),
-    new Promise((_, rej) => setTimeout(() => rej(new Error("2nd browser close timeout")), 5000)),
-  ]);
-  const reason = reasonBuf ? reasonBuf.toString() : "";
-  console.log(`[test] (c) 2nd browser closed with code=${code} reason=${JSON.stringify(reason)}`);
-  assert.equal(code, 4001, "2nd browser must be rejected with single-attach close code 4001");
-  assert.match(reason, /single-attach/, "close reason should explain single-attach");
-  console.log("[test] (c) PASS — single-attach enforced");
+  /** Connect a browser leg and resolve with its [closeCode, reason]. */
+  async function expectClose(token, label) {
+    const ws = new WebSocket(`${relay.url}/?session=${session}&role=browser&token=${encodeURIComponent(token)}`);
+    const [code, reasonBuf] = await Promise.race([
+      once(ws, "close"),
+      new Promise((_, rej) => setTimeout(() => rej(new Error(`${label} close timeout`)), 5000)),
+    ]);
+    return [code, reasonBuf ? reasonBuf.toString() : ""];
+  }
 
-  // sanity: the original browser is still attached and live.
+  // (c) a 2nd browser (SAME user, valid token) is rejected (single-attach).
+  {
+    const [code, reason] = await expectClose(tokensA.browser, "2nd browser");
+    console.log(`[test] (c) 2nd browser (same user) closed code=${code} reason=${JSON.stringify(reason)}`);
+    assert.equal(code, 4001, "2nd browser must be rejected with single-attach close code 4001");
+    assert.match(reason, /single-attach/, "close reason should explain single-attach");
+    console.log("[test] (c) PASS — single-attach enforced");
+  }
+
+  // (d) a browser whose token is for a DIFFERENT user is rejected (owner-mismatch).
+  {
+    const tokensB = await mintSessionTokens({ sub: ownerB, idea: "idea-X", sid: session, secret: SECRET });
+    const [code, reason] = await expectClose(tokensB.browser, "foreign-user browser");
+    console.log(`[test] (d) different-user browser closed code=${code} reason=${JSON.stringify(reason)}`);
+    assert.equal(code, 4005, "cross-user attach must be rejected with OWNER_MISMATCH code 4005");
+    assert.match(reason, /owner/, "close reason should explain the owner mismatch");
+    console.log("[test] (d) PASS — owner-mismatch rejected");
+  }
+
+  // (e) a browser with an EXPIRED token is rejected (bad/expired token).
+  {
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const expired = await signToken(
+      { sub: ownerA, sid: session, idea: "idea-X", role: "browser", iat: past, exp: past + 60 },
+      SECRET,
+    );
+    const [code, reason] = await expectClose(expired, "expired browser");
+    console.log(`[test] (e) expired-token browser closed code=${code} reason=${JSON.stringify(reason)}`);
+    assert.equal(code, 4006, "expired token must be rejected with BAD_TOKEN code 4006");
+    console.log("[test] (e) PASS — expired token rejected");
+  }
+
+  // sanity: the original (authenticated) browser is still attached and live.
   assert.equal(browser.readyState, WebSocket.OPEN, "first browser must remain connected");
   console.log("[test] ALL ASSERTIONS PASSED");
 });

--- a/terminal/test/roundtrip.test.mjs
+++ b/terminal/test/roundtrip.test.mjs
@@ -1,0 +1,120 @@
+// End-to-end round-trip proof — SLICE 1.
+//
+// Wires up the real moving parts:
+//   sentinel-cmd  --[node-pty PTY]-->  BRIDGE  --ws-->  RELAY  --ws-->  BROWSER leg
+//
+// and asserts the three things slice 1 must prove:
+//   (a) the browser leg receives the bridge's PTY output (the READY sentinel),
+//   (b) bytes sent from the browser leg reach the PTY and echo back (round-trip),
+//   (c) a 2nd browser attach for the same session is rejected (single-attach).
+//
+// The relay here is the Node stand-in (../test/standin-relay.mjs), which shares
+// the exact pairing/single-attach logic with the Cloudflare DO. The real DO is
+// exercised manually with `npx wrangler dev` (see RUN.md).
+//
+// Hard timeouts guard every wait; the process exits non-zero on any failure and
+// always tears down the bridge child + relay server.
+//
+// Run: cd terminal/test && node --test   (or: npm test)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BRIDGE_ENTRY = path.resolve(__dirname, "../bridge/src/index.js");
+const SENTINEL = path.resolve(__dirname, "./sentinel-cmd.mjs");
+const HARD_TIMEOUT_MS = 20000;
+
+/** Resolve when `text` appears in accumulated browser-leg output, else reject. */
+function waitForText(getBuf, text, ms, label) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const iv = setInterval(() => {
+      if (getBuf().includes(text)) {
+        clearInterval(iv);
+        resolve(Date.now() - started);
+      } else if (Date.now() - started > ms) {
+        clearInterval(iv);
+        reject(new Error(`timed out after ${ms}ms waiting for ${label}: ${JSON.stringify(text)}`));
+      }
+    }, 25);
+  });
+}
+
+test("bridge <-> relay <-> browser round-trip + single-attach", { timeout: 60000 }, async (t) => {
+  const session = `test-${Math.random().toString(36).slice(2, 8)}`;
+  let relay;
+  let bridge;
+  let browser;
+
+  t.after(async () => {
+    try { browser?.terminate(); } catch { /* ignore */ }
+    if (bridge && bridge.exitCode === null) {
+      bridge.kill("SIGKILL");
+    }
+    if (relay) await relay.close();
+  });
+
+  // 1) Start the stand-in relay.
+  relay = await startStandinRelay({ port: 0 });
+  console.log(`[test] relay listening at ${relay.url}`);
+
+  // 2) Connect the BROWSER leg FIRST so it is attached before the bridge's PTY
+  //    emits its banner (slice-1 relay has no buffering).
+  let browserBuf = "";
+  browser = new WebSocket(`${relay.url}/?session=${session}&role=browser`);
+  browser.on("message", (data) => {
+    browserBuf += Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+  });
+  await Promise.race([
+    once(browser, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error("browser ws open timeout")), 5000)),
+  ]);
+  console.log("[test] browser leg connected");
+
+  // 3) Start the BRIDGE leg, running the cheap sentinel command in a node-pty PTY.
+  bridge = spawn(process.execPath, [BRIDGE_ENTRY, "--cmd", `${process.execPath} ${SENTINEL}`], {
+    env: {
+      ...process.env,
+      RELAY_URL: relay.url,
+      SESSION_ID: session,
+      // keep timeouts short so a hang fails fast rather than dangling
+      "BRIDGE_MAX_SECONDS": "60",
+    },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  bridge.on("exit", (code, sig) => console.log(`[test] bridge exited code=${code} sig=${sig}`));
+
+  // (a) browser receives the bridge's PTY output through the relay.
+  const tReady = await waitForText(() => browserBuf, "READY", HARD_TIMEOUT_MS, "PTY sentinel");
+  console.log(`[test] (a) PASS — browser received "READY" via relay in ${tReady}ms`);
+
+  // (b) bytes from the browser leg reach the PTY and echo back (round-trip).
+  const token = `PING-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+  browserBuf = ""; // reset so we only match the echo, not the sentinel
+  browser.send(Buffer.from(token + "\n", "utf8"), { binary: true });
+  const tEcho = await waitForText(() => browserBuf, token, HARD_TIMEOUT_MS, "PTY echo");
+  console.log(`[test] (b) PASS — browser->PTY->browser round-trip of ${token} in ${tEcho}ms`);
+
+  // (c) a 2nd browser attach for the same session is rejected (single-attach).
+  const second = new WebSocket(`${relay.url}/?session=${session}&role=browser`);
+  const [code, reasonBuf] = await Promise.race([
+    once(second, "close"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error("2nd browser close timeout")), 5000)),
+  ]);
+  const reason = reasonBuf ? reasonBuf.toString() : "";
+  console.log(`[test] (c) 2nd browser closed with code=${code} reason=${JSON.stringify(reason)}`);
+  assert.equal(code, 4001, "2nd browser must be rejected with single-attach close code 4001");
+  assert.match(reason, /single-attach/, "close reason should explain single-attach");
+  console.log("[test] (c) PASS — single-attach enforced");
+
+  // sanity: the original browser is still attached and live.
+  assert.equal(browser.readyState, WebSocket.OPEN, "first browser must remain connected");
+  console.log("[test] ALL ASSERTIONS PASSED");
+});

--- a/terminal/test/roundtrip.test.mjs
+++ b/terminal/test/roundtrip.test.mjs
@@ -30,6 +30,7 @@ import { fileURLToPath } from "node:url";
 import WebSocket from "ws";
 import { startStandinRelay } from "./standin-relay.mjs";
 import { mintSessionTokens, signToken } from "../shared/session-token.mjs";
+import { buildLaunchDeepLink } from "../shared/deep-link.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const BRIDGE_ENTRY = path.resolve(__dirname, "../bridge/src/index.js");
@@ -160,4 +161,71 @@ test("bridge <-> relay <-> browser round-trip + single-attach + owner-binding", 
   // sanity: the original (authenticated) browser is still attached and live.
   assert.equal(browser.readyState, WebSocket.OPEN, "first browser must remain connected");
   console.log("[test] ALL ASSERTIONS PASSED");
+});
+
+// ── SLICE 4: vibecodes:// launch deep link, end to end ────────────────────────
+// Proves the FULL launch chain logically (the OS scheme-routing is slice-7
+// packaging, deliberately out of scope here):
+//   app BUILDS `vibecodes://launch?relay&session&token` (shared builder)
+//     → the SAME string is handed to `bridge --launch-url <url>`
+//     → the bridge PARSES it for relay/session/token (no RELAY/SESSION/TOKEN env)
+//     → it connects to the relay and the browser leg round-trips.
+test("bridge --launch-url parses the deep link and round-trips through the relay", { timeout: 60000 }, async (t) => {
+  const session = `dl-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = "user-DL-" + Math.random().toString(36).slice(2, 8);
+  let relay;
+  let bridge;
+  let browser;
+
+  t.after(async () => {
+    try { browser?.terminate(); } catch { /* ignore */ }
+    if (bridge && bridge.exitCode === null) bridge.kill("SIGKILL");
+    if (relay) await relay.close();
+  });
+
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-DL", sid: session, secret: SECRET });
+  relay = await startStandinRelay({ port: 0, secret: SECRET });
+  console.log(`[test/dl] relay listening at ${relay.url}`);
+
+  // The app builds this EXACT string and fires it as window.location.assign(...).
+  const launchUrl = buildLaunchDeepLink({ relay: relay.url, session, token: tokens.bridge });
+  console.log(`[test/dl] launch url = ${launchUrl.replace(/token=[^&]*/, "token=***")}`);
+
+  // Browser leg attaches first (relay has no buffering), with its browser token.
+  let browserBuf = "";
+  browser = new WebSocket(`${relay.url}/?session=${session}&role=browser&token=${encodeURIComponent(tokens.browser)}`);
+  browser.on("message", (data) => {
+    browserBuf += Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+  });
+  await Promise.race([
+    once(browser, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error("browser ws open timeout")), 5000)),
+  ]);
+  console.log("[test/dl] browser leg connected");
+
+  // Spawn the bridge with ONLY --launch-url (+ the cheap sentinel cmd). Crucially we
+  // pass NO RELAY_URL/SESSION_ID/BRIDGE_TOKEN env — the deep link is the sole source.
+  bridge = spawn(
+    process.execPath,
+    [BRIDGE_ENTRY, "--launch-url", launchUrl, "--cmd", `${process.execPath} ${SENTINEL}`],
+    {
+      env: { PATH: process.env.PATH, BRIDGE_MAX_SECONDS: "60" },
+      stdio: ["ignore", "inherit", "inherit"],
+    },
+  );
+  bridge.on("exit", (code, sig) => console.log(`[test/dl] bridge exited code=${code} sig=${sig}`));
+
+  // (a) browser receives the PTY output → the bridge parsed the link + connected.
+  const tReady = await waitForText(() => browserBuf, "READY", HARD_TIMEOUT_MS, "PTY sentinel (deep link)");
+  console.log(`[test/dl] (a) PASS — bridge connected via --launch-url, "READY" relayed in ${tReady}ms`);
+
+  // (b) full round-trip: browser → relay → PTY → relay → browser.
+  const token = `PING-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+  browserBuf = "";
+  browser.send(Buffer.from(token + "\n", "utf8"), { binary: true });
+  const tEcho = await waitForText(() => browserBuf, token, HARD_TIMEOUT_MS, "PTY echo (deep link)");
+  console.log(`[test/dl] (b) PASS — deep-link bridge round-trip of ${token} in ${tEcho}ms`);
+
+  assert.equal(browser.readyState, WebSocket.OPEN, "browser must remain connected");
+  console.log("[test/dl] ALL ASSERTIONS PASSED");
 });

--- a/terminal/test/sentinel-cmd.mjs
+++ b/terminal/test/sentinel-cmd.mjs
@@ -1,0 +1,7 @@
+// A cheap, NON-interactive command for the bridge to run in its PTY during
+// tests (stand-in for `claude`). It prints a known sentinel, then echoes back
+// anything it receives on stdin — letting the test prove bytes flow both ways
+// through the relay without launching interactive `claude` (which could hang).
+process.stdout.write("READY\n");
+process.stdin.on("data", (d) => process.stdout.write(d));
+process.stdin.resume();

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -1,17 +1,21 @@
 // Plain-ws stand-in relay (Node) — for AUTOMATED testing.
 //
 // It is a faithful, lightweight twin of the Cloudflare Worker + Durable Object
-// in ../relay/src/index.js: same opaque forwarding, same single-attach rule,
-// because it imports the SAME pure decision logic (../relay/src/pairing.js).
+// in ../relay/src/index.js: same opaque forwarding, same single-attach + owner
+// rules, and (slice 6) the SAME idle / max-duration lifecycle limits and close
+// codes/reasons — because it imports the SAME pure decision logic + reason
+// builders (../relay/src/pairing.js). It does NOT hibernate (it's plain Node), so
+// it uses plain setTimeout where the real DO uses storage alarms, but the
+// observable behaviour (close code 1000 + idle/max reason) is identical.
 //
 // Why a stand-in: `wrangler dev` boots a full workerd runtime (slow, heavy, and
 // can need a one-time binary download), which is a poor dependency for a fast,
 // hermetic round-trip assertion. The real DO is exercised manually via
-// `npx wrangler dev` (see RUN.md); this twin proves the bridge<->relay<->browser
-// byte path deterministically in CI-style runs.
+// `npx wrangler dev` (see RUN.md / verify-against-relay.mjs / verify-lifecycle.mjs);
+// this twin proves the byte path + lifecycle deterministically in CI-style runs.
 //
 // Usage (programmatic): import { startStandinRelay } from "./standin-relay.mjs"
-//   const relay = await startStandinRelay({ port: 0 });
+//   const relay = await startStandinRelay({ port: 0, idleMs: 200 });
 //   ... relay.url ("ws://127.0.0.1:<port>") ... await relay.close();
 
 import { WebSocketServer } from "ws";
@@ -19,21 +23,54 @@ import {
   decideAttach,
   isValidSession,
   CLOSE,
+  DEFAULT_IDLE_MS,
+  DEFAULT_MAX_MS,
+  idleCloseReason,
+  maxCloseReason,
+  resolveMs,
 } from "../relay/src/pairing.js";
 import { authorizeAttach } from "../shared/session-token.mjs";
 
+const NORMAL_CLOSURE = 1000;
+
 /**
- * @param {{ port?: number, secret?: string, log?: (msg:string, extra?:object)=>void }} [opts]
+ * @param {{ port?: number, secret?: string, idleMs?: number, maxMs?: number,
+ *           log?: (msg:string, extra?:object)=>void }} [opts]
  *   `secret` — TERMINAL_SESSION_SECRET used to verify leg tokens (defaults to env).
+ *   `idleMs` / `maxMs` — lifecycle caps (default 30 min / 4 h); tests pass small values.
  * @returns {Promise<{ url:string, port:number, close:()=>Promise<void>, sessions: Map }>}
  */
 export function startStandinRelay(opts = {}) {
   const log = opts.log || (() => {});
   const secret = opts.secret ?? process.env.TERMINAL_SESSION_SECRET;
-  // session id -> { bridge: ws|null, browser: ws|null, owner: string|null }
+  const idleMs = resolveMs(opts.idleMs, DEFAULT_IDLE_MS);
+  const maxMs = resolveMs(opts.maxMs, DEFAULT_MAX_MS);
+  // session id -> { bridge: ws|null, browser: ws|null, owner: string|null,
+  //                 idleTimer, maxTimer }
   const sessions = new Map();
 
   const wss = new WebSocketServer({ port: opts.port ?? 0 });
+
+  /** Close both legs with code 1000 + a lifecycle reason, then forget the session. */
+  function endSession(session, reason) {
+    const legs = sessions.get(session);
+    if (!legs) return;
+    clearTimeout(legs.idleTimer);
+    clearTimeout(legs.maxTimer);
+    for (const leg of [legs.bridge, legs.browser]) {
+      if (leg && leg.readyState === leg.OPEN) {
+        try { leg.close(NORMAL_CLOSURE, reason); } catch { /* closing */ }
+      }
+    }
+    sessions.delete(session);
+  }
+
+  /** (Re)arm the idle timer for a session (called on attach + every message). */
+  function bumpIdle(session, legs) {
+    clearTimeout(legs.idleTimer);
+    legs.idleTimer = setTimeout(() => endSession(session, idleCloseReason(idleMs)), idleMs);
+    legs.idleTimer.unref?.();
+  }
 
   wss.on("connection", async (ws, req) => {
     const url = new URL(req.url, "ws://localhost");
@@ -54,7 +91,9 @@ export function startStandinRelay(opts = {}) {
       return;
     }
 
-    if (!sessions.has(session)) sessions.set(session, { bridge: null, browser: null, owner: null });
+    if (!sessions.has(session)) {
+      sessions.set(session, { bridge: null, browser: null, owner: null, idleTimer: null, maxTimer: null });
+    }
     const legs = sessions.get(session);
 
     const state = { bridge: legs.bridge !== null, browser: legs.browser !== null, owner: legs.owner };
@@ -65,15 +104,25 @@ export function startStandinRelay(opts = {}) {
       return;
     }
 
+    const firstLeg = legs.bridge === null && legs.browser === null;
     if (legs.owner === null) legs.owner = auth.sub;
     legs[role] = ws;
     log("attached", { session, role });
+
+    // Arm the max-duration cap once, on the first leg; arm/refresh idle now.
+    if (firstLeg) {
+      legs.maxTimer = setTimeout(() => endSession(session, maxCloseReason(maxMs)), maxMs);
+      legs.maxTimer.unref?.();
+    }
+    bumpIdle(session, legs);
 
     ws.on("message", (data, isBinary) => {
       const peer = role === "bridge" ? legs.browser : legs.bridge;
       if (peer && peer.readyState === peer.OPEN) {
         peer.send(data, { binary: isBinary }); // verbatim, opaque
       }
+      // Activity → push the idle deadline out (max-duration is untouched).
+      if (sessions.get(session) === legs) bumpIdle(session, legs);
     });
 
     const teardown = () => {
@@ -85,7 +134,11 @@ export function startStandinRelay(opts = {}) {
       }
       if (role === "bridge") legs.browser = null;
       else legs.bridge = null;
-      if (!legs.bridge && !legs.browser) sessions.delete(session);
+      if (!legs.bridge && !legs.browser) {
+        clearTimeout(legs.idleTimer);
+        clearTimeout(legs.maxTimer);
+        sessions.delete(session);
+      }
     };
 
     ws.on("close", teardown);
@@ -101,6 +154,10 @@ export function startStandinRelay(opts = {}) {
         sessions,
         close: () =>
           new Promise((res) => {
+            for (const legs of sessions.values()) {
+              clearTimeout(legs.idleTimer);
+              clearTimeout(legs.maxTimer);
+            }
             for (const client of wss.clients) {
               try { client.terminate(); } catch { /* ignore */ }
             }

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -20,40 +20,52 @@ import {
   isValidSession,
   CLOSE,
 } from "../relay/src/pairing.js";
+import { authorizeAttach } from "../shared/session-token.mjs";
 
 /**
- * @param {{ port?: number, log?: (msg:string, extra?:object)=>void }} [opts]
+ * @param {{ port?: number, secret?: string, log?: (msg:string, extra?:object)=>void }} [opts]
+ *   `secret` — TERMINAL_SESSION_SECRET used to verify leg tokens (defaults to env).
  * @returns {Promise<{ url:string, port:number, close:()=>Promise<void>, sessions: Map }>}
  */
 export function startStandinRelay(opts = {}) {
   const log = opts.log || (() => {});
-  // session id -> { bridge: ws|null, browser: ws|null }
+  const secret = opts.secret ?? process.env.TERMINAL_SESSION_SECRET;
+  // session id -> { bridge: ws|null, browser: ws|null, owner: string|null }
   const sessions = new Map();
 
   const wss = new WebSocketServer({ port: opts.port ?? 0 });
 
-  wss.on("connection", (ws, req) => {
+  wss.on("connection", async (ws, req) => {
     const url = new URL(req.url, "ws://localhost");
     const session = url.searchParams.get("session");
     const role = url.searchParams.get("role");
+    const token = url.searchParams.get("token");
 
-    // TODO(slice 2): validate app-minted session token + owner binding.
     if (!isValidSession(session)) {
       ws.close(CLOSE.BAD_SESSION.code, CLOSE.BAD_SESSION.reason);
       return;
     }
 
-    if (!sessions.has(session)) sessions.set(session, { bridge: null, browser: null });
+    // Authenticate the leg with the SAME shared verifier the real relay uses.
+    const auth = await authorizeAttach({ token, secret, session, role });
+    if (!auth.ok) {
+      log("attach rejected (auth)", { session, role, reason: auth.reason });
+      ws.close(CLOSE.BAD_TOKEN.code, CLOSE.BAD_TOKEN.reason);
+      return;
+    }
+
+    if (!sessions.has(session)) sessions.set(session, { bridge: null, browser: null, owner: null });
     const legs = sessions.get(session);
 
-    const state = { bridge: legs.bridge !== null, browser: legs.browser !== null };
-    const decision = decideAttach(state, role);
+    const state = { bridge: legs.bridge !== null, browser: legs.browser !== null, owner: legs.owner };
+    const decision = decideAttach(state, role, auth.sub);
     if (!decision.ok) {
       log("attach rejected", { session, role, code: decision.code, reason: decision.reason });
       ws.close(decision.code, decision.reason);
       return;
     }
 
+    if (legs.owner === null) legs.owner = auth.sub;
     legs[role] = ws;
     log("attached", { session, role });
 

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -1,0 +1,100 @@
+// Plain-ws stand-in relay (Node) — for AUTOMATED testing.
+//
+// It is a faithful, lightweight twin of the Cloudflare Worker + Durable Object
+// in ../relay/src/index.js: same opaque forwarding, same single-attach rule,
+// because it imports the SAME pure decision logic (../relay/src/pairing.js).
+//
+// Why a stand-in: `wrangler dev` boots a full workerd runtime (slow, heavy, and
+// can need a one-time binary download), which is a poor dependency for a fast,
+// hermetic round-trip assertion. The real DO is exercised manually via
+// `npx wrangler dev` (see RUN.md); this twin proves the bridge<->relay<->browser
+// byte path deterministically in CI-style runs.
+//
+// Usage (programmatic): import { startStandinRelay } from "./standin-relay.mjs"
+//   const relay = await startStandinRelay({ port: 0 });
+//   ... relay.url ("ws://127.0.0.1:<port>") ... await relay.close();
+
+import { WebSocketServer } from "ws";
+import {
+  decideAttach,
+  isValidSession,
+  CLOSE,
+} from "../relay/src/pairing.js";
+
+/**
+ * @param {{ port?: number, log?: (msg:string, extra?:object)=>void }} [opts]
+ * @returns {Promise<{ url:string, port:number, close:()=>Promise<void>, sessions: Map }>}
+ */
+export function startStandinRelay(opts = {}) {
+  const log = opts.log || (() => {});
+  // session id -> { bridge: ws|null, browser: ws|null }
+  const sessions = new Map();
+
+  const wss = new WebSocketServer({ port: opts.port ?? 0 });
+
+  wss.on("connection", (ws, req) => {
+    const url = new URL(req.url, "ws://localhost");
+    const session = url.searchParams.get("session");
+    const role = url.searchParams.get("role");
+
+    // TODO(slice 2): validate app-minted session token + owner binding.
+    if (!isValidSession(session)) {
+      ws.close(CLOSE.BAD_SESSION.code, CLOSE.BAD_SESSION.reason);
+      return;
+    }
+
+    if (!sessions.has(session)) sessions.set(session, { bridge: null, browser: null });
+    const legs = sessions.get(session);
+
+    const state = { bridge: legs.bridge !== null, browser: legs.browser !== null };
+    const decision = decideAttach(state, role);
+    if (!decision.ok) {
+      log("attach rejected", { session, role, code: decision.code, reason: decision.reason });
+      ws.close(decision.code, decision.reason);
+      return;
+    }
+
+    legs[role] = ws;
+    log("attached", { session, role });
+
+    ws.on("message", (data, isBinary) => {
+      const peer = role === "bridge" ? legs.browser : legs.bridge;
+      if (peer && peer.readyState === peer.OPEN) {
+        peer.send(data, { binary: isBinary }); // verbatim, opaque
+      }
+    });
+
+    const teardown = () => {
+      if (legs[role] === ws) legs[role] = null;
+      log("detached", { session, role });
+      const peer = role === "bridge" ? legs.browser : legs.bridge;
+      if (peer && peer.readyState === peer.OPEN) {
+        try { peer.close(CLOSE.PEER_GONE.code, CLOSE.PEER_GONE.reason); } catch { /* closing */ }
+      }
+      if (role === "bridge") legs.browser = null;
+      else legs.bridge = null;
+      if (!legs.bridge && !legs.browser) sessions.delete(session);
+    };
+
+    ws.on("close", teardown);
+    ws.on("error", teardown);
+  });
+
+  return new Promise((resolve) => {
+    wss.on("listening", () => {
+      const { port } = wss.address();
+      resolve({
+        url: `ws://127.0.0.1:${port}`,
+        port,
+        sessions,
+        close: () =>
+          new Promise((res) => {
+            for (const client of wss.clients) {
+              try { client.terminate(); } catch { /* ignore */ }
+            }
+            wss.close(() => res());
+          }),
+      });
+    });
+  });
+}

--- a/terminal/test/verify-against-relay.mjs
+++ b/terminal/test/verify-against-relay.mjs
@@ -1,0 +1,82 @@
+// Manual verification against an EXTERNALLY-running relay (e.g. `wrangler dev`).
+// Unlike roundtrip.test.mjs (which starts the Node stand-in), this points the
+// bridge + browser legs at whatever RELAY_URL you give it — used to prove the
+// real Cloudflare Worker + Durable Object.
+//
+//   cd terminal/relay && npx wrangler dev          # terminal 1
+//   RELAY_URL=ws://127.0.0.1:8787 node ../test/verify-against-relay.mjs   # terminal 2
+//
+// Exits 0 on success, non-zero on any failure. Hard timeouts throughout.
+
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import WebSocket from "ws";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BRIDGE_ENTRY = path.resolve(__dirname, "../bridge/src/index.js");
+const SENTINEL = path.resolve(__dirname, "./sentinel-cmd.mjs");
+const RELAY_URL = process.env.RELAY_URL || "ws://127.0.0.1:8787";
+const HARD_TIMEOUT_MS = 20000;
+const session = `verify-${Math.random().toString(36).slice(2, 8)}`;
+
+function waitForText(getBuf, text, ms, label) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const iv = setInterval(() => {
+      if (getBuf().includes(text)) { clearInterval(iv); resolve(Date.now() - started); }
+      else if (Date.now() - started > ms) { clearInterval(iv); reject(new Error(`timeout waiting for ${label}`)); }
+    }, 25);
+  });
+}
+
+let bridge, browser;
+function cleanup() {
+  try { browser?.terminate(); } catch { /* ignore */ }
+  if (bridge && bridge.exitCode === null) bridge.kill("SIGKILL");
+}
+
+try {
+  console.log(`[verify] relay = ${RELAY_URL}  session = ${session}`);
+
+  let browserBuf = "";
+  browser = new WebSocket(`${RELAY_URL}/?session=${session}&role=browser`);
+  browser.on("message", (d) => { browserBuf += Buffer.isBuffer(d) ? d.toString("utf8") : String(d); });
+  await Promise.race([
+    once(browser, "open"),
+    new Promise((_, r) => setTimeout(() => r(new Error("browser open timeout")), 5000)),
+  ]);
+  console.log("[verify] browser leg connected");
+
+  bridge = spawn(process.execPath, [BRIDGE_ENTRY, "--cmd", `${process.execPath} ${SENTINEL}`], {
+    env: { ...process.env, RELAY_URL, SESSION_ID: session, BRIDGE_MAX_SECONDS: "60" },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+
+  const tReady = await waitForText(() => browserBuf, "READY", HARD_TIMEOUT_MS, "PTY sentinel");
+  console.log(`[verify] (a) PASS — browser received "READY" via real DO in ${tReady}ms`);
+
+  const token = `PING-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+  browserBuf = "";
+  browser.send(Buffer.from(token + "\n", "utf8"), { binary: true });
+  const tEcho = await waitForText(() => browserBuf, token, HARD_TIMEOUT_MS, "PTY echo");
+  console.log(`[verify] (b) PASS — round-trip of ${token} via real DO in ${tEcho}ms`);
+
+  const second = new WebSocket(`${RELAY_URL}/?session=${session}&role=browser`);
+  const [code, reasonBuf] = await Promise.race([
+    once(second, "close"),
+    new Promise((_, r) => setTimeout(() => r(new Error("2nd browser close timeout")), 5000)),
+  ]);
+  const reason = reasonBuf ? reasonBuf.toString() : "";
+  if (code !== 4001) throw new Error(`expected close 4001, got ${code} (${reason})`);
+  console.log(`[verify] (c) PASS — 2nd browser rejected by real DO: code=${code} reason=${JSON.stringify(reason)}`);
+
+  console.log("[verify] ALL ASSERTIONS PASSED against the real Cloudflare DO");
+  cleanup();
+  setTimeout(() => process.exit(0), 200).unref();
+} catch (e) {
+  console.error("[verify] FAILED:", e.message);
+  cleanup();
+  setTimeout(() => process.exit(1), 200).unref();
+}

--- a/terminal/test/verify-against-relay.mjs
+++ b/terminal/test/verify-against-relay.mjs
@@ -1,11 +1,13 @@
 // Manual verification against an EXTERNALLY-running relay (e.g. `wrangler dev`).
 // Unlike roundtrip.test.mjs (which starts the Node stand-in), this points the
 // bridge + browser legs at whatever RELAY_URL you give it — used to prove the
-// real Cloudflare Worker + Durable Object.
+// real Cloudflare Worker + Durable Object, now WITH owner-bound auth (slice 2).
 //
-//   cd terminal/relay && npx wrangler dev          # terminal 1
-//   RELAY_URL=ws://127.0.0.1:8787 node ../test/verify-against-relay.mjs   # terminal 2
+//   cd terminal/relay && npx wrangler dev          # terminal 1 (loads .dev.vars)
+//   TERMINAL_SESSION_SECRET=<same-as-.dev.vars> \
+//     RELAY_URL=ws://127.0.0.1:8787 node ../test/verify-against-relay.mjs   # terminal 2
 //
+// The SECRET here must match the relay's TERMINAL_SESSION_SECRET (in .dev.vars).
 // Exits 0 on success, non-zero on any failure. Hard timeouts throughout.
 
 import { spawn } from "node:child_process";
@@ -13,13 +15,22 @@ import { once } from "node:events";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import WebSocket from "ws";
+import { mintSessionTokens, signToken } from "../shared/session-token.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const BRIDGE_ENTRY = path.resolve(__dirname, "../bridge/src/index.js");
 const SENTINEL = path.resolve(__dirname, "./sentinel-cmd.mjs");
 const RELAY_URL = process.env.RELAY_URL || "ws://127.0.0.1:8787";
+const SECRET = process.env.TERMINAL_SESSION_SECRET;
 const HARD_TIMEOUT_MS = 20000;
 const session = `verify-${Math.random().toString(36).slice(2, 8)}`;
+const ownerA = `userA-${Math.random().toString(36).slice(2, 8)}`;
+const ownerB = `userB-${Math.random().toString(36).slice(2, 8)}`;
+
+if (!SECRET) {
+  console.error("[verify] set TERMINAL_SESSION_SECRET to match the relay's .dev.vars");
+  process.exit(2);
+}
 
 function waitForText(getBuf, text, ms, label) {
   return new Promise((resolve, reject) => {
@@ -40,17 +51,19 @@ function cleanup() {
 try {
   console.log(`[verify] relay = ${RELAY_URL}  session = ${session}`);
 
+  const tokensA = await mintSessionTokens({ sub: ownerA, idea: "idea-X", sid: session, secret: SECRET });
+
   let browserBuf = "";
-  browser = new WebSocket(`${RELAY_URL}/?session=${session}&role=browser`);
+  browser = new WebSocket(`${RELAY_URL}/?session=${session}&role=browser&token=${encodeURIComponent(tokensA.browser)}`);
   browser.on("message", (d) => { browserBuf += Buffer.isBuffer(d) ? d.toString("utf8") : String(d); });
   await Promise.race([
     once(browser, "open"),
     new Promise((_, r) => setTimeout(() => r(new Error("browser open timeout")), 5000)),
   ]);
-  console.log("[verify] browser leg connected");
+  console.log("[verify] browser leg connected (authenticated)");
 
   bridge = spawn(process.execPath, [BRIDGE_ENTRY, "--cmd", `${process.execPath} ${SENTINEL}`], {
-    env: { ...process.env, RELAY_URL, SESSION_ID: session, BRIDGE_MAX_SECONDS: "60" },
+    env: { ...process.env, RELAY_URL, SESSION_ID: session, BRIDGE_TOKEN: tokensA.bridge, BRIDGE_MAX_SECONDS: "60" },
     stdio: ["ignore", "inherit", "inherit"],
   });
 
@@ -63,14 +76,47 @@ try {
   const tEcho = await waitForText(() => browserBuf, token, HARD_TIMEOUT_MS, "PTY echo");
   console.log(`[verify] (b) PASS — round-trip of ${token} via real DO in ${tEcho}ms`);
 
-  const second = new WebSocket(`${RELAY_URL}/?session=${session}&role=browser`);
-  const [code, reasonBuf] = await Promise.race([
-    once(second, "close"),
-    new Promise((_, r) => setTimeout(() => r(new Error("2nd browser close timeout")), 5000)),
-  ]);
-  const reason = reasonBuf ? reasonBuf.toString() : "";
-  if (code !== 4001) throw new Error(`expected close 4001, got ${code} (${reason})`);
-  console.log(`[verify] (c) PASS — 2nd browser rejected by real DO: code=${code} reason=${JSON.stringify(reason)}`);
+  // (c) single-attach: a 2nd browser with the SAME owner's valid token is refused.
+  {
+    const second = new WebSocket(`${RELAY_URL}/?session=${session}&role=browser&token=${encodeURIComponent(tokensA.browser)}`);
+    const [code, reasonBuf] = await Promise.race([
+      once(second, "close"),
+      new Promise((_, r) => setTimeout(() => r(new Error("2nd browser close timeout")), 5000)),
+    ]);
+    const reason = reasonBuf ? reasonBuf.toString() : "";
+    if (code !== 4001) throw new Error(`expected close 4001, got ${code} (${reason})`);
+    console.log(`[verify] (c) PASS — 2nd browser (same user) rejected: code=${code} reason=${JSON.stringify(reason)}`);
+  }
+
+  // (d) owner-mismatch: a browser with a DIFFERENT user's valid token is refused.
+  {
+    const tokensB = await mintSessionTokens({ sub: ownerB, idea: "idea-X", sid: session, secret: SECRET });
+    const foreign = new WebSocket(`${RELAY_URL}/?session=${session}&role=browser&token=${encodeURIComponent(tokensB.browser)}`);
+    const [code, reasonBuf] = await Promise.race([
+      once(foreign, "close"),
+      new Promise((_, r) => setTimeout(() => r(new Error("foreign browser close timeout")), 5000)),
+    ]);
+    const reason = reasonBuf ? reasonBuf.toString() : "";
+    if (code !== 4005) throw new Error(`expected close 4005 (owner mismatch), got ${code} (${reason})`);
+    console.log(`[verify] (d) PASS — different-user browser rejected by real DO: code=${code} reason=${JSON.stringify(reason)}`);
+  }
+
+  // (e) expired token: refused with BAD_TOKEN.
+  {
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const expired = await signToken(
+      { sub: ownerA, sid: session, idea: "idea-X", role: "browser", iat: past, exp: past + 60 },
+      SECRET,
+    );
+    const stale = new WebSocket(`${RELAY_URL}/?session=${session}&role=browser&token=${encodeURIComponent(expired)}`);
+    const [code, reasonBuf] = await Promise.race([
+      once(stale, "close"),
+      new Promise((_, r) => setTimeout(() => r(new Error("expired browser close timeout")), 5000)),
+    ]);
+    const reason = reasonBuf ? reasonBuf.toString() : "";
+    if (code !== 4006) throw new Error(`expected close 4006 (bad/expired token), got ${code} (${reason})`);
+    console.log(`[verify] (e) PASS — expired token rejected by real DO: code=${code} reason=${JSON.stringify(reason)}`);
+  }
 
   console.log("[verify] ALL ASSERTIONS PASSED against the real Cloudflare DO");
   cleanup();

--- a/terminal/test/verify-lifecycle.mjs
+++ b/terminal/test/verify-lifecycle.mjs
@@ -1,0 +1,89 @@
+// Manual verification of the REAL Durable Object's idle-timeout against a running
+// `wrangler dev` — slice 6. Unlike lifecycle.test.mjs (Node stand-in), this drives
+// two raw WebSocket legs at the actual Cloudflare runtime and proves an idle
+// session is closed by the DO ALARM with code 1000 + an "idle" reason.
+//
+// Start the relay with a SHORT idle so the test is fast (overrides the 30-min
+// default; `--var` injects an env binding the DO reads as env.TERMINAL_IDLE_MS):
+//
+//   cd terminal/relay && npx wrangler dev --port 8787 --var TERMINAL_IDLE_MS:3000
+//
+// then (matching the relay's .dev.vars secret):
+//   cd terminal/test && TERMINAL_SESSION_SECRET=<same-as-.dev.vars> \
+//     RELAY_URL=ws://127.0.0.1:8787 EXPECT_IDLE_MS=3000 node verify-lifecycle.mjs
+//
+// Exits 0 on success, non-zero on any failure. Hard timeouts throughout.
+
+import { once } from "node:events";
+import WebSocket from "ws";
+import { mintSessionTokens } from "../shared/session-token.mjs";
+
+const RELAY_URL = process.env.RELAY_URL || "ws://127.0.0.1:8787";
+const SECRET = process.env.TERMINAL_SESSION_SECRET;
+const EXPECT_IDLE_MS = Number(process.env.EXPECT_IDLE_MS || 3000);
+const session = `idle-${Math.random().toString(36).slice(2, 8)}`;
+const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+
+if (!SECRET) {
+  console.error("[verify-lifecycle] set TERMINAL_SESSION_SECRET to match the relay's .dev.vars");
+  process.exit(2);
+}
+
+async function openLeg(role, token) {
+  const ws = new WebSocket(`${RELAY_URL}/?session=${session}&role=${role}&token=${encodeURIComponent(token)}`);
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, r) => setTimeout(() => r(new Error(`${role} open timeout`)), 5000)),
+  ]);
+  return ws;
+}
+
+/** Capture a leg's close (code+reason) — listener attached EAGERLY so a near-
+ *  simultaneous close on both legs can't be missed by listening too late. */
+function captureClose(ws) {
+  return new Promise((resolve) => {
+    ws.once("close", (code, reasonBuf) => resolve([code, reasonBuf ? reasonBuf.toString() : ""]));
+  });
+}
+function withTimeout(p, label, ms) {
+  return Promise.race([
+    p,
+    new Promise((_, r) => setTimeout(() => r(new Error(`${label} idle close timeout`)), ms)),
+  ]);
+}
+
+let browser, bridge;
+try {
+  console.log(`[verify-lifecycle] relay=${RELAY_URL} session=${session} expectIdleMs=${EXPECT_IDLE_MS}`);
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-L", sid: session, secret: SECRET });
+
+  browser = await openLeg("browser", tokens.browser);
+  bridge = await openLeg("bridge", tokens.bridge);
+  // Attach close-captures BEFORE going idle so neither near-simultaneous close is missed.
+  const browserClosed = captureClose(browser);
+  const bridgeClosed = captureClose(bridge);
+  console.log("[verify-lifecycle] both legs attached; sending one byte then going idle…");
+  bridge.send(Buffer.from("READY\n", "utf8"), { binary: true });
+
+  const started = Date.now();
+  const waitMs = EXPECT_IDLE_MS + 8000;
+  const [bCode, bReason] = await withTimeout(browserClosed, "browser", waitMs);
+  const [gCode, gReason] = await withTimeout(bridgeClosed, "bridge", waitMs);
+  const elapsed = Date.now() - started;
+
+  if (bCode !== 1000 || gCode !== 1000) {
+    throw new Error(`expected both legs to close 1000, got browser=${bCode} bridge=${gCode}`);
+  }
+  if (!/idle/.test(bReason) || !/idle/.test(gReason)) {
+    throw new Error(`expected an 'idle' reason, got browser=${JSON.stringify(bReason)} bridge=${JSON.stringify(gReason)}`);
+  }
+  console.log(`[verify-lifecycle] PASS — DO alarm closed BOTH legs after ~${elapsed}ms`);
+  console.log(`[verify-lifecycle]   browser: code=${bCode} reason=${JSON.stringify(bReason)}`);
+  console.log(`[verify-lifecycle]   bridge:  code=${gCode} reason=${JSON.stringify(gReason)}`);
+  process.exit(0);
+} catch (e) {
+  console.error("[verify-lifecycle] FAILED:", e.message);
+  try { browser?.terminate(); } catch { /* ignore */ }
+  try { bridge?.terminate(); } catch { /* ignore */ }
+  process.exit(1);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,11 @@ export default defineConfig({
     setupFiles: ["./src/test/setup.ts"],
     globals: true,
     css: false,
-    exclude: ["e2e/**", "node_modules/**", "mcp-server/node_modules/**"],
+    // Root vitest runs the app's `src/` tests only. Exclude e2e, all vendored
+    // node_modules (incl. nested ones under terminal/* and scripts/*), and the
+    // terminal/ workspace + scripts/, which ship their own `node --test` runners
+    // (see terminal/RUN.md) and would otherwise pollute the app suite.
+    exclude: ["e2e/**", "**/node_modules/**", "terminal/**", "scripts/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Ships the P1 **in-app local Claude Code terminal**: watch/drive your *local* Claude Code session inside the web app via `local bridge → Cloudflare relay → in-browser xterm dock`.

## What's included (slices 1–7 + download route)
- **Relay** (`terminal/relay/`): Cloudflare Worker + SQLite Durable Object, WebSocket Hibernation, idle/max-duration timers. Live + free-tier. Opaque byte forwarding, owner-bound, single-attach.
- **Auth**: app-minted HMAC session tokens (`terminal/shared/session-token.mjs`), verified by the relay.
- **Board dock** (`terminal-dock.tsx`): xterm.js browser leg, 6-state connection reducer.
- **Launch menu** (`launch-claude-code-button.tsx`): pick-one — "In a terminal window" (unchanged) vs "In the browser" (new dock) via `vibecodes://` deep link.
- **macOS helper** (`terminal/helper/`): signed + **notarized** Electron app registering the `vibecodes://` scheme; forks the existing bridge (no logic dup). Published as a GitHub Release.
- **`/download/terminal-helper`**: public redirect to the notarized installer.

## Gating / rollout
- Entire feature is behind `NEXT_PUBLIC_TERMINAL_ENABLED` (now `true` in prod) **and** a team-member check.
- Prod env set: relay URL + session secret (matching the live relay).

## Caveats
- Installer is **Apple Silicon (arm64) only** for now; Intel/x64 + Windows are follow-ups.
- ~1430 app tests green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)