### PR TITLE
feat(terminal): bootstrap-prompt parity — in-browser claude launches with task context

### DIFF
--- a/docs/terminal-bootstrap-prompt-ux.html
+++ b/docs/terminal-bootstrap-prompt-ux.html
@@ -1,0 +1,610 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>In-App Terminal — Bootstrap Prompt UX (Compass)</title>
+<style>
+  :root{
+    /* Pulled from src/components/board/terminal-dock.tsx to match the live dock */
+    --dock-header:#141417;
+    --dock-body:#0c0c0e;
+    --dock-deep:#0a0a0b;
+    --page:#09090b;
+    --card:#141417;
+    --border:#3f3f46;      /* zinc-700 */
+    --border-soft:#27272a; /* zinc-800 */
+    --text:#e4e4e7;        /* zinc-200 */
+    --text-dim:#a1a1aa;    /* zinc-400 */
+    --text-faint:#71717a;  /* zinc-500 */
+    --emerald:#34d399;
+    --amber:#fbbf24;
+    --sky:#38bdf8;
+    --rose:#fb7185;
+    --violet:#c4b5fd;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{
+    background:var(--page);
+    color:var(--text);
+    font:15px/1.6 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    padding:0 0 96px;
+  }
+  .wrap{max-width:1120px;margin:0 auto;padding:0 20px}
+  header.doc{
+    border-bottom:1px solid var(--border-soft);
+    background:linear-gradient(180deg,#141417,#0c0c0e);
+    padding:40px 0 30px;margin-bottom:8px;
+  }
+  .kicker{font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:var(--emerald);font-weight:700}
+  h1{font-size:30px;margin:8px 0 6px;letter-spacing:-.01em}
+  .sub{color:var(--text-dim);font-size:15px;max-width:800px}
+  .meta-row{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+  .tag{font-size:12px;border:1px solid var(--border);border-radius:999px;padding:4px 11px;color:var(--text-dim);background:#18181b}
+  .tag.ok{border-color:rgba(52,211,153,.5);color:var(--emerald);background:rgba(52,211,153,.08)}
+
+  h2{font-size:21px;margin:44px 0 4px;letter-spacing:-.01em}
+  h2 .num{color:var(--text-faint);font-weight:600;margin-right:10px}
+  .lead{color:var(--text-dim);margin:6px 0 20px;max-width:840px}
+  h3{font-size:15px;margin:26px 0 10px;color:var(--text)}
+
+  /* ---- The mock dock ---- */
+  .dock{
+    border:1px solid var(--border);
+    border-radius:12px;
+    overflow:hidden;
+    background:var(--dock-header);
+    box-shadow:0 18px 50px rgba(0,0,0,.5);
+    max-width:860px;
+  }
+  .dock.narrow{max-width:375px}
+  .dockbar{
+    display:flex;align-items:center;gap:10px;
+    padding:8px 12px;background:var(--dock-header);
+    font-size:12px;
+  }
+  .dot{width:9px;height:9px;border-radius:50%;flex:0 0 auto}
+  .dot.emerald{background:var(--emerald)}
+  .dot.amber{background:var(--amber)}
+  .dot.zinc{background:var(--text-faint)}
+  .termlabel{display:inline-flex;align-items:center;gap:8px;font-weight:600}
+  .termlabel .sess{color:var(--text-faint);font-weight:400;font-family:ui-monospace,Menlo,monospace;font-size:11px}
+  .pill{
+    display:inline-flex;align-items:center;gap:6px;
+    border:1px solid var(--border);border-radius:7px;
+    padding:2px 9px;font-size:11px;font-weight:600;
+  }
+  .pill.emerald{border-color:rgba(52,211,153,.5);background:rgba(52,211,153,.1);color:var(--emerald)}
+  .pill.amber{border-color:rgba(251,191,36,.5);background:rgba(251,191,36,.1);color:var(--amber)}
+  .pill.zinc{border-color:var(--border);background:#27272a99;color:var(--text-dim)}
+  .pill.rose{border-color:rgba(251,113,133,.55);background:rgba(251,113,133,.1);color:var(--rose)}
+  .spacer{margin-left:auto}
+  .ghostbtn{color:var(--text-dim);font-size:12px;display:inline-flex;align-items:center;gap:5px}
+
+  .dockhead{
+    display:flex;flex-wrap:wrap;align-items:center;gap:8px;
+    border-top:1px solid var(--border-soft);border-bottom:1px solid var(--border-soft);
+    background:var(--dock-header);padding:9px 12px;font-size:12px;
+  }
+  .dockhead .idea{color:var(--text-faint);font-family:ui-monospace,Menlo,monospace;font-size:12px}
+
+  .dockbody{
+    background:var(--dock-body);
+    min-height:300px;
+    display:flex;align-items:center;justify-content:center;
+    padding:30px 22px;position:relative;
+  }
+  .dockbody.tall{min-height:340px}
+
+  .overlay{max-width:520px;width:100%;text-align:center;display:flex;flex-direction:column;align-items:center;gap:14px}
+  .overlay .icon{font-size:26px;line-height:1}
+  .overlay h4{font-size:17px;margin:0;font-weight:700}
+  .overlay p{margin:0;font-size:13.5px;color:var(--text-dim);max-width:460px}
+  .overlay .muted{color:var(--text-faint)}
+
+  .btn{
+    display:inline-flex;align-items:center;justify-content:center;gap:8px;
+    border-radius:8px;padding:11px 18px;font-size:14px;font-weight:600;
+    border:1px solid transparent;cursor:default;min-height:44px;
+  }
+  .btn.sky{background:var(--sky);color:#04121b}
+  .btn.outline{background:#27272a99;border-color:var(--border);color:var(--text)}
+  .btnrow{display:flex;gap:10px;flex-wrap:wrap;justify-content:center;width:100%}
+  .subtle{font-size:11.5px;color:var(--text-faint);text-align:center}
+
+  /* faux terminal stream */
+  .stream{
+    width:100%;height:100%;min-height:260px;
+    background:var(--dock-body);
+    font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:12.5px;line-height:1.7;
+    color:#cfd8df;text-align:left;padding:10px 14px;align-self:stretch;
+    overflow-x:auto;
+  }
+  .stream .g{color:var(--emerald)}
+  .stream .d{color:var(--text-faint)}
+  .stream .u{color:var(--sky)}
+  .stream .cursor{display:inline-block;width:8px;height:15px;background:#cfd8df;vertical-align:-2px;animation:blink 1s step-end infinite}
+  @keyframes blink{50%{opacity:0}}
+  .inputbar{
+    display:flex;align-items:center;gap:8px;
+    border-top:1px solid var(--border-soft);background:var(--dock-header);
+    padding:9px 14px;font-size:12px;color:var(--text-faint);
+  }
+  .inputbar .prompt{color:var(--emerald);font-family:ui-monospace,Menlo,monospace}
+
+  /* one-line hint bar (edge C) — same construction as the shipped amber
+     "Lost the connection" strip in terminal-dock.tsx, on the sky accent */
+  .hintbar{
+    display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+    border-top:1px solid rgba(56,189,248,.3);background:rgba(56,189,248,.05);
+    padding:8px 14px;font-size:11.5px;color:#9adcf8;
+  }
+  .hintbar b{color:#c8ecfb}
+  .hintbar a{color:#9adcf8;text-decoration:underline;cursor:default;padding:6px 2px}
+  .hintbar .dismiss{margin-left:auto;color:var(--text-faint);text-decoration:none;padding:6px 8px}
+
+  /* annotation block */
+  .anno{
+    margin:14px 0 0;max-width:860px;
+    border-left:3px solid var(--emerald);
+    background:#101013;border:1px solid var(--border-soft);border-left-width:3px;
+    border-radius:0 10px 10px 0;padding:14px 18px;
+  }
+  .anno h5{margin:0 0 8px;font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--emerald)}
+  .anno ul{margin:0;padding-left:18px}
+  .anno li{margin:5px 0;font-size:13.5px;color:var(--text-dim)}
+  .anno li b{color:var(--text)}
+  .anno.sky{border-left-color:var(--sky)}
+  .anno.sky h5{color:var(--sky)}
+  .anno.amber{border-left-color:var(--amber)}
+  .anno.amber h5{color:var(--amber)}
+  .anno.rose{border-left-color:var(--rose)}
+  .anno.rose h5{color:var(--rose)}
+
+  .callout{
+    border:1px solid var(--border);border-radius:10px;background:#101013;
+    padding:16px 18px;margin:18px 0;max-width:860px;
+  }
+  .callout h4{margin:0 0 8px;font-size:14px}
+  .callout p{margin:0;color:var(--text-dim);font-size:13.5px}
+  .callout.good{border-color:rgba(52,211,153,.4);background:rgba(52,211,153,.05)}
+  .callout.good h4{color:var(--emerald)}
+
+  /* flow map */
+  .flow{
+    border:1px solid var(--border);border-radius:12px;background:#0d0d10;
+    padding:22px;overflow-x:auto;max-width:1000px;
+  }
+  .flowrow{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin:0 0 18px}
+  .flowrow:last-child{margin-bottom:0}
+  .node{
+    border:1px solid var(--border);border-radius:9px;padding:9px 13px;font-size:12.5px;
+    background:#18181b;white-space:nowrap;font-weight:600;
+  }
+  .node small{display:block;font-weight:400;color:var(--text-faint);font-size:10.5px;white-space:normal;max-width:190px}
+  .node.entry{border-color:rgba(56,189,248,.5);background:rgba(56,189,248,.08);color:var(--sky)}
+  .node.build{border-color:rgba(196,181,253,.45);background:rgba(196,181,253,.07);color:var(--violet)}
+  .node.gate{border-color:rgba(251,191,36,.6);background:rgba(251,191,36,.1);color:var(--amber)}
+  .node.win{border-color:rgba(52,211,153,.6);background:rgba(52,211,153,.14);color:var(--emerald)}
+  .node.fall{border-color:var(--border);background:#27272a;color:var(--text-dim)}
+  .node.deny{border-color:rgba(251,113,133,.5);background:rgba(251,113,133,.08);color:var(--rose)}
+  .arrow{color:var(--text-faint);font-size:16px}
+  .arrow .lbl{display:block;font-size:10px;color:var(--text-faint);text-align:center;margin-top:-2px}
+  .flowlabel{font-size:12px;color:var(--text-faint);width:130px;flex:0 0 130px;font-weight:600}
+
+  table{border-collapse:collapse;width:100%;max-width:860px;font-size:13px;margin:8px 0}
+  th,td{border:1px solid var(--border-soft);padding:9px 12px;text-align:left;vertical-align:top}
+  th{background:#18181b;color:var(--text);font-size:12px;letter-spacing:.03em}
+  td{color:var(--text-dim)}
+  td b,th b{color:var(--text)}
+  .crit{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--emerald);white-space:nowrap}
+  .copystr{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--text)}
+
+  .grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:22px;align-items:start}
+  .caption{font-size:12px;color:var(--text-faint);margin:8px 0 0;text-align:center;max-width:860px}
+  hr.sec{border:0;border-top:1px solid var(--border-soft);margin:40px 0}
+  .footnote{font-size:12.5px;color:var(--text-faint);max-width:860px;margin-top:8px}
+  code.inline{background:#18181b;border:1px solid var(--border-soft);border-radius:5px;padding:1px 6px;font-size:12px;color:var(--sky)}
+  @media (max-width:520px){
+    .flowlabel{width:100%;flex-basis:100%}
+    h1{font-size:24px}
+  }
+</style>
+</head>
+<body>
+
+<header class="doc">
+  <div class="wrap">
+    <div class="kicker">UX Design · Step 2 of 6 · Feature Development</div>
+    <h1>In-App Terminal — Bootstrap Prompt Flow</h1>
+    <p class="sub">
+      The in-browser dock launch must start Claude Code with the <b>same compact bootstrap prompt</b> the
+      terminal-window deep link already uses (<code class="inline">buildCompactBootstrapPrompt</code> in
+      <code class="inline">src/lib/launch-claude-code.ts</code>). Per the ProdOwner Requirements handoff, the happy
+      path is <b>intentionally invisible</b> — same button, same dock, claude simply wakes up already knowing the idea
+      and task. This document therefore designs the <b>system flow</b> and the <b>edge states only</b>.
+    </p>
+    <div class="meta-row">
+      <span class="tag ok">Designer: Compass (UX)</span>
+      <span class="tag">Built on: ProdOwner Requirements (R1, R2, R4 / AC4, AC6, AC8)</span>
+      <span class="tag">Surface: board bottom terminal dock — no new surface</span>
+      <span class="tag">Palette matched to terminal-dock.tsx</span>
+      <span class="tag">Companion: docs/install-first-terminal-ux.html</span>
+    </div>
+  </div>
+</header>
+
+<div class="wrap">
+
+<!-- ============================================================= -->
+<h2><span class="num">§1</span>Happy path statement — nothing new to learn</h2>
+<p class="lead">
+  Per the Requirements handoff: <b>no new buttons, no new settings, no new screens.</b> The user presses the same
+  Connect (or a paired browser auto-connects), the same install-first flow from
+  <code class="inline">docs/install-first-terminal-ux.html</code> runs unchanged — and the only visible difference is
+  the terminal's first screen: claude opens <i>already primed with the task</i> instead of a blank shell.
+</p>
+
+<div class="callout good">
+  <h4>✓ The whole visible feature</h4>
+  <p>Today the in-browser terminal opens cold and the user must paste or type context. After this change it opens
+  with the compact bootstrap prompt already delivered — claude connects the board tools, records the project path,
+  and picks up the task on its own. The user's mental model doesn't change; the terminal is just smarter on arrival
+  (Jakob's Law: keep the pattern they already learned, improve what it yields).</p>
+</div>
+
+<div class="dock" role="img" aria-label="Connected dock — claude opens already primed with the task">
+  <div class="dockbar">
+    <span class="dot emerald"></span>
+    <span class="termlabel">◱ Terminal <span class="sess">· session 8f3a1c2b</span></span>
+    <span class="spacer"></span>
+    <span class="pill emerald">◉ Connected</span>
+    <span class="ghostbtn">▾ Collapse</span>
+  </div>
+  <div class="dockhead">
+    <span class="pill emerald">◉ Connected</span>
+    <span class="idea">My First App · session 8f3a1c2b</span>
+    <span class="spacer"></span>
+    <span class="pill zinc" style="cursor:default">🔓 Read-only</span>
+    <span class="pill rose" style="cursor:default">⏻ End</span>
+    <span class="ghostbtn">⌄</span>
+  </div>
+  <div class="dockbody tall" style="padding:0;align-items:stretch">
+    <div class="stream">
+      <div><span class="g">➜</span> <span class="d">~</span> claude <span class="d">(launched by the VibeCodes helper)</span></div>
+      <div class="d">Welcome to Claude Code.</div>
+      <div>&nbsp;</div>
+      <div><span class="u">›</span> <span class="u">Set up VibeCodes and work a board task for "My First App".</span></div>
+      <div class="u">&nbsp;&nbsp;1. Get into the repo nickball/my-first-app first: cd your local clone, or git clone … Never work in your home directory.</div>
+      <div class="u">&nbsp;&nbsp;2. Connect the board tools: run `claude mcp add -s local --transport http vibecodes …/api/mcp`, then `/mcp` → vibecodes → Authenticate…</div>
+      <div class="u">&nbsp;&nbsp;3. Once the board tools work, call record_project_path (idea_id …, your machine `hostname`, and `pwd`)…</div>
+      <div class="u">&nbsp;&nbsp;4. Work this task: get_task (task_id …), move it to In Progress, then start. Comment as you go.</div>
+      <div>&nbsp;</div>
+      <div>● I'll start by getting into the project folder, then connect the board tools.</div>
+      <div>&nbsp;&nbsp;<span class="d">Bash(cd ~/projects/my-first-app && pwd)…</span></div>
+      <div><span class="g">›</span> <span class="cursor"></span></div>
+    </div>
+  </div>
+  <div class="inputbar">
+    <span class="prompt">›</span>
+    <span>Click the terminal and type to steer the agent. Enter sends.</span>
+  </div>
+</div>
+<p class="caption">
+  The only visible difference from today: the first message in the scrollback is the compact bootstrap prompt (shown
+  in sky above as claude renders the user turn), and claude is already acting on it. Dock bar, pills, controls, and
+  input bar are pixel-identical to the shipped <code class="inline">terminal-dock.tsx</code>.
+</p>
+
+<div class="anno">
+  <h5>Why the happy path is invisible on purpose</h5>
+  <ul>
+    <li><b>No new affordance to find</b> — the deep-link (terminal-window) flow already primes claude this way; the in-browser flow is catching up to parity, not adding a capability the user chooses (recognition over recall: they recognise the same launch, it simply does more).</li>
+    <li><b>The prompt itself is the receipt.</b> It lands in the scrollback as the first turn, so a curious user can read exactly what claude was told — full transparency without any explanatory chrome.</li>
+    <li><b>Human-in-the-loop preserved</b> — the user watches claude execute the bootstrap live and can interrupt by typing at any point (the shipped read-write input bar), same as any terminal session.</li>
+  </ul>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§2</span>System flow — where the prompt travels</h2>
+<p class="lead">
+  The prompt is built in the browser, rides the <code class="inline">vibecodes://launch</code> deep link as an inert
+  string, and is <b>held by the helper until the relay accepts the owner-bound token</b> (the R1 gate, amber below).
+  Only after acceptance does the helper pass it to claude. Rejected token ⇒ the prompt is discarded unexecuted.
+</p>
+
+<div class="flow" role="img" aria-label="System flow map of the bootstrap prompt from board state to claude">
+  <div class="flowrow">
+    <span class="flowlabel">Browser (web)</span>
+    <span class="node entry">Board state<br><small>idea / task / repo / recorded path</small></span>
+    <span class="arrow">→</span>
+    <span class="node build">buildCompactBootstrapPrompt()<br><small>+ enforcePromptLength — MCP head always survives (R2)</small></span>
+    <span class="arrow">→</span>
+    <span class="node">Session mint<br><small>POST /api/terminal/session</small></span>
+    <span class="arrow">→</span>
+    <span class="node entry">vibecodes://launch?…&amp;prompt=<br><small>URL ≤ ~2KB · prompt is an inert string</small></span>
+  </div>
+  <div class="flowrow">
+    <span class="flowlabel">Helper (Mac)</span>
+    <span class="node">Helper opens<br><small>parses link · HOLDS the prompt · runs nothing</small></span>
+    <span class="arrow">→</span>
+    <span class="node">Bridge attaches to relay<br><small>presents the owner-bound token</small></span>
+    <span class="arrow">→</span>
+    <span class="node gate">⛨ R1 GATE — relay validates token<br><small>owner-bound · single-use · short-lived</small></span>
+  </div>
+  <div class="flowrow">
+    <span class="flowlabel">Gate passes</span>
+    <span class="node gate">⛨ accepted</span>
+    <span class="arrow">→</span>
+    <span class="node win">claude launches with the prompt<br><small>first turn in the PTY (post-auth only)</small></span>
+    <span class="arrow">→</span>
+    <span class="node win">PTY bytes → dock<br><small>§1 happy path</small></span>
+  </div>
+  <div class="flowrow">
+    <span class="flowlabel">Gate fails</span>
+    <span class="node gate">⛨ rejected<br><small>forged / expired / foreign token</small></span>
+    <span class="arrow">→</span>
+    <span class="node deny">Zero execution<br><small>prompt discarded · no claude · no shell</small></span>
+    <span class="arrow">→</span>
+    <span class="node fall">Dock: shipped ~8s timeout fallback<br><small>§3 — no new UI</small></span>
+  </div>
+</div>
+<p class="footnote">
+  The prompt crosses three trust boundaries (web → OS link → helper → relay-authenticated bridge) but is only ever
+  <i>data</i> until the amber gate passes. This ordering is the whole of R1: a crafted link on a victim's machine can
+  make the helper open, but never make anything run.
+</p>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§3</span>Edge A — pre-auth rejection (R1 / AC4): no new UI</h2>
+<p class="lead">
+  A forged, expired, or foreign-account link fails at the relay gate: the helper attaches nothing and exits quietly.
+  On the machine, <b>nothing happens</b> — which is the security win. In the dock, the launch simply never streams,
+  so the shipped install-first flow already covers it: <b>Connecting… → (~8s) → the calm timeout fallback.</b>
+</p>
+
+<div class="dock" role="img" aria-label="Rejected launch lands on the existing timeout fallback">
+  <div class="dockbar">
+    <span class="dot zinc"></span>
+    <span class="termlabel">◱ Terminal <span class="sess">· session 4d90ee71</span></span>
+    <span class="spacer"></span>
+    <span class="pill zinc">◔ Not connected yet</span>
+    <span class="ghostbtn">▾ Collapse</span>
+  </div>
+  <div class="dockhead">
+    <span class="pill zinc">◔ Not connected yet</span>
+    <span class="idea">My First App · session 4d90ee71</span>
+    <span class="spacer"></span>
+    <span class="ghostbtn">⌄</span>
+  </div>
+  <div class="dockbody tall">
+    <div class="overlay">
+      <div class="icon" style="color:var(--sky)">◔</div>
+      <h4>Didn’t connect yet</h4>
+      <p>It may not be running. Try again — or re-install the helper if it keeps happening.</p>
+      <div class="btnrow">
+        <span class="btn sky">↻ Retry</span>
+        <span class="btn outline">⭳ Re-install the helper</span>
+      </div>
+      <span class="subtle">Your work on your Mac is safe.</span>
+    </div>
+  </div>
+</div>
+<p class="caption">This is the already-shipped timeout fallback from the install-first design — reused verbatim. Zero new strings, zero new states.</p>
+
+<div class="anno sky">
+  <h5>Why no new “security” state — deliberate decision</h5>
+  <ul>
+    <li><b>The legitimate user can't reach this state through the product.</b> Every dock launch mints a fresh valid token milliseconds before firing. Expired/forged/foreign tokens arrive only via stale or crafted links opened <i>outside</i> the dock — and then there is no dock waiting, so there is nothing to show. When a dock <i>is</i> waiting and the helper doesn't stream (whatever the cause), “Didn't connect yet → Retry” is both accurate and the correct recovery: Retry mints a fresh token, which fixes the token-expiry case by construction.</li>
+    <li><b>An alarm state would misfire.</b> The dock cannot distinguish “token rejected” from “helper not running” (the helper never streams in either case). A red “security” banner on what is usually a sleeping helper violates the no-alarm-for-non-actionable-info rule and trains users to ignore red.</li>
+    <li><b>Don't brief the attacker.</b> Distinct rejection UI would give a probing attacker a feedback channel. Silence on the machine + a generic “not yet” in the dock leaks nothing.</li>
+    <li><b>Browser-leg failures are already covered</b> — the dock's own socket has explicit error states (“Couldn't verify this session”, “This bridge belongs to another account”) in <code class="inline">terminal-dock.tsx</code>; those are untouched and out of scope here.</li>
+  </ul>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§4</span>Edge B — truncated prompt (R2 / AC6): no in-dock signal</h2>
+<p class="lead">
+  On very long task titles/context the URL cap forces deterministic truncation — but
+  <code class="inline">enforcePromptLength</code> always preserves the MCP-setup head, so claude still connects the
+  board tools and <b>re-fetches the full task from the board itself</b> (<code class="inline">get_task</code>). The
+  trimmed tail was a convenience copy, not the source of truth. <b>Recommendation: no dock UI at all.</b>
+</p>
+
+<div class="dock" role="img" aria-label="Truncated prompt — the marker is visible in the scrollback, nothing else changes">
+  <div class="dockbar">
+    <span class="dot emerald"></span>
+    <span class="termlabel">◱ Terminal <span class="sess">· session 9b21d6e0</span></span>
+    <span class="spacer"></span>
+    <span class="pill emerald">◉ Connected</span>
+    <span class="ghostbtn">▾ Collapse</span>
+  </div>
+  <div class="dockbody" style="padding:0;align-items:stretch;min-height:210px">
+    <div class="stream" style="min-height:190px">
+      <div><span class="u">›</span> <span class="u">Set up VibeCodes and work a board task for "A very long idea title that goes on and on and eventually forces the…".</span></div>
+      <div class="u">&nbsp;&nbsp;1. Get into the repo … 2. Connect the board tools … 3. record_project_path …</div>
+      <div class="u">&nbsp;&nbsp;4. Work this task: get_task (task_id 7c…, idea_id 3f…), move it to In Progr</div>
+      <div class="u">&nbsp;&nbsp;…(truncated)</div>
+      <div>&nbsp;</div>
+      <div>● Connecting the board tools, then I'll read the full task from the board.</div>
+      <div><span class="g">›</span> <span class="cursor"></span></div>
+    </div>
+  </div>
+</div>
+<p class="caption">
+  The <code class="inline">…(truncated)</code> marker (already appended by <code class="inline">enforcePromptLength</code>)
+  is visible in the scrollback for the curious. That is the entire signal.
+</p>
+
+<div class="anno">
+  <h5>Why silence is correct here</h5>
+  <ul>
+    <li><b>Nothing is lost.</b> The head (project dir + MCP connect + record path + task id) survives by contract; claude reads the authoritative task body from the board over MCP anyway. Outcome for the user: identical to the untruncated case.</li>
+    <li><b>Non-actionable ⇒ no alarm.</b> There is no user action that improves anything (“shorten your idea title” is absurd advice). A banner would add a decision point with zero payoff — pure Hick's-Law cost, and it would fire on exactly the boards with the richest context, punishing power users.</li>
+    <li><b>Never a dropped launch (R2).</b> Truncation is the overflow behaviour; the launch always proceeds. A warning would imply something failed when nothing did.</li>
+    <li><b>Escape hatch exists for the 1%:</b> the marker in the scrollback is honest and findable; anyone who cares can also use the copy-command flow, which carries the full verbose prompt with no URL limit.</li>
+  </ul>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§5</span>Edge C — version skew (R4 / AC8): one low-key hint, feasibility-gated</h2>
+<p class="lead">
+  New web + <b>old installed helper</b>: the old helper ignores the unknown <code class="inline">prompt</code> param
+  and claude opens cold — exactly today's behaviour, so nothing breaks (R4). But unlike Edge B, here the user
+  <b>silently loses real value they can actually recover</b> with one action: update the helper. This is the one place
+  a small piece of new UI earns its keep — a single dismissible hint line, built exactly like the dock's shipped
+  amber “Lost the connection” strip, on the calm sky accent.
+</p>
+
+<div class="dock" role="img" aria-label="Version-skew state — connected cold terminal with a one-line update hint">
+  <div class="dockbar">
+    <span class="dot emerald"></span>
+    <span class="termlabel">◱ Terminal <span class="sess">· session c07be412</span></span>
+    <span class="spacer"></span>
+    <span class="pill emerald">◉ Connected</span>
+    <span class="ghostbtn">▾ Collapse</span>
+  </div>
+  <div class="dockhead">
+    <span class="pill emerald">◉ Connected</span>
+    <span class="idea">My First App · session c07be412</span>
+    <span class="spacer"></span>
+    <span class="pill zinc" style="cursor:default">🔓 Read-only</span>
+    <span class="pill rose" style="cursor:default">⏻ End</span>
+    <span class="ghostbtn">⌄</span>
+  </div>
+  <div class="dockbody" style="padding:0;align-items:stretch;min-height:240px">
+    <div class="stream" style="min-height:200px">
+      <div><span class="g">➜</span> <span class="d">~</span> claude</div>
+      <div class="d">Welcome to Claude Code.</div>
+      <div>&nbsp;</div>
+      <div><span class="g">›</span> <span class="cursor"></span></div>
+    </div>
+  </div>
+  <div class="hintbar" role="status">
+    <span aria-hidden="true">↑</span>
+    <span><b>Claude started without your task details.</b> Update the helper and your next launch will include them.</span>
+    <a href="#">Get the update</a>
+    <a href="#" class="dismiss">Dismiss</a>
+  </div>
+  <div class="inputbar">
+    <span class="prompt">›</span>
+    <span>Click the terminal and type to steer the agent. Enter sends.</span>
+  </div>
+</div>
+<p class="caption">
+  The hint sits between the terminal and the input bar — same slot and construction as the shipped amber
+  reconnect strip, so it reads as “dock status”, not an error. The session above it is fully usable.
+</p>
+
+<div class="anno amber">
+  <h5>Behaviour &amp; why</h5>
+  <ul>
+    <li><b>Why hint at all (vs Edge B's silence):</b> here the loss is real (claude opens cold; the user must hand-type context) <i>and</i> the fix is a single user action. Actionable + recurring on every launch until fixed ⇒ worth one quiet line. Non-actionable Edge B stays silent.</li>
+    <li><b>Never blocks, never modal.</b> The session is connected and fully usable; the hint is informational (<code class="inline">role="status"</code>, not <code class="inline">alert</code>). “Get the update” opens the existing <code class="inline">/download/terminal-helper</code> route — same link, same styling family as every helper-download affordance in the dock.</li>
+    <li><b>Dismiss is remembered</b> (localStorage, per browser) so it shows at most once per user decision, not once per session — no nagging. It naturally disappears for good once the updated helper delivers the prompt.</li>
+    <li><b>Feasibility gate:</b> the hint requires the dock to <i>know</i> the helper is old. Proposed detection: the new helper announces its version in a TEXT control frame on attach (the dock already ignores TEXT frames today, so old helpers are safely mute) — <b>no version frame before first PTY bytes ⇒ old helper ⇒ show the hint</b>. If engineering judges this signal unreliable, ship Edge C <b>silent</b> (graceful cold launch is already the R4 requirement); the hint is an enhancement, not a dependency.</li>
+    <li><b>WCAG:</b> sky text on near-black ≥4.5:1; “Get the update” and “Dismiss” are real links with ≥44px effective touch targets (padded); icon + bold lead-in + text — never colour alone.</li>
+  </ul>
+</div>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§6</span>Copy — exact strings (everything new)</h2>
+<p class="lead">Only Edge C introduces user-facing strings. Calm, non-technical: no “token”, “relay”, “argv”, “prompt”, or “version skew”.</p>
+
+<table>
+  <thead>
+    <tr><th style="width:220px">Where</th><th>String</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><b>Edge C hint — lead</b></td><td class="copystr">Claude started without your task details.</td></tr>
+    <tr><td><b>Edge C hint — body</b></td><td class="copystr">Update the helper and your next launch will include them.</td></tr>
+    <tr><td><b>Edge C hint — action link</b></td><td class="copystr">Get the update</td></tr>
+    <tr><td><b>Edge C hint — dismiss link</b></td><td class="copystr">Dismiss</td></tr>
+    <tr><td><b>Truncation marker (Edge B)</b></td><td class="copystr">…(truncated) <span style="color:var(--text-faint)">— already emitted by enforcePromptLength; appears only inside the terminal scrollback, not in dock chrome. Not a new string.</span></td></tr>
+  </tbody>
+</table>
+<p class="footnote">
+  Edge A and the happy path introduce <b>zero</b> new strings — they reuse the shipped install-first copy
+  (<code class="inline">FIRST_RUN_COPY</code>) verbatim.
+</p>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§7</span>Requirements coverage</h2>
+<p class="lead">Mapping this document's sections to the ProdOwner Requirements (UX-relevant ACs; others are engineering-only).</p>
+
+<table>
+  <thead>
+    <tr><th style="width:110px">Requirement</th><th>What it demands</th><th style="width:230px">Covered by</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="crit">Parity (core)</td>
+      <td>In-browser launch carries the same compact bootstrap prompt as the terminal-window deep link; claude wakes primed.</td>
+      <td>§1 happy-path frame (prompt as first turn); §2 flow map</td>
+    </tr>
+    <tr>
+      <td class="crit">R1 / AC4</td>
+      <td>URL-carried prompt never executes before the relay validates the owner-bound token; forged/expired/foreign ⇒ zero execution.</td>
+      <td>§2 amber gate (prompt held pre-auth); §3 (rejection lands on the shipped timeout fallback — no new UI, no attacker feedback)</td>
+    </tr>
+    <tr>
+      <td class="crit">R2 / AC6</td>
+      <td>URL ≤ ~2KB; overflow ⇒ deterministic truncation preserving the MCP head; never a dropped launch.</td>
+      <td>§4 (no in-dock signal — justified; scrollback marker is the whole signal); §2 build node annotation</td>
+    </tr>
+    <tr>
+      <td class="crit">R4 / AC8</td>
+      <td>Version skew graceful: new web + old helper ⇒ promptless (cold) launch, no breakage.</td>
+      <td>§5 (cold launch preserved; optional one-line update hint, feasibility-gated, dismissible)</td>
+    </tr>
+    <tr>
+      <td class="crit">Handoff scope</td>
+      <td>Happy path intentionally invisible — no new buttons, no new settings.</td>
+      <td>§1 (explicit statement + annotated frame); only new UI in the whole design = the §5 hint line</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ============================================================= -->
+<hr class="sec">
+<h2><span class="num">§8</span>Design-system, responsive &amp; scope notes</h2>
+<div class="anno">
+  <h5>Reuse &amp; consistency</h5>
+  <ul>
+    <li>All frames use the shipped dock chrome from <code class="inline">terminal-dock.tsx</code> — <code class="inline">#141417</code> header, <code class="inline">#0c0c0e</code> body, zinc-700 borders, emerald/amber/sky/rose status accents, the same pills and input bar.</li>
+    <li>The Edge C hint is structurally the existing bottom strip (amber “Lost the connection” bar) re-skinned to the sky accent — same slot, same padding, same inline-link pattern. No new component class.</li>
+    <li>Edge A reuses the install-first timeout fallback screen and copy with zero changes.</li>
+  </ul>
+</div>
+<div class="anno sky">
+  <h5>375px behaviour</h5>
+  <ul>
+    <li>The Edge C hint wraps to two lines at phone width; “Get the update” and “Dismiss” keep ≥44px padded targets and never truncate. Everything else in this design is existing, already-verified dock chrome.</li>
+  </ul>
+</div>
+<div class="anno amber">
+  <h5>Scope guard (no gold-plating)</h5>
+  <ul>
+    <li>No “task context attached ✓” badge, toast, or preview panel on the happy path — the prompt in the scrollback is the receipt.</li>
+    <li>No truncation warning (§4 justification) and no distinct security state (§3 justification).</li>
+    <li>The Edge C hint is the <b>only</b> new UI, and it is explicitly droppable if version detection proves unreliable — the feature ships whole without it.</li>
+  </ul>
+</div>
+
+<p class="footnote" style="margin-top:30px">
+  Compass · UX Design step · Feature Development workflow. Built on the ProdOwner Requirements step (R1/AC4, R2/AC6,
+  R4/AC8). Engineering notes: prompt joins the deep link at <code class="inline">buildLaunchDeepLink</code>; helper
+  must hold it until post-auth; Edge C detection = version TEXT control frame on bridge attach (absence ⇒ old helper),
+  dismiss flag in localStorage alongside the existing paired-before flag.
+</p>
+
+</div>
+</body>
+</html>

--- a/src/app/(main)/ideas/[id]/board/page.tsx
+++ b/src/app/(main)/ideas/[id]/board/page.tsx
@@ -362,7 +362,7 @@ export default async function BoardPage({ params, searchParams }: PageProps) {
       {/* In-app local Claude Code terminal — OFF by default (NEXT_PUBLIC_TERMINAL_ENABLED),
           team-members only. Renders nothing when the flag is off → board unchanged. */}
       {isTerminalEnabled() && isTeamMember && (
-        <TerminalDock ideaId={id} ideaTitle={idea.title} />
+        <TerminalDock ideaId={id} ideaTitle={idea.title} ideaGithubUrl={idea.github_url} />
       )}
     </div>
   );

--- a/src/components/board/launch-claude-code-button.tsx
+++ b/src/components/board/launch-claude-code-button.tsx
@@ -14,6 +14,7 @@ import {
 import { usePostHog } from "posthog-js/react";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import {
+  type CompactPromptParts,
   type LaunchMode,
   type LaunchPathState,
   type RecordedProjectPath,
@@ -21,19 +22,18 @@ import {
   buildLaunchCommand,
   buildBoardBootstrapPrompt,
   buildTaskBootstrapPrompt,
-  buildCompactBootstrapPrompt,
+  buildCompactBootstrapPromptParts,
   readLaunchPath,
+  resolveAppUrl,
+  resolveDefaultLaunchState,
   resolveEffectiveLaunchTarget,
-  slugifyIdeaTitle,
-  composeNewProjectPath,
-  DEFAULT_NEW_PROJECT_PARENT,
+  resolveLaunchCwd,
 } from "@/lib/launch-claude-code";
 import { LaunchPathDialog } from "./launch-path-dialog";
 import { isTerminalEnabled } from "@/lib/terminal/connection";
 import { isBrowserLaunchAvailable, requestBrowserLaunch } from "@/lib/terminal/launch-mode";
 
-const APP_URL =
-  process.env.NEXT_PUBLIC_APP_URL?.replace(/\/+$/, "") || "https://vibecodes.co.uk";
+const APP_URL = resolveAppUrl();
 const INSTALL_GUIDE_URL = "https://docs.claude.com/en/docs/claude-code";
 // Visibility-race window: if the page never blurs/hides within this, assume no handler.
 const SCHEME_RACE_MS = 1200;
@@ -101,26 +101,14 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
   // rapid double-clicks don't fire two window.location.assign + two fallback timers.
   const launchingRef = useRef(false);
 
-  // Read fresh on each interaction (localStorage may change in another tab/window).
-  const getSaved = useCallback(() => readLaunchPath(ideaId), [ideaId]);
-
-  const defaultSlug = useMemo(() => slugifyIdeaTitle(ideaTitle), [ideaTitle]);
-
-  // The launch state used when the user hasn't pinned one. No browser path needed:
-  //  - idea has a GitHub repo → existing mode, empty path; the deep link's `repo`
-  //    param makes Claude Code open (or clone) the repo locally.
-  //  - no repo → a brand-new project under ~/projects/<slug>; the agent mkdir's it.
-  const resolveState = useCallback((): LaunchPathState => {
-    const saved = getSaved();
-    if (saved) return saved;
-    if (ideaGithubUrl) return { mode: "existing", path: "" };
-    return {
-      mode: "new",
-      path: composeNewProjectPath(DEFAULT_NEW_PROJECT_PARENT, defaultSlug),
-      parent: DEFAULT_NEW_PROJECT_PARENT,
-      name: defaultSlug,
-    };
-  }, [getSaved, ideaGithubUrl, defaultSlug]);
+  // The launch state used when the user hasn't pinned one (reads localStorage
+  // fresh on each interaction — it may change in another tab/window). The SHARED
+  // resolver is also what the terminal dock uses for its dock-initiated launches,
+  // so the two paths can never resolve different states for the same idea.
+  const resolveState = useCallback(
+    (): LaunchPathState => resolveDefaultLaunchState(ideaId, ideaTitle, ideaGithubUrl),
+    [ideaId, ideaTitle, ideaGithubUrl]
+  );
 
   const buildPrompt = useCallback(
     (state: LaunchPathState): string => {
@@ -149,14 +137,17 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
     [props, ideaId, ideaTitle, ideaGithubUrl]
   );
 
-  // Compact variant for the DEEP LINK only — the claude-cli:// URL has an OS
-  // length ceiling and an over-long URL silently fails to launch. The verbose
-  // buildPrompt above stays on the copy-command path (a shell arg, no limit).
-  const buildDeepLinkPrompt = useCallback(
-    (state: LaunchPathState): string => {
+  // Compact variant for URL-limited launches — the claude-cli:// deep link and
+  // the in-browser terminal's vibecodes:// launch both have OS URL ceilings and
+  // an over-long URL silently fails to launch. Built as head/tail PARTS so the
+  // in-browser path can budget-truncate the tail (the dock alone knows its
+  // session/token overhead); the deep-link path joins them. ONE builder, so the
+  // two launch destinations carry a byte-identical prompt for the same state.
+  const buildCompactParts = useCallback(
+    (state: LaunchPathState): CompactPromptParts => {
       const newProject =
         state.mode === "new" ? { newProjectPath: state.path } : undefined;
-      return buildCompactBootstrapPrompt({
+      return buildCompactBootstrapPromptParts({
         appUrl: APP_URL,
         ideaId,
         ideaTitle,
@@ -167,6 +158,14 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
       });
     },
     [props, ideaId, ideaTitle, ideaGithubUrl]
+  );
+
+  const buildDeepLinkPrompt = useCallback(
+    (state: LaunchPathState): string => {
+      const { head, tail } = buildCompactParts(state);
+      return head + tail;
+    },
+    [buildCompactParts]
   );
 
   const posthog = usePostHog();
@@ -208,21 +207,14 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
       });
 
       const prompt = buildDeepLinkPrompt(state);
-      // cwd resolution:
-      //  - existing mode with a user-pinned absolute path → use it.
-      //  - new (no-repo) mode → use the effective target's cwd (the saved path or,
-      //    falling back, the agent-recorded path for THIS machine). This is the
-      //    SAME value the dropdown displays, so display and launch can't diverge.
-      //    Otherwise none, and the bootstrap prompt's directory block creates
-      //    ~/projects/<slug>. (`~`-paths don't expand in the cwd param.)
-      //  - repo-backed → no cwd; the `repo` slug resolves the working copy
-      //    (effectiveTarget.cwd is undefined for repo ideas).
-      const cwd =
-        state.mode === "existing" && state.path.trim()
-          ? state.path.trim()
-          : state.mode === "new"
-            ? effectiveTarget.cwd
-            : undefined;
+      // cwd resolution — the SHARED rule (resolveLaunchCwd): pinned existing path
+      // → that path; new (no-repo) mode → the effective target's cwd (the saved
+      // path or the agent-recorded path for THIS machine — the SAME value the
+      // dropdown displays, so display and launch can't diverge); repo-backed →
+      // none (the `repo` slug resolves the working copy; effectiveTarget.cwd is
+      // undefined for repo ideas). The in-browser launch payload uses the same
+      // rule, so both destinations open in the same folder.
+      const cwd = resolveLaunchCwd(state, effectiveTarget.cwd);
       const link = buildClaudeDeepLink({
         prompt,
         cwd,
@@ -307,8 +299,19 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
   const browserLaunchAvailable = isBrowserLaunchAvailable(isTerminalEnabled());
   const handleLaunchInBrowser = useCallback(() => {
     posthog?.capture("launch_claude_code_clicked", { method: "in_browser" });
-    requestBrowserLaunch();
-  }, [posthog]);
+    // Carry the SAME compact bootstrap prompt AND cwd the terminal-window deep
+    // link would use for this state (bootstrap-prompt + folder parity). Prompt is
+    // sent as head/tail parts so the dock can enforce its vibecodes:// URL budget
+    // without re-splitting; cwd rides the payload so a pinned/recorded existing
+    // folder is honoured in the browser too.
+    const state = resolveState();
+    const { head, tail } = buildCompactParts(state);
+    requestBrowserLaunch({
+      promptHead: head,
+      promptTail: tail,
+      cwd: resolveLaunchCwd(state, effectiveTarget.cwd),
+    });
+  }, [posthog, buildCompactParts, resolveState, effectiveTarget.cwd]);
 
   const openDialog = useCallback((mode: LaunchMode, launch: boolean) => {
     setPendingLaunch(launch);

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -67,8 +67,19 @@ import {
   type TerminalConnectionState,
   type TerminalStatus,
 } from "@/lib/terminal/connection";
-import { buildLaunchDeepLink, redactDeepLinkToken } from "@/lib/terminal/deep-link";
-import { subscribeBrowserLaunch } from "@/lib/terminal/launch-mode";
+import {
+  MAX_LAUNCH_URL_LENGTH,
+  buildLaunchDeepLink,
+  redactDeepLinkToken,
+} from "@/lib/terminal/deep-link";
+import { type BrowserLaunchPayload, subscribeBrowserLaunch } from "@/lib/terminal/launch-mode";
+import {
+  buildCompactBootstrapPromptParts,
+  enforcePromptLength,
+  resolveAppUrl,
+  resolveDefaultLaunchState,
+  resolveLaunchCwd,
+} from "@/lib/launch-claude-code";
 import {
   type TerminalPlatform,
   TERMINAL_HELPER_DOWNLOAD_URL,
@@ -97,6 +108,13 @@ const HELPER_OPEN_TIMEOUT_MS = 8000;
 interface TerminalDockProps {
   ideaId: string;
   ideaTitle: string;
+  /**
+   * The idea's GitHub URL (or null). Needed so dock-initiated launches — paired
+   * auto-connect and Retry, which never pass through the launch button — can
+   * build the SAME board-level compact bootstrap prompt the button would
+   * (shared resolveDefaultLaunchState + buildCompactBootstrapPromptParts).
+   */
+  ideaGithubUrl: string | null;
 }
 
 interface PairInfo {
@@ -154,7 +172,7 @@ function dotClass(status: TerminalStatus): string {
   }
 }
 
-export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
+export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockProps) {
   // Defence-in-depth: also gated at the page mount. When off, render nothing —
   // no dock, no entry point, board unchanged.
   const enabled = isTerminalEnabled();
@@ -190,6 +208,12 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
   // otherwise two sessions + two bridges race and the relay tears both down
   // (single-attach / peer-gone). This is the fix for the "connect fires twice" bug.
   const connectGenRef = useRef(0);
+  // The compact bootstrap prompt (head/tail parts) the LAST launch-bus event
+  // carried — i.e. what the launch button resolved. Dock-initiated launches with
+  // no bus payload (paired auto-connect on open, Retry) fall back to building the
+  // board-level prompt themselves via the same shared builder (see
+  // resolveLaunchPromptParts), so every launch is primed.
+  const promptPartsRef = useRef<BrowserLaunchPayload | null>(null);
 
   // Mirror live state into refs so the stable xterm onData handler + socket handlers
   // read current values without re-binding on every render.
@@ -319,9 +343,37 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
     if (frame && frame.parentNode) frame.parentNode.removeChild(frame);
   }, []);
 
+  // The compact bootstrap prompt + cwd for THIS launch: the payload the launch
+  // button put on the bus (its exact resolved state — task- or board-level) or,
+  // for dock-initiated launches (paired auto-connect / Retry), the board-level
+  // prompt built here from the SAME shared state resolver + builder the button
+  // uses — so the in-browser prompt is byte-identical to the terminal-window deep
+  // link's for the same state, and never duplicated. The fallback's cwd uses the
+  // same shared rule (resolveLaunchCwd); the dock has no recordedProjectPaths, so
+  // it passes no effective cwd — a pinned existing-mode folder still resolves
+  // (rule 1), while the recorded-path injection only flows through the button
+  // payload, exactly as the terminal-window default path would behave.
+  const resolveLaunchPromptParts = useCallback((): BrowserLaunchPayload => {
+    const carried = promptPartsRef.current;
+    if (carried) return carried;
+    const state = resolveDefaultLaunchState(ideaId, ideaTitle, ideaGithubUrl);
+    const { head, tail } = buildCompactBootstrapPromptParts({
+      appUrl: resolveAppUrl(),
+      ideaId,
+      ideaTitle,
+      mode: state.mode,
+      repoUrl: ideaGithubUrl,
+      newProject: state.mode === "new" ? { newProjectPath: state.path } : undefined,
+    });
+    return { promptHead: head, promptTail: tail, cwd: resolveLaunchCwd(state, undefined) };
+  }, [ideaId, ideaTitle, ideaGithubUrl]);
+
   // Fire the signed vibecodes:// deep link so a same-machine helper attaches as the
   // bridge leg with no copied command. The bridge token is a secret — it travels in
-  // the link but is NEVER logged (only the redacted form is).
+  // the link but is NEVER logged (only the redacted form is). The link also carries
+  // the compact bootstrap prompt as an INERT string: the helper/bridge hold it and
+  // only pass it to a spawned claude AFTER the relay accepts the owner-bound token
+  // (R1); an old helper simply ignores the unknown param (graceful cold launch).
   //
   // BEST-EFFORT dialog mitigation (criterion #8): we fire via a hidden, detached
   // iframe rather than a top-level window.location.assign. A top-level navigation to
@@ -334,8 +386,32 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
   const fireLaunchDeepLink = useCallback(
     (sessionId: string, bridgeToken: string) => {
       let link: string;
+      let promptChars = 0;
+      let hasCwd = false;
       try {
-        link = buildLaunchDeepLink({ relay: relayBaseUrl(), session: sessionId, token: bridgeToken });
+        const { promptHead, promptTail, cwd } = resolveLaunchPromptParts();
+        hasCwd = !!cwd;
+        // Budget the prompt against the vibecodes:// URL ceiling: everything the
+        // base link needs (relay/session/token, and the cwd when present) is
+        // spent first, the prompt gets the rest. enforcePromptLength trims only
+        // the work-step tail and always keeps the MCP-setup head (+ the
+        // …(truncated) marker on overflow).
+        const base = buildLaunchDeepLink({
+          relay: relayBaseUrl(),
+          session: sessionId,
+          token: bridgeToken,
+          cwd,
+        });
+        const budget = MAX_LAUNCH_URL_LENGTH - base.length - "&prompt=".length;
+        const prompt = enforcePromptLength(promptHead, promptTail, budget);
+        promptChars = prompt.length;
+        link = buildLaunchDeepLink({
+          relay: relayBaseUrl(),
+          session: sessionId,
+          token: bridgeToken,
+          cwd,
+          prompt,
+        });
       } catch (err) {
         logger.error("Terminal deep-link build failed", {
           error: err instanceof Error ? err.message : String(err),
@@ -343,7 +419,15 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
         setLaunchPhase("helper-timeout");
         return;
       }
-      logger.info("Terminal firing launch deep link", { sessionId, url: redactDeepLinkToken(link) });
+      // redactDeepLinkToken elides BOTH the token (secret) and the prompt (user
+      // content); the cwd (a local filesystem path) is stripped here too — only
+      // its PRESENCE and the prompt's length are logged.
+      logger.info("Terminal firing launch deep link", {
+        sessionId,
+        url: redactDeepLinkToken(link).replace(/([?&]cwd=)[^&]*/g, "$1***"),
+        promptChars,
+        hasCwd,
+      });
       setLaunchPhase("opening");
 
       removeLaunchIframe();
@@ -372,7 +456,7 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
         setLaunchPhase(nextLaunchPhaseOnTimeout);
       }, HELPER_OPEN_TIMEOUT_MS);
     },
-    [clearHelperTimer, removeLaunchIframe],
+    [clearHelperTimer, removeLaunchIframe, resolveLaunchPromptParts],
   );
 
   const teardownSocket = useCallback(() => {
@@ -470,8 +554,9 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
       dispatch({ type: "relay-open" });
     };
     ws.onmessage = (ev) => {
-      // BINARY = opaque PTY bytes → xterm. TEXT = control frame (none expected from
-      // the bridge today); ignore so it never reaches the screen as garbage.
+      // BINARY = opaque PTY bytes → xterm. TEXT = control frame — none expected on
+      // the BROWSER leg (the relay's R1 `attached` confirmation goes to the bridge
+      // leg only); ignore so a frame never reaches the screen as garbage.
       if (typeof ev.data === "string") return;
       // The helper attached and is streaming — the launch succeeded; drop the
       // "opening helper" nudge and clean up the probe iframe/timer.
@@ -538,11 +623,25 @@ export function TerminalDock({ ideaId, ideaTitle }: TerminalDockProps) {
 
   // The "In the browser" menu item (board toolbar) fires the launch bus; pick it up
   // here and run the install-first gate. Keeping the mint in ONE place (the dock)
-  // means the session — and its bridge token — is never created twice.
+  // means the session — and its bridge token — is never created twice. The payload
+  // (the button's resolved compact prompt, as head/tail parts) is remembered so
+  // this launch AND a later Retry carry the exact prompt the user launched with;
+  // a payload-less event falls back to the dock-built board-level prompt.
   useEffect(() => {
     if (!enabled) return;
-    return subscribeBrowserLaunch(() => beginBrowserLaunch());
+    return subscribeBrowserLaunch((payload) => {
+      promptPartsRef.current = payload ?? null;
+      beginBrowserLaunch();
+    });
   }, [enabled, beginBrowserLaunch]);
+
+  // The carried payload is scoped to ONE launch intent: it survives Retry (same
+  // intent, fresh session/token) but is dropped once the session ENDS (user End
+  // or a relay idle/max close), so a stale task prompt can never ride a later
+  // paired auto-connect — that launch rebuilds the board-level default instead.
+  useEffect(() => {
+    if (state.status === "session-ended") promptPartsRef.current = null;
+  }, [state.status]);
 
   // Auto-connect a paired browser whenever the body becomes visible while idle — so
   // a returning user who simply expands the dock also skips the setup wall

--- a/src/lib/launch-claude-code.test.ts
+++ b/src/lib/launch-claude-code.test.ts
@@ -19,12 +19,16 @@ const localStorageMock = (() => {
 Object.defineProperty(window, "localStorage", { value: localStorageMock, configurable: true });
 
 import {
+  type CompactBootstrapArgs,
   buildClaudeDeepLink,
   mcpEndpoint,
   enforcePromptLength,
   MAX_DEEP_LINK_PROMPT_LENGTH,
   MAX_DEEP_LINK_URL_LENGTH,
   buildCompactBootstrapPrompt,
+  buildCompactBootstrapPromptParts,
+  resolveDefaultLaunchState,
+  resolveLaunchCwd,
   parseRepoFromGithubUrl,
   validateFolderName,
   looksAbsolutePath,
@@ -879,5 +883,181 @@ describe("buildCompactBootstrapPrompt (deep-link prompt)", () => {
     expect(p).toContain("task_id task-9");
     expect(p).toContain("get_task");
     expect(p).not.toContain("get_board");
+  });
+});
+
+// ── In-browser terminal — bootstrap prompt parity (docs/terminal-bootstrap-prompt-ux.html) ──
+
+describe("buildCompactBootstrapPromptParts (in-browser terminal parity)", () => {
+  const APP_URL = "https://vibecodes.co.uk";
+  const IDEA_ID = "1beea99a-0377-421b-9a8b-a9956ae34b5d";
+  const TASK_ID = "7c1c1c1c-2222-3333-4444-555555555555";
+
+  // The four launch shapes the acceptance criteria name (AC1–AC3).
+  const FIXTURES: Record<string, CompactBootstrapArgs> = {
+    "task-selected": {
+      appUrl: APP_URL,
+      ideaId: IDEA_ID,
+      ideaTitle: "My First App",
+      mode: "new",
+      repoUrl: null,
+      newProject: { newProjectPath: "~/projects/my-first-app" },
+      taskId: TASK_ID,
+    },
+    "board-level": {
+      appUrl: APP_URL,
+      ideaId: IDEA_ID,
+      ideaTitle: "My First App",
+      mode: "existing",
+      repoUrl: null,
+    },
+    "repo-backed": {
+      appUrl: APP_URL,
+      ideaId: IDEA_ID,
+      ideaTitle: "Horse Racing Predictor",
+      mode: "existing",
+      repoUrl: "https://github.com/acme/horse-racing-predictor",
+    },
+    "new-project": {
+      appUrl: APP_URL,
+      ideaId: IDEA_ID,
+      ideaTitle: "Horse Racing Predictor",
+      mode: "new",
+      repoUrl: null,
+      newProject: { newProjectPath: "~/projects/horse-racing-predictor" },
+    },
+  };
+
+  it("head + tail is byte-identical to buildCompactBootstrapPrompt for every fixture (AC1 — one prompt source)", () => {
+    for (const [name, args] of Object.entries(FIXTURES)) {
+      const { head, tail } = buildCompactBootstrapPromptParts(args);
+      expect(head + tail, `fixture ${name}`).toBe(buildCompactBootstrapPrompt(args));
+    }
+  });
+
+  it("the load-bearing steps live in the head; only the work step is the trimmable tail", () => {
+    for (const [name, args] of Object.entries(FIXTURES)) {
+      const { head, tail } = buildCompactBootstrapPromptParts(args);
+      expect(head, `fixture ${name} head has MCP connect`).toContain("claude mcp add");
+      expect(head, `fixture ${name} head has record_project_path`).toContain("record_project_path");
+      expect(tail, `fixture ${name} tail never carries MCP setup`).not.toContain("claude mcp add");
+    }
+  });
+
+  it("task launch carries task_id + idea_id + MCP connect (AC2)", () => {
+    const { head, tail } = buildCompactBootstrapPromptParts(FIXTURES["task-selected"]);
+    expect(head).toContain(`claude mcp add -s local --transport http vibecodes ${APP_URL}/api/mcp`);
+    expect(tail).toContain(`task_id ${TASK_ID}`);
+    expect(tail).toContain(`idea_id ${IDEA_ID}`);
+    expect(tail).toContain("get_task");
+  });
+
+  it("board launch is the board-level compact prompt (AC3)", () => {
+    const { tail } = buildCompactBootstrapPromptParts(FIXTURES["board-level"]);
+    expect(tail).toContain("get_board");
+    expect(tail).toContain("NOT get_my_tasks");
+    expect(tail).not.toContain("task_id");
+  });
+
+  it("a roomy budget leaves the parts untouched — parity holds end to end (AC1)", () => {
+    for (const [name, args] of Object.entries(FIXTURES)) {
+      const { head, tail } = buildCompactBootstrapPromptParts(args);
+      expect(
+        enforcePromptLength(head, tail, MAX_DEEP_LINK_PROMPT_LENGTH),
+        `fixture ${name}`
+      ).toBe(buildCompactBootstrapPrompt(args));
+    }
+  });
+
+  it("a tight budget keeps the whole MCP head and marks the trimmed tail (AC6 overflow)", () => {
+    const { head, tail } = buildCompactBootstrapPromptParts(FIXTURES["task-selected"]);
+    const budget = encodeURIComponent(head).length + 50; // room for head + a sliver of tail
+    const fitted = enforcePromptLength(head, tail, budget);
+    expect(fitted.startsWith(head)).toBe(true);
+    expect(fitted).toContain("claude mcp add");
+    expect(fitted).toContain("…(truncated)");
+    expect(encodeURIComponent(fitted).length).toBeLessThanOrEqual(budget);
+  });
+});
+
+describe("enforcePromptLength with a custom cap (in-browser URL budget)", () => {
+  it("still defaults to MAX_DEEP_LINK_PROMPT_LENGTH", () => {
+    const head = "H".repeat(10);
+    const tail = "T".repeat(MAX_DEEP_LINK_PROMPT_LENGTH);
+    const p = enforcePromptLength(head, tail);
+    expect(encodeURIComponent(p).length).toBeLessThanOrEqual(MAX_DEEP_LINK_PROMPT_LENGTH);
+  });
+
+  it("caps the ENCODED length to the supplied budget and preserves the head", () => {
+    const head = "HEAD\n";
+    const tail = "x".repeat(500);
+    const p = enforcePromptLength(head, tail, 100);
+    expect(p.startsWith(head)).toBe(true);
+    expect(p).toContain("…(truncated)");
+    expect(encodeURIComponent(p).length).toBeLessThanOrEqual(100);
+  });
+
+  it("keeps the whole head even when the head alone exceeds the budget", () => {
+    const head = "H".repeat(200);
+    const p = enforcePromptLength(head, "tail", 100);
+    expect(p).toBe(head);
+  });
+});
+
+describe("resolveDefaultLaunchState (shared by launch button + terminal dock)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("prefers the user's saved localStorage config", () => {
+    writeLaunchPath("idea-1", { mode: "existing", path: "/Users/me/projects/x" });
+    expect(resolveDefaultLaunchState("idea-1", "My Idea", null)).toEqual({
+      mode: "existing",
+      path: "/Users/me/projects/x",
+      parent: undefined,
+      name: undefined,
+    });
+  });
+
+  it("repo-backed idea → existing mode with an empty path (repo slug resolves the folder)", () => {
+    expect(
+      resolveDefaultLaunchState("idea-1", "My Idea", "https://github.com/acme/widget")
+    ).toEqual({ mode: "existing", path: "" });
+  });
+
+  it("no repo → a new project under ~/projects/<slug>", () => {
+    expect(resolveDefaultLaunchState("idea-1", "My First App", null)).toEqual({
+      mode: "new",
+      path: `${DEFAULT_NEW_PROJECT_PARENT}/my-first-app`,
+      parent: DEFAULT_NEW_PROJECT_PARENT,
+      name: "my-first-app",
+    });
+  });
+});
+
+describe("resolveLaunchCwd (shared cwd rule: claude-cli:// + vibecodes:// launches)", () => {
+  it("existing mode with a pinned path → that path, trimmed", () => {
+    expect(
+      resolveLaunchCwd({ mode: "existing", path: "  /Users/me/projects/x  " }, undefined)
+    ).toBe("/Users/me/projects/x");
+    // A pinned path wins even when an effective cwd is supplied.
+    expect(
+      resolveLaunchCwd({ mode: "existing", path: "/Users/me/projects/x" }, "/elsewhere")
+    ).toBe("/Users/me/projects/x");
+  });
+
+  it("new mode → the caller's effective cwd (saved/recorded path), or none", () => {
+    const state = { mode: "new" as const, path: "~/projects/my-idea" };
+    expect(resolveLaunchCwd(state, "/Users/me/projects/my-idea")).toBe(
+      "/Users/me/projects/my-idea"
+    );
+    // No effective cwd (e.g. the dock's payload-less fallback, which has no
+    // recorded paths) → none; the prompt's directory step creates the folder.
+    expect(resolveLaunchCwd(state, undefined)).toBeUndefined();
+  });
+
+  it("repo-backed (existing mode, empty path) → no cwd", () => {
+    expect(resolveLaunchCwd({ mode: "existing", path: "" }, undefined)).toBeUndefined();
+    expect(resolveLaunchCwd({ mode: "existing", path: "   " }, "/ignored")).toBeUndefined();
   });
 });

--- a/src/lib/launch-claude-code.ts
+++ b/src/lib/launch-claude-code.ts
@@ -85,21 +85,29 @@ function encodedLength(s: string): number {
 }
 
 /**
- * Enforce the ≤ MAX_DEEP_LINK_PROMPT_LENGTH guard on the URL-ENCODED prompt
- * (acceptance criterion #6). The MCP-setup `head` is load-bearing (without it
- * the agent can't connect), so it is ALWAYS preserved verbatim — we trim only
- * the variable `tail` until `encodeURIComponent(head + tail).length <= cap`.
+ * Enforce a cap on the URL-ENCODED prompt (acceptance criterion #6). The
+ * MCP-setup `head` is load-bearing (without it the agent can't connect), so it
+ * is ALWAYS preserved verbatim — we trim only the variable `tail` until
+ * `encodeURIComponent(head + tail).length <= cap`.
  *
  * `head` must already contain whatever joins it to the tail (e.g. a trailing
  * newline); `tail` is appended as-is. If the head alone exceeds the cap we keep
  * the whole head (correctness of the bootstrap beats the cap; an extreme edge).
+ *
+ * `cap` defaults to the claude-cli:// deep-link budget; the in-browser terminal
+ * launch passes its own per-launch budget (the vibecodes:// URL ceiling minus
+ * the session/token overhead — see terminal-dock.tsx).
  */
-export function enforcePromptLength(head: string, tail: string): string {
+export function enforcePromptLength(
+  head: string,
+  tail: string,
+  cap: number = MAX_DEEP_LINK_PROMPT_LENGTH
+): string {
   const full = head + tail;
-  if (encodedLength(full) <= MAX_DEEP_LINK_PROMPT_LENGTH) return full;
+  if (encodedLength(full) <= cap) return full;
 
   // Never sacrifice the head, even if it alone overflows the cap.
-  if (encodedLength(head) >= MAX_DEEP_LINK_PROMPT_LENGTH) return head;
+  if (encodedLength(head) >= cap) return head;
 
   const ellipsis = "\n…(truncated)";
   // Largest tail length whose encoded (head + tail + ellipsis) fits. Binary
@@ -109,7 +117,7 @@ export function enforcePromptLength(head: string, tail: string): string {
   while (lo < hi) {
     const mid = Math.ceil((lo + hi) / 2);
     const candidate = head + tail.slice(0, mid) + ellipsis;
-    if (encodedLength(candidate) <= MAX_DEEP_LINK_PROMPT_LENGTH) {
+    if (encodedLength(candidate) <= cap) {
       lo = mid;
     } else {
       hi = mid - 1;
@@ -524,21 +532,35 @@ export interface CompactBootstrapArgs extends CommonPromptArgs {
 }
 
 /**
- * COMPACT bootstrap prompt — used ONLY for the deep link, whose URL must stay
- * under MAX_DEEP_LINK_URL_LENGTH (see that constant). It keeps every ESSENTIAL
- * step (project dir first, MCP connect, record_project_path, find/start work)
- * but terse, so the encoded claude-cli:// URL stays well under the OS ceiling.
- * The verbose buildBoard/TaskBootstrapPrompt is reserved for the copy-command,
- * which is a shell arg with no URL-length limit.
+ * The compact prompt split into the LOAD-BEARING head (header + project-dir +
+ * MCP-connect + record_project_path steps — must always survive truncation) and
+ * the trimmable tail (the final "work" step). `head + tail` is byte-identical to
+ * buildCompactBootstrapPrompt for the same args; enforcePromptLength consumes
+ * the two parts when a launch has a hard URL budget (the in-browser terminal's
+ * vibecodes:// deep link — see terminal-dock.tsx).
  */
-export function buildCompactBootstrapPrompt({
+export interface CompactPromptParts {
+  head: string;
+  tail: string;
+}
+
+/**
+ * COMPACT bootstrap prompt, as head/tail parts — the SINGLE source of the
+ * compact prompt's content. See buildCompactBootstrapPrompt for the semantics;
+ * this variant exists so URL-budgeted launch paths can truncate the tail with
+ * enforcePromptLength while the head (title header + dir + MCP connect +
+ * record_project_path steps) survives verbatim. The task/idea ids live in the
+ * TAIL's work step; on (rare) truncation the agent recovers them from the board
+ * over MCP — the head's connect step is what makes that possible.
+ */
+export function buildCompactBootstrapPromptParts({
   appUrl,
   ideaId,
   ideaTitle,
   repoUrl,
   newProject,
   taskId,
-}: CompactBootstrapArgs): string {
+}: CompactBootstrapArgs): CompactPromptParts {
   const title = ideaTitle.length > 80 ? `${ideaTitle.slice(0, 79)}…` : ideaTitle;
   const repo = parseRepoFromGithubUrl(repoUrl);
   const steps: string[] = [];
@@ -567,17 +589,32 @@ export function buildCompactBootstrapPrompt({
     `Once the board tools work, call record_project_path (idea_id ${ideaId}, your machine \`hostname\`, and \`pwd\`) so future launches reopen in this folder.`
   );
 
-  steps.push(
-    taskId
-      ? `Work this task: get_task (task_id ${taskId}, idea_id ${ideaId}), move it to In Progress, then start. Comment as you go.`
-      : `Find work: call get_board (idea_id ${ideaId}) — NOT get_my_tasks, which only returns tasks already assigned to you (a new board has none). Take the top task in To Do (then Backlog), get_task it, assign it to yourself, move it to In Progress, then start. Comment as you go.`
-  );
+  const work = taskId
+    ? `Work this task: get_task (task_id ${taskId}, idea_id ${ideaId}), move it to In Progress, then start. Comment as you go.`
+    : `Find work: call get_board (idea_id ${ideaId}) — NOT get_my_tasks, which only returns tasks already assigned to you (a new board has none). Take the top task in To Do (then Backlog), get_task it, assign it to yourself, move it to In Progress, then start. Comment as you go.`;
 
   const header = taskId
     ? `Set up VibeCodes and work a board task for "${title}".`
     : `Set up VibeCodes and pick up board work for "${title}".`;
   const numbered = steps.map((s, i) => `${i + 1}. ${s}`).join("\n");
-  return `${header}\n\n${numbered}`;
+  return {
+    head: `${header}\n\n${numbered}\n`,
+    tail: `${steps.length + 1}. ${work}`,
+  };
+}
+
+/**
+ * COMPACT bootstrap prompt — used ONLY for launch paths with a URL ceiling: the
+ * claude-cli:// deep link (MAX_DEEP_LINK_URL_LENGTH) and the in-browser
+ * terminal's vibecodes:// launch. It keeps every ESSENTIAL step (project dir
+ * first, MCP connect, record_project_path, find/start work) but terse, so the
+ * encoded URL stays well under the OS ceiling. The verbose
+ * buildBoard/TaskBootstrapPrompt is reserved for the copy-command, which is a
+ * shell arg with no URL-length limit.
+ */
+export function buildCompactBootstrapPrompt(args: CompactBootstrapArgs): string {
+  const { head, tail } = buildCompactBootstrapPromptParts(args);
+  return head + tail;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -657,4 +694,65 @@ export function writeLaunchPath(ideaId: string, state: LaunchPathState): void {
   } catch {
     // Storage full / disabled — caller surfaces failure via the launch flow.
   }
+}
+
+/**
+ * The public app URL every bootstrap prompt points the MCP connector at.
+ * NEXT_PUBLIC_APP_URL is inlined at build time; trailing-slash safe.
+ */
+export function resolveAppUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL?.replace(/\/+$/, "") || "https://vibecodes.co.uk";
+}
+
+/**
+ * The launch state used when the user hasn't pinned one — the ONE resolution
+ * shared by the launch button AND the terminal dock's dock-initiated launches
+ * (paired auto-connect / Retry), so both build the compact prompt from the same
+ * state and can never diverge (bootstrap-prompt parity, AC1/AC3):
+ *
+ *  - saved localStorage config for this idea → use it verbatim.
+ *  - idea has a GitHub repo → existing mode, empty path; the repo slug resolves
+ *    the working copy locally.
+ *  - no repo → a brand-new project under ~/projects/<slug>; the agent mkdir's it.
+ *
+ * SSR-safe (readLaunchPath returns null on the server).
+ */
+export function resolveDefaultLaunchState(
+  ideaId: string,
+  ideaTitle: string,
+  ideaGithubUrl: string | null
+): LaunchPathState {
+  const saved = readLaunchPath(ideaId);
+  if (saved) return saved;
+  if (ideaGithubUrl) return { mode: "existing", path: "" };
+  const name = slugifyIdeaTitle(ideaTitle);
+  return {
+    mode: "new",
+    path: composeNewProjectPath(DEFAULT_NEW_PROJECT_PARENT, name),
+    parent: DEFAULT_NEW_PROJECT_PARENT,
+    name,
+  };
+}
+
+/**
+ * The cwd a launch should carry for a given state — the ONE rule shared by the
+ * claude-cli:// deep link (launch button) and the in-browser vibecodes:// launch
+ * (bus payload + terminal dock), so both destinations open in the same folder:
+ *
+ *  - existing mode with a user-pinned absolute path → use it.
+ *  - new (no-repo) mode → the caller's effective cwd (the saved path or the
+ *    agent-recorded path for THIS machine — resolveEffectiveLaunchTarget.cwd).
+ *    Callers without the recorded paths (the dock's payload-less fallback) pass
+ *    undefined, and the bootstrap prompt's directory step creates
+ *    ~/projects/<slug> instead. (`~`-paths don't expand in the cwd param.)
+ *  - repo-backed (existing mode, empty path) → no cwd; the repo slug / prompt
+ *    directory step resolves the working copy.
+ */
+export function resolveLaunchCwd(
+  state: LaunchPathState,
+  effectiveCwd: string | undefined
+): string | undefined {
+  if (state.mode === "existing" && state.path.trim()) return state.path.trim();
+  if (state.mode === "new") return effectiveCwd;
+  return undefined;
 }

--- a/src/lib/terminal/deep-link.test.ts
+++ b/src/lib/terminal/deep-link.test.ts
@@ -4,11 +4,16 @@ import {
   redactDeepLinkToken,
   LAUNCH_SCHEME,
   LAUNCH_HOST,
+  MAX_LAUNCH_URL_LENGTH,
 } from "./deep-link";
 // The bridge/helper PARSES with the shared .mjs. Importing it here pins the two
 // implementations together: a link this (TS) module builds MUST parse back to the
 // same fields with the shared parser, or this test fails — catching any drift.
 import { parseLaunchDeepLink } from "../../../terminal/shared/deep-link.mjs";
+import {
+  buildCompactBootstrapPromptParts,
+  enforcePromptLength,
+} from "../launch-claude-code";
 
 const SAMPLE = {
   relay: "ws://127.0.0.1:8787",
@@ -63,5 +68,135 @@ describe("redactDeepLinkToken", () => {
     expect(redacted).not.toContain(encodeURIComponent(SAMPLE.token));
     // Non-secret params survive for debugging.
     expect(redacted).toContain(`session=${SAMPLE.session}`);
+  });
+});
+
+// ── bootstrap-prompt transport (docs/terminal-bootstrap-prompt-ux.html) ────────
+
+// A hostile prompt: shell metacharacters, quotes, expansion, newlines. It must
+// ride the URL as INERT data and round-trip verbatim (argv safety is proven on
+// the bridge side; this pins the transport layer).
+const HOSTILE_PROMPT =
+  "Set up $(rm -rf ~) `hostname` \"double\" 'single' ; & | > < \\ %20 + \n second line $HOME";
+
+describe("buildLaunchDeepLink with a prompt", () => {
+  it("appends prompt as the LAST param, url-encoded", () => {
+    const url = buildLaunchDeepLink({ ...SAMPLE, prompt: "hello world" });
+    expect(url.endsWith(`prompt=${encodeURIComponent("hello world")}`)).toBe(true);
+    expect(url).not.toContain("hello world"); // the space must be encoded
+  });
+
+  it("omits prompt entirely when absent — promptless links keep today's exact shape (AC8)", () => {
+    const url = buildLaunchDeepLink(SAMPLE);
+    expect(url).not.toContain("prompt=");
+    expect(parseLaunchDeepLink(url)).toEqual(SAMPLE);
+  });
+
+  it("round-trips the prompt through the shared parser the helper/bridge use (AC7 drift guard)", () => {
+    const withPrompt = { ...SAMPLE, prompt: "Set up VibeCodes and work a board task." };
+    expect(parseLaunchDeepLink(buildLaunchDeepLink(withPrompt))).toEqual(withPrompt);
+  });
+
+  it("round-trips a hostile-characters prompt verbatim (AC5 transport leg)", () => {
+    const withPrompt = { ...SAMPLE, prompt: HOSTILE_PROMPT };
+    const parsed = parseLaunchDeepLink(buildLaunchDeepLink(withPrompt));
+    expect(parsed?.prompt).toBe(HOSTILE_PROMPT);
+  });
+
+  it("redacts the prompt (user content) as well as the token (AC9)", () => {
+    const url = buildLaunchDeepLink({ ...SAMPLE, prompt: HOSTILE_PROMPT });
+    const redacted = redactDeepLinkToken(url);
+    expect(redacted).toContain("token=***");
+    expect(redacted).toContain("prompt=***");
+    expect(redacted).not.toContain(SAMPLE.token);
+    expect(redacted).not.toContain(encodeURIComponent(SAMPLE.token));
+    expect(redacted).not.toContain(encodeURIComponent(HOSTILE_PROMPT));
+    expect(redacted).toContain(`session=${SAMPLE.session}`);
+  });
+});
+
+describe("vibecodes:// URL budget (AC6)", () => {
+  // Realistic overhead: a production relay host, a UUID session, and a token the
+  // size the app actually mints (b64url payload {sub,sid,idea,role,iat,exp} ≈ 240
+  // chars + "." + 43-char HMAC signature).
+  const RELAY = "wss://terminal-relay.vibecodes.workers.dev";
+  const SESSION = "11111111-2222-3333-4444-555555555555";
+  const TOKEN = "p".repeat(240) + "." + "s".repeat(43);
+  const APP_URL = "https://vibecodes.co.uk";
+  const IDEA_ID = "1beea99a-0377-421b-9a8b-a9956ae34b5d";
+
+  /** The dock's exact budgeting recipe (terminal-dock.tsx → fireLaunchDeepLink). */
+  function buildBudgetedLink(head: string, tail: string): { url: string; prompt: string } {
+    const base = buildLaunchDeepLink({ relay: RELAY, session: SESSION, token: TOKEN });
+    const budget = MAX_LAUNCH_URL_LENGTH - base.length - "&prompt=".length;
+    const prompt = enforcePromptLength(head, tail, budget);
+    return { url: buildLaunchDeepLink({ relay: RELAY, session: SESSION, token: TOKEN, prompt }), prompt };
+  }
+
+  it("realistic fixtures fit untruncated — full parity — and the URL stays ≤ 2048", () => {
+    const fixtures = [
+      { name: "board-level", args: { appUrl: APP_URL, ideaId: IDEA_ID, ideaTitle: "My First App", mode: "existing" as const, repoUrl: null } },
+      { name: "task-selected", args: { appUrl: APP_URL, ideaId: IDEA_ID, ideaTitle: "My First App", mode: "new" as const, repoUrl: null, newProject: { newProjectPath: "~/projects/my-first-app" }, taskId: "7c1c1c1c-2222-3333-4444-555555555555" } },
+      { name: "repo-backed", args: { appUrl: APP_URL, ideaId: IDEA_ID, ideaTitle: "Horse Racing Predictor", mode: "existing" as const, repoUrl: "https://github.com/acme/horse-racing-predictor" } },
+      { name: "new-project", args: { appUrl: APP_URL, ideaId: IDEA_ID, ideaTitle: "Horse Racing Predictor", mode: "new" as const, repoUrl: null, newProject: { newProjectPath: "~/projects/horse-racing-predictor" } } },
+    ];
+    for (const { name, args } of fixtures) {
+      const { head, tail } = buildCompactBootstrapPromptParts(args);
+      const { url, prompt } = buildBudgetedLink(head, tail);
+      expect(url.length, `fixture ${name}`).toBeLessThanOrEqual(MAX_LAUNCH_URL_LENGTH);
+      expect(prompt, `fixture ${name} must not truncate`).toBe(head + tail);
+      expect(parseLaunchDeepLink(url)?.prompt, `fixture ${name} parses back`).toBe(head + tail);
+    }
+  });
+
+  it("overflow truncates deterministically: MCP head survives, marker appended, URL ≤ 2048", () => {
+    const { head, tail } = buildCompactBootstrapPromptParts({
+      appUrl: APP_URL,
+      ideaId: IDEA_ID,
+      // An absurd title inflates only the header line inside the head; pad the
+      // TAIL via the task work step by an absurd task id to force overflow.
+      ideaTitle: "An extremely long idea title that goes on and on and eventually forces the URL over its ceiling",
+      mode: "new",
+      repoUrl: null,
+      newProject: { newProjectPath: "~/projects/a-very-long-project-folder-name-here" },
+      taskId: "t".repeat(1200),
+    });
+    const { url, prompt } = buildBudgetedLink(head, tail);
+    expect(url.length).toBeLessThanOrEqual(MAX_LAUNCH_URL_LENGTH);
+    expect(prompt.startsWith(head)).toBe(true); // dir + MCP + record steps intact
+    expect(prompt).toContain("claude mcp add");
+    expect(prompt).toContain("…(truncated)");
+  });
+
+  it("a launch with a pinned cwd carries it, budgets around it, and it parses back (folder parity)", () => {
+    // A pinned existing-mode folder (the user-felt case: the button resolves it
+    // via resolveLaunchCwd and rides it on the bus payload → the dock puts it on
+    // the link). Existing-no-repo compact prompts omit the directory step on the
+    // assumption the cwd param carries — so the cwd MUST survive to the bridge.
+    const cwd = "/Users/nickball/projects/horse racing predictor";
+    const { head, tail } = buildCompactBootstrapPromptParts({
+      appUrl: APP_URL,
+      ideaId: IDEA_ID,
+      ideaTitle: "Horse Racing Predictor",
+      mode: "existing",
+      repoUrl: null,
+    });
+    // The dock's exact recipe, cwd included in the BASE so the budget accounts for it.
+    const base = buildLaunchDeepLink({ relay: RELAY, session: SESSION, token: TOKEN, cwd });
+    const budget = MAX_LAUNCH_URL_LENGTH - base.length - "&prompt=".length;
+    const prompt = enforcePromptLength(head, tail, budget);
+    const url = buildLaunchDeepLink({ relay: RELAY, session: SESSION, token: TOKEN, cwd, prompt });
+
+    expect(url.length).toBeLessThanOrEqual(MAX_LAUNCH_URL_LENGTH);
+    const parsed = parseLaunchDeepLink(url);
+    expect(parsed?.cwd).toBe(cwd);
+    expect(parsed?.prompt).toBe(head + tail); // realistic fixture: untruncated
+
+    // Log hygiene (the dock's log recipe): token+prompt elided by the shared
+    // redactor, the cwd (a local filesystem path) stripped on top.
+    const logged = redactDeepLinkToken(url).replace(/([?&]cwd=)[^&]*/g, "$1***");
+    expect(logged).toContain("cwd=***");
+    expect(logged).not.toContain(encodeURIComponent(cwd));
+    expect(logged).toContain(`session=${SESSION}`);
   });
 });

--- a/src/lib/terminal/deep-link.ts
+++ b/src/lib/terminal/deep-link.ts
@@ -17,6 +17,17 @@ export const LAUNCH_SCHEME = "vibecodes";
 /** The single action this scheme exposes today: `vibecodes://launch?…`. */
 export const LAUNCH_HOST = "launch";
 
+/**
+ * Hard ceiling on the FULL `vibecodes://launch` URL. Custom-scheme URLs past an
+ * OS limit can silently fail to launch (Windows ShellExecute ≈ 2083; macOS is
+ * higher but finite — same failure mode as MAX_DEEP_LINK_URL_LENGTH in
+ * launch-claude-code.ts). The dock budgets the optional `prompt` param against
+ * this: budget = ceiling − (base link) − "&prompt=", enforced with the shared
+ * enforcePromptLength (MCP head always survives; tail gets the …(truncated)
+ * marker).
+ */
+export const MAX_LAUNCH_URL_LENGTH = 2048;
+
 export interface LaunchDeepLinkParams {
   /** Relay base ws URL the helper should dial out to. */
   relay: string;
@@ -26,13 +37,23 @@ export interface LaunchDeepLinkParams {
   token: string;
   /** Optional working directory for the spawned `claude`. */
   cwd?: string;
+  /**
+   * Optional compact bootstrap prompt for the spawned `claude`. Rides the link
+   * as an INERT string: the bridge passes it to claude as ONE argv element and
+   * NEVER executes, shell-splits, or logs it — and only spawns at all after the
+   * relay has accepted the owner-bound token (R1). Elided from logs by
+   * redactDeepLinkToken (it can contain user task/idea content).
+   */
+  prompt?: string;
 }
 
 /**
- * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…]` deep link.
- * Throws when a required field is missing so a malformed link is never fired.
+ * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…][&prompt=…]`
+ * deep link. Throws when a required field is missing so a malformed link is
+ * never fired. `prompt` is always the LAST param so the base-link length (and
+ * therefore the prompt budget) is stable.
  */
-export function buildLaunchDeepLink({ relay, session, token, cwd }: LaunchDeepLinkParams): string {
+export function buildLaunchDeepLink({ relay, session, token, cwd, prompt }: LaunchDeepLinkParams): string {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
   }
@@ -42,13 +63,18 @@ export function buildLaunchDeepLink({ relay, session, token, cwd }: LaunchDeepLi
     `token=${encodeURIComponent(token)}`,
   ];
   if (cwd) parts.push(`cwd=${encodeURIComponent(cwd)}`);
+  if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
 }
 
 /**
- * Redact the `token` value from a launch link so it is safe to log. Replaces the
- * value with `***` while keeping the rest intact for debugging.
+ * Redact the secret/user-content params from a launch link so it is safe to
+ * log: the `token` (a credential) and the `prompt` (user task/idea content —
+ * log only its length via a separate field if needed) both become `***` while
+ * relay/session survive for debugging.
  */
 export function redactDeepLinkToken(url: string): string {
-  return url.replace(/([?&]token=)[^&]*/g, "$1***");
+  return url
+    .replace(/([?&]token=)[^&]*/g, "$1***")
+    .replace(/([?&]prompt=)[^&]*/g, "$1***");
 }

--- a/src/lib/terminal/launch-mode.test.ts
+++ b/src/lib/terminal/launch-mode.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { launchModeOptions, isBrowserLaunchAvailable } from "./launch-mode";
+import { describe, it, expect, vi } from "vitest";
+import {
+  type BrowserLaunchPayload,
+  launchModeOptions,
+  isBrowserLaunchAvailable,
+  requestBrowserLaunch,
+  subscribeBrowserLaunch,
+} from "./launch-mode";
 
 describe("launchModeOptions", () => {
   it("flag OFF → only the terminal-window mode (in-browser item not rendered)", () => {
@@ -14,5 +20,47 @@ describe("launchModeOptions", () => {
     // action is never moved or removed by enabling the flag.
     expect(opts[0]).toBe("terminal-window");
     expect(isBrowserLaunchAvailable(true)).toBe(true);
+  });
+});
+
+describe("launch bus payload (bootstrap-prompt transport)", () => {
+  it("delivers the compact-prompt parts AND the launch cwd from the button to the dock", () => {
+    const handler = vi.fn<(payload?: BrowserLaunchPayload) => void>();
+    const unsubscribe = subscribeBrowserLaunch(handler);
+    const payload: BrowserLaunchPayload = {
+      promptHead: "Set up VibeCodes…\n\n1. connect\n",
+      promptTail: "2. work the task",
+      cwd: "/Users/me/projects/my-idea",
+    };
+    requestBrowserLaunch(payload);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(payload);
+    unsubscribe();
+  });
+
+  it("cwd is optional — a payload without one arrives without one", () => {
+    const handler = vi.fn<(payload?: BrowserLaunchPayload) => void>();
+    const unsubscribe = subscribeBrowserLaunch(handler);
+    requestBrowserLaunch({ promptHead: "h", promptTail: "t" });
+    expect(handler).toHaveBeenCalledWith({ promptHead: "h", promptTail: "t" });
+    expect(handler.mock.calls[0][0]?.cwd).toBeUndefined();
+    unsubscribe();
+  });
+
+  it("a payload-less request still fires, with an undefined payload (dock builds its own prompt)", () => {
+    const handler = vi.fn<(payload?: BrowserLaunchPayload) => void>();
+    const unsubscribe = subscribeBrowserLaunch(handler);
+    requestBrowserLaunch();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(undefined);
+    unsubscribe();
+  });
+
+  it("unsubscribe stops delivery", () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeBrowserLaunch(handler);
+    unsubscribe();
+    requestBrowserLaunch({ promptHead: "h", promptTail: "t" });
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/terminal/launch-mode.ts
+++ b/src/lib/terminal/launch-mode.ts
@@ -36,16 +36,42 @@ export function isBrowserLaunchAvailable(terminalEnabled: boolean): boolean {
 
 const LAUNCH_EVENT = "vibecodes:terminal-browser-launch";
 
+/**
+ * The compact bootstrap prompt the launch button resolved for this launch,
+ * split head/tail (buildCompactBootstrapPromptParts) so the dock — which alone
+ * knows the final vibecodes:// URL's session/token overhead — can budget-truncate
+ * the tail with enforcePromptLength while the load-bearing head survives.
+ * Carrying the PARTS (not a joined string) keeps that truncation on the one
+ * shared implementation instead of re-splitting a built prompt.
+ */
+export interface BrowserLaunchPayload {
+  promptHead: string;
+  promptTail: string;
+  /**
+   * The working directory the launch should open in — resolved by the button
+   * with the SAME rule the claude-cli:// path uses (resolveLaunchCwd over the
+   * pinned/effective path), so a pinned or recorded existing-mode folder is
+   * honoured in the browser too. Omitted when the state carries no cwd
+   * (repo-backed, or a brand-new ~/projects/<slug> the agent creates).
+   */
+  cwd?: string;
+}
+
 /** Ask the board's terminal dock to open + auto-launch in the browser. */
-export function requestBrowserLaunch(): void {
+export function requestBrowserLaunch(payload?: BrowserLaunchPayload): void {
   if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent(LAUNCH_EVENT));
+  window.dispatchEvent(
+    new CustomEvent<BrowserLaunchPayload | undefined>(LAUNCH_EVENT, { detail: payload })
+  );
 }
 
 /** Subscribe to in-browser launch requests; returns an unsubscribe fn. SSR-safe. */
-export function subscribeBrowserLaunch(handler: () => void): () => void {
+export function subscribeBrowserLaunch(
+  handler: (payload?: BrowserLaunchPayload) => void
+): () => void {
   if (typeof window === "undefined") return () => {};
-  const listener = () => handler();
+  const listener = (e: Event) =>
+    handler((e as CustomEvent<BrowserLaunchPayload | undefined>).detail ?? undefined);
   window.addEventListener(LAUNCH_EVENT, listener);
   return () => window.removeEventListener(LAUNCH_EVENT, listener);
 }

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -40,6 +40,7 @@ import { createRequire } from "node:module";
 import WebSocket from "ws";
 import { parseControlMessage } from "./framing.js";
 import { parseLaunchDeepLink, redactDeepLinkToken } from "../../shared/deep-link.mjs";
+import { isAttachedFrame } from "../../shared/control-frames.mjs";
 
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -102,10 +103,26 @@ const SESSION = launched?.session || args.session || process.env.SESSION_ID || `
 const TOKEN = launched?.token || args.token || process.env.BRIDGE_TOKEN || "";
 const CMD = args.cmd || process.env.BRIDGE_CMD || "claude";
 const CWD = launched?.cwd || args.cwd || process.env.BRIDGE_CWD || process.cwd();
+// The URL-carried bootstrap prompt (deep-link launches only). INERT DATA with two
+// hard rules (see docs/terminal-bootstrap-prompt-ux.html + the shared deep-link
+// module):
+//   1. ARGV SAFETY — it becomes exactly ONE argv element appended after the
+//      shell-split CMD (`claude "<prompt>"`), NEVER concatenated into CMD or
+//      passed through shellSplit, so hostile characters arrive verbatim as data.
+//   2. NO PRE-AUTH EXECUTION (R1) — a prompt-carrying launch defers pty.spawn
+//      until the relay confirms the owner-bound token with the `attached`
+//      control frame (accept-then-close rejections make ws.onopen meaningless
+//      as an auth signal). No frame in time → exit WITHOUT spawning anything.
+const PROMPT = launched?.prompt || "";
 const MAX_SECONDS = Number(args["max-seconds"] || process.env.BRIDGE_MAX_SECONDS || 28800);
 const CONNECT_TIMEOUT_MS = Number(args["connect-timeout-ms"] || 30000);
+// How long after the socket opens we wait for the relay's `attached` frame before
+// giving up (prompt launches only). An OLD relay never sends it → clean exit, no
+// spawn — the dock's existing ~8s fallback covers the UX.
+const ATTACH_CONFIRM_TIMEOUT_MS = Number(args["attach-confirm-timeout-ms"] || 10000);
 
 const [file, ...cmdArgs] = shellSplit(CMD);
+const spawnArgs = PROMPT ? [...cmdArgs, PROMPT] : cmdArgs;
 
 // ── the known macOS spawn-helper fix ──────────────────────────────────────────
 // node-pty ships a `spawn-helper` binary under prebuilds/<platform>-<arch>/.
@@ -182,20 +199,98 @@ async function main() {
 
   const pty = require("node-pty");
 
-  log("info", "spawning PTY", { file, args: cmdArgs, cwd: CWD });
-  let term;
-  try {
-    term = pty.spawn(file, cmdArgs, {
-      name: "xterm-color",
-      cols: 80,
-      rows: 24,
-      cwd: CWD,
-      env: resolveSpawnEnv(),
-    });
-  } catch (e) {
-    log("error", "PTY spawn failed", { err: String(e?.message || e) });
-    process.exit(1);
+  let term = null; // spawned lazily for prompt-carrying launches (R1 gate below)
+  let pendingResize = null; // a resize that arrived while the spawn was deferred
+  let ws = null;
+  let bytesOut = 0; // PTY -> ws
+  let bytesIn = 0; // ws -> PTY
+  let open = false;
+  let shuttingDown = false;
+  let connectTimer = null;
+  let maxTimer = null;
+  let attachTimer = null;
+
+  // PTY output produced before the relay socket is open (e.g. the program's
+  // startup banner), flushed on open so the first bytes never lose the race.
+  /** @type {Buffer[]} */
+  const preOpenBuffer = [];
+
+  function shutdown(code, why) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    clearTimeout(connectTimer);
+    clearTimeout(maxTimer);
+    clearTimeout(attachTimer);
+    log("info", "shutting down", { why, bytesOut, bytesIn });
+    try { ws?.close(1000, why); } catch { /* ignore */ }
+    try { term?.kill(); } catch { /* ignore */ }
+    // Record the code first: with NO PTY (a blocked prompt launch) the event
+    // loop can drain before the unref'd hard-exit timer fires, and the process
+    // then exits naturally — exitCode makes that natural exit carry the right
+    // status. The timer stays as the hard stop for the PTY-alive case.
+    process.exitCode = code;
+    // give sockets a tick to flush their close frame, then exit hard
+    setTimeout(() => process.exit(code), 200).unref();
   }
+
+  /**
+   * Spawn the PTY and wire its handlers. Called immediately for promptless
+   * launches (today's behaviour, unchanged) and ONLY after the relay's
+   * `attached` confirmation for prompt-carrying launches (R1 — see below).
+   * The prompt is one argv element in `spawnArgs`; it is deliberately NOT
+   * logged (only its length is).
+   */
+  function spawnPty() {
+    if (term || shuttingDown) return;
+    log("info", "spawning PTY", { file, args: cmdArgs, cwd: CWD, promptChars: PROMPT.length });
+    let spawned;
+    try {
+      spawned = pty.spawn(file, spawnArgs, {
+        name: "xterm-color",
+        cols: 80,
+        rows: 24,
+        cwd: CWD,
+        env: resolveSpawnEnv(),
+      });
+    } catch (e) {
+      log("error", "PTY spawn failed", { err: String(e?.message || e) });
+      if (open) shutdown(1, "spawn-failed");
+      else process.exit(1);
+      return;
+    }
+    term = spawned;
+
+    // PTY -> relay (binary, verbatim).
+    term.onData((data) => {
+      const buf = Buffer.from(data, "utf8");
+      bytesOut += buf.length;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(buf, { binary: true });
+      } else if (!shuttingDown) {
+        preOpenBuffer.push(buf);
+      }
+    });
+
+    term.onExit(({ exitCode, signal }) => {
+      log("info", "PTY exited", { exitCode, signal });
+      shutdown(0, "pty-exit");
+    });
+
+    // Apply the browser's size if it resized while the spawn was deferred.
+    if (pendingResize) {
+      try { term.resize(pendingResize.cols, pendingResize.rows); } catch { /* best effort */ }
+      pendingResize = null;
+    }
+  }
+
+  // R1 SEQUENCING. Promptless launches spawn FIRST, exactly as before — nothing
+  // in their flow changes. A URL-carried prompt is different: it must NEVER
+  // reach a child process unless the relay has accepted the owner-bound token,
+  // and the relay REJECTS bad legs by accept()ing then immediately closing
+  // (4005/4006/…) — so `open` alone proves nothing. The spawn is therefore
+  // gated on the relay's explicit `attached` control frame, sent only after
+  // authorizeAttach + decideAttach pass. No frame → exit, zero spawn.
+  if (!PROMPT) spawnPty();
 
   // The relay requires an app-minted `bridge`-role token (slice 2). It binds this
   // leg to its owning user; the matching `browser` token must carry the same owner.
@@ -208,77 +303,56 @@ async function main() {
     `&role=bridge&token=${encodeURIComponent(TOKEN)}`;
   // Log the URL WITHOUT the token (never log secrets).
   log("info", "connecting to relay", { url: url.replace(/token=[^&]*/, "token=***"), host: os.hostname() });
-  const ws = new WebSocket(url);
-
-  let bytesOut = 0; // PTY -> ws
-  let bytesIn = 0; // ws -> PTY
-  let open = false;
-  let shuttingDown = false;
+  ws = new WebSocket(url);
 
   // Hard timeouts so nothing hangs.
-  const connectTimer = setTimeout(() => {
+  connectTimer = setTimeout(() => {
     if (!open) {
       log("error", "connect timeout — relay never opened", { ms: CONNECT_TIMEOUT_MS });
       shutdown(1, "connect-timeout");
     }
   }, CONNECT_TIMEOUT_MS);
 
-  const maxTimer = setTimeout(() => {
+  maxTimer = setTimeout(() => {
     log("warn", "max-duration cap reached — ending session", { seconds: MAX_SECONDS });
     shutdown(0, "max-duration");
   }, MAX_SECONDS * 1000);
 
-  function shutdown(code, why) {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    clearTimeout(connectTimer);
-    clearTimeout(maxTimer);
-    log("info", "shutting down", { why, bytesOut, bytesIn });
-    try { ws.close(1000, why); } catch { /* ignore */ }
-    try { term.kill(); } catch { /* ignore */ }
-    // give sockets a tick to flush their close frame, then exit hard
-    setTimeout(() => process.exit(code), 200).unref();
-  }
-
-  // PTY -> relay (binary, verbatim). Buffer output produced before the relay
-  // WebSocket is open (e.g. the program's startup banner) and flush on open, so
-  // the first bytes are never lost to a connect race.
-  /** @type {Buffer[]} */
-  const preOpenBuffer = [];
-  term.onData((data) => {
-    const buf = Buffer.from(data, "utf8");
-    bytesOut += buf.length;
-    if (ws.readyState === WebSocket.OPEN) {
-      ws.send(buf, { binary: true });
-    } else if (!shuttingDown) {
-      preOpenBuffer.push(buf);
-    }
-  });
-
-  term.onExit(({ exitCode, signal }) => {
-    log("info", "PTY exited", { exitCode, signal });
-    shutdown(0, "pty-exit");
-  });
-
   // relay -> PTY
   ws.on("message", (data, isBinary) => {
     if (isBinary) {
-      // opaque keystroke bytes -> PTY stdin
+      // opaque keystroke bytes -> PTY stdin. While a prompt spawn is still
+      // gated there is no PTY; pre-auth keystrokes are dropped, never buffered.
       bytesIn += data.length;
-      term.write(data.toString("utf8"));
-    } else {
-      // TEXT control frame (resize). Never written to the PTY as input.
-      const ctrl = parseControlMessage(data.toString("utf8"));
-      if (ctrl?.type === "resize") {
-        try {
-          term.resize(ctrl.cols, ctrl.rows);
-          log("debug", "resized PTY", { cols: ctrl.cols, rows: ctrl.rows });
-        } catch (e) {
-          log("warn", "resize failed", { err: String(e?.message || e) });
-        }
-      } else {
-        log("warn", "ignored unknown control frame");
+      if (term) term.write(data.toString("utf8"));
+      return;
+    }
+    const text = data.toString("utf8");
+    // R1: the relay's post-auth confirmation — the ONLY signal that releases a
+    // prompt-carrying spawn. For promptless launches (already spawned) or an
+    // already-spawned PTY it is a harmless no-op.
+    if (isAttachedFrame(text)) {
+      clearTimeout(attachTimer);
+      attachTimer = null;
+      log("info", "relay confirmed attach", { session: SESSION });
+      if (PROMPT) spawnPty();
+      return;
+    }
+    // TEXT control frame (resize). Never written to the PTY as input.
+    const ctrl = parseControlMessage(text);
+    if (ctrl?.type === "resize") {
+      if (!term) {
+        pendingResize = ctrl; // applied right after the gated spawn
+        return;
       }
+      try {
+        term.resize(ctrl.cols, ctrl.rows);
+        log("debug", "resized PTY", { cols: ctrl.cols, rows: ctrl.rows });
+      } catch (e) {
+        log("warn", "resize failed", { err: String(e?.message || e) });
+      }
+    } else {
+      log("warn", "ignored unknown control frame");
     }
   });
 
@@ -286,6 +360,17 @@ async function main() {
     open = true;
     clearTimeout(connectTimer);
     log("info", "relay connected (bridge leg)", { session: SESSION });
+    // Prompt launches: arm the attach-confirmation window. An OLD relay never
+    // sends the frame → clean exit with NOTHING spawned (graceful skew; the
+    // dock's existing ~8s fallback covers the UX).
+    if (PROMPT && !term && !attachTimer) {
+      attachTimer = setTimeout(() => {
+        log("error", "no attach confirmation from relay — exiting without spawning", {
+          ms: ATTACH_CONFIRM_TIMEOUT_MS,
+        });
+        shutdown(1, "attach-confirm-timeout");
+      }, ATTACH_CONFIRM_TIMEOUT_MS);
+    }
     // Flush any PTY output produced before the socket opened.
     while (preOpenBuffer.length > 0) {
       ws.send(preOpenBuffer.shift(), { binary: true });
@@ -295,7 +380,9 @@ async function main() {
   ws.on("close", (code, reasonBuf) => {
     const reason = reasonBuf?.toString?.() || "";
     log("info", "relay closed", { code, reason });
-    shutdown(open ? 0 : 1, "ws-close");
+    // A prompt launch whose spawn never got released (auth rejected / old relay)
+    // is a failure even though the socket technically opened.
+    shutdown(open && !(PROMPT && !term) ? 0 : 1, "ws-close");
   });
 
   ws.on("error", (e) => {

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -41,6 +41,7 @@ import {
   resolveMs,
 } from "./pairing.js";
 import { authorizeAttach } from "../../shared/session-token.mjs";
+import { encodeAttachedFrame } from "../../shared/control-frames.mjs";
 
 /** Normal WebSocket closure code used for clean, server-initiated session ends. */
 const NORMAL_CLOSURE = 1000;
@@ -180,6 +181,21 @@ export class TerminalRelay {
     }
     await this.state.storage.put("lastActivityAt", now);
     await this.armAlarm(now);
+
+    // 5) R1 attach confirmation — BRIDGE leg only. A rejected leg is also
+    //    accept()ed then closed (see steps 1–2), so the bridge cannot treat its
+    //    own `onopen` as proof of auth; this frame, sent strictly AFTER
+    //    authorizeAttach + decideAttach passed, is the signal a prompt-carrying
+    //    bridge waits on before spawning the PTY. The browser dock ignores TEXT
+    //    frames, and old bridges log-and-ignore unknown control frames, so this
+    //    is version-skew safe.
+    if (role === "bridge") {
+      try {
+        server.send(encodeAttachedFrame());
+      } catch (e) {
+        this.log("attached-frame send failed", { session, err: String(e) });
+      }
+    }
 
     this.log("attached", { session, role, ...(await this.computeAttachState()) });
     return new Response(null, { status: 101, webSocket: client });

--- a/terminal/shared/control-frames.mjs
+++ b/terminal/shared/control-frames.mjs
@@ -1,0 +1,45 @@
+// Shared relay→bridge control frame — the R1 "attached" confirmation.
+//
+// The relay REJECTS a bad leg by `accept()`ing the WebSocket and immediately
+// closing it with an app close code (4005/4006/…), so a client-side `onopen`
+// alone does NOT prove the token was accepted. A prompt-carrying bridge must
+// therefore defer its PTY spawn until the relay explicitly confirms the attach
+// (acceptance criterion: the URL-carried prompt never reaches a child process
+// before the owner-bound token passes authorizeAttach + decideAttach).
+//
+// This module is that confirmation's ONE definition, imported by:
+//   - the Cloudflare relay DO   (relay/src/index.js)     — SENDS it to the
+//     bridge leg only, immediately after a successful accept
+//   - the Node stand-in relay   (test/standin-relay.mjs) — same
+//   - the bridge                (bridge/src/index.js)    — WAITS on it before
+//     spawning a prompt-carrying PTY (promptless launches spawn immediately,
+//     exactly as before — version-skew safe with an old relay)
+//
+// Wire form: a TEXT frame `{"t":"attached"}`. TEXT frames are already the
+// control channel (see bridge/src/framing.js); the browser dock ignores TEXT
+// frames entirely, and an OLD bridge treats an unknown control frame as a
+// logged no-op — so sending this unconditionally is skew-safe in both
+// directions. The key `t` (not `type`) keeps it disjoint from the browser→
+// bridge control namespace (`{"type":"resize",…}`).
+
+/** The exact TEXT frame the relay sends the bridge leg on successful attach. */
+export function encodeAttachedFrame() {
+  return JSON.stringify({ t: "attached" });
+}
+
+/**
+ * Whether a received TEXT frame is the relay's attach confirmation.
+ * Cheap + strict: bounded length, valid JSON, `t === "attached"`.
+ *
+ * @param {unknown} text
+ * @returns {boolean}
+ */
+export function isAttachedFrame(text) {
+  if (typeof text !== "string" || text.length === 0 || text.length > 64) return false;
+  try {
+    const msg = JSON.parse(text);
+    return !!msg && typeof msg === "object" && msg.t === "attached";
+  } catch {
+    return false;
+  }
+}

--- a/terminal/shared/deep-link.mjs
+++ b/terminal/shared/deep-link.mjs
@@ -16,8 +16,13 @@
 //   token   — the app-minted, HMAC-signed BRIDGE-role token (this IS the launch's
 //             credential; the relay verifies it, so no extra signature is needed)
 //   cwd     — optional working directory
+//   prompt  — optional compact bootstrap prompt for the spawned `claude`. INERT
+//             DATA: the bridge passes it as ONE argv element (never through
+//             shellSplit / a shell) and only spawns AFTER the relay has accepted
+//             the owner-bound token (R1 — see bridge/src/index.js).
 //
-// The `token` is a secret. NEVER log a raw link — use redactDeepLinkToken first.
+// The `token` is a secret and the `prompt` is user content. NEVER log a raw
+// link — use redactDeepLinkToken first (it elides both).
 //
 // Pure + dependency-free (only the global WHATWG `URL`), so it runs unchanged in
 // Node (bridge) and is trivially unit-testable.
@@ -28,16 +33,19 @@ export const LAUNCH_SCHEME = "vibecodes";
 export const LAUNCH_HOST = "launch";
 
 /**
- * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…]` deep link.
+ * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…][&prompt=…]`
+ * deep link.
  *
- * Uses encodeURIComponent so reserved characters in the relay URL / token survive
- * the round-trip. `cwd` is omitted entirely when absent (no empty param). Throws
- * when a required field is missing so a malformed link is never fired.
+ * Uses encodeURIComponent so reserved characters in the relay URL / token /
+ * prompt survive the round-trip. `cwd` / `prompt` are omitted entirely when
+ * absent (no empty params); `prompt` is always LAST so the base-link length
+ * (and therefore the app-side prompt budget) is stable. Throws when a required
+ * field is missing so a malformed link is never fired.
  *
- * @param {{ relay: string, session: string, token: string, cwd?: string }} params
+ * @param {{ relay: string, session: string, token: string, cwd?: string, prompt?: string }} params
  * @returns {string}
  */
-export function buildLaunchDeepLink({ relay, session, token, cwd } = {}) {
+export function buildLaunchDeepLink({ relay, session, token, cwd, prompt } = {}) {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
   }
@@ -47,17 +55,21 @@ export function buildLaunchDeepLink({ relay, session, token, cwd } = {}) {
     `token=${encodeURIComponent(token)}`,
   ];
   if (cwd) parts.push(`cwd=${encodeURIComponent(cwd)}`);
+  if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
 }
 
 /**
- * Parse a `vibecodes://launch?…` deep link into `{ relay, session, token, cwd }`,
- * or null when it is not a well-formed launch link (wrong scheme/action, or any
- * required field missing). This is exactly the logic a packaged helper's
- * URL-scheme handler will run before connecting as the bridge leg.
+ * Parse a `vibecodes://launch?…` deep link into `{ relay, session, token, cwd?,
+ * prompt? }`, or null when it is not a well-formed launch link (wrong
+ * scheme/action, or any required field missing). This is exactly the logic a
+ * packaged helper's URL-scheme handler will run before connecting as the bridge
+ * leg. `cwd` / `prompt` keys are only present when the link carried them, so a
+ * promptless link parses to exactly the same object shape as before the prompt
+ * param existed (version-skew safe both ways).
  *
  * @param {unknown} url
- * @returns {{ relay: string, session: string, token: string, cwd?: string } | null}
+ * @returns {{ relay: string, session: string, token: string, cwd?: string, prompt?: string } | null}
  */
 export function parseLaunchDeepLink(url) {
   if (typeof url !== "string" || url.length === 0) return null;
@@ -77,18 +89,26 @@ export function parseLaunchDeepLink(url) {
   const session = parsed.searchParams.get("session");
   const token = parsed.searchParams.get("token");
   const cwd = parsed.searchParams.get("cwd") || undefined;
+  const prompt = parsed.searchParams.get("prompt") || undefined;
   if (!relay || !session || !token) return null;
 
-  return cwd ? { relay, session, token, cwd } : { relay, session, token };
+  const out = { relay, session, token };
+  if (cwd) out.cwd = cwd;
+  if (prompt) out.prompt = prompt;
+  return out;
 }
 
 /**
- * Redact the `token` value from a launch link so it is safe to log. Replaces the
- * value with `***` while keeping the rest intact for debugging.
+ * Redact the secret/user-content params from a launch link so it is safe to
+ * log: the `token` (a credential) and the `prompt` (user task/idea content)
+ * both become `***` while relay/session survive for debugging. Callers that
+ * want to debug prompt delivery log the prompt LENGTH as a separate field.
  *
  * @param {unknown} url
  * @returns {string}
  */
 export function redactDeepLinkToken(url) {
-  return String(url).replace(/([?&]token=)[^&]*/g, "$1***");
+  return String(url)
+    .replace(/([?&]token=)[^&]*/g, "$1***")
+    .replace(/([?&]prompt=)[^&]*/g, "$1***");
 }

--- a/terminal/test/argv-cmd.mjs
+++ b/terminal/test/argv-cmd.mjs
@@ -1,0 +1,9 @@
+// A cheap, NON-interactive command for the bridge to run in its PTY during the
+// PROMPT tests (stand-in for `claude "<prompt>"`). It prints its argv (exactly
+// what the PTY spawn handed it) between fixed markers as JSON — so a test can
+// prove the URL-carried prompt arrived as ONE argv element, verbatim, with no
+// shell splitting — then echoes stdin like sentinel-cmd.mjs.
+process.stdout.write(`ARGV_BEGIN${JSON.stringify(process.argv.slice(2))}ARGV_END\n`);
+process.stdout.write("READY\n");
+process.stdin.on("data", (d) => process.stdout.write(d));
+process.stdin.resume();

--- a/terminal/test/control-frames.test.mjs
+++ b/terminal/test/control-frames.test.mjs
@@ -1,0 +1,33 @@
+// Unit tests for the shared relay→bridge `attached` control frame (R1).
+//
+// The frame is the ONLY signal that releases a prompt-carrying PTY spawn, so its
+// encode/detect pair must be strict, symmetric, and disjoint from the existing
+// browser→bridge control namespace ({"type":"resize",…}).
+//
+// Run: cd terminal/test && node --test
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { encodeAttachedFrame, isAttachedFrame } from "../shared/control-frames.mjs";
+import { parseControlMessage } from "../bridge/src/framing.js";
+
+test("encode ⇄ detect round-trips", () => {
+  assert.equal(isAttachedFrame(encodeAttachedFrame()), true);
+});
+
+test("rejects non-attached / malformed / hostile inputs", () => {
+  assert.equal(isAttachedFrame(""), false);
+  assert.equal(isAttachedFrame(null), false);
+  assert.equal(isAttachedFrame(undefined), false);
+  assert.equal(isAttachedFrame("attached"), false);
+  assert.equal(isAttachedFrame('{"type":"resize","cols":80,"rows":24}'), false);
+  assert.equal(isAttachedFrame('{"t":"detached"}'), false);
+  assert.equal(isAttachedFrame('{"t":"attached"' /* truncated */), false);
+  // Oversized frames are rejected outright (bounded parse).
+  assert.equal(isAttachedFrame(`{"t":"attached","pad":"${"x".repeat(200)}"}`), false);
+});
+
+test("stays disjoint from the resize control namespace (an attached frame is NOT a resize)", () => {
+  assert.equal(parseControlMessage(encodeAttachedFrame()), null);
+  assert.equal(isAttachedFrame(JSON.stringify({ type: "resize", cols: 80, rows: 24 })), false);
+});

--- a/terminal/test/deep-link.test.mjs
+++ b/terminal/test/deep-link.test.mjs
@@ -59,3 +59,35 @@ test("redactDeepLinkToken hides the token but keeps the rest", () => {
   assert.ok(!redacted.includes(encodeURIComponent(SAMPLE.token)), "encoded token must not appear");
   assert.ok(redacted.includes(`session=${SAMPLE.session}`), "non-secret params survive");
 });
+
+// ── bootstrap prompt param (in-browser terminal parity) ───────────────────────
+
+// Hostile prompt: shell metacharacters, quotes, expansion, newlines. It is INERT
+// DATA end to end — must round-trip verbatim and never appear in a redacted log.
+const HOSTILE_PROMPT =
+  "Set up $(rm -rf ~) `hostname` \"double\" 'single' ; & | > < \\ %20 + \n second line $HOME";
+
+test("build ⇄ parse round-trips a prompt (incl. hostile characters, verbatim)", () => {
+  const withPrompt = { ...SAMPLE, prompt: HOSTILE_PROMPT };
+  const url = buildLaunchDeepLink(withPrompt);
+  assert.ok(url.endsWith(`prompt=${encodeURIComponent(HOSTILE_PROMPT)}`), "prompt is the LAST param");
+  assert.deepEqual(parseLaunchDeepLink(url), withPrompt);
+});
+
+test("promptless links keep today's exact shape — no prompt key, no prompt param", () => {
+  const url = buildLaunchDeepLink(SAMPLE);
+  assert.ok(!url.includes("prompt="));
+  const parsed = parseLaunchDeepLink(url);
+  assert.deepEqual(parsed, SAMPLE);
+  assert.ok(!("prompt" in parsed), "no prompt key on a promptless link");
+});
+
+test("redactDeepLinkToken elides the prompt (user content) as well as the token", () => {
+  const url = buildLaunchDeepLink({ ...SAMPLE, prompt: HOSTILE_PROMPT });
+  const redacted = redactDeepLinkToken(url);
+  assert.match(redacted, /token=\*\*\*/);
+  assert.match(redacted, /prompt=\*\*\*/);
+  assert.ok(!redacted.includes(SAMPLE.token), "raw token must not appear");
+  assert.ok(!redacted.includes(encodeURIComponent(HOSTILE_PROMPT)), "encoded prompt must not appear");
+  assert.ok(redacted.includes(`session=${SAMPLE.session}`), "non-secret params survive");
+});

--- a/terminal/test/prompt-launch.test.mjs
+++ b/terminal/test/prompt-launch.test.mjs
@@ -1,0 +1,281 @@
+// Bootstrap-prompt launch — bridge-side proof of the two hard rules
+// (docs/terminal-bootstrap-prompt-ux.html; Requirements R1/R2):
+//
+//   AC4 — NO PRE-AUTH EXECUTION: a prompt-carrying launch spawns NOTHING until
+//         the relay confirms the owner-bound token with the `attached` control
+//         frame. Rejected (expired / foreign-owner) tokens and an OLD relay that
+//         never sends the frame ⇒ the bridge exits with ZERO child processes and
+//         zero prompt bytes delivered anywhere.
+//   AC5 — ARGV SAFETY: the URL-carried prompt reaches the spawned command as
+//         exactly ONE argv element, verbatim — never through shellSplit or a
+//         shell — proven with a hostile-characters fixture.
+//   AC8 — promptless launches keep TODAY'S behaviour exactly (PTY spawns first,
+//         before the relay connect).
+//
+// Uses the Node stand-in relay (same pairing/owner logic + the same R1 attached
+// frame as the Cloudflare DO; `sendAttachedFrame:false` simulates an OLD relay).
+//
+// Run: cd terminal/test && node --test   (or: node prompt-launch.test.mjs)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens, signToken } from "../shared/session-token.mjs";
+import { buildLaunchDeepLink } from "../shared/deep-link.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BRIDGE_ENTRY = path.resolve(__dirname, "../bridge/src/index.js");
+const ARGV_CMD = path.resolve(__dirname, "./argv-cmd.mjs");
+const SENTINEL = path.resolve(__dirname, "./sentinel-cmd.mjs");
+const HARD_TIMEOUT_MS = 20000;
+const SECRET = "prompt-launch-test-secret";
+
+// Hostile prompt: command substitution, quotes, pipes, redirects, newline,
+// variable expansion. If ANY of this were interpreted (shell, shellSplit, PTY
+// line discipline aside) the argv round-trip below would not match verbatim.
+const HOSTILE_PROMPT =
+  "Set up $(rm -rf ~) `hostname` \"double\" 'single' ; & | > < \\ %20 + \n work task_id abc; echo $HOME";
+
+/** Spawn the bridge with piped stderr; resolves helpers for logs + exit. */
+function spawnBridge(argv, env = {}) {
+  const child = spawn(process.execPath, [BRIDGE_ENTRY, ...argv], {
+    env: { PATH: process.env.PATH, BRIDGE_MAX_SECONDS: "60", ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (d) => process.stdout.write(d));
+  child.stderr.on("data", (d) => {
+    stderr += d;
+    process.stderr.write(d);
+  });
+  return { child, getStderr: () => stderr };
+}
+
+function waitForText(getBuf, text, ms, label) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const iv = setInterval(() => {
+      if (getBuf().includes(text)) {
+        clearInterval(iv);
+        resolve(Date.now() - started);
+      } else if (Date.now() - started > ms) {
+        clearInterval(iv);
+        reject(new Error(`timed out after ${ms}ms waiting for ${label}: ${JSON.stringify(text)}`));
+      }
+    }, 25);
+  });
+}
+
+async function waitForExit(child, ms, label) {
+  const [code, signal] = await Promise.race([
+    once(child, "exit"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${label} exit timeout`)), ms)),
+  ]);
+  return { code, signal };
+}
+
+async function connectBrowserLeg(relayUrl, session, browserToken) {
+  let buf = "";
+  const ws = new WebSocket(
+    `${relayUrl}/?session=${session}&role=browser&token=${encodeURIComponent(browserToken)}`,
+  );
+  ws.on("message", (data) => {
+    buf += Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+  });
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error("browser ws open timeout")), 5000)),
+  ]);
+  return { ws, getBuf: () => buf };
+}
+
+// ── AC5 + R1 happy path: verbatim single-argv prompt, spawned only post-attach ─
+test("prompt launch: spawn is deferred until the relay's attach confirmation, and the prompt arrives as ONE verbatim argv element", { timeout: 60000 }, async (t) => {
+  const session = `pl-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = "user-P-" + Math.random().toString(36).slice(2, 8);
+  let relay;
+  let bridge;
+  let browser;
+
+  t.after(async () => {
+    try { browser?.terminate(); } catch { /* ignore */ }
+    if (bridge && bridge.exitCode === null) bridge.kill("SIGKILL");
+    if (relay) await relay.close();
+  });
+
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-P", sid: session, secret: SECRET });
+  relay = await startStandinRelay({ port: 0, secret: SECRET });
+
+  const launchUrl = buildLaunchDeepLink({
+    relay: relay.url,
+    session,
+    token: tokens.bridge,
+    prompt: HOSTILE_PROMPT,
+  });
+
+  const leg = await connectBrowserLeg(relay.url, session, tokens.browser);
+  browser = leg.ws;
+
+  const spawned = spawnBridge([
+    "--launch-url", launchUrl,
+    "--cmd", `${process.execPath} ${ARGV_CMD}`,
+  ]);
+  bridge = spawned.child;
+
+  // The spawned command echoes its argv between markers — extract + compare.
+  await waitForText(leg.getBuf, "ARGV_END", HARD_TIMEOUT_MS, "argv marker");
+  const m = leg.getBuf().match(/ARGV_BEGIN(.*?)ARGV_END/s);
+  assert.ok(m, "argv markers present in the PTY stream");
+  const argv = JSON.parse(m[1]);
+  assert.deepEqual(argv, [HOSTILE_PROMPT], "prompt must be exactly ONE argv element, verbatim (AC5)");
+
+  // R1 ordering: the bridge connected + received the attach confirmation BEFORE
+  // it spawned the PTY (promptless launches spawn first — see the AC8 test).
+  const logs = spawned.getStderr();
+  const iConfirmed = logs.indexOf("relay confirmed attach");
+  const iSpawn = logs.indexOf("spawning PTY");
+  assert.ok(iConfirmed !== -1, "bridge logged the attach confirmation");
+  assert.ok(iSpawn !== -1, "bridge spawned the PTY");
+  assert.ok(iConfirmed < iSpawn, "spawn must happen strictly AFTER the attach confirmation (R1)");
+
+  // Log hygiene: the prompt (user content) never appears in bridge logs — only
+  // its length does (the launch URL is logged redacted).
+  assert.ok(!logs.includes("rm -rf"), "prompt content must not leak into bridge logs");
+  assert.ok(logs.includes("promptChars"), "spawn log carries only the prompt length");
+  console.log("[test/pl] PASS — deferred spawn + verbatim single-argv prompt");
+});
+
+// ── AC4: rejected tokens ⇒ ZERO spawn ──────────────────────────────────────────
+test("prompt launch with an expired or foreign-owner token spawns NOTHING", { timeout: 60000 }, async (t) => {
+  const session = `pl4-${Math.random().toString(36).slice(2, 8)}`;
+  const ownerA = "user-A-" + Math.random().toString(36).slice(2, 8);
+  const ownerB = "user-B-" + Math.random().toString(36).slice(2, 8);
+  let relay;
+  let browser;
+  const bridges = [];
+
+  t.after(async () => {
+    try { browser?.terminate(); } catch { /* ignore */ }
+    for (const b of bridges) if (b.exitCode === null) b.kill("SIGKILL");
+    if (relay) await relay.close();
+  });
+
+  const tokensA = await mintSessionTokens({ sub: ownerA, idea: "idea-P", sid: session, secret: SECRET });
+  relay = await startStandinRelay({ port: 0, secret: SECRET });
+
+  // Bind the session to owner A (the legitimate browser leg).
+  const leg = await connectBrowserLeg(relay.url, session, tokensA.browser);
+  browser = leg.ws;
+
+  /** Fire a prompt-carrying bridge with `token` and assert zero execution. */
+  async function expectNoSpawn(token, label) {
+    const launchUrl = buildLaunchDeepLink({ relay: relay.url, session, token, prompt: HOSTILE_PROMPT });
+    // NOTE: --cmd swallows the rest of argv, so every other flag comes first.
+    const spawned = spawnBridge([
+      "--launch-url", launchUrl,
+      "--attach-confirm-timeout-ms", "1500",
+      "--cmd", `${process.execPath} ${ARGV_CMD}`,
+    ]);
+    bridges.push(spawned.child);
+    const { code } = await waitForExit(spawned.child, HARD_TIMEOUT_MS, label);
+    const logs = spawned.getStderr();
+    assert.ok(!logs.includes("spawning PTY"), `${label}: no PTY spawn may be attempted`);
+    assert.ok(!leg.getBuf().includes("ARGV_BEGIN"), `${label}: no prompt bytes may reach any child`);
+    assert.equal(code, 1, `${label}: a blocked prompt launch exits non-zero`);
+    console.log(`[test/pl4] PASS — ${label}: zero execution`);
+  }
+
+  // (a) expired token — fails authorizeAttach (relay close 4006).
+  const past = Math.floor(Date.now() / 1000) - 3600;
+  const expired = await signToken(
+    { sub: ownerA, sid: session, idea: "idea-P", role: "bridge", iat: past, exp: past + 60 },
+    SECRET,
+  );
+  await expectNoSpawn(expired, "expired token");
+
+  // (b) foreign-owner token — valid signature, wrong owner (relay close 4005).
+  const tokensB = await mintSessionTokens({ sub: ownerB, idea: "idea-P", sid: session, secret: SECRET });
+  await expectNoSpawn(tokensB.bridge, "foreign-owner token");
+});
+
+// ── version skew: OLD relay (no attached frame) ⇒ clean exit, zero spawn ───────
+test("prompt launch against a relay that never confirms the attach exits WITHOUT spawning", { timeout: 60000 }, async (t) => {
+  const session = `pls-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = "user-S-" + Math.random().toString(36).slice(2, 8);
+  let relay;
+  let bridge;
+  let browser;
+
+  t.after(async () => {
+    try { browser?.terminate(); } catch { /* ignore */ }
+    if (bridge && bridge.exitCode === null) bridge.kill("SIGKILL");
+    if (relay) await relay.close();
+  });
+
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-P", sid: session, secret: SECRET });
+  // sendAttachedFrame:false = an OLD relay that accepts the leg but predates R1.
+  relay = await startStandinRelay({ port: 0, secret: SECRET, sendAttachedFrame: false });
+
+  const leg = await connectBrowserLeg(relay.url, session, tokens.browser);
+  browser = leg.ws;
+
+  const launchUrl = buildLaunchDeepLink({ relay: relay.url, session, token: tokens.bridge, prompt: HOSTILE_PROMPT });
+  // NOTE: --cmd swallows the rest of argv, so every other flag comes first.
+  const spawned = spawnBridge([
+    "--launch-url", launchUrl,
+    "--attach-confirm-timeout-ms", "800",
+    "--cmd", `${process.execPath} ${ARGV_CMD}`,
+  ]);
+  bridge = spawned.child;
+
+  const { code } = await waitForExit(spawned.child, HARD_TIMEOUT_MS, "old-relay bridge");
+  const logs = spawned.getStderr();
+  assert.ok(logs.includes("no attach confirmation"), "bridge explains the skew timeout");
+  assert.ok(!logs.includes("spawning PTY"), "no PTY spawn on an unconfirmed attach");
+  assert.ok(!leg.getBuf().includes("ARGV_BEGIN"), "no prompt bytes reached any child");
+  assert.equal(code, 1, "unconfirmed prompt launch exits non-zero");
+  console.log("[test/pls] PASS — old relay ⇒ graceful no-spawn exit");
+});
+
+// ── AC8: promptless launches keep TODAY'S spawn-first behaviour exactly ────────
+test("promptless --launch-url spawns the PTY FIRST (before the relay connect), as today", { timeout: 60000 }, async (t) => {
+  const session = `pl8-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = "user-8-" + Math.random().toString(36).slice(2, 8);
+  let relay;
+  let bridge;
+  let browser;
+
+  t.after(async () => {
+    try { browser?.terminate(); } catch { /* ignore */ }
+    if (bridge && bridge.exitCode === null) bridge.kill("SIGKILL");
+    if (relay) await relay.close();
+  });
+
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-P", sid: session, secret: SECRET });
+  relay = await startStandinRelay({ port: 0, secret: SECRET });
+
+  const leg = await connectBrowserLeg(relay.url, session, tokens.browser);
+  browser = leg.ws;
+
+  const launchUrl = buildLaunchDeepLink({ relay: relay.url, session, token: tokens.bridge });
+  const spawned = spawnBridge([
+    "--launch-url", launchUrl,
+    "--cmd", `${process.execPath} ${SENTINEL}`,
+  ]);
+  bridge = spawned.child;
+
+  await waitForText(leg.getBuf, "READY", HARD_TIMEOUT_MS, "sentinel via relay");
+  const logs = spawned.getStderr();
+  const iSpawn = logs.indexOf("spawning PTY");
+  const iConnect = logs.indexOf("connecting to relay");
+  assert.ok(iSpawn !== -1 && iConnect !== -1, "both lifecycle logs present");
+  assert.ok(iSpawn < iConnect, "promptless spawn happens BEFORE the relay connect — unchanged (AC8)");
+  console.log("[test/pl8] PASS — promptless behaviour byte-for-byte as before");
+});

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -30,14 +30,18 @@ import {
   resolveMs,
 } from "../relay/src/pairing.js";
 import { authorizeAttach } from "../shared/session-token.mjs";
+import { encodeAttachedFrame } from "../shared/control-frames.mjs";
 
 const NORMAL_CLOSURE = 1000;
 
 /**
  * @param {{ port?: number, secret?: string, idleMs?: number, maxMs?: number,
+ *           sendAttachedFrame?: boolean,
  *           log?: (msg:string, extra?:object)=>void }} [opts]
  *   `secret` — TERMINAL_SESSION_SECRET used to verify leg tokens (defaults to env).
  *   `idleMs` / `maxMs` — lifecycle caps (default 30 min / 4 h); tests pass small values.
+ *   `sendAttachedFrame` — default true (mirrors the real DO's R1 confirmation to
+ *   the bridge leg); tests pass false to simulate an OLD relay for skew coverage.
  * @returns {Promise<{ url:string, port:number, close:()=>Promise<void>, sessions: Map }>}
  */
 export function startStandinRelay(opts = {}) {
@@ -45,6 +49,7 @@ export function startStandinRelay(opts = {}) {
   const secret = opts.secret ?? process.env.TERMINAL_SESSION_SECRET;
   const idleMs = resolveMs(opts.idleMs, DEFAULT_IDLE_MS);
   const maxMs = resolveMs(opts.maxMs, DEFAULT_MAX_MS);
+  const sendAttachedFrame = opts.sendAttachedFrame !== false;
   // session id -> { bridge: ws|null, browser: ws|null, owner: string|null,
   //                 idleTimer, maxTimer }
   const sessions = new Map();
@@ -108,6 +113,12 @@ export function startStandinRelay(opts = {}) {
     if (legs.owner === null) legs.owner = auth.sub;
     legs[role] = ws;
     log("attached", { session, role });
+
+    // R1 attach confirmation to the BRIDGE leg — mirrors the Cloudflare DO. A
+    // prompt-carrying bridge defers its PTY spawn until this frame arrives.
+    if (role === "bridge" && sendAttachedFrame) {
+      try { ws.send(encodeAttachedFrame()); } catch { /* leg already gone */ }
+    }
 
     // Arm the max-duration cap once, on the first leg; arm/refresh idle now.
     if (firstLeg) {


### PR DESCRIPTION
The in-browser terminal spawned **bare `claude`** (cold, no idea/task context) while "In a terminal window" launched with the compact bootstrap prompt. Now both paths carry the **same prompt from one shared builder** — the session opens knowing the idea, the task, and how to connect the board tools.

## How it works
Button resolves state (shared `resolveDefaultLaunchState`) → `buildCompactBootstrapPromptParts` (QA-proven **byte-identical to master's builder**) → launch-bus payload → dock budgets `2048 − baseLink` (`enforcePromptLength`) → `&prompt=` on the `vibecodes://` link → shared parser (drift-tested TS⇄mjs) → bridge passes it as **one argv element** (never through `shellSplit`, never logged — token *and* prompt redacted). Pinned/recorded project folders now also carried (`resolveLaunchCwd`, shared so the paths can't drift).

## Security (R1)
The relay rejects bad tokens by accept-then-close, so `ws.onopen` proves nothing. The relay DO now sends `{"t":"attached"}` to the bridge leg **strictly after** token+owner validation; a prompt-bearing bridge **defers `pty.spawn`** until that frame (10s timeout → exit, zero spawn). Adversarial e2e: expired / foreign-owner / old-relay ⇒ **zero execution**. Promptless launches keep today's spawn-first behaviour byte-for-byte.

## Process
Full Feature Development workflow: Requirements (10 ACs) → UX (`docs/terminal-bootstrap-prompt-ux.html`) → Design Review (✅ human, **silent-v1** directive) → Implementation → QA (**SHIP** — AC1 independently proven, AC4 line-traced) → post-QA fix round (cwd threading + 2 cosmetics) → Final Sign-off (✅ human).

## Tests
tsc clean · vitest **831/831** · prompt-launch 4/4 (adversarial, real PTY) · deep-link 9/9 · control-frames 3/3 · roundtrip 2/2

## Rollout
- **Relay already deployed** (`fdc70938`) — required before this lands so prompt launches work.
- Old helpers ignore the new param → graceful, silent cold launch (version-skew safe both ways).
- `terminal/bridge` + `terminal/shared` changes ride the next **batched notarized helper release** (with orphaned-claude cleanup `2efba98c` + relay-host pinning `c5f9d86b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)