### PR TITLE
feat(terminal): install-first first-run UX (no blind deep-link firing)

### DIFF
--- a/docs/install-first-terminal-ux.html
+++ b/docs/install-first-terminal-ux.html
@@ -1,0 +1,819 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Install-First Terminal — UX Design (Compass)</title>
+<style>
+  :root{
+    /* Pulled from src/components/board/terminal-dock.tsx to match the live dock */
+    --dock-header:#141417;
+    --dock-body:#0c0c0e;
+    --dock-deep:#0a0a0b;
+    --page:#09090b;
+    --card:#141417;
+    --border:#3f3f46;      /* zinc-700 */
+    --border-soft:#27272a; /* zinc-800 */
+    --text:#e4e4e7;        /* zinc-200 */
+    --text-dim:#a1a1aa;    /* zinc-400 */
+    --text-faint:#71717a;  /* zinc-500 */
+    --emerald:#34d399;
+    --emerald-deep:#052e1b;
+    --amber:#fbbf24;
+    --sky:#38bdf8;
+    --rose:#fb7185;
+    --violet:#c4b5fd;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{
+    background:var(--page);
+    color:var(--text);
+    font:15px/1.6 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    padding:0 0 96px;
+  }
+  .wrap{max-width:1120px;margin:0 auto;padding:0 20px}
+  header.doc{
+    border-bottom:1px solid var(--border-soft);
+    background:linear-gradient(180deg,#141417,#0c0c0e);
+    padding:40px 0 30px;margin-bottom:8px;
+  }
+  header.doc .wrap{max-width:1120px}
+  .kicker{font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:var(--emerald);font-weight:700}
+  h1{font-size:30px;margin:8px 0 6px;letter-spacing:-.01em}
+  .sub{color:var(--text-dim);font-size:15px;max-width:760px}
+  .meta-row{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+  .tag{font-size:12px;border:1px solid var(--border);border-radius:999px;padding:4px 11px;color:var(--text-dim);background:#18181b}
+  .tag.ok{border-color:rgba(52,211,153,.5);color:var(--emerald);background:rgba(52,211,153,.08)}
+
+  h2{font-size:21px;margin:44px 0 4px;letter-spacing:-.01em}
+  h2 .num{color:var(--text-faint);font-weight:600;margin-right:10px}
+  .lead{color:var(--text-dim);margin:6px 0 20px;max-width:820px}
+  h3{font-size:15px;margin:26px 0 10px;color:var(--text)}
+
+  /* ---- The mock dock ---- */
+  .dock{
+    border:1px solid var(--border);
+    border-radius:12px;
+    overflow:hidden;
+    background:var(--dock-header);
+    box-shadow:0 18px 50px rgba(0,0,0,.5);
+    max-width:860px;
+  }
+  .dock.narrow{max-width:375px}
+  .dockbar{
+    display:flex;align-items:center;gap:10px;
+    padding:8px 12px;background:var(--dock-header);
+    font-size:12px;
+  }
+  .dot{width:9px;height:9px;border-radius:50%;flex:0 0 auto}
+  .dot.emerald{background:var(--emerald)}
+  .dot.amber{background:var(--amber)}
+  .dot.sky{background:var(--sky)}
+  .dot.zinc{background:var(--text-faint)}
+  .dot.rose{background:var(--rose)}
+  .termlabel{display:inline-flex;align-items:center;gap:8px;font-weight:600}
+  .termlabel .sess{color:var(--text-faint);font-weight:400;font-family:ui-monospace,Menlo,monospace;font-size:11px}
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;
+    border:1px solid var(--border);border-radius:7px;
+    padding:2px 9px;font-size:11px;font-weight:600;
+  }
+  .pill .ic{font-size:11px}
+  .pill.emerald{border-color:rgba(52,211,153,.5);background:rgba(52,211,153,.1);color:var(--emerald)}
+  .pill.amber{border-color:rgba(251,191,36,.5);background:rgba(251,191,36,.1);color:var(--amber)}
+  .pill.sky{border-color:rgba(56,189,248,.5);background:rgba(56,189,248,.1);color:var(--sky)}
+  .pill.zinc{border-color:var(--border);background:#27272a99;color:var(--text-dim)}
+  .pill.rose{border-color:rgba(251,113,133,.55);background:rgba(251,113,133,.1);color:var(--rose)}
+  .spacer{margin-left:auto}
+  .ghostbtn{color:var(--text-dim);font-size:12px;display:inline-flex;align-items:center;gap:5px}
+
+  .dockhead{
+    display:flex;flex-wrap:wrap;align-items:center;gap:8px;
+    border-top:1px solid var(--border-soft);border-bottom:1px solid var(--border-soft);
+    background:var(--dock-header);padding:9px 12px;font-size:12px;
+  }
+  .dockhead .idea{color:var(--text-faint);font-family:ui-monospace,Menlo,monospace;font-size:12px}
+
+  .dockbody{
+    background:var(--dock-body);
+    min-height:300px;
+    display:flex;align-items:center;justify-content:center;
+    padding:30px 22px;position:relative;
+  }
+  .dockbody.tall{min-height:340px}
+
+  /* centred overlay content */
+  .overlay{max-width:520px;width:100%;text-align:center;display:flex;flex-direction:column;align-items:center;gap:14px}
+  .overlay .icon{font-size:26px;line-height:1}
+  .overlay h4{font-size:17px;margin:0;font-weight:700}
+  .overlay p{margin:0;font-size:13.5px;color:var(--text-dim);max-width:460px}
+  .overlay .muted{color:var(--text-faint)}
+
+  .btn{
+    display:inline-flex;align-items:center;justify-content:center;gap:8px;
+    border-radius:8px;padding:11px 18px;font-size:14px;font-weight:600;
+    border:1px solid transparent;cursor:default;min-height:44px;
+  }
+  .btn.primary{background:var(--emerald);color:#04160c}
+  .btn.sky{background:var(--sky);color:#04121b}
+  .btn.outline{background:#27272a99;border-color:var(--border);color:var(--text)}
+  .btn.block{width:100%}
+  .btn.disabled{background:#1c1c20;border-color:var(--border-soft);color:var(--text-faint);cursor:not-allowed}
+  .btnrow{display:flex;gap:10px;flex-wrap:wrap;justify-content:center;width:100%}
+
+  /* numbered one-time setup */
+  .setup{width:100%;max-width:520px;text-align:left;display:flex;flex-direction:column;gap:0}
+  .setup .head{text-align:center;margin-bottom:18px}
+  .setup .head .icon{font-size:24px}
+  .setup .head h4{font-size:17px;margin:8px 0 4px;font-weight:700}
+  .setup .head p{font-size:13px;color:var(--text-dim);margin:0}
+  .step{display:flex;gap:14px;padding:14px 0;border-top:1px solid var(--border-soft)}
+  .step:first-of-type{border-top:0}
+  .badge{
+    flex:0 0 auto;width:28px;height:28px;border-radius:50%;
+    display:flex;align-items:center;justify-content:center;
+    font-size:13px;font-weight:700;
+    background:rgba(52,211,153,.12);color:var(--emerald);
+    border:1px solid rgba(52,211,153,.4);
+  }
+  .step .body{flex:1;min-width:0}
+  .step .title{font-size:14px;font-weight:600;margin-bottom:6px}
+  .step .desc{font-size:12.5px;color:var(--text-dim);margin:0 0 10px}
+  .prewarn{
+    display:flex;gap:9px;align-items:flex-start;
+    border:1px solid rgba(251,191,36,.35);background:rgba(251,191,36,.06);
+    border-radius:8px;padding:10px 12px;margin:2px 0 12px;font-size:12.5px;color:#fcd77f;
+  }
+  .prewarn b{color:#fde3a0}
+  .connectwrap{padding-top:14px;border-top:1px solid var(--border-soft);display:flex;flex-direction:column;gap:8px}
+  .subtle{font-size:11.5px;color:var(--text-faint);text-align:center}
+
+  /* faux terminal stream */
+  .stream{
+    width:100%;height:100%;min-height:260px;
+    background:var(--dock-body);border-radius:6px;
+    font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:12.5px;line-height:1.7;
+    color:#cfd8df;text-align:left;padding:10px 14px;align-self:stretch;
+  }
+  .stream .g{color:var(--emerald)}
+  .stream .d{color:var(--text-faint)}
+  .stream .cursor{display:inline-block;width:8px;height:15px;background:#cfd8df;vertical-align:-2px;animation:blink 1s step-end infinite}
+  @keyframes blink{50%{opacity:0}}
+  .inputbar{
+    display:flex;align-items:center;gap:8px;
+    border-top:1px solid var(--border-soft);background:var(--dock-header);
+    padding:9px 14px;font-size:12px;color:var(--text-faint);
+  }
+  .inputbar .prompt{color:var(--emerald);font-family:ui-monospace,Menlo,monospace}
+
+  /* mac dialog mock (the one we PREVENT / the one we PRE-EXPLAIN) */
+  .macdlg{
+    max-width:340px;border-radius:12px;overflow:hidden;
+    background:#2b2b2e;border:1px solid #3a3a3d;
+    box-shadow:0 20px 60px rgba(0,0,0,.6);text-align:center;
+    color:#e9e9ea;font-size:13px;
+  }
+  .macdlg .top{padding:20px 22px 14px}
+  .macdlg .appicon{font-size:30px;margin-bottom:10px}
+  .macdlg h5{margin:0 0 6px;font-size:14px}
+  .macdlg p{margin:0;font-size:12px;color:#b7b7bb}
+  .macdlg .btns{display:flex;border-top:1px solid #3a3a3d}
+  .macdlg .btns button{flex:1;padding:11px;background:transparent;border:0;color:#5aa9ff;font-size:13px;font-weight:600;cursor:default}
+  .macdlg .btns button.primary{background:#3a6df0;color:#fff;font-weight:700}
+  .macdlg .btns button+button{border-left:1px solid #3a3a3d}
+
+  /* annotation block */
+  .anno{
+    margin:14px 0 0;max-width:860px;
+    border-left:3px solid var(--emerald);
+    background:#101013;border:1px solid var(--border-soft);border-left-width:3px;
+    border-radius:0 10px 10px 0;padding:14px 18px;
+  }
+  .anno h5{margin:0 0 8px;font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--emerald)}
+  .anno ul{margin:0;padding-left:18px}
+  .anno li{margin:5px 0;font-size:13.5px;color:var(--text-dim)}
+  .anno li b{color:var(--text)}
+  .anno.sky{border-left-color:var(--sky)}
+  .anno.sky h5{color:var(--sky)}
+  .anno.amber{border-left-color:var(--amber)}
+  .anno.amber h5{color:var(--amber)}
+  .anno.rose{border-left-color:var(--rose)}
+  .anno.rose h5{color:var(--rose)}
+
+  .callout{
+    border:1px solid var(--border);border-radius:10px;background:#101013;
+    padding:16px 18px;margin:18px 0;max-width:860px;
+  }
+  .callout.bad{border-color:rgba(251,113,133,.4);background:rgba(251,113,133,.05)}
+  .callout.bad h4{color:var(--rose)}
+  .callout h4{margin:0 0 8px;font-size:14px}
+  .callout p{margin:0;color:var(--text-dim);font-size:13.5px}
+
+  /* flow / state map */
+  .flow{
+    border:1px solid var(--border);border-radius:12px;background:#0d0d10;
+    padding:22px;overflow-x:auto;max-width:860px;
+  }
+  .flowrow{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin:0 0 18px}
+  .flowrow:last-child{margin-bottom:0}
+  .node{
+    border:1px solid var(--border);border-radius:9px;padding:9px 13px;font-size:12.5px;
+    background:#18181b;white-space:nowrap;font-weight:600;
+  }
+  .node.entry{border-color:rgba(56,189,248,.5);background:rgba(56,189,248,.08);color:var(--sky)}
+  .node.connect{border-color:rgba(52,211,153,.5);background:rgba(52,211,153,.08);color:var(--emerald)}
+  .node.wait{border-color:rgba(251,191,36,.5);background:rgba(251,191,36,.08);color:var(--amber)}
+  .node.win{border-color:rgba(52,211,153,.6);background:rgba(52,211,153,.14);color:var(--emerald)}
+  .node.fall{border-color:var(--border);background:#27272a;color:var(--text-dim)}
+  .arrow{color:var(--text-faint);font-size:16px}
+  .arrow .lbl{display:block;font-size:10px;color:var(--text-faint);text-align:center;margin-top:-2px}
+  .flowlabel{font-size:12px;color:var(--text-faint);width:130px;flex:0 0 130px;font-weight:600}
+
+  /* mapping table */
+  table{border-collapse:collapse;width:100%;max-width:860px;font-size:13px;margin:8px 0}
+  th,td{border:1px solid var(--border-soft);padding:9px 12px;text-align:left;vertical-align:top}
+  th{background:#18181b;color:var(--text);font-size:12px;letter-spacing:.03em}
+  td{color:var(--text-dim)}
+  td b,th b{color:var(--text)}
+  .crit{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--emerald);white-space:nowrap}
+
+  .grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:22px;align-items:start}
+  .caption{font-size:12px;color:var(--text-faint);margin:8px 0 0;text-align:center}
+  hr.sec{border:0;border-top:1px solid var(--border-soft);margin:40px 0}
+  .footnote{font-size:12.5px;color:var(--text-faint);max-width:860px;margin-top:8px}
+  code.inline{background:#18181b;border:1px solid var(--border-soft);border-radius:5px;padding:1px 6px;font-size:12px;color:var(--sky)}
+  @media (max-width:520px){
+    .flowlabel{width:100%;flex-basis:100%}
+    h1{font-size:24px}
+  }
+</style>
+</head>
+<body>
+
+<header class="doc">
+  <div class="wrap">
+    <div class="kicker">UX Design · Step 2 of 6 · Feature Development</div>
+    <h1>Install-First Terminal — First-Run Flow</h1>
+    <p class="sub">
+      Redesign of the in-browser terminal dock so a first-timer with nothing installed is guided through a calm,
+      one-time setup <b>before</b> any <code class="inline">vibecodes://</code> deep link fires — never seeing the
+      scary macOS “no application set” dialog. Returning users skip straight to connecting.
+    </p>
+    <div class="meta-row">
+      <span class="tag ok">Designer: Compass (UX)</span>
+      <span class="tag">Surface: board bottom terminal dock</span>
+      <span class="tag">Replaces: auto-fire deep link on “In the browser”</span>
+      <span class="tag">Palette matched to terminal-dock.tsx</span>
+      <span class="tag">Mac-first · Windows deferred</span>
+    </div>
+  </div>
+</header>
+
+<div class="wrap">
+
+<!-- ============================================================= -->
+<h2><span class="num">§1</span>The problem we are fixing</h2>
+<p class="lead">
+  Built on the <b>Requirements step (ProdOwner)</b> and its 12 acceptance criteria — those criteria are the spec for
+  every screen below (see the mapping table in §9). Today the board button
+  <b>“Launch Claude Code → In the browser”</b> opens the dock and <i>immediately</i> fires the deep link. A first-timer
+  with no helper installed gets macOS’s alarming dialog first, then a backwards “Nothing opened. Install the helper”
+  fallback.
+</p>
+
+<div class="grid2">
+  <div>
+    <div class="callout bad">
+      <h4>✕ Today (broken order)</h4>
+      <p>Open dock → deep link fires blind → macOS “no application set / Search App Store” → confusing fallback.
+      The user is punished for not having a thing they were never told to install.</p>
+    </div>
+    <div class="macdlg" role="img" aria-label="Mock of the scary macOS dialog we must never show first-timers">
+      <div class="top">
+        <div class="appicon">⚠️</div>
+        <h5>There is no application set to open the URL vibecodes://launch…</h5>
+        <p>Search the App Store for an application that can open this document, or choose an existing application on your computer.</p>
+      </div>
+      <div class="btns">
+        <button>Cancel</button>
+        <button>Choose Application…</button>
+        <button class="primary">Search App Store</button>
+      </div>
+    </div>
+    <p class="caption">The dialog acceptance criterion #1 forbids for first-timers. We prevent it by never firing the link until the user has explicitly set up + pressed Connect.</p>
+  </div>
+  <div>
+    <div class="callout">
+      <h4>✓ New (install-first order)</h4>
+      <p>Open dock → calm numbered <b>one-time setup</b> (no link fired) → user downloads &amp; installs →
+      presses <b>Connect</b> → link fires <i>once</i>, pre-explained → connecting → success. The paired flag then lets
+      returning users skip the setup entirely.</p>
+    </div>
+    <div class="anno" style="margin-top:16px">
+      <h5>Core inference model</h5>
+      <ul>
+        <li>The web page <b>cannot detect</b> if the native helper is installed.</li>
+        <li>We infer readiness from an <b>explicit action</b> (pressing Connect) + a
+          <code class="inline">localStorage “paired-before”</code> flag set on first success.</li>
+        <li>Unpaired → show setup. Paired → auto-connect. That single flag is the whole branch.</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§2</span>Flow &amp; state map</h2>
+<p class="lead">Two entry points (unpaired vs paired) converge on one connect→result loop. Retry never re-shows the setup wall.</p>
+
+<div class="flow" role="img" aria-label="State map of the install-first terminal flow">
+  <div class="flowrow">
+    <span class="flowlabel">Unpaired entry</span>
+    <span class="node entry">Open dock</span>
+    <span class="arrow">→</span>
+    <span class="node">① Setup panel<br><span style="font-weight:400;color:var(--text-faint)">no link fired</span></span>
+    <span class="arrow">→<span class="lbl">press Connect</span></span>
+    <span class="node connect">Deep link fires ×1</span>
+    <span class="arrow">→</span>
+    <span class="node wait">② Connecting</span>
+  </div>
+  <div class="flowrow">
+    <span class="flowlabel">Paired entry</span>
+    <span class="node entry">Open dock</span>
+    <span class="arrow">→<span class="lbl">flag set</span></span>
+    <span class="node wait">② Connecting<br><span style="font-weight:400;color:var(--text-faint)">skips setup wall</span></span>
+    <span class="arrow" style="visibility:hidden">→</span>
+  </div>
+  <div class="flowrow">
+    <span class="flowlabel">Result (both)</span>
+    <span class="node wait">② Connecting</span>
+    <span class="arrow">→<span class="lbl">~8s ok</span></span>
+    <span class="node win">③ Success<br><span style="font-weight:400;color:#a7f3d0">set paired flag</span></span>
+    <span class="arrow" style="margin:0 10px">│</span>
+    <span class="arrow">→<span class="lbl">~8s no conn.</span></span>
+    <span class="node fall">④ Calm fallback</span>
+    <span class="arrow">→<span class="lbl">Retry</span></span>
+    <span class="node wait">↺ back to ②</span>
+  </div>
+  <div class="flowrow">
+    <span class="flowlabel">Non-Mac</span>
+    <span class="node entry">Open dock</span>
+    <span class="arrow">→<span class="lbl">no link</span></span>
+    <span class="node fall">⑥ “Mac-only for now”</span>
+  </div>
+</div>
+<p class="footnote">
+  The deep link fires at exactly one edge — the Connect press on the unpaired path, and the auto-connect on the paired
+  path (both are the user opening a session on purpose). It never fires on dock open for an unpaired browser
+  (criterion #2).
+</p>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§3</span>Screen ① — First-run setup panel (unpaired)</h2>
+<p class="lead">
+  The default when an unpaired browser opens the dock. <b>No deep link has fired.</b> A calm, numbered one-time setup
+  with the OS/arch-aware download, the drag-to-Applications step, and a pre-warned primary <b>Connect</b>. This screen
+  <b>replaces</b> the current auto-fire.
+</p>
+
+<div class="dock" role="img" aria-label="Setup panel state">
+  <div class="dockbar">
+    <span class="dot zinc"></span>
+    <span class="termlabel">◱ Terminal <span class="sess">· session —</span></span>
+    <span class="spacer"></span>
+    <span class="pill zinc"><span class="ic">○</span> One-time setup</span>
+    <span class="ghostbtn">▾ Collapse</span>
+  </div>
+  <div class="dockhead">
+    <span class="pill zinc"><span class="ic">○</span> Set up once</span>
+    <span class="idea">My First App · session —</span>
+    <span class="spacer"></span>
+    <span class="ghostbtn">⌄</span>
+  </div>
+  <div class="dockbody tall">
+    <div class="setup">
+      <div class="head">
+        <div class="icon">◱</div>
+        <h4>Run Claude Code here — one-time setup</h4>
+        <p>Takes about a minute. You only do this once on this Mac.</p>
+      </div>
+
+      <div class="step">
+        <div class="badge">1</div>
+        <div class="body">
+          <div class="title">Download the VibeCodes helper</div>
+          <p class="desc">A small, Apple-notarized app that lets this page mirror Claude Code from your Mac. Your code stays on your computer.</p>
+          <span class="btn primary">⭳ Download for Mac (Apple Silicon)</span>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="badge">2</div>
+        <div class="body">
+          <div class="title">Open the file and drag VibeCodes to Applications</div>
+          <p class="desc">When the download finishes, open it and drag the <b>VibeCodes</b> icon onto the <b>Applications</b> folder shown next to it.</p>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="badge">3</div>
+        <div class="body">
+          <div class="title">Connect this board to the helper</div>
+          <div class="prewarn">
+            <span aria-hidden="true">ℹ️</span>
+            <span>When you click Connect, your Mac may ask <b>“Open VibeCodes?”</b> — click <b>Open</b>. That’s expected, and it only happens the first time.</span>
+          </div>
+          <div class="connectwrap">
+            <span class="btn primary block">Connect</span>
+            <span class="subtle">Already installed it? Just click Connect.</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="anno">
+  <h5>Interaction &amp; why</h5>
+  <ul>
+    <li><b>No link on open.</b> Nothing fires until the user presses Connect in step 3 — directly satisfies criteria #1 and #2. The user is never ambushed by the macOS dialog.</li>
+    <li><b>Gestalt numbering.</b> The 3 numbered badges + hairline dividers group the setup into an obvious ordered sequence (recognition over recall). Progressive disclosure keeps it to 3 choices, not a wizard (Hick’s Law; no gold-plated onboarding per Requirements).</li>
+    <li><b>Information scent.</b> Button reads <b>“Download for Mac (Apple Silicon)”</b> and <b>“Connect”</b> — never “Submit”/“Download”. Arch is detected so the file always matches the machine.</li>
+    <li><b>Pre-warning near the trigger (Fitts).</b> The “Open VibeCodes?” explanation sits immediately above Connect — satisfies criterion #4 so the OS prompt is never a surprise.</li>
+    <li><b>Recovery for the already-installed user:</b> “Already installed it? Just click Connect.” lets a partway user skip straight to step 3.</li>
+    <li><b>WCAG:</b> Connect is a full-width ≥44px target; all steps carry text labels + numerals, never colour alone; emerald on near-black passes 4.5:1.</li>
+  </ul>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§4</span>Screen ② — Connecting</h2>
+<p class="lead">After Connect (or auto-connect for returning users). Calm reassurance while we wait for the helper to attach — with the “click Open” nudge repeated in context.</p>
+
+<div class="dock" role="img" aria-label="Connecting state">
+  <div class="dockbar">
+    <span class="dot amber"></span>
+    <span class="termlabel">◱ Terminal <span class="sess">· session 8f3a1c2b</span></span>
+    <span class="spacer"></span>
+    <span class="pill amber"><span class="ic">◴</span> Connecting…</span>
+    <span class="ghostbtn">▾ Collapse</span>
+  </div>
+  <div class="dockhead">
+    <span class="pill amber"><span class="ic">◴</span> Connecting…</span>
+    <span class="idea">My First App · session 8f3a1c2b</span>
+    <span class="spacer"></span>
+    <span class="pill rose" style="cursor:default">⏻ End</span>
+    <span class="ghostbtn">⌄</span>
+  </div>
+  <div class="dockbody tall">
+    <div class="overlay">
+      <div class="icon" style="color:var(--amber)">◴</div>
+      <h4 style="color:var(--amber)">Connecting to your Mac…</h4>
+      <p>Setting up a secure link to the VibeCodes helper. This is usually a few seconds.</p>
+      <p class="muted">(If your Mac asks, click <b style="color:var(--text)">Open VibeCodes</b>.)</p>
+    </div>
+  </div>
+</div>
+
+<div class="anno amber">
+  <h5>Interaction &amp; why</h5>
+  <ul>
+    <li><b>Loading state handled explicitly.</b> Spinner pill in the header + centred status; the “End” control stays reachable so the user is never trapped.</li>
+    <li><b>The OS-prompt nudge repeats here</b> in muted text — if the “Open VibeCodes?” dialog is on screen, the answer is right behind it (criterion #4 reinforcement).</li>
+    <li><b>Calm, non-technical copy</b> — “secure link”, no ports/tokens/relay jargon (audience = non-coders).</li>
+    <li><b>Same screen for both entry points</b> — returning users land here directly (§7), so it must stand alone without the setup context.</li>
+  </ul>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§5</span>Screen ③ — Success (connected)</h2>
+<p class="lead">The helper attached; the live terminal fills the dock. On the first success we set the <code class="inline">localStorage paired-before</code> flag so this Mac never sees the setup wall again.</p>
+
+<div class="dock" role="img" aria-label="Connected success state">
+  <div class="dockbar">
+    <span class="dot emerald"></span>
+    <span class="termlabel">◱ Terminal <span class="sess">· session 8f3a1c2b</span></span>
+    <span class="spacer"></span>
+    <span class="pill emerald"><span class="ic">◉</span> Connected</span>
+    <span class="ghostbtn">▾ Collapse</span>
+  </div>
+  <div class="dockhead">
+    <span class="pill emerald"><span class="ic">◉</span> Connected</span>
+    <span class="idea">My First App · session 8f3a1c2b</span>
+    <span class="spacer"></span>
+    <span class="pill zinc" style="cursor:default">🔓 Read-only</span>
+    <span class="pill rose" style="cursor:default">⏻ End</span>
+    <span class="ghostbtn">⌄</span>
+  </div>
+  <div class="dockbody tall" style="padding:0;align-items:stretch">
+    <div class="stream">
+      <div><span class="g">➜</span> <span class="d">my-first-app</span> claude</div>
+      <div class="d">Welcome to Claude Code — connected to VibeCodes.</div>
+      <div>&nbsp;</div>
+      <div>● Reading your project…</div>
+      <div>● Ready. What should we build?</div>
+      <div>&nbsp;</div>
+      <div><span class="g">›</span> <span class="cursor"></span></div>
+    </div>
+  </div>
+  <div class="inputbar">
+    <span class="prompt">›</span>
+    <span>Click the terminal and type to steer the agent. Enter sends.</span>
+  </div>
+</div>
+
+<div class="anno">
+  <h5>Interaction &amp; why</h5>
+  <ul>
+    <li><b>Set the paired flag on success</b> (criterion tie to #6): from now on this Mac auto-connects.</li>
+    <li><b>Reuses the existing connected chrome</b> — emerald “Connected” pill (icon + text, not colour alone), the live xterm host, the read-write input bar, and the End control in the header, exactly matching <code class="inline">terminal-dock.tsx</code>. No new component (Jakob’s Law).</li>
+    <li><b>The terminal is the reward</b> — success is the live stream itself, not a congratulatory modal (avoid modals for inline content).</li>
+  </ul>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§6</span>Screen ④ — Timeout fallback (~8s, no connection)</h2>
+<p class="lead">
+  After ~8s with no attach, we replace the spinner with a <b>calm, actionable</b> fallback — never error-speak. The
+  forbidden words <b>“Nothing opened” / “Failed” / “Error”</b> do not appear (criterion #7).
+</p>
+
+<div class="grid2">
+  <div>
+    <h3>First-timer variant (just installed)</h3>
+    <div class="dock" role="img" aria-label="Timeout fallback for a new user">
+      <div class="dockbar">
+        <span class="dot zinc"></span>
+        <span class="termlabel">◱ Terminal <span class="sess">· session 8f3a1c2b</span></span>
+        <span class="spacer"></span>
+        <span class="pill zinc"><span class="ic">◔</span> Not connected yet</span>
+        <span class="ghostbtn">▾ Collapse</span>
+      </div>
+      <div class="dockhead">
+        <span class="pill zinc"><span class="ic">◔</span> Not connected yet</span>
+        <span class="idea">My First App · session 8f3a1c2b</span>
+        <span class="spacer"></span>
+        <span class="ghostbtn">⌄</span>
+      </div>
+      <div class="dockbody tall">
+        <div class="overlay">
+          <div class="icon" style="color:var(--sky)">◔</div>
+          <h4>Didn’t connect yet</h4>
+          <p>If you just installed it, make sure you clicked <b style="color:var(--text)">Open</b> when your Mac asked — then try again.</p>
+          <div class="btnrow">
+            <span class="btn sky">↻ Retry</span>
+            <span class="btn outline">⭳ Download the helper</span>
+          </div>
+          <span class="subtle">Not installed yet? Get the helper, then Retry.</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <h3>Returning-user variant (paired, helper unreachable)</h3>
+    <div class="dock" role="img" aria-label="Timeout fallback for a returning user">
+      <div class="dockbar">
+        <span class="dot zinc"></span>
+        <span class="termlabel">◱ Terminal <span class="sess">· session 4d90ee71</span></span>
+        <span class="spacer"></span>
+        <span class="pill zinc"><span class="ic">◔</span> Not connected yet</span>
+        <span class="ghostbtn">▾ Collapse</span>
+      </div>
+      <div class="dockhead">
+        <span class="pill zinc"><span class="ic">◔</span> Not connected yet</span>
+        <span class="idea">My First App · session 4d90ee71</span>
+        <span class="spacer"></span>
+        <span class="ghostbtn">⌄</span>
+      </div>
+      <div class="dockbody tall">
+        <div class="overlay">
+          <div class="icon" style="color:var(--sky)">◔</div>
+          <h4>Couldn’t reach the helper on this Mac</h4>
+          <p>It may not be running. Try again — or re-install the helper if it keeps happening.</p>
+          <div class="btnrow">
+            <span class="btn sky">↻ Retry</span>
+            <span class="btn outline">⭳ Re-install the helper</span>
+          </div>
+          <span class="subtle">Your work on your Mac is safe.</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="anno sky">
+  <h5>Interaction &amp; why</h5>
+  <ul>
+    <li><b>~8s calm timeout</b> (criterion #7). Header pill reads <b>“Not connected yet”</b> — provisional, not a dead end. No red, no alarm icon.</li>
+    <li><b>Forbidden words absent</b> across both variants — verified copy: no “Nothing opened”, “Failed”, or “Error”. Tone is “not yet”, always with a next action.</li>
+    <li><b>Two clear actions, right precedence.</b> <b>Retry</b> is the primary (sky, most likely fix); <b>Download / Re-install the helper</b> is the secondary. Both ≥44px, side by side, both labelled (no colour-only).</li>
+    <li><b>Retry loops to Connecting (§4)</b>, never back to the setup wall — a returning user is never demoted to “set up from scratch”.</li>
+    <li><b>Returning-user variant</b> (criterion #4b): paired flag is set but the helper didn’t answer → “Couldn’t reach the helper on this Mac … re-install”. Same calm pattern, machine-aware wording, plus reassurance that local work is safe.</li>
+  </ul>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§7</span>Screen ⑤ — Returning user (paired flag set)</h2>
+<p class="lead">
+  Opening the dock with the paired flag present <b>skips the setup panel entirely</b> and goes straight to Connecting
+  (§4) — no setup wall (criterion #6). This is the distinct annotated entry, shown at the instant of open.
+</p>
+
+<div class="dock" role="img" aria-label="Returning user auto-connect">
+  <div class="dockbar">
+    <span class="dot amber"></span>
+    <span class="termlabel">◱ Terminal <span class="sess">· session c07be412</span></span>
+    <span class="spacer"></span>
+    <span class="pill amber"><span class="ic">◴</span> Connecting…</span>
+    <span class="ghostbtn">▾ Collapse</span>
+  </div>
+  <div class="dockhead">
+    <span class="pill amber"><span class="ic">◴</span> Connecting…</span>
+    <span class="idea">My First App · session c07be412</span>
+    <span class="spacer"></span>
+    <span class="pill rose" style="cursor:default">⏻ End</span>
+    <span class="ghostbtn">⌄</span>
+  </div>
+  <div class="dockbody tall">
+    <div class="overlay">
+      <div class="icon" style="color:var(--amber)">◴</div>
+      <h4 style="color:var(--amber)">Connecting to your Mac…</h4>
+      <p>Welcome back — reopening your terminal. No setup needed this time.</p>
+      <p class="muted">(If your Mac asks, click <b style="color:var(--text)">Open VibeCodes</b>.)</p>
+    </div>
+  </div>
+</div>
+
+<div class="anno amber">
+  <h5>Interaction &amp; why</h5>
+  <ul>
+    <li><b>No setup wall</b> — the branch is purely the <code class="inline">paired-before</code> flag; a paired browser lands on Connecting, satisfying criterion #6.</li>
+    <li><b>The deep link fires here too</b>, because auto-connect is the returning user deliberately reopening their session — still an explicit intent, not a blind dock-open fire.</li>
+    <li><b>“Welcome back … No setup needed this time.”</b> confirms recognition of the paired state so the skipped steps feel intentional, not missing.</li>
+    <li><b>Graceful degradation:</b> if it doesn’t attach in ~8s, it falls through to the returning-user fallback in §6 — never back to setup.</li>
+  </ul>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§8</span>Screen ⑥ — Non-Mac user</h2>
+<p class="lead">On Windows/Linux we show a calm “coming soon”. <b>No deep link, no download.</b> (criterion #10)</p>
+
+<div class="dock" role="img" aria-label="Non-Mac coming soon">
+  <div class="dockbar">
+    <span class="dot zinc"></span>
+    <span class="termlabel">◱ Terminal <span class="sess">· session —</span></span>
+    <span class="spacer"></span>
+    <span class="pill zinc"><span class="ic">◷</span> Coming soon</span>
+    <span class="ghostbtn">▾ Collapse</span>
+  </div>
+  <div class="dockhead">
+    <span class="pill zinc"><span class="ic">◷</span> Coming soon</span>
+    <span class="idea">My First App</span>
+    <span class="spacer"></span>
+    <span class="ghostbtn">⌄</span>
+  </div>
+  <div class="dockbody tall">
+    <div class="overlay">
+      <div class="icon" style="color:var(--text-dim)">🖥️</div>
+      <h4 style="color:var(--text)">The in-browser terminal is Mac-only for now</h4>
+      <p>Windows support is on the way. In the meantime you can still run Claude Code the usual way in your own terminal.</p>
+      <div class="btnrow">
+        <span class="btn disabled" aria-disabled="true">Download for Windows</span>
+      </div>
+      <span class="subtle">The download unlocks automatically when Windows support ships.</span>
+    </div>
+  </div>
+</div>
+
+<div class="anno">
+  <h5>Interaction &amp; why</h5>
+  <ul>
+    <li><b>No deep link, ever</b> on non-Mac (criterion #10) — there is no helper to route to, so nothing fires.</li>
+    <li><b>Disabled button carries an adjacent explanation</b> (“unlocks automatically when Windows support ships”) — honours the constraint that no disabled control stands without saying what’s needed.</li>
+    <li><b>An escape hatch</b> — points power users to their own terminal, so the state isn’t a hard dead end.</li>
+    <li><b>Calm, no colour-only signal</b> — zinc “Coming soon” pill with icon + text; no red/error framing for a platform gap.</li>
+  </ul>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§9</span>Acceptance-criteria coverage</h2>
+<p class="lead">Every one of the ProdOwner Requirements criteria mapped to the screen(s) that satisfy it.</p>
+
+<table>
+  <thead>
+    <tr><th style="width:60px">#</th><th>Acceptance criterion (Requirements step)</th><th style="width:210px">Satisfied by</th></tr>
+  </thead>
+  <tbody>
+    <tr><td class="crit">1</td><td>First-timer with nothing installed <b>never</b> sees the macOS “no application set / Search App Store” dialog.</td><td>§3 setup panel (no link until Connect); §1 rationale</td></tr>
+    <tr><td class="crit">2</td><td>Deep link fires <b>only</b> on explicit Connect for unpaired browsers.</td><td>§2 state map; §3 (fires at Connect edge only)</td></tr>
+    <tr><td class="crit">3</td><td>One-time setup is a clear, ordered, non-technical sequence.</td><td>§3 numbered steps ①②③ (Gestalt grouping)</td></tr>
+    <tr><td class="crit">4</td><td>The macOS “Open VibeCodes?” prompt is pre-explained.</td><td>§3 pre-warning above Connect; echoed in §4 &amp; §7</td></tr>
+    <tr><td class="crit">5</td><td>Download is OS/architecture-aware.</td><td>§3 “Download for Mac (Apple Silicon)”; §8 Windows gated</td></tr>
+    <tr><td class="crit">6</td><td>Returning/paired browser auto-connects — no setup wall.</td><td>§7 (paired flag → straight to Connecting)</td></tr>
+    <tr><td class="crit">7</td><td>~8s timeout → calm fallback (Retry + Download); no “Nothing opened / Failed / Error”.</td><td>§6 both variants (forbidden words absent)</td></tr>
+    <tr><td class="crit">8</td><td>Every state is handled explicitly (loading / success / partial / recovery).</td><td>§4 loading, §5 success, §6 recovery, §2 map</td></tr>
+    <tr><td class="crit">9</td><td>On first success, mark the browser paired for next time.</td><td>§5 (set <code class="inline">localStorage paired-before</code>)</td></tr>
+    <tr><td class="crit">10</td><td>Non-Mac → calm “coming soon”, no deep link.</td><td>§8 (no link, disabled download + explanation)</td></tr>
+    <tr><td class="crit">11</td><td>Retry recovers without re-showing the setup wall.</td><td>§6 (Retry → §4 Connecting loop)</td></tr>
+    <tr><td class="crit">12</td><td>Reuses the existing dock chrome/design system; no new modal wizard.</td><td>All screens (matched to <code class="inline">terminal-dock.tsx</code>); §5</td></tr>
+  </tbody>
+</table>
+<p class="footnote">If the ProdOwner numbering differs slightly, the coverage still holds — each named requirement (dialog prevention, explicit-Connect firing, pre-explained OS prompt, paired auto-connect, calm timeout, non-Mac coming-soon) is mapped above.</p>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§10</span>Responsive — 375px</h2>
+<p class="lead">The flow must hold on a phone-width board. The setup panel stacks; buttons stay full-width ≥44px; the pre-warning wraps without truncation.</p>
+
+<div class="dock narrow" role="img" aria-label="Setup panel at 375px width">
+  <div class="dockbar">
+    <span class="dot zinc"></span>
+    <span class="termlabel">◱ <span class="sess">setup</span></span>
+    <span class="spacer"></span>
+    <span class="pill zinc"><span class="ic">○</span> Setup</span>
+  </div>
+  <div class="dockbody" style="min-height:auto;padding:20px 16px">
+    <div class="setup">
+      <div class="head">
+        <div class="icon">◱</div>
+        <h4 style="font-size:15px">Run Claude Code here</h4>
+        <p>One-time setup, about a minute.</p>
+      </div>
+      <div class="step">
+        <div class="badge">1</div>
+        <div class="body">
+          <div class="title">Download the helper</div>
+          <span class="btn primary block" style="font-size:13px">⭳ Download for Mac (Apple Silicon)</span>
+        </div>
+      </div>
+      <div class="step">
+        <div class="badge">2</div>
+        <div class="body">
+          <div class="title">Drag VibeCodes to Applications</div>
+          <p class="desc" style="margin-bottom:0">Open the file, drag the icon onto Applications.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="badge">3</div>
+        <div class="body">
+          <div class="title">Connect</div>
+          <div class="prewarn" style="font-size:12px">
+            <span aria-hidden="true">ℹ️</span>
+            <span>Your Mac may ask <b>“Open VibeCodes?”</b> — click <b>Open</b>.</span>
+          </div>
+          <span class="btn primary block">Connect</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<p class="caption">Single column, full-bleed 44px controls, no horizontal scroll. Long idea titles/session ids truncate in the header, never in body copy.</p>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§11</span>Design-system &amp; accessibility notes</h2>
+<div class="anno">
+  <h5>Reuse &amp; consistency</h5>
+  <ul>
+    <li>Colours, radii, and the header/body split are lifted from <b>terminal-dock.tsx</b> (<code class="inline">#141417</code> header, <code class="inline">#0c0c0e</code> body, zinc-700 borders, emerald/amber/sky/rose status accents). Setup replaces only the centred <code class="inline">StateOverlay</code> “idle” content.</li>
+    <li>Status pills keep the existing <b>icon + text + colour</b> pattern (never colour alone). New pills: “One-time setup” (zinc), “Not connected yet” (zinc), “Coming soon” (zinc).</li>
+    <li>Buttons map to existing shadcn variants — primary = emerald (matches the live “Launch”), secondary/outline = zinc, fallback primary = sky (matches the existing helper-install accent).</li>
+  </ul>
+</div>
+<div class="anno sky">
+  <h5>WCAG 2.1 AA checklist</h5>
+  <ul>
+    <li><b>Contrast:</b> emerald/amber/sky/zinc text on near-black all ≥4.5:1; pill borders ≥3:1 for UI components.</li>
+    <li><b>Targets:</b> Connect, Retry, Download, Reinstall all ≥44×44px; full-width on mobile.</li>
+    <li><b>No colour-only signals:</b> every state pairs an icon + text label with its colour.</li>
+    <li><b>No naked disabled control:</b> the non-Mac download always carries its “unlocks when Windows ships” explanation.</li>
+    <li><b>Keyboard:</b> steps are real focusable buttons/links in reading order; the OS-prompt warning is inline text (not a tooltip), so it’s never hover-gated.</li>
+    <li><b>No primary action behind hover; no essential info in modals</b> — success is inline, setup is inline.</li>
+  </ul>
+</div>
+<div class="anno amber">
+  <h5>Scope guard (no gold-plating)</h5>
+  <ul>
+    <li>No animated onboarding, video, or progress-wizard bar — the numbered list is the whole affordance (per Requirements).</li>
+    <li>Windows is a single gated state, not a parallel flow.</li>
+    <li>The “Advanced — pair a remote machine” disclosure already in the dock is untouched and out of scope for this first-run redesign.</li>
+  </ul>
+</div>
+
+<p class="footnote" style="margin-top:30px">
+  Compass · UX Design step · Feature Development workflow. Built on the ProdOwner Requirements step. Next step: engineering
+  can implement by branching the <code class="inline">StateOverlay</code> on <code class="inline">os</code> +
+  <code class="inline">localStorage paired-before</code>, gating the deep-link fire behind the Connect press.
+</p>
+
+</div>
+</body>
+</html>

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1,29 +1,38 @@
 "use client";
 
-// In-app local Claude Code terminal — the board bottom dock (SLICE 3, browser leg).
+// In-app local Claude Code terminal — the board bottom dock (browser leg).
 //
-// Renders the collapsible VS Code-style terminal dock from the approved design
-// (docs/in-app-terminal-design.html) and wires it to the opaque Cloudflare relay
-// as the `browser` leg:
+// Renders the collapsible VS Code-style terminal dock and wires it to the opaque
+// Cloudflare relay as the `browser` leg:
 //
 //   POST /api/terminal/session  →  { sessionId, browserToken, bridgeToken }
 //   WebSocket  <relay>/?session&role=browser&token  →  xterm.js
 //
+// INSTALL-FIRST FIRST RUN (docs/install-first-terminal-ux.html, Compass UX; built on
+// the ProdOwner Requirements): an unpaired browser lands on a calm numbered SETUP
+// panel and NO `vibecodes://` deep link fires until the user explicitly presses
+// Connect — so a first-timer with nothing installed never sees macOS's scary
+// "no application set / Search App Store" dialog. On the first successful connection
+// we set a localStorage paired flag; a paired browser then auto-connects on open and
+// skips the setup wall. Non-Mac machines get a "coming soon" and never fire the link.
+//
 // The connection STATE MACHINE + close-code mapping + framing are pure and live in
-// src/lib/terminal/connection.ts (unit-tested); this component owns only the side
-// effects (fetch, socket, xterm, timers) and renders the six visible states.
+// src/lib/terminal/connection.ts; the OS/arch detection, the paired-flag gate, and
+// the first-run copy are pure and live in src/lib/terminal/{platform,paired-flag,
+// first-run-copy}.ts (all unit-tested). This component owns only the side effects
+// (fetch, socket, xterm, timers, the deep-link fire) and renders the visible states.
 //
 // GATING: off by default. Renders nothing unless NEXT_PUBLIC_TERMINAL_ENABLED is
-// exactly "true" (checked here AND at the board page mount). xterm is imported
-// dynamically (client-only) so there is no SSR / window access at module load.
+// exactly "true" (checked here AND at the board page mount).
 
 import "@xterm/xterm/css/xterm.css";
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState, type ReactNode } from "react";
 import {
   ChevronUp,
   ChevronDown,
   Circle,
   CircleDot,
+  CircleDashed,
   Loader2,
   WifiOff,
   Square,
@@ -32,6 +41,9 @@ import {
   Lock,
   LockOpen,
   Copy,
+  Clock,
+  Info,
+  Laptop,
   Terminal as TerminalIcon,
   RotateCw,
   Download,
@@ -57,17 +69,30 @@ import {
 } from "@/lib/terminal/connection";
 import { buildLaunchDeepLink, redactDeepLinkToken } from "@/lib/terminal/deep-link";
 import { subscribeBrowserLaunch } from "@/lib/terminal/launch-mode";
+import {
+  type TerminalPlatform,
+  TERMINAL_HELPER_DOWNLOAD_URL,
+  readPlatformSignals,
+  resolveTerminalPlatform,
+} from "@/lib/terminal/platform";
+import {
+  isBrowserPaired,
+  markBrowserPaired,
+  resolveFirstRunEntry,
+} from "@/lib/terminal/paired-flag";
+import { FIRST_RUN_COPY } from "@/lib/terminal/first-run-copy";
+import {
+  type DockView,
+  type LaunchPhase,
+  nextLaunchPhaseOnTimeout,
+  resolveDockView,
+} from "@/lib/terminal/first-run-flow";
 
-// Where the dock points the user when no helper catches the vibecodes:// link.
-// Slice 7 ships the signed, notarized macOS helper (terminal/helper/) whose
-// install lives at this path. HOSTING TODO: publish the notarized .dmg there and
-// have this page link to it (see terminal/helper/BUILD-AND-SIGN.md → "Hosting").
-const HELPER_INSTALL_URL = "/download/terminal-helper";
-// How long to wait for the helper to attach before nudging "install it / Advanced".
-const HELPER_OPEN_TIMEOUT_MS = 6000;
-
-/** Launch UI phase for the same-machine deep-link auto-launch path. */
-type LaunchPhase = "idle" | "opening" | "helper-timeout";
+// How long we wait for the helper to attach after firing the deep link before
+// dropping to the calm fallback (~8s, per the approved UX). This is the safety net
+// for criterion #8: a custom-scheme link with no handler can't be reliably detected,
+// so we always fall through here rather than spin forever.
+const HELPER_OPEN_TIMEOUT_MS = 8000;
 
 interface TerminalDockProps {
   ideaId: string;
@@ -86,15 +111,23 @@ interface StatusMeta {
   className: string;
 }
 
-// Header pill — icon + text + colour (never colour alone), one per status.
-function statusMeta(state: TerminalConnectionState): StatusMeta {
-  switch (state.status) {
+// Header pill — icon + text + colour (never colour alone), one per view.
+function dockStatusMeta(view: DockView, state: TerminalConnectionState): StatusMeta {
+  switch (view) {
     case "connected":
       return { label: "Connected", Icon: CircleDot, className: "border-emerald-500/50 bg-emerald-500/10 text-emerald-400" };
     case "connecting":
+    case "connecting-returning":
       return { label: "Connecting…", Icon: Loader2, spin: true, className: "border-amber-500/50 bg-amber-500/10 text-amber-400" };
-    case "waiting-to-pair":
+    case "legacy-waiting":
       return { label: "Waiting to pair", Icon: Loader2, spin: true, className: "border-sky-500/50 bg-sky-500/10 text-sky-400" };
+    case "timeout-new":
+    case "timeout-returning":
+      return { label: FIRST_RUN_COPY.pill.notConnected, Icon: CircleDashed, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
+    case "setup":
+      return { label: FIRST_RUN_COPY.pill.setup, Icon: Circle, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
+    case "coming-soon":
+      return { label: FIRST_RUN_COPY.pill.comingSoon, Icon: Clock, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
     case "disconnected":
       return { label: "Reconnecting…", Icon: WifiOff, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
     case "session-ended":
@@ -132,9 +165,16 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
   const [pair, setPair] = useState<PairInfo | null>(null);
   const [xtermReady, setXtermReady] = useState(false);
   // Same-machine auto-launch UI (the vibecodes:// deep-link path). "idle" = the
-  // manual cross-machine flow (copy a command); "opening"/"helper-timeout" = we
-  // fired a deep link and are waiting on the local helper.
+  // manual cross-machine flow (copy a command); "opening" = we fired a deep link and
+  // are waiting on the local helper; "helper-timeout" = the calm ~8s fallback.
   const [launchPhase, setLaunchPhase] = useState<LaunchPhase>("idle");
+  // Install-first gate inputs. Initialised SSR-safe (server → unsupported/unpaired)
+  // then corrected on mount; the dock body is only visible after an explicit open,
+  // which always re-reads these first.
+  const [platform, setPlatform] = useState<TerminalPlatform>(() =>
+    resolveTerminalPlatform(readPlatformSignals()),
+  );
+  const [paired, setPaired] = useState<boolean>(() => isBrowserPaired());
 
   const wsRef = useRef<WebSocket | null>(null);
   const termRef = useRef<XTerm | null>(null);
@@ -142,14 +182,17 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const connectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const helperTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const launchIframeRef = useRef<HTMLIFrameElement | null>(null);
   const lastDimsRef = useRef<string>("");
 
-  // Mirror live state into refs so the stable xterm onData handler reads current
-  // values without re-binding on every render.
+  // Mirror live state into refs so the stable xterm onData handler + socket handlers
+  // read current values without re-binding on every render.
   const statusRef = useRef(state.status);
   const readOnlyRef = useRef(readOnly);
+  const pairedRef = useRef(paired);
   statusRef.current = state.status;
   readOnlyRef.current = readOnly;
+  pairedRef.current = paired;
 
   // ── lazy, client-only xterm init ────────────────────────────────────────────
   useEffect(() => {
@@ -206,6 +249,14 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
     };
   }, [enabled]);
 
+  // Correct the install-first gate inputs on mount (navigator is only reliable
+  // client-side; the SSR defaults above assume unsupported/unpaired).
+  useEffect(() => {
+    if (!enabled) return;
+    setPlatform(resolveTerminalPlatform(readPlatformSignals()));
+    setPaired(isBrowserPaired());
+  }, [enabled]);
+
   // Fit + emit a resize control frame (TEXT) matching the bridge's framing.
   const sendResize = useCallback(() => {
     const term = termRef.current;
@@ -255,11 +306,25 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
     }
   }, []);
 
+  // Remove the hidden probe iframe used to fire the deep link (see fireLaunchDeepLink).
+  const removeLaunchIframe = useCallback(() => {
+    const frame = launchIframeRef.current;
+    launchIframeRef.current = null;
+    if (frame && frame.parentNode) frame.parentNode.removeChild(frame);
+  }, []);
+
   // Fire the signed vibecodes:// deep link so a same-machine helper attaches as the
   // bridge leg with no copied command. The bridge token is a secret — it travels in
-  // the link but is NEVER logged (only the redacted form is). The OS routing of the
-  // scheme to the installed helper is slice 7 (packaging); here we just fire it and
-  // fall back to the Advanced manual command if nothing attaches.
+  // the link but is NEVER logged (only the redacted form is).
+  //
+  // BEST-EFFORT dialog mitigation (criterion #8): we fire via a hidden, detached
+  // iframe rather than a top-level window.location.assign. A top-level navigation to
+  // an unhandled custom scheme is the surest way to trigger macOS's "no application
+  // set / Search App Store" dialog; routing it through a probe iframe suppresses that
+  // dialog in most Chromium builds. It is NOT a cross-browser guarantee (Safari /
+  // Firefox may still surface a milder prompt) — the ~8s timeout below is the real
+  // safety net, and the authoritative success signal is the first byte from the
+  // bridge (ws.onmessage), which proves the helper actually opened AND attached.
   const fireLaunchDeepLink = useCallback(
     (sessionId: string, bridgeToken: string) => {
       let link: string;
@@ -274,20 +339,34 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
       }
       logger.info("Terminal firing launch deep link", { sessionId, url: redactDeepLinkToken(link) });
       setLaunchPhase("opening");
+
+      removeLaunchIframe();
       try {
-        window.location.assign(link);
+        const frame = document.createElement("iframe");
+        frame.setAttribute("aria-hidden", "true");
+        frame.style.display = "none";
+        frame.src = link;
+        document.body.appendChild(frame);
+        launchIframeRef.current = frame;
       } catch {
-        // Some browsers throw synchronously on a blocked/unknown custom scheme.
-        setLaunchPhase("helper-timeout");
-        return;
+        // Iframe path unavailable — fall back to a direct assign.
+        try {
+          window.location.assign(link);
+        } catch {
+          setLaunchPhase("helper-timeout");
+          return;
+        }
       }
-      // If the helper doesn't attach within a few seconds, nudge install / Advanced.
+
+      // If the helper doesn't stream within ~8s, drop to the calm fallback (never an
+      // infinite spinner — criterion #8).
       clearHelperTimer();
       helperTimerRef.current = setTimeout(() => {
-        setLaunchPhase((p) => (p === "opening" ? "helper-timeout" : p));
+        removeLaunchIframe();
+        setLaunchPhase(nextLaunchPhaseOnTimeout);
       }, HELPER_OPEN_TIMEOUT_MS);
     },
-    [clearHelperTimer],
+    [clearHelperTimer, removeLaunchIframe],
   );
 
   const teardownSocket = useCallback(() => {
@@ -307,11 +386,14 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
   // ── connect (browser leg) ───────────────────────────────────────────────────
   // `autoLaunch` = the same-machine path: after minting, fire the vibecodes:// deep
   // link so the local helper attaches automatically (no copied command). Without it
-  // (manual reconnect), we stay in the cross-machine "copy a command" flow.
+  // (manual reconnect), we stay in the cross-machine "copy a command" flow. Callers
+  // must gate autoLaunch behind the install-first flow (setup Connect / paired
+  // auto-connect / Retry) — never on a bare dock open for an unpaired browser.
   const connect = useCallback(async (options?: { autoLaunch?: boolean }) => {
     const autoLaunch = options?.autoLaunch ?? false;
     teardownSocket();
     clearHelperTimer();
+    removeLaunchIframe();
     setLaunchPhase(autoLaunch ? "opening" : "idle");
     setExpanded(true);
     lastDimsRef.current = "";
@@ -375,9 +457,16 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
       // the bridge today); ignore so it never reaches the screen as garbage.
       if (typeof ev.data === "string") return;
       // The helper attached and is streaming — the launch succeeded; drop the
-      // "opening helper / install it" nudge.
+      // "opening helper" nudge and clean up the probe iframe/timer.
       clearHelperTimer();
+      removeLaunchIframe();
       setLaunchPhase("idle");
+      // First successful connection on this browser → remember it so future opens
+      // auto-connect and skip the setup wall (criteria #5 / #6).
+      if (!pairedRef.current) {
+        markBrowserPaired();
+        setPaired(true);
+      }
       dispatch({ type: "data" });
       termRef.current?.write(new Uint8Array(ev.data as ArrayBuffer));
     };
@@ -390,11 +479,29 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
       wsRef.current = null;
       dispatch({ type: "closed", code: ev.code, reason: ev.reason });
     };
-  }, [ideaId, teardownSocket, clearConnectTimer, clearHelperTimer, fireLaunchDeepLink]);
+  }, [ideaId, teardownSocket, clearConnectTimer, clearHelperTimer, removeLaunchIframe, fireLaunchDeepLink]);
+
+  // Install-first entry gate. This is the ONE place a browser "open" is turned into
+  // either a setup panel, a coming-soon panel, or an auto-connect — the deep link is
+  // never fired for an unpaired browser here (criterion #2).
+  const beginBrowserLaunch = useCallback(() => {
+    setExpanded(true);
+    const fresh = resolveTerminalPlatform(readPlatformSignals());
+    setPlatform(fresh);
+    const nowPaired = isBrowserPaired();
+    setPaired(nowPaired);
+    const entry = resolveFirstRunEntry({ supported: fresh.supported, paired: nowPaired });
+    if (entry === "connecting") {
+      // Paired browser deliberately reopening its session → auto-connect (fires the
+      // deep link). "setup" / "coming-soon" just show the overlay; no link fires.
+      void connect({ autoLaunch: true });
+    }
+  }, [connect]);
 
   const endSession = useCallback(() => {
     dispatch({ type: "user-end" });
     clearHelperTimer();
+    removeLaunchIframe();
     setLaunchPhase("idle");
     const ws = wsRef.current;
     if (ws) {
@@ -405,22 +512,37 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
       }
     }
     teardownSocket();
-  }, [teardownSocket, clearHelperTimer]);
+  }, [teardownSocket, clearHelperTimer, removeLaunchIframe]);
 
-  // Clean up the socket if the dock unmounts mid-session.
+  // Clean up the socket + helper timer + probe iframe if the dock unmounts mid-flow.
   useEffect(() => () => teardownSocket(), [teardownSocket]);
-
-  // Clear the helper-open timer on unmount.
   useEffect(() => () => clearHelperTimer(), [clearHelperTimer]);
+  useEffect(() => () => removeLaunchIframe(), [removeLaunchIframe]);
 
   // The "In the browser" menu item (board toolbar) fires the launch bus; pick it up
-  // here and run the auto-launch (mint → open browser leg → fire deep link). Keeping
-  // the mint in ONE place (the dock) means the session — and its bridge token — is
-  // never created twice.
+  // here and run the install-first gate. Keeping the mint in ONE place (the dock)
+  // means the session — and its bridge token — is never created twice.
   useEffect(() => {
     if (!enabled) return;
-    return subscribeBrowserLaunch(() => void connect({ autoLaunch: true }));
-  }, [enabled, connect]);
+    return subscribeBrowserLaunch(() => beginBrowserLaunch());
+  }, [enabled, beginBrowserLaunch]);
+
+  // Auto-connect a paired browser whenever the body becomes visible while idle — so
+  // a returning user who simply expands the dock also skips the setup wall
+  // (criterion #6). Unpaired / unsupported browsers never satisfy this guard, so no
+  // deep link fires for them.
+  useEffect(() => {
+    if (!enabled) return;
+    if (
+      expanded &&
+      state.status === "idle" &&
+      platform.supported &&
+      paired &&
+      launchPhase === "idle"
+    ) {
+      void connect({ autoLaunch: true });
+    }
+  }, [enabled, expanded, state.status, platform.supported, paired, launchPhase, connect]);
 
   const copyBridgeCommand = useCallback(() => {
     if (!pair) return;
@@ -433,7 +555,8 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
 
   if (!enabled) return null;
 
-  const meta = statusMeta(state);
+  const view = resolveDockView(state.status, launchPhase, platform.supported, paired);
+  const meta = dockStatusMeta(view, state);
   const inputEnabled = isInputEnabled(state, readOnly);
   const showStream = state.status === "connected" || state.status === "disconnected";
   const canLaunch =
@@ -441,6 +564,13 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
     state.status === "error" ||
     state.status === "session-ended" ||
     state.status === "disconnected";
+  // The End control is only meaningful once a session exists and is still live/opening.
+  const showEnd =
+    view === "connected" ||
+    view === "disconnected" ||
+    view === "connecting" ||
+    view === "connecting-returning" ||
+    view === "legacy-waiting";
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-40 border-t border-zinc-700 bg-[#141417] text-zinc-200 shadow-[0_-8px_30px_rgba(0,0,0,0.4)]">
@@ -506,7 +636,7 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
                 {readOnly ? "Read-only · on" : "Read-only"}
               </Button>
             )}
-            {(showStream || state.status === "connecting" || state.status === "waiting-to-pair") && (
+            {showEnd && (
               <Button
                 variant="outline"
                 size="xs"
@@ -538,12 +668,14 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
           />
           {!showStream && (
             <StateOverlay
+              view={view}
               state={state}
               pair={pair}
+              platform={platform}
               canLaunch={canLaunch}
-              launchPhase={launchPhase}
-              onLaunch={() => void connect({ autoLaunch: true })}
-              onReconnect={() => void connect()}
+              onConnect={() => void connect({ autoLaunch: true })}
+              onRetry={() => void connect({ autoLaunch: true })}
+              onLaunchAgain={beginBrowserLaunch}
               onCopyBridge={copyBridgeCommand}
             />
           )}
@@ -580,92 +712,54 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
   );
 }
 
-// ── per-state centred overlays (icon + text + next step) ──────────────────────
+// ── per-view centred overlays (icon + text + next step) ───────────────────────
 function StateOverlay({
+  view,
   state,
   pair,
+  platform,
   canLaunch,
-  launchPhase,
-  onLaunch,
-  onReconnect,
+  onConnect,
+  onRetry,
+  onLaunchAgain,
   onCopyBridge,
 }: {
+  view: DockView;
   state: TerminalConnectionState;
   pair: PairInfo | null;
+  platform: TerminalPlatform;
   canLaunch: boolean;
-  launchPhase: LaunchPhase;
-  onLaunch: () => void;
-  onReconnect: () => void;
+  onConnect: () => void;
+  onRetry: () => void;
+  onLaunchAgain: () => void;
   onCopyBridge: () => void;
 }) {
   return (
-    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-[#0c0c0e]/95 px-6 text-center">
-      {state.status === "idle" && (
-        <>
-          <TerminalIcon className="h-7 w-7 text-emerald-400" />
-          <div className="text-base font-semibold text-emerald-400">Ready when you are</div>
-          <p className="max-w-md text-[13px] text-zinc-400">
-            Start Claude Code on your machine and mirror it here. Your code stays on your computer — we only relay the screen.
-          </p>
-          <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onLaunch}>
-            <TerminalIcon className="h-4 w-4" /> Launch in browser
-          </Button>
-        </>
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 overflow-y-auto bg-[#0c0c0e]/95 px-6 py-6 text-center">
+      {view === "coming-soon" && <ComingSoonPanel />}
+
+      {view === "setup" && <SetupPanel platform={platform} onConnect={onConnect} />}
+
+      {(view === "connecting" || view === "connecting-returning") && (
+        <ConnectingPanel returning={view === "connecting-returning"} />
       )}
 
-      {state.status === "connecting" && (
-        <>
-          <Loader2 className="h-7 w-7 animate-spin text-amber-400" />
-          <div className="text-base font-semibold text-amber-400">Starting your session…</div>
-          <p className="max-w-md text-[13px] text-zinc-400">
-            Opening the encrypted relay — usually instant. <span className="text-zinc-600">(waiting up to 30s)</span>
-          </p>
-        </>
+      {view === "timeout-new" && (
+        <TimeoutPanel variant="new" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
+      )}
+      {view === "timeout-returning" && (
+        <TimeoutPanel variant="returning" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
       )}
 
-      {state.status === "waiting-to-pair" && (
+      {view === "legacy-waiting" && (
         <>
-          {launchPhase === "opening" && (
-            <>
-              <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
-              <div className="text-base font-semibold text-sky-400">Opening the VibeCodes helper…</div>
-              <p className="max-w-md text-[13px] text-zinc-400">
-                Your computer may ask to open VibeCodes — click <b className="text-zinc-200">Open</b>. The helper
-                starts Claude Code and attaches here automatically.
-              </p>
-            </>
-          )}
-
-          {launchPhase === "helper-timeout" && (
-            <>
-              <Download className="h-7 w-7 text-sky-400" />
-              <div className="text-base font-semibold text-sky-200">Don&apos;t have the helper?</div>
-              <p className="max-w-md text-[13px] text-zinc-400">
-                Nothing opened. Install the small VibeCodes helper once, then launch again — or pair another
-                machine by hand under Advanced.
-              </p>
-              <a
-                href={HELPER_INSTALL_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded-md bg-sky-500 px-3 py-1.5 text-sm font-semibold text-sky-950 hover:bg-sky-400"
-              >
-                <Download className="h-4 w-4" /> Install the helper
-              </a>
-            </>
-          )}
-
-          {launchPhase === "idle" && (
-            <>
-              <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
-              <div className="text-base font-semibold text-sky-400">Waiting for your machine to attach</div>
-              <p className="max-w-md text-[13px] text-zinc-400">
-                The relay is up. Start a bridge on your computer for this session to go live.
-              </p>
-            </>
-          )}
-
-          {/* Advanced ▾ — cross-machine fallback: copy the manual bridge command. */}
+          <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
+          <div className="text-base font-semibold text-sky-400">Waiting for your machine to attach</div>
+          <p className="max-w-md text-[13px] text-zinc-400">
+            The link is up. Start a bridge on your computer for this session to go live.
+          </p>
+          {/* Advanced ▾ — cross-machine fallback: copy the manual bridge command.
+              Untouched by the install-first redesign (per the approved UX scope guard). */}
           {pair && (
             <details className="mt-1 w-full max-w-md text-left">
               <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-[12px] text-zinc-500 hover:text-zinc-300 [&::-webkit-details-marker]:hidden">
@@ -690,18 +784,18 @@ function StateOverlay({
         </>
       )}
 
-      {state.status === "session-ended" && (
+      {view === "session-ended" && (
         <>
           <Square className="h-7 w-7 text-zinc-400" />
           <div className="text-base font-semibold text-zinc-300">{endedTitle(state)}</div>
           <p className="max-w-md text-[13px] text-zinc-400">{endedMessage(state)}</p>
-          <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onLaunch}>
+          <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onLaunchAgain}>
             <TerminalIcon className="h-4 w-4" /> Launch again
           </Button>
         </>
       )}
 
-      {state.status === "error" && (
+      {view === "error" && (
         <>
           <CircleAlert className="h-7 w-7 text-rose-400" />
           <div className="text-base font-semibold text-rose-400">{errorTitle(state)}</div>
@@ -711,7 +805,7 @@ function StateOverlay({
               variant="outline"
               size="sm"
               className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
-              onClick={onReconnect}
+              onClick={onLaunchAgain}
             >
               <RotateCw className="h-3.5 w-3.5" /> Try again
             </Button>
@@ -719,6 +813,139 @@ function StateOverlay({
         </>
       )}
     </div>
+  );
+}
+
+// ── install-first panels ──────────────────────────────────────────────────────
+
+// Screen ① — the numbered one-time setup (unpaired). No deep link has fired here.
+function SetupPanel({ platform, onConnect }: { platform: TerminalPlatform; onConnect: () => void }) {
+  const copy = FIRST_RUN_COPY.setup;
+  return (
+    <div className="flex w-full max-w-lg flex-col text-left">
+      <div className="mb-3 text-center">
+        <TerminalIcon className="mx-auto h-6 w-6 text-emerald-400" />
+        <h4 className="mt-2 text-[17px] font-bold text-zinc-100">{copy.heading}</h4>
+        <p className="mt-1 text-[13px] text-zinc-400">{copy.subheading}</p>
+      </div>
+
+      <SetupStep n={1} title={copy.step1Title}>
+        <p className="mb-2.5 text-[12.5px] text-zinc-400">{copy.step1Desc}</p>
+        <a
+          href={platform.downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-md bg-emerald-500 px-4 text-sm font-semibold text-emerald-950 hover:bg-emerald-400"
+        >
+          <Download className="h-4 w-4" /> {platform.downloadLabel}
+        </a>
+      </SetupStep>
+
+      <SetupStep n={2} title={copy.step2Title}>
+        <p className="text-[12.5px] text-zinc-400">{copy.step2Desc}</p>
+      </SetupStep>
+
+      <SetupStep n={3} title={copy.step3Title}>
+        <div className="mb-3 flex items-start gap-2 rounded-md border border-amber-500/35 bg-amber-500/[0.06] px-3 py-2.5 text-[12.5px] text-amber-200/90">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-300" aria-hidden="true" />
+          <span>{copy.openPrompt}</span>
+        </div>
+        <Button
+          className="min-h-[44px] w-full bg-emerald-500 text-sm font-semibold text-emerald-950 hover:bg-emerald-400"
+          onClick={onConnect}
+        >
+          {copy.connect}
+        </Button>
+        <p className="mt-2 text-center text-[11.5px] text-zinc-500">{copy.alreadyInstalled}</p>
+      </SetupStep>
+    </div>
+  );
+}
+
+function SetupStep({ n, title, children }: { n: number; title: string; children: ReactNode }) {
+  return (
+    <div className="flex gap-3.5 border-t border-zinc-800 py-3.5 first-of-type:border-t-0">
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-emerald-500/40 bg-emerald-500/[0.12] text-[13px] font-bold text-emerald-400">
+        {n}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="mb-1.5 text-sm font-semibold text-zinc-200">{title}</div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// Screen ② — connecting (after Connect, or auto-connect for a returning user).
+function ConnectingPanel({ returning }: { returning: boolean }) {
+  const copy = FIRST_RUN_COPY.connecting;
+  return (
+    <>
+      <Loader2 className="h-7 w-7 animate-spin text-amber-400" />
+      <div className="text-base font-semibold text-amber-400">{copy.heading}</div>
+      <p className="max-w-md text-[13px] text-zinc-400">{returning ? copy.returningBody : copy.body}</p>
+      <p className="max-w-md text-[12.5px] text-zinc-500">{copy.openNudge}</p>
+    </>
+  );
+}
+
+// Screen ④ — the calm ~8s fallback. `variant` picks the first-timer vs returning copy.
+function TimeoutPanel({
+  variant,
+  downloadUrl,
+  onRetry,
+}: {
+  variant: "new" | "returning";
+  downloadUrl: string | null;
+  onRetry: () => void;
+}) {
+  const copy = variant === "new" ? FIRST_RUN_COPY.timeoutNew : FIRST_RUN_COPY.timeoutReturning;
+  const href = downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL;
+  const secondaryLabel = variant === "new" ? FIRST_RUN_COPY.timeoutNew.download : FIRST_RUN_COPY.timeoutReturning.reinstall;
+  const footer = variant === "new" ? FIRST_RUN_COPY.timeoutNew.hint : FIRST_RUN_COPY.timeoutReturning.reassure;
+  return (
+    <>
+      <CircleDashed className="h-7 w-7 text-sky-400" />
+      <div className="text-base font-semibold text-zinc-200">{copy.heading}</div>
+      <p className="max-w-md text-[13px] text-zinc-400">{copy.body}</p>
+      <div className="flex w-full flex-wrap justify-center gap-2.5">
+        <Button
+          className="min-h-[44px] bg-sky-500 px-4 text-sm font-semibold text-sky-950 hover:bg-sky-400"
+          onClick={onRetry}
+        >
+          <RotateCw className="h-4 w-4" /> {copy.retry}
+        </Button>
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-md border border-zinc-700 bg-zinc-800/60 px-4 text-sm font-semibold text-zinc-200 hover:bg-zinc-700"
+        >
+          <Download className="h-4 w-4" /> {secondaryLabel}
+        </a>
+      </div>
+      <p className="text-[11.5px] text-zinc-500">{footer}</p>
+    </>
+  );
+}
+
+// Screen ⑥ — non-Mac / unsupported machine. No deep link, gated download.
+function ComingSoonPanel() {
+  const copy = FIRST_RUN_COPY.comingSoon;
+  return (
+    <>
+      <Laptop className="h-7 w-7 text-zinc-300" />
+      <div className="text-base font-semibold text-zinc-100">{copy.heading}</div>
+      <p className="max-w-md text-[13px] text-zinc-400">{copy.body}</p>
+      <Button
+        disabled
+        aria-disabled="true"
+        className="min-h-[44px] cursor-not-allowed border border-zinc-800 bg-zinc-900 text-sm font-semibold text-zinc-500"
+      >
+        {copy.download}
+      </Button>
+      <p className="text-[11.5px] text-zinc-500">{copy.hint}</p>
+    </>
   );
 }
 
@@ -755,7 +982,7 @@ function errorTitle(state: TerminalConnectionState): string {
       return "This session is already open elsewhere";
     case "connect-timeout":
     case "relay-unreachable":
-      return "Couldn't reach the relay";
+      return "Couldn't reach your machine";
     case "session-mint-failed":
       return "Couldn't start a session";
     default:
@@ -768,16 +995,16 @@ function errorMessage(state: TerminalConnectionState): string {
     case "owner-mismatch":
       return "For safety, a bridge only attaches to the person who launched it. Start your own bridge, or sign in as the owning account.";
     case "bad-token":
-      return "The session token was invalid or expired. Launch again to mint a fresh one.";
+      return "The session couldn't be verified. Launch again to start a fresh one.";
     case "duplicate":
       return "Another browser tab is already attached to this session. Close it, then launch again.";
     case "connect-timeout":
-      return "We waited 30s but nothing connected. Is a bridge running and allowed to open?";
+      return "We waited a while but nothing connected. Is the helper running and allowed to open?";
     case "relay-unreachable":
-      return "The terminal relay didn't respond. Check it's running, then try again.";
+      return "We couldn't set up the secure link. Check your connection, then try again.";
     case "session-mint-failed":
-      return "The session request failed. Check your connection and try again.";
+      return "The session request didn't go through. Check your connection and try again.";
     default:
-      return "The terminal session failed. Try launching again.";
+      return "The terminal session didn't start. Try launching again.";
   }
 }

--- a/src/lib/terminal/first-run-copy.test.ts
+++ b/src/lib/terminal/first-run-copy.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import {
+  FIRST_RUN_COPY,
+  FORBIDDEN_FIRST_RUN_COPY,
+  collectFirstRunCopy,
+} from "./first-run-copy";
+
+describe("first-run copy — no error-speak or jargon", () => {
+  const strings = collectFirstRunCopy();
+
+  it("collects every string in the copy tree", () => {
+    // Sanity: the flatten found the nested step/timeout/coming-soon strings.
+    expect(strings.length).toBeGreaterThan(15);
+    expect(strings).toContain(FIRST_RUN_COPY.setup.connect);
+    expect(strings).toContain(FIRST_RUN_COPY.timeoutNew.heading);
+  });
+
+  it.each(FORBIDDEN_FIRST_RUN_COPY)(
+    "never uses the forbidden word/phrase %s (criteria #7, #12)",
+    (word) => {
+      // Word-boundary, case-insensitive — so legitimate words like "support" don't
+      // trip the "port" check, but "Error"/"Failed"/"token" would.
+      const re = new RegExp(`\\b${word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i");
+      const offenders = strings.filter((s) => re.test(s));
+      expect(offenders, `forbidden "${word}" in: ${offenders.join(" | ")}`).toEqual([]);
+    },
+  );
+
+  it("pre-explains the macOS 'Open VibeCodes?' prompt before Connect (criterion #4)", () => {
+    expect(FIRST_RUN_COPY.setup.openPrompt).toContain("Open VibeCodes?");
+    expect(FIRST_RUN_COPY.setup.openPrompt.toLowerCase()).toContain("click open");
+  });
+
+  it("the download label is OS/arch-specific (criterion #9)", () => {
+    expect(FIRST_RUN_COPY.setup.step1Title).toContain("VibeCodes helper");
+  });
+
+  it("the non-Mac panel is a calm 'coming soon', not an error (criterion #10)", () => {
+    expect(FIRST_RUN_COPY.comingSoon.heading.toLowerCase()).toContain("mac-only");
+    expect(FIRST_RUN_COPY.comingSoon.body.toLowerCase()).toContain("windows support");
+  });
+});

--- a/src/lib/terminal/first-run-copy.ts
+++ b/src/lib/terminal/first-run-copy.ts
@@ -1,0 +1,87 @@
+// In-app terminal — install-first first-run copy.
+//
+// Centralised so it can be (a) reused by the dock overlay and (b) unit-asserted to
+// contain no error-speak or jargon. The audience is a non-coder: the tone is calm
+// and reassuring, never "Failed / Error / Nothing opened" (criterion #7) and never
+// port/token/relay jargon (criterion #12). Matches the approved UX (Compass) in
+// docs/install-first-terminal-ux.html.
+
+export const FIRST_RUN_COPY = {
+  setup: {
+    heading: "Run Claude Code here — one-time setup",
+    subheading: "Takes about a minute. You only do this once on this Mac.",
+    step1Title: "Download the VibeCodes helper",
+    step1Desc:
+      "A small, Apple-notarized app that lets this page mirror Claude Code from your Mac. Your code stays on your computer.",
+    step2Title: "Open the file and drag VibeCodes to Applications",
+    step2Desc:
+      "When the download finishes, open it and drag the VibeCodes icon onto the Applications folder shown next to it.",
+    step3Title: "Connect this board to the helper",
+    // Pre-warns the OS prompt right above the trigger — criterion #4.
+    openPrompt:
+      "When you click Connect, your Mac may ask “Open VibeCodes?” — click Open. That’s expected, and it only happens the first time.",
+    connect: "Connect",
+    alreadyInstalled: "Already installed it? Just click Connect.",
+  },
+  connecting: {
+    heading: "Connecting to your Mac…",
+    body: "Setting up a secure link to the VibeCodes helper. This is usually a few seconds.",
+    // The OS-prompt nudge, repeated in context — criterion #4 reinforcement.
+    openNudge: "If your Mac asks, click Open VibeCodes.",
+    returningBody: "Welcome back — reopening your terminal. No setup needed this time.",
+  },
+  // ~8s fallback for a first-timer who just installed (criterion #7).
+  timeoutNew: {
+    heading: "Didn’t connect yet",
+    body: "If you just installed it, make sure you clicked Open when your Mac asked — then try again.",
+    retry: "Retry",
+    download: "Download the helper",
+    hint: "Not installed yet? Get the helper, then Retry.",
+  },
+  // ~8s fallback for a paired browser whose helper didn't answer (criterion #8).
+  timeoutReturning: {
+    heading: "Couldn’t reach the helper on this Mac",
+    body: "It may not be running. Try again — or re-install the helper if it keeps happening.",
+    retry: "Retry",
+    reinstall: "Re-install the helper",
+    reassure: "Your work on your Mac is safe.",
+  },
+  // Non-Mac / unsupported machine — calm "coming soon", no deep link (criterion #10).
+  comingSoon: {
+    heading: "The in-browser terminal is Mac-only for now",
+    body: "Windows support is on the way. In the meantime you can still run Claude Code the usual way in your own terminal.",
+    download: "Download for Windows",
+    hint: "The download unlocks automatically when Windows support ships.",
+  },
+  pill: {
+    setup: "One-time setup",
+    notConnected: "Not connected yet",
+    comingSoon: "Coming soon",
+  },
+} as const;
+
+/**
+ * Words/phrases that read as error-speak (criterion #7) or infrastructure jargon
+ * (criterion #12) to a non-coder. Asserted absent from every FIRST_RUN_COPY string
+ * with word-boundary matching (so legitimate words like "support" don't trip the
+ * "port" check).
+ */
+export const FORBIDDEN_FIRST_RUN_COPY = [
+  "Nothing opened",
+  "Failed",
+  "Error",
+  "port",
+  "token",
+  "relay",
+] as const;
+
+/** Flatten every string value in FIRST_RUN_COPY (used by the forbidden-words test). */
+export function collectFirstRunCopy(): string[] {
+  const out: string[] = [];
+  const walk = (value: unknown): void => {
+    if (typeof value === "string") out.push(value);
+    else if (value && typeof value === "object") Object.values(value).forEach(walk);
+  };
+  walk(FIRST_RUN_COPY);
+  return out;
+}

--- a/src/lib/terminal/first-run-flow.test.ts
+++ b/src/lib/terminal/first-run-flow.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveDockView,
+  nextLaunchPhaseOnTimeout,
+  isTimeoutFallbackView,
+} from "./first-run-flow";
+
+describe("resolveDockView — install-first entry", () => {
+  it("idle + unsupported → coming-soon (never a deep-link target)", () => {
+    expect(resolveDockView("idle", "idle", false, false)).toBe("coming-soon");
+    // Even a stray paired flag on an unsupported machine stays coming-soon.
+    expect(resolveDockView("idle", "idle", false, true)).toBe("coming-soon");
+  });
+
+  it("idle + supported + unpaired → setup (no deep link yet)", () => {
+    expect(resolveDockView("idle", "idle", true, false)).toBe("setup");
+  });
+
+  it("connecting maps to the returning variant when paired", () => {
+    expect(resolveDockView("connecting", "opening", true, false)).toBe("connecting");
+    expect(resolveDockView("connecting", "opening", true, true)).toBe("connecting-returning");
+  });
+
+  it("waiting-to-pair while opening shows the connecting panel", () => {
+    expect(resolveDockView("waiting-to-pair", "opening", true, false)).toBe("connecting");
+  });
+
+  it("waiting-to-pair with the idle launch phase is the legacy manual pairing flow", () => {
+    expect(resolveDockView("waiting-to-pair", "idle", true, true)).toBe("legacy-waiting");
+  });
+});
+
+describe("resolveDockView — the ~8s timeout fallback", () => {
+  it("new user vs returning user pick different fallback copy", () => {
+    expect(resolveDockView("waiting-to-pair", "helper-timeout", true, false)).toBe("timeout-new");
+    expect(resolveDockView("waiting-to-pair", "helper-timeout", true, true)).toBe("timeout-returning");
+  });
+
+  it("both fallbacks are recognised as the calm timeout view", () => {
+    expect(isTimeoutFallbackView("timeout-new")).toBe(true);
+    expect(isTimeoutFallbackView("timeout-returning")).toBe(true);
+    expect(isTimeoutFallbackView("connecting")).toBe(false);
+  });
+});
+
+describe("nextLaunchPhaseOnTimeout — opening → helper-timeout, else untouched", () => {
+  it("an 'opening' launch drops to the calm fallback", () => {
+    expect(nextLaunchPhaseOnTimeout("opening")).toBe("helper-timeout");
+  });
+
+  it("a launch that already succeeded (idle) is left alone — no spurious fallback", () => {
+    expect(nextLaunchPhaseOnTimeout("idle")).toBe("idle");
+  });
+
+  it("a fallback already showing stays put (idempotent)", () => {
+    expect(nextLaunchPhaseOnTimeout("helper-timeout")).toBe("helper-timeout");
+  });
+});

--- a/src/lib/terminal/first-run-flow.ts
+++ b/src/lib/terminal/first-run-flow.ts
@@ -1,0 +1,84 @@
+// In-app terminal — install-first presentation flow (pure).
+//
+// The connection STATE MACHINE (connection.ts) tracks the socket lifecycle; this
+// module layers the install-first *presentation* on top of it: which centred panel
+// + header pill the dock shows, and how the deep-link launch phase advances on the
+// ~8s timeout. Kept pure so the branch logic is unit-testable without React or a DOM.
+
+import type { TerminalStatus } from "./connection";
+
+/** UI phase for the same-machine deep-link auto-launch path. */
+export type LaunchPhase = "idle" | "opening" | "helper-timeout";
+
+/**
+ * The presentation view of the dock body, derived from the connection status, the
+ * launch phase, and the install-first gate (platform supported + browser paired).
+ * Drives BOTH the header pill and the centred overlay from one decision.
+ */
+export type DockView =
+  | "coming-soon"
+  | "setup"
+  | "connecting"
+  | "connecting-returning"
+  | "legacy-waiting"
+  | "timeout-new"
+  | "timeout-returning"
+  | "connected"
+  | "disconnected"
+  | "session-ended"
+  | "error";
+
+/**
+ * Decide the current view. Pure over its inputs so the pill + overlay never diverge.
+ *
+ *  - idle + unsupported            → "coming-soon"  (no deep link)
+ *  - idle + supported + unpaired   → "setup"        (numbered setup; no deep link yet)
+ *  - connecting/opening            → "connecting"[-returning]
+ *  - waiting + helper-timeout      → "timeout-new" | "timeout-returning" (~8s fallback)
+ *  - waiting + idle launch phase   → "legacy-waiting" (manual cross-machine pairing)
+ *
+ * A paired browser auto-connects out of idle immediately, so it never lingers on the
+ * "setup" view.
+ */
+export function resolveDockView(
+  status: TerminalStatus,
+  launchPhase: LaunchPhase,
+  supported: boolean,
+  paired: boolean,
+): DockView {
+  switch (status) {
+    case "connected":
+      return "connected";
+    case "disconnected":
+      return "disconnected";
+    case "session-ended":
+      return "session-ended";
+    case "error":
+      return "error";
+    case "connecting":
+      return paired ? "connecting-returning" : "connecting";
+    case "waiting-to-pair":
+      if (launchPhase === "helper-timeout") return paired ? "timeout-returning" : "timeout-new";
+      if (launchPhase === "opening") return paired ? "connecting-returning" : "connecting";
+      return "legacy-waiting";
+    case "idle":
+    default:
+      if (!supported) return "coming-soon";
+      return "setup";
+  }
+}
+
+/**
+ * Advance the launch phase when the ~8s helper-open timer fires. Only an "opening"
+ * (deep-link fired, still waiting) drops to the calm fallback; any other phase is
+ * left untouched (e.g. the helper already streamed and reset us to "idle"). This is
+ * the safety net for criterion #8 — we always leave "opening", never spin forever.
+ */
+export function nextLaunchPhaseOnTimeout(current: LaunchPhase): LaunchPhase {
+  return current === "opening" ? "helper-timeout" : current;
+}
+
+/** Whether the ~8s calm fallback is currently showing (Retry + Download). */
+export function isTimeoutFallbackView(view: DockView): boolean {
+  return view === "timeout-new" || view === "timeout-returning";
+}

--- a/src/lib/terminal/paired-flag.test.ts
+++ b/src/lib/terminal/paired-flag.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  PAIRED_FLAG_KEY,
+  isBrowserPaired,
+  markBrowserPaired,
+  clearBrowserPaired,
+  resolveFirstRunEntry,
+} from "./paired-flag";
+
+describe("paired flag — localStorage round-trip", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("is false before any successful pairing", () => {
+    expect(isBrowserPaired()).toBe(false);
+  });
+
+  it("marks + reads the paired flag under the versioned key", () => {
+    markBrowserPaired();
+    expect(isBrowserPaired()).toBe(true);
+    expect(window.localStorage.getItem(PAIRED_FLAG_KEY)).toBe("1");
+  });
+
+  it("clearBrowserPaired resets it", () => {
+    markBrowserPaired();
+    clearBrowserPaired();
+    expect(isBrowserPaired()).toBe(false);
+  });
+
+  it("treats a non-'1' value as not paired", () => {
+    window.localStorage.setItem(PAIRED_FLAG_KEY, "true");
+    expect(isBrowserPaired()).toBe(false);
+  });
+});
+
+describe("resolveFirstRunEntry — the unpaired vs paired gate", () => {
+  it("unsupported machine → coming-soon regardless of the paired flag", () => {
+    expect(resolveFirstRunEntry({ supported: false, paired: false })).toBe("coming-soon");
+    expect(resolveFirstRunEntry({ supported: false, paired: true })).toBe("coming-soon");
+  });
+
+  it("supported + never paired → setup (no deep link yet)", () => {
+    expect(resolveFirstRunEntry({ supported: true, paired: false })).toBe("setup");
+  });
+
+  it("supported + paired before → connecting (auto-connect, skip setup)", () => {
+    expect(resolveFirstRunEntry({ supported: true, paired: true })).toBe("connecting");
+  });
+
+  it("end-to-end: a machine that pairs graduates from setup to connecting", () => {
+    window.localStorage.clear();
+    const supported = true;
+    expect(resolveFirstRunEntry({ supported, paired: isBrowserPaired() })).toBe("setup");
+    markBrowserPaired();
+    expect(resolveFirstRunEntry({ supported, paired: isBrowserPaired() })).toBe("connecting");
+  });
+});

--- a/src/lib/terminal/paired-flag.ts
+++ b/src/lib/terminal/paired-flag.ts
@@ -1,0 +1,64 @@
+// In-app terminal — the "this browser has paired before" flag + the first-run gate.
+//
+// One localStorage flag is the WHOLE branch between the numbered setup panel (an
+// unpaired browser) and silent auto-connect (a browser that has paired before). The
+// web page cannot detect whether the native helper is installed, so we infer
+// readiness from an explicit past success: on the first connection we set this flag,
+// and every future open trusts it.
+//
+// Pure gate + SSR-safe storage helpers, all unit-tested without React.
+
+/** localStorage key marking that THIS browser has paired at least once (v1). */
+export const PAIRED_FLAG_KEY = "vibecodes:terminal:paired-v1";
+
+/** True once this browser has successfully paired at least once. SSR-safe. */
+export function isBrowserPaired(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(PAIRED_FLAG_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Mark this browser paired (called on the first successful connection). SSR-safe. */
+export function markBrowserPaired(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PAIRED_FLAG_KEY, "1");
+  } catch {
+    // Storage disabled/full — worst case the user simply sees the setup panel again.
+  }
+}
+
+/** Clear the paired flag (for tests / a future "reset this Mac" affordance). SSR-safe. */
+export function clearBrowserPaired(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(PAIRED_FLAG_KEY);
+  } catch {
+    // Nothing to do — storage unavailable.
+  }
+}
+
+export type FirstRunEntry = "coming-soon" | "setup" | "connecting";
+
+/**
+ * The install-first entry decision. Pure: given whether we ship a helper for this
+ * machine and whether this browser has paired before, decide the first screen.
+ *
+ *  - unsupported machine       → "coming-soon"  (no deep link, ever)
+ *  - supported + never paired  → "setup"        (numbered setup; NO deep link yet)
+ *  - supported + paired before → "connecting"   (auto-connect; fire the deep link)
+ *
+ * This is the single source of truth for criterion #2 (link fires only after an
+ * explicit Connect for an unpaired browser) and #6 (a paired browser auto-connects
+ * and skips the setup wall).
+ */
+export function resolveFirstRunEntry(input: {
+  supported: boolean;
+  paired: boolean;
+}): FirstRunEntry {
+  if (!input.supported) return "coming-soon";
+  return input.paired ? "connecting" : "setup";
+}

--- a/src/lib/terminal/platform.test.ts
+++ b/src/lib/terminal/platform.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveTerminalPlatform,
+  TERMINAL_HELPER_DOWNLOAD_URL,
+  type PlatformSignals,
+} from "./platform";
+
+// Representative UA strings (trimmed) — browsers report "Intel Mac OS X" even on
+// Apple Silicon, which is exactly why the arch signal (not the UA) decides Intel.
+const APPLE_SILICON_MAC: PlatformSignals = {
+  userAgent:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+  platform: "MacIntel",
+  uaDataPlatform: "macOS",
+  maxTouchPoints: 0,
+};
+
+const WINDOWS: PlatformSignals = {
+  userAgent:
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+  platform: "Win32",
+  uaDataPlatform: "Windows",
+  maxTouchPoints: 0,
+};
+
+describe("resolveTerminalPlatform — Apple Silicon Mac (supported)", () => {
+  it("is a supported Apple-Silicon target with the OS/arch-aware download", () => {
+    const p = resolveTerminalPlatform(APPLE_SILICON_MAC);
+    expect(p.os).toBe("mac");
+    expect(p.isAppleSilicon).toBe(true);
+    expect(p.supported).toBe(true);
+    expect(p.downloadLabel).toBe("Download for Mac (Apple Silicon)");
+    expect(p.downloadUrl).toBe(TERMINAL_HELPER_DOWNLOAD_URL);
+  });
+
+  it("stays Apple Silicon when the arch signal confirms arm", () => {
+    const p = resolveTerminalPlatform({ ...APPLE_SILICON_MAC, architecture: "arm" });
+    expect(p.supported).toBe(true);
+    expect(p.isAppleSilicon).toBe(true);
+  });
+});
+
+describe("resolveTerminalPlatform — Intel Mac (unsupported)", () => {
+  it("routes an x86 Mac to coming-soon with no download target", () => {
+    const p = resolveTerminalPlatform({ ...APPLE_SILICON_MAC, architecture: "x86" });
+    expect(p.os).toBe("mac");
+    expect(p.isAppleSilicon).toBe(false);
+    expect(p.supported).toBe(false);
+    expect(p.downloadUrl).toBeNull();
+  });
+
+  it("treats x86_64 the same as x86", () => {
+    const p = resolveTerminalPlatform({ ...APPLE_SILICON_MAC, architecture: "x86_64" });
+    expect(p.supported).toBe(false);
+  });
+});
+
+describe("resolveTerminalPlatform — non-Mac (coming soon, no deep link)", () => {
+  it("Windows is unsupported with a null download url", () => {
+    const p = resolveTerminalPlatform(WINDOWS);
+    expect(p.os).toBe("windows");
+    expect(p.supported).toBe(false);
+    expect(p.downloadUrl).toBeNull();
+    expect(p.downloadLabel).toBe("Download for Windows");
+  });
+
+  it("Linux resolves to 'other' and unsupported", () => {
+    const p = resolveTerminalPlatform({
+      userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36",
+      platform: "Linux x86_64",
+    });
+    expect(p.os).toBe("other");
+    expect(p.supported).toBe(false);
+  });
+
+  it("iPhone is unsupported even though it is Apple hardware", () => {
+    const p = resolveTerminalPlatform({
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Version/17.0 Mobile/15E148 Safari/604.1",
+      platform: "iPhone",
+      maxTouchPoints: 5,
+    });
+    expect(p.os).toBe("other");
+    expect(p.supported).toBe(false);
+  });
+
+  it("an iPad masquerading as Macintosh (touch points) is not treated as a Mac", () => {
+    const p = resolveTerminalPlatform({
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15",
+      platform: "MacIntel",
+      uaDataPlatform: "macOS",
+      maxTouchPoints: 5,
+    });
+    expect(p.os).toBe("other");
+    expect(p.supported).toBe(false);
+  });
+});
+
+describe("resolveTerminalPlatform — SSR / empty signals", () => {
+  it("an empty navigator (server) is unsupported, never a deep-link target", () => {
+    const p = resolveTerminalPlatform({ userAgent: "" });
+    expect(p.os).toBe("other");
+    expect(p.supported).toBe(false);
+    expect(p.downloadUrl).toBeNull();
+  });
+});

--- a/src/lib/terminal/platform.ts
+++ b/src/lib/terminal/platform.ts
@@ -1,0 +1,122 @@
+// In-app terminal — client OS / architecture detection for the install-first flow.
+//
+// The in-browser terminal only works on machines we ship a helper for. Today that
+// is an Apple-Silicon Mac; everything else lands on a calm "coming soon" and NEVER
+// fires the `vibecodes://` deep link (so a non-Mac user is never ambushed by an OS
+// dialog for a scheme nothing can handle).
+//
+// resolveTerminalPlatform() is PURE — it takes explicit signals so the whole
+// OS/arch policy is unit-testable without a real navigator. readPlatformSignals()
+// is the only impure part: it pulls those signals off `navigator` at the call site
+// and is SSR-safe (no navigator → treated as an unsupported machine).
+
+export type TerminalOs = "mac" | "windows" | "other";
+
+/** Where the OS-aware download always points for a supported (Apple Silicon) Mac. */
+export const TERMINAL_HELPER_DOWNLOAD_URL = "/download/terminal-helper";
+
+export interface PlatformSignals {
+  /** navigator.userAgent — always present in a browser. */
+  userAgent: string;
+  /** navigator.platform (legacy, still a useful coarse signal). */
+  platform?: string;
+  /** navigator.userAgentData.platform (Chromium) — "macOS" | "Windows" | … */
+  uaDataPlatform?: string;
+  /**
+   * UA-CH high-entropy architecture ("arm" | "x86" | …) when the caller has
+   * fetched it. Usually absent for the synchronous read; see the Apple-Silicon
+   * note in resolveTerminalPlatform.
+   */
+  architecture?: string;
+  /** navigator.maxTouchPoints — disambiguates an iPad that reports as "Macintosh". */
+  maxTouchPoints?: number;
+}
+
+export interface TerminalPlatform {
+  os: TerminalOs;
+  /** Best-effort: is this an Apple-Silicon Mac (the shipped helper target)? */
+  isAppleSilicon: boolean;
+  /** Do we ship a helper this machine can run? (Apple-Silicon Mac only, today.) */
+  supported: boolean;
+  /** Download control label — information scent, never "Download" / "Submit". */
+  downloadLabel: string;
+  /** Where the download points, or null when we ship nothing for this machine. */
+  downloadUrl: string | null;
+}
+
+function detectOs(signals: PlatformSignals): TerminalOs {
+  const ua = signals.userAgent ?? "";
+  const uaData = signals.uaDataPlatform?.toLowerCase() ?? "";
+  const plat = signals.platform?.toLowerCase() ?? "";
+  const touch = signals.maxTouchPoints ?? 0;
+
+  // iPhone / iPod / an explicit iPad string never runs the helper.
+  if (/iphone|ipod|ipad/i.test(ua)) return "other";
+
+  const looksMac =
+    uaData === "macos" || /mac/.test(plat) || /macintosh|mac os x/i.test(ua);
+  if (looksMac) {
+    // iPadOS 13+ masquerades as "Macintosh"; a touch-capable "Mac" is really an
+    // iPad → unsupported.
+    if (touch > 1) return "other";
+    return "mac";
+  }
+
+  const looksWindows =
+    uaData === "windows" || /win/.test(plat) || /windows/i.test(ua);
+  if (looksWindows) return "windows";
+
+  return "other";
+}
+
+/**
+ * Resolve the terminal platform from raw signals. Pure + deterministic.
+ *
+ * Apple-Silicon caveat: browsers report "Intel Mac OS X" in the UA even on Apple
+ * Silicon (a compatibility lie), so the UA alone can NEVER prove Apple Silicon. We
+ * therefore treat any Mac as Apple Silicon — the only helper we ship is arm64 —
+ * UNLESS a trustworthy UA-CH `architecture` says "x86"/"x86_64", the one case where
+ * we can be reasonably sure it is an Intel Mac and route it to "coming soon".
+ */
+export function resolveTerminalPlatform(signals: PlatformSignals): TerminalPlatform {
+  const os = detectOs(signals);
+  const arch = signals.architecture?.toLowerCase();
+  const isAppleSilicon = os === "mac" && arch !== "x86" && arch !== "x86_64";
+  const supported = os === "mac" && isAppleSilicon;
+
+  if (supported) {
+    return {
+      os,
+      isAppleSilicon,
+      supported,
+      downloadLabel: "Download for Mac (Apple Silicon)",
+      downloadUrl: TERMINAL_HELPER_DOWNLOAD_URL,
+    };
+  }
+
+  return {
+    os,
+    isAppleSilicon,
+    supported,
+    // Windows is the next platform on the roadmap; the button is gated (disabled)
+    // in the UI, so this label is informational, not an active target.
+    downloadLabel: "Download for Windows",
+    downloadUrl: null,
+  };
+}
+
+/** Read detection signals from the live navigator. SSR-safe (empty → unsupported). */
+export function readPlatformSignals(): PlatformSignals {
+  if (typeof navigator === "undefined") return { userAgent: "" };
+  const nav = navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  };
+  return {
+    userAgent: nav.userAgent ?? "",
+    platform: nav.platform,
+    uaDataPlatform: nav.userAgentData?.platform,
+    maxTouchPoints: nav.maxTouchPoints,
+    // `architecture` needs an async UA-CH high-entropy call; left undefined for the
+    // synchronous read (we default Mac → Apple Silicon — see resolveTerminalPlatform).
+  };
+}


### PR DESCRIPTION
Fixes the P0 first-run defect on the in-app terminal: picking **"Launch → In the browser"** auto-fired the `vibecodes://` deep link, so a first-timer with no helper installed got macOS's scary *"There is no application set to open the URL… Search App Store"* dialog. Observed live in prod testing.

## Fix
The deep link now fires at exactly **one edge** — an explicit **Connect** press (or a returning-user auto-connect) — **never** on dock-open for an unpaired browser. A web page can't detect a native install, so readiness is inferred from one localStorage flag (`vibecodes:terminal:paired-v1`), set on the first bridge byte:
- **unsupported OS** → "coming soon", no deep link
- **supported + unpaired** → one-time setup panel (Download → drag to Applications → Connect), macOS "Open VibeCodes?" prompt pre-explained
- **supported + paired** → auto-connect, no setup wall
- fire via hidden iframe + 8s timeout net → calm fallback (Retry + Download); never an infinite spinner or error-speak

## How it was built
Full **Feature Development workflow** on the board — Requirements (ProdOwner) → UX Design (Compass) → Design Review (✅ human) → Implementation (Atlas) → QA (Sentinel, **SHIP**) → Final Sign-off (✅ human). Design: `docs/install-first-terminal-ux.html`.

## Tests / safety
- 4 new pure modules under `src/lib/terminal/` + rewired `terminal-dock.tsx`
- **72/72** terminal tests (35 prior regression + 37 new); `tsc` + `eslint` clean; no new deps; no DB/schema changes
- Ships behind `NEXT_PUBLIC_TERMINAL_ENABLED` (already on)

## Known follow-ups (filed separately, non-blocking)
- Intel-Mac "Windows coming soon" copy (low reachability)
- `connect()` in-flight guard (low-likelihood race)
- Post-deploy cross-browser criterion-8 manual check (gates *wider* rollout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)