### PR TITLE
fix(terminal): verified-kill escalation — stop leaking orphaned claude processes

### DIFF
--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -41,6 +41,7 @@ import WebSocket from "ws";
 import { parseControlMessage } from "./framing.js";
 import { parseLaunchDeepLink, redactDeepLinkToken } from "../../shared/deep-link.mjs";
 import { isAttachedFrame } from "../../shared/control-frames.mjs";
+import { reapPidGroupEscalated } from "../../shared/reap.mjs";
 
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -121,6 +122,22 @@ const CONNECT_TIMEOUT_MS = Number(args["connect-timeout-ms"] || 30000);
 // spawn — the dock's existing ~8s fallback covers the UX.
 const ATTACH_CONFIRM_TIMEOUT_MS = Number(args["attach-confirm-timeout-ms"] || 10000);
 
+// ── verified-kill escalation bounds (the orphaned-`claude` fix) ────────────────
+// node-pty's kill() is ONE unverified SIGHUP that `claude` can outlive — and the
+// PTY child is its own session/group leader (spawn-helper setsid), so nothing
+// implicit ever reaps it. Shutdown now VERIFIES death: SIGHUP → (2s) → SIGTERM →
+// (1s) → SIGKILL(+process group), and never exits with the child unconfirmed
+// unless the overall hard cap trips. See ../../shared/reap.mjs.
+const KILL_HUP_WAIT_MS = 2000;
+const KILL_TERM_WAIT_MS = 1000;
+const SHUTDOWN_CAP_MS = 5000;
+
+// ws keepalive: a dead relay link (sleep/network drop, no FIN) must not hold a
+// session — and its PTY child — alive for hours. Client-side ping only; the ws
+// server (and Cloudflare's edge) answers protocol pings automatically.
+const PING_INTERVAL_MS = Number(process.env.BRIDGE_PING_INTERVAL_MS || 30000);
+const PING_MAX_MISSED = 2;
+
 const [file, ...cmdArgs] = shellSplit(CMD);
 const spawnArgs = PROMPT ? [...cmdArgs, PROMPT] : cmdArgs;
 
@@ -199,7 +216,14 @@ async function main() {
 
   const pty = require("node-pty");
 
+  // Expose shutdown so the top-level catch can tear down (kill the PTY child)
+  // instead of process.exit()ing over a live grandchild. Assigned FIRST (the
+  // function declaration below is hoisted) so any throw in this body after the
+  // PTY spawn still reaps.
+  shutdownRef = shutdown;
+
   let term = null; // spawned lazily for prompt-carrying launches (R1 gate below)
+  let ptyExited = false; // set by term.onExit — authoritative "child is dead"
   let pendingResize = null; // a resize that arrived while the spawn was deferred
   let ws = null;
   let bytesOut = 0; // PTY -> ws
@@ -209,6 +233,15 @@ async function main() {
   let connectTimer = null;
   let maxTimer = null;
   let attachTimer = null;
+  let pingTimer = null;
+  let missedPongs = 0;
+
+  function stopKeepalive() {
+    if (pingTimer) {
+      clearInterval(pingTimer);
+      pingTimer = null;
+    }
+  }
 
   // PTY output produced before the relay socket is open (e.g. the program's
   // startup banner), flushed on open so the first bytes never lose the race.
@@ -221,16 +254,59 @@ async function main() {
     clearTimeout(connectTimer);
     clearTimeout(maxTimer);
     clearTimeout(attachTimer);
+    stopKeepalive();
     log("info", "shutting down", { why, bytesOut, bytesIn });
     try { ws?.close(1000, why); } catch { /* ignore */ }
-    try { term?.kill(); } catch { /* ignore */ }
     // Record the code first: with NO PTY (a blocked prompt launch) the event
     // loop can drain before the unref'd hard-exit timer fires, and the process
     // then exits naturally — exitCode makes that natural exit carry the right
-    // status. The timer stays as the hard stop for the PTY-alive case.
+    // status.
     process.exitCode = code;
-    // give sockets a tick to flush their close frame, then exit hard
-    setTimeout(() => process.exit(code), 200).unref();
+    // give sockets a tick to flush their close frame, then exit
+    const exitSoon = () => setTimeout(() => process.exit(code), 200).unref();
+
+    // No PTY (blocked prompt launch) or Windows (conpty — no POSIX signal
+    // escalation): node-pty's own kill + the short flush window is all there is.
+    if (!term || process.platform === "win32") {
+      try { term?.kill(); } catch { /* ignore */ }
+      exitSoon();
+      return;
+    }
+
+    // Verified-kill escalation (the orphaned-`claude` fix). The old code fired
+    // ONE unverified SIGHUP and hard-exited 200ms later; a child that ignores
+    // SIGHUP (claude does) survived as an orphan because it is its own session/
+    // group leader (spawn-helper setsid). Now: SIGHUP → SIGTERM → SIGKILL(+the
+    // child's process group), and we do NOT exit until the child is confirmed
+    // dead or the SIGKILL has been sent. The escalation's own (ref'd) poll
+    // timers keep the event loop alive; SHUTDOWN_CAP_MS is the hard stop.
+    const pid = term.pid;
+    const hardCap = setTimeout(() => {
+      log("warn", "shutdown hard cap reached — exiting", { ms: SHUTDOWN_CAP_MS, pid });
+      process.exit(code);
+    }, SHUTDOWN_CAP_MS);
+    reapPidGroupEscalated(pid, {
+      hupWaitMs: KILL_HUP_WAIT_MS,
+      termWaitMs: KILL_TERM_WAIT_MS,
+      isDead: () => ptyExited,
+      onStage: (stage) => log("warn", "pty kill escalated", { stage, pid }),
+    })
+      .then((res) => {
+        if (res.confirmedDead) {
+          if (res.stage !== "already-dead") log("info", "pty child confirmed dead", { pid, stage: res.stage });
+        } else {
+          log("error", "pty child NOT confirmed dead after SIGKILL", { pid });
+        }
+        clearTimeout(hardCap);
+        exitSoon();
+      })
+      .catch((e) => {
+        log("error", "pty kill escalation failed — sending SIGKILL", { pid, err: String(e?.message || e) });
+        try { process.kill(-pid, "SIGKILL"); } catch { /* ignore */ }
+        try { process.kill(pid, "SIGKILL"); } catch { /* ignore */ }
+        clearTimeout(hardCap);
+        exitSoon();
+      });
   }
 
   /**
@@ -260,6 +336,15 @@ async function main() {
     }
     term = spawned;
 
+    // Tell the supervising helper (if any) which pid to verify-kill should WE
+    // die uncleanly (a SIGKILL'd bridge can run no cleanup — matrix row c).
+    // Standalone CLI runs have no IPC channel; this is a guarded no-op there.
+    if (process.send && process.channel) {
+      try {
+        process.send({ type: "pty-pid", pid: spawned.pid });
+      } catch { /* channel already closing */ }
+    }
+
     // PTY -> relay (binary, verbatim).
     term.onData((data) => {
       const buf = Buffer.from(data, "utf8");
@@ -272,6 +357,7 @@ async function main() {
     });
 
     term.onExit(({ exitCode, signal }) => {
+      ptyExited = true; // lets an in-flight kill escalation confirm instantly
       log("info", "PTY exited", { exitCode, signal });
       shutdown(0, "pty-exit");
     });
@@ -283,6 +369,25 @@ async function main() {
     }
   }
 
+  // The relay requires an app-minted `bridge`-role token (slice 2). It binds this
+  // leg to its owning user; the matching `browser` token must carry the same owner.
+  // Checked BEFORE any spawn — a doomed launch must never create a child process.
+  if (!TOKEN) {
+    log("error", "missing bridge token — set --token or BRIDGE_TOKEN (minted by the app)");
+    process.exit(1);
+  }
+
+  // Helper-fork parent-death detection: the helper forks us with an IPC channel.
+  // If the helper dies uncleanly (crash/SIGKILL) the channel drops — tear down
+  // instead of running parentless forever. Standalone CLI runs have no channel,
+  // so this never arms outside a helper fork.
+  if (process.channel) {
+    process.on("disconnect", () => {
+      log("warn", "IPC channel to parent dropped — supervising helper is gone");
+      shutdown(1, "helper-gone");
+    });
+  }
+
   // R1 SEQUENCING. Promptless launches spawn FIRST, exactly as before — nothing
   // in their flow changes. A URL-carried prompt is different: it must NEVER
   // reach a child process unless the relay has accepted the owner-bound token,
@@ -291,13 +396,6 @@ async function main() {
   // gated on the relay's explicit `attached` control frame, sent only after
   // authorizeAttach + decideAttach pass. No frame → exit, zero spawn.
   if (!PROMPT) spawnPty();
-
-  // The relay requires an app-minted `bridge`-role token (slice 2). It binds this
-  // leg to its owning user; the matching `browser` token must carry the same owner.
-  if (!TOKEN) {
-    log("error", "missing bridge token — set --token or BRIDGE_TOKEN (minted by the app)");
-    process.exit(1);
-  }
   const url =
     `${RELAY.replace(/\/$/, "")}/?session=${encodeURIComponent(SESSION)}` +
     `&role=bridge&token=${encodeURIComponent(TOKEN)}`;
@@ -356,10 +454,31 @@ async function main() {
     }
   });
 
+  // Keepalive: protocol-level ping every PING_INTERVAL_MS; the ws server (and
+  // Cloudflare's edge) auto-answers with pongs. A link that misses
+  // PING_MAX_MISSED pongs in a row is dead (sleep/network drop with no FIN) —
+  // terminate it so `close` fires and shutdown() reaps the PTY child, instead
+  // of the session holding a live `claude` for hours.
+  ws.on("pong", () => {
+    missedPongs = 0;
+  });
+
   ws.on("open", () => {
     open = true;
     clearTimeout(connectTimer);
     log("info", "relay connected (bridge leg)", { session: SESSION });
+    missedPongs = 0;
+    pingTimer = setInterval(() => {
+      if (!ws || ws.readyState !== WebSocket.OPEN) return;
+      if (missedPongs >= PING_MAX_MISSED) {
+        log("warn", "keepalive: pongs missed — terminating dead relay link", { missed: missedPongs });
+        try { ws.terminate(); } catch { /* ignore */ }
+        return;
+      }
+      missedPongs += 1;
+      try { ws.ping(); } catch { /* ignore */ }
+    }, PING_INTERVAL_MS);
+    pingTimer.unref?.();
     // Prompt launches: arm the attach-confirmation window. An OLD relay never
     // sends the frame → clean exit with NOTHING spawned (graceful skew; the
     // dock's existing ~8s fallback covers the UX).
@@ -399,7 +518,10 @@ async function main() {
   }
 }
 
+let shutdownRef = null; // set by main() once its shutdown() closure exists
+
 main().catch((e) => {
   log("error", "fatal", { err: String(e?.stack || e) });
-  process.exit(1);
+  if (shutdownRef) shutdownRef(1, "fatal");
+  else process.exit(1);
 });

--- a/terminal/helper/main.js
+++ b/terminal/helper/main.js
@@ -37,6 +37,10 @@ const SHARED_DEEPLINK = app.isPackaged
   ? path.join(process.resourcesPath, "shared", "deep-link.mjs")
   : path.resolve(__dirname, "..", "shared", "deep-link.mjs");
 
+const SHARED_REAP = app.isPackaged
+  ? path.join(process.resourcesPath, "shared", "reap.mjs")
+  : path.resolve(__dirname, "..", "shared", "reap.mjs");
+
 // ── logging (metadata only — NEVER log the deep-link token) ───────────────────
 const t0 = Date.now();
 function log(level, msg, extra) {
@@ -51,24 +55,73 @@ async function shared() {
   return _shared;
 }
 
+// Lazily import the shared verified-kill escalation (same module the bridge uses).
+let _reap = null;
+async function reapMod() {
+  if (!_reap) _reap = await import(pathToFileURL(SHARED_REAP).href);
+  return _reap;
+}
+
 // ── child-bridge bookkeeping + idle quit ─────────────────────────────────────
 const children = new Set();
+// bridge child -> its PTY child's pid (the grandchild — `claude`). Reported by
+// the bridge over IPC ({type:"pty-pid"}) right after its pty.spawn. Needed
+// because the grandchild is its OWN session/group leader (spawn-helper setsid):
+// if the bridge dies uncleanly (SIGKILL — it can run no cleanup), WE are the
+// only thing left that can verify the grandchild died and escalate if not.
+const ptyPids = new Map();
+// In-flight grandchild verifications. The idle-quit must NOT fire — and
+// before-quit must not let the process vanish — while one is pending.
+const activeReaps = new Set();
+let quitting = false;
 let quitTimer = null;
 const IDLE_QUIT_MS = 2000; // grace after the last bridge exits before we quit
+const REAP_HUP_WAIT_MS = 1000; // grandchild SIGHUP grace before SIGKILL(+group)
 
 function scheduleQuitIfIdle() {
-  if (children.size > 0) {
+  if (quitting) return;
+  if (children.size > 0 || activeReaps.size > 0) {
     if (quitTimer) { clearTimeout(quitTimer); quitTimer = null; }
     return;
   }
   if (quitTimer) clearTimeout(quitTimer);
   quitTimer = setTimeout(() => {
-    if (children.size === 0) {
+    if (children.size === 0 && activeReaps.size === 0) {
       log("info", "idle — no active sessions, quitting");
       app.quit();
     }
   }, IDLE_QUIT_MS);
   quitTimer.unref?.();
+}
+
+/**
+ * Verify a dead bridge's PTY grandchild actually died; escalate
+ * SIGHUP → (1s) → SIGKILL(+process group) if not. Bounded (~1.6s worst case).
+ * This is the ONLY cleanup path when the bridge is SIGKILL'd (matrix row c).
+ */
+function reapGrandchild(pid, why) {
+  const p = (async () => {
+    const { pidAlive, reapPidGroupEscalated } = await reapMod();
+    if (!pidAlive(pid)) {
+      log("debug", "grandchild already dead", { pid, why });
+      return;
+    }
+    log("warn", "bridge gone but its PTY child is still alive — escalating", { pid, why });
+    const res = await reapPidGroupEscalated(pid, { hupWaitMs: REAP_HUP_WAIT_MS, termWaitMs: 0 });
+    log(res.confirmedDead ? "info" : "error", "grandchild reap finished", {
+      pid,
+      stage: res.stage,
+      confirmedDead: res.confirmedDead,
+    });
+  })().catch((err) => {
+    log("error", "grandchild reap failed", { pid, err: String(err?.message || err) });
+  });
+  activeReaps.add(p);
+  p.finally(() => {
+    activeReaps.delete(p);
+    scheduleQuitIfIdle();
+  });
+  return p;
 }
 
 /**
@@ -106,14 +159,32 @@ async function handleLaunchUrl(rawUrl) {
   child.stdout?.on("data", relay);
   child.stderr?.on("data", relay);
 
+  // The bridge reports its PTY child's pid over IPC so we can verify-kill the
+  // grandchild if the bridge itself dies uncleanly.
+  child.on("message", (m) => {
+    if (m && m.type === "pty-pid" && Number.isInteger(m.pid) && m.pid > 0) {
+      ptyPids.set(child, m.pid);
+      log("debug", "recorded bridge's pty pid", { pid: m.pid });
+    }
+  });
+
   child.on("exit", (code, signal) => {
     children.delete(child);
     log("info", "bridge exited", { code, signal, active: children.size });
+    // Trust nothing: whatever the bridge's exit looked like, VERIFY the
+    // grandchild is gone (reapGrandchild registers in activeReaps synchronously,
+    // so the idle-quit below cannot fire before the verification completes).
+    const ptyPid = ptyPids.get(child);
+    ptyPids.delete(child);
+    if (ptyPid) reapGrandchild(ptyPid, `bridge-exit code=${code} signal=${signal}`);
     scheduleQuitIfIdle();
   });
   child.on("error", (err) => {
     children.delete(child);
     log("error", "bridge failed to start", { err: String(err?.message || err) });
+    const ptyPid = ptyPids.get(child);
+    ptyPids.delete(child);
+    if (ptyPid) reapGrandchild(ptyPid, "bridge-error");
     scheduleQuitIfIdle();
   });
 }
@@ -170,9 +241,34 @@ if (!gotLock) {
   // We never open a window; keep the app alive on our own terms.
   app.on("window-all-closed", () => { /* no-op: managed via scheduleQuitIfIdle */ });
 
-  app.on("before-quit", () => {
+  app.on("before-quit", (event) => {
+    if (quitting) return; // our own deferred quit path re-entering — let it go
     for (const child of children) {
       try { child.kill(); } catch { /* ignore */ }
     }
+    const pids = [...ptyPids.values()];
+    if (pids.length === 0 && activeReaps.size === 0) return; // nothing to verify
+    // Hold the quit until every known grandchild is VERIFIED dead (bounded:
+    // ~1s SIGHUP grace then SIGKILL(+group), per pid, in parallel) and any
+    // in-flight reaps have finished — then exit for real.
+    quitting = true;
+    event.preventDefault();
+    (async () => {
+      try {
+        const inflight = [...activeReaps];
+        const { pidAlive, reapPidGroupEscalated } = await reapMod();
+        await Promise.all(
+          pids.map(async (pid) => {
+            if (!pidAlive(pid)) return;
+            const res = await reapPidGroupEscalated(pid, { hupWaitMs: REAP_HUP_WAIT_MS, termWaitMs: 0 });
+            log("info", "before-quit reaped grandchild", { pid, stage: res.stage, confirmedDead: res.confirmedDead });
+          }),
+        );
+        await Promise.allSettled(inflight);
+      } catch (err) {
+        log("error", "before-quit reap failed", { err: String(err?.message || err) });
+      }
+      app.exit(0);
+    })();
   });
 }

--- a/terminal/shared/reap.mjs
+++ b/terminal/shared/reap.mjs
@@ -1,0 +1,100 @@
+// Verified process-kill escalation — shared by the BRIDGE (killing its own PTY
+// child at shutdown) and the HELPER (reaping a dead bridge's orphaned PTY
+// grandchild). POSIX only; callers guard win32.
+//
+// WHY THIS EXISTS (the orphaned-`claude` bug): node-pty's `term.kill()` is ONE
+// unverified SIGHUP. `claude` can ignore/outlive it, and because node-pty's
+// spawn-helper `setsid`s the PTY child into its OWN session + process group,
+// nothing else (parent death, group signals from the bridge's group) ever
+// reaches it. The fix is to VERIFY death and escalate:
+//
+//   SIGHUP  → poll up to hupWaitMs  →
+//   SIGTERM → poll up to termWaitMs → (skipped when termWaitMs <= 0)
+//   SIGKILL to the PROCESS GROUP (-pid) and the pid itself
+//
+// The group kill at the SIGKILL stage matters: the PTY child is its own group
+// leader, so `-pid` sweeps any children IT spawned (sub-shells, MCP servers, …).
+
+/** Is `pid` still alive? EPERM means "alive but not ours" — still alive. */
+export function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e?.code === "EPERM";
+  }
+}
+
+/** Best-effort signal; returns false instead of throwing (ESRCH/EPERM). */
+export function sendSignal(pid, signal) {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve true as soon as `pid` is dead (or `isDead()` reports it), false if it
+ * is still alive after `capMs`. Polls every `pollMs`; checks immediately first.
+ */
+export function waitForPidExit(pid, capMs, { pollMs = 50, isDead } = {}) {
+  const dead = () => Boolean(isDead?.()) || !pidAlive(pid);
+  return new Promise((resolve) => {
+    if (dead()) return resolve(true);
+    const started = Date.now();
+    const iv = setInterval(() => {
+      if (dead()) {
+        clearInterval(iv);
+        resolve(true);
+      } else if (Date.now() - started >= capMs) {
+        clearInterval(iv);
+        resolve(false);
+      }
+    }, pollMs);
+  });
+}
+
+/**
+ * Kill `pid` with verified escalation (see module header). Total time is
+ * bounded by hupWaitMs + termWaitMs + ~500ms of final confirmation.
+ *
+ * @param {number} pid  the PTY child (its own session/group leader).
+ * @param {{ hupWaitMs?: number, termWaitMs?: number, pollMs?: number,
+ *           isDead?: () => boolean, onStage?: (stage: string) => void }} [opts]
+ *   `termWaitMs <= 0` skips the SIGTERM stage (the helper's HUP→KILL profile).
+ *   `isDead` — an extra authoritative liveness source (e.g. node-pty's onExit).
+ *   `onStage` — called before each ESCALATED stage (SIGTERM / SIGKILL) for logs.
+ * @returns {Promise<{ stage: "already-dead"|"SIGHUP"|"SIGTERM"|"SIGKILL",
+ *                     confirmedDead: boolean }>}
+ *   `stage` = the signal that (finally) took it down; `confirmedDead: false`
+ *   means even SIGKILL could not be confirmed within the bound (caller logs it).
+ */
+export async function reapPidGroupEscalated(pid, opts = {}) {
+  const { hupWaitMs = 2000, termWaitMs = 1000, pollMs = 50, isDead, onStage } = opts;
+  const dead = () => Boolean(isDead?.()) || !pidAlive(pid);
+
+  if (dead()) return { stage: "already-dead", confirmedDead: true };
+
+  sendSignal(pid, "SIGHUP");
+  if (await waitForPidExit(pid, hupWaitMs, { pollMs, isDead })) {
+    return { stage: "SIGHUP", confirmedDead: true };
+  }
+
+  if (termWaitMs > 0) {
+    onStage?.("SIGTERM");
+    sendSignal(pid, "SIGTERM");
+    if (await waitForPidExit(pid, termWaitMs, { pollMs, isDead })) {
+      return { stage: "SIGTERM", confirmedDead: true };
+    }
+  }
+
+  onStage?.("SIGKILL");
+  // Group first (sweeps the child's own children), then the leader itself.
+  sendSignal(-pid, "SIGKILL");
+  sendSignal(pid, "SIGKILL");
+  const confirmedDead = await waitForPidExit(pid, 500, { pollMs, isDead });
+  return { stage: "SIGKILL", confirmedDead };
+}

--- a/terminal/test/mini-parent.mjs
+++ b/terminal/test/mini-parent.mjs
@@ -1,0 +1,37 @@
+// Mini-parent fixture — a stand-in for the HELPER's supervision of the bridge,
+// used by orphan-cleanup.test.mjs. It forks the bridge exactly the way
+// terminal/helper/main.js does (node `fork` ⇒ an IPC channel on fd 3) and
+// relays the bridge's IPC messages ({type:"pty-pid",…}) to stdout as JSON
+// lines, so the test can observe the helper protocol without Electron.
+//
+// The bridge's stdout/stderr are INHERITED — they stay bound to the pipes the
+// test gave THIS process, so bridge logs keep flowing to the test even after
+// this parent is SIGKILL'd (that is precisely the parent-death scenario).
+//
+// Usage: node mini-parent.mjs <bridge-entry.js> [bridge args...]
+
+import { fork } from "node:child_process";
+
+const [entry, ...rest] = process.argv.slice(2);
+if (!entry) {
+  process.stderr.write("mini-parent: missing bridge entry path\n");
+  process.exit(2);
+}
+
+const child = fork(entry, rest, {
+  env: process.env,
+  stdio: ["ignore", "inherit", "inherit", "ipc"],
+});
+
+process.stdout.write(JSON.stringify({ type: "bridge-pid", pid: child.pid }) + "\n");
+
+child.on("message", (m) => {
+  process.stdout.write(JSON.stringify({ relayed: true, ...m }) + "\n");
+});
+
+child.on("exit", (code, signal) => {
+  process.stdout.write(JSON.stringify({ type: "bridge-exit", code, signal }) + "\n");
+});
+
+// Stay alive until killed — the test SIGKILLs us to simulate a dead helper.
+setInterval(() => {}, 60_000);

--- a/terminal/test/orphan-cleanup.test.mjs
+++ b/terminal/test/orphan-cleanup.test.mjs
@@ -1,0 +1,402 @@
+// Orphaned-`claude` cleanup — regression proof for the verified-kill fix.
+//
+// ROOT CAUSE (Reproduce & Investigate step): teardown rested on ONE unverified
+// SIGHUP (node-pty's kill()), the bridge hard-exited 200ms later, and the PTY
+// child is its OWN session/group leader (spawn-helper setsid) — so a child that
+// ignores SIGHUP (claude does) survived every teardown path as an orphan.
+//
+// THE FIX under test:
+//   bridge  — shutdown() now escalates SIGHUP → SIGTERM → SIGKILL(+group) and
+//             does not exit until the child is confirmed dead (shared/reap.mjs);
+//   bridge  — process.on("disconnect") tears down when the forking helper dies;
+//   bridge  — sends {type:"pty-pid",pid} over IPC so the helper can supervise;
+//   helper  — verifies the grandchild died on bridge exit / before-quit and
+//             escalates SIGHUP → SIGKILL(+group) (same shared module).
+//
+// Matrix rows covered here: (a) ws-close, (b) SIGTERM-to-bridge, (e) connect
+// timeout, (d1) parent/helper death via IPC disconnect, (c) bridge-SIGKILL via
+// the helper-side escalation logic (simulated — see the row-c test's note).
+//
+// Sentinels are made SIGHUP-immune (`bash -c "trap '' HUP; exec sleep <MARK>"`,
+// unique MARK per test for pid discovery) so ONLY a real escalation can kill
+// them — exactly the property claude exhibited.
+//
+// Run: cd terminal/test && node orphan-cleanup.test.mjs   (or: node --test)
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, execFile } from "node:child_process";
+import { once } from "node:events";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens } from "../shared/session-token.mjs";
+import { pidAlive, reapPidGroupEscalated } from "../shared/reap.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BRIDGE_ENTRY = path.resolve(__dirname, "../bridge/src/index.js");
+const MINI_PARENT = path.resolve(__dirname, "./mini-parent.mjs");
+const HARD_TIMEOUT_MS = 25_000;
+const SECRET = "orphan-cleanup-test-secret";
+
+// Every sentinel sleeps a unique 46xxxxxx-second mark → discoverable via
+// `pgrep -f "^sleep 46…"` and sweepable at the end. The anchor matters: the
+// bridge/mini-parent argv also CONTAINS the mark inside their --cmd string.
+const SWEEP_PREFIX = "^sleep 46";
+function newMark() {
+  return String(46_000_000 + Math.floor(Math.random() * 1_000_000));
+}
+/** A PTY command that ignores SIGHUP (and optionally SIGTERM) — like claude. */
+function immuneCmd(mark, { alsoTerm = false } = {}) {
+  const traps = alsoTerm ? "trap '' HUP TERM" : "trap '' HUP";
+  return `bash -c "${traps}; exec sleep ${mark}"`;
+}
+
+function pgrepPids(pattern) {
+  return new Promise((resolve) => {
+    execFile("pgrep", ["-f", pattern], (_err, stdout) => {
+      resolve(
+        String(stdout || "")
+          .trim()
+          .split("\n")
+          .filter(Boolean)
+          .map(Number),
+      );
+    });
+  });
+}
+
+async function waitFor(pred, ms, label, pollMs = 50) {
+  const started = Date.now();
+  for (;;) {
+    const v = await pred();
+    if (v) return v;
+    if (Date.now() - started > ms) throw new Error(`timed out after ${ms}ms waiting for ${label}`);
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+/** Find the exec'd `sleep <mark>` sentinel pid (exactly one expected). */
+async function findSentinel(mark) {
+  return waitFor(
+    async () => {
+      const pids = await pgrepPids(`^sleep ${mark}$`);
+      return pids.length === 1 ? pids[0] : null;
+    },
+    15_000,
+    `sentinel "sleep ${mark}"`,
+    100,
+  );
+}
+
+function killHard(pid) {
+  try { process.kill(-pid, "SIGKILL"); } catch { /* ignore */ }
+  try { process.kill(pid, "SIGKILL"); } catch { /* ignore */ }
+}
+
+/** Spawn the bridge (env-configured, like roundtrip.test.mjs) with stderr capture. */
+function spawnBridge({ relayUrl, session, token, cmd, extraArgv = [], env = {} }) {
+  const child = spawn(process.execPath, [BRIDGE_ENTRY, ...extraArgv, "--cmd", cmd], {
+    env: {
+      PATH: process.env.PATH,
+      RELAY_URL: relayUrl,
+      SESSION_ID: session,
+      BRIDGE_TOKEN: token,
+      BRIDGE_MAX_SECONDS: "60",
+      ...env,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (d) => process.stdout.write(d));
+  child.stderr.on("data", (d) => {
+    stderr += d;
+    process.stderr.write(d);
+  });
+  return { child, getStderr: () => stderr };
+}
+
+async function waitForExit(child, ms, label) {
+  const [code, signal] = await Promise.race([
+    once(child, "exit"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${label} exit timeout`)), ms)),
+  ]);
+  return { code, signal };
+}
+
+async function connectBrowserLeg(relayUrl, session, browserToken) {
+  const ws = new WebSocket(
+    `${relayUrl}/?session=${session}&role=browser&token=${encodeURIComponent(browserToken)}`,
+  );
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error("browser ws open timeout")), 5000)),
+  ]);
+  return ws;
+}
+
+/** Shared scaffolding: relay + tokens + attached browser leg. */
+async function startSession(t, relayOpts = {}) {
+  const session = `oc-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-OC-${Math.random().toString(36).slice(2, 8)}`;
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-OC", sid: session, secret: SECRET });
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, ...relayOpts });
+  t.after(() => relay.close());
+  const browser = await connectBrowserLeg(relay.url, session, tokens.browser);
+  t.after(() => { try { browser.terminate(); } catch { /* ignore */ } });
+  return { session, tokens, relay, browser };
+}
+
+// ── (a) ws-close teardown must reap even a HUP+TERM-immune child ──────────────
+test("(a) ws-close: escalation reaches SIGKILL(+group) and the bridge exits only after the child is confirmed dead", { timeout: 40_000 }, async (t) => {
+  const { session, tokens, relay, browser } = await startSession(t);
+  const mark = newMark();
+  const spawned = spawnBridge({
+    relayUrl: relay.url,
+    session,
+    token: tokens.bridge,
+    cmd: immuneCmd(mark, { alsoTerm: true }), // ignores HUP *and* TERM → only SIGKILL works
+  });
+  t.after(() => { if (spawned.child.exitCode === null) spawned.child.kill("SIGKILL"); });
+
+  const sentinelPid = await findSentinel(mark);
+  t.after(() => killHard(sentinelPid));
+  console.log(`[oc/a] sentinel pid=${sentinelPid}`);
+
+  // Browser leg leaves → relay closes the bridge leg (peer-gone) → teardown.
+  browser.close();
+  const { code } = await waitForExit(spawned.child, HARD_TIMEOUT_MS, "bridge (ws-close)");
+
+  // The bridge may exit ONLY once the child is dead — assert both, and that
+  // the full escalation actually ran (HUP ignored → TERM ignored → KILL).
+  assert.equal(pidAlive(sentinelPid), false, "sentinel must be dead when the bridge has exited");
+  const logs = spawned.getStderr();
+  assert.match(logs, /"msg":"pty kill escalated".*"stage":"SIGTERM"/, "escalated to SIGTERM");
+  assert.match(logs, /"msg":"pty kill escalated".*"stage":"SIGKILL"/, "escalated to SIGKILL");
+  assert.match(logs, /"msg":"pty child confirmed dead"/, "death was VERIFIED before exit");
+  assert.equal(code, 0, "ws-close teardown exits 0");
+  console.log("[oc/a] PASS — HUP+TERM-immune child reaped via SIGKILL escalation");
+});
+
+// ── (b) SIGTERM to the bridge ─────────────────────────────────────────────────
+test("(b) SIGTERM to the bridge: HUP-immune child dies at the SIGTERM stage, verified", { timeout: 40_000 }, async (t) => {
+  const { session, tokens, relay } = await startSession(t);
+  const mark = newMark();
+  const spawned = spawnBridge({
+    relayUrl: relay.url,
+    session,
+    token: tokens.bridge,
+    cmd: immuneCmd(mark), // ignores HUP only → SIGTERM stage kills it
+  });
+  t.after(() => { if (spawned.child.exitCode === null) spawned.child.kill("SIGKILL"); });
+
+  const sentinelPid = await findSentinel(mark);
+  t.after(() => killHard(sentinelPid));
+
+  spawned.child.kill("SIGTERM");
+  const { code } = await waitForExit(spawned.child, HARD_TIMEOUT_MS, "bridge (SIGTERM)");
+
+  assert.equal(pidAlive(sentinelPid), false, "sentinel must be dead when the bridge has exited");
+  const logs = spawned.getStderr();
+  assert.match(logs, /"msg":"pty kill escalated".*"stage":"SIGTERM"/, "escalated to SIGTERM");
+  assert.doesNotMatch(logs, /"stage":"SIGKILL"/, "SIGTERM sufficed — no SIGKILL stage");
+  assert.match(logs, /"msg":"pty child confirmed dead"/, "death was VERIFIED before exit");
+  assert.equal(code, 0, "signal teardown exits 0");
+  console.log("[oc/b] PASS — SIGTERM teardown verified-kills a HUP-immune child");
+});
+
+// ── (e) connect-timeout path ──────────────────────────────────────────────────
+test("(e) connect-timeout: a bridge that never reaches the relay still reaps its child", { timeout: 40_000 }, async (t) => {
+  // A TCP server that accepts and then says NOTHING → the ws handshake hangs
+  // and the bridge's own connect timeout is what fires (not an ECONNREFUSED).
+  // Track accepted sockets so teardown can destroy them — server.close() only
+  // calls back once every connection is gone.
+  const held = new Set();
+  const hang = net.createServer((s) => {
+    held.add(s);
+    s.on("close", () => held.delete(s));
+  });
+  await new Promise((res) => hang.listen(0, "127.0.0.1", res));
+  t.after(() => {
+    for (const s of held) s.destroy();
+    return new Promise((res) => hang.close(() => res()));
+  });
+  const port = hang.address().port;
+
+  const mark = newMark();
+  const spawned = spawnBridge({
+    relayUrl: `ws://127.0.0.1:${port}`,
+    session: "oc-timeout",
+    token: "irrelevant-never-verified",
+    cmd: immuneCmd(mark),
+    extraArgv: ["--connect-timeout-ms", "700"],
+  });
+  t.after(() => { if (spawned.child.exitCode === null) spawned.child.kill("SIGKILL"); });
+
+  const sentinelPid = await findSentinel(mark); // promptless → PTY spawns first
+  t.after(() => killHard(sentinelPid));
+
+  const { code } = await waitForExit(spawned.child, HARD_TIMEOUT_MS, "bridge (connect-timeout)");
+  assert.equal(pidAlive(sentinelPid), false, "sentinel must be dead when the bridge has exited");
+  const logs = spawned.getStderr();
+  assert.match(logs, /connect timeout/, "the connect-timeout path fired");
+  assert.match(logs, /"msg":"pty child confirmed dead"/, "death was VERIFIED before exit");
+  assert.equal(code, 1, "connect-timeout exits 1");
+  console.log("[oc/e] PASS — connect-timeout teardown reaps the child");
+});
+
+// ── (d1) parent (helper) death: IPC disconnect ────────────────────────────────
+test("(d1) helper death: the IPC disconnect shuts the bridge down and the child dies; pty-pid was reported", { timeout: 40_000 }, async (t) => {
+  const { session, tokens, relay } = await startSession(t);
+  const mark = newMark();
+
+  // Fork the bridge from a mini-parent EXACTLY like the helper does (IPC on fd 3).
+  const mini = spawn(
+    process.execPath,
+    [MINI_PARENT, BRIDGE_ENTRY, "--cmd", immuneCmd(mark)],
+    {
+      env: {
+        PATH: process.env.PATH,
+        RELAY_URL: relay.url,
+        SESSION_ID: session,
+        BRIDGE_TOKEN: tokens.bridge,
+        BRIDGE_MAX_SECONDS: "60",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let out = "";
+  let err = "";
+  mini.stdout.setEncoding("utf8");
+  mini.stderr.setEncoding("utf8");
+  mini.stdout.on("data", (d) => { out += d; });
+  mini.stderr.on("data", (d) => { err += d; process.stderr.write(d); });
+  t.after(() => { if (mini.exitCode === null) mini.kill("SIGKILL"); });
+
+  const lines = () => out.split("\n").filter(Boolean).map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+  const bridgePid = (await waitFor(() => lines().find((m) => m.type === "bridge-pid"), 10_000, "bridge-pid line")).pid;
+  t.after(() => { try { process.kill(bridgePid, "SIGKILL"); } catch { /* ignore */ } });
+
+  // The helper-protocol message: the bridge reports its PTY child's pid over IPC.
+  const ptyPidMsg = await waitFor(() => lines().find((m) => m.type === "pty-pid"), 15_000, "relayed pty-pid message");
+  const sentinelPid = await findSentinel(mark);
+  t.after(() => killHard(sentinelPid));
+  assert.equal(ptyPidMsg.pid, sentinelPid, "the IPC-reported pty pid IS the sentinel's pid");
+
+  // Kill the parent the un-cleanest way possible. The bridge must notice the
+  // dropped channel and tear itself (and its child) down.
+  process.kill(mini.pid, "SIGKILL");
+  await waitFor(() => !pidAlive(bridgePid), 15_000, "bridge exit after parent death", 100);
+  await waitFor(() => !pidAlive(sentinelPid), 5_000, "sentinel death after parent death", 100);
+
+  // The bridge's stderr stayed bound to our pipe (inherited) — check the reason.
+  assert.match(err, /helper-gone|IPC channel to parent dropped/, "bridge logged the parent-death teardown");
+  console.log("[oc/d1] PASS — parent SIGKILL ⇒ bridge disconnect teardown ⇒ child reaped");
+});
+
+// ── (c) bridge SIGKILL: the ONLY survivor row — covered by the helper's reap ──
+// A SIGKILL'd bridge can run no cleanup, so this row is covered by the HELPER
+// verifying the pty-pid it recorded and escalating. Electron itself is not
+// bootable in this suite, so we prove (1) the orphan really happens (the bug),
+// and (2) the EXACT escalation call the helper makes (reapGrandchild →
+// reapPidGroupEscalated with the HUP→KILL profile) cleans it. What only the
+// packaged helper can prove end-to-end: Electron's fork/IPC delivery of
+// {type:"pty-pid"} (asserted in d1 via the identical Node fork API) and the
+// before-quit hold — flagged for QA in the step report.
+test("(c) SIGKILL'd bridge orphans the child; the helper-side escalation reaps it (+ verified already-dead path)", { timeout: 40_000 }, async (t) => {
+  const { session, tokens, relay } = await startSession(t);
+  const mark = newMark();
+  const spawned = spawnBridge({
+    relayUrl: relay.url,
+    session,
+    token: tokens.bridge,
+    cmd: immuneCmd(mark),
+  });
+  t.after(() => { if (spawned.child.exitCode === null) spawned.child.kill("SIGKILL"); });
+
+  const sentinelPid = await findSentinel(mark);
+  t.after(() => killHard(sentinelPid));
+
+  spawned.child.kill("SIGKILL");
+  await waitForExit(spawned.child, HARD_TIMEOUT_MS, "bridge (SIGKILL)");
+
+  // (1) The orphan is real: nothing bridge-side can help after SIGKILL.
+  await new Promise((r) => setTimeout(r, 600));
+  assert.equal(pidAlive(sentinelPid), true, "row c reproduced: SIGKILL'd bridge leaves the child running");
+
+  // (2) The helper's escalation profile (SIGHUP → wait → SIGKILL+group) reaps it.
+  const res = await reapPidGroupEscalated(sentinelPid, { hupWaitMs: 500, termWaitMs: 0 });
+  assert.equal(res.stage, "SIGKILL", "HUP-immune orphan requires the SIGKILL stage");
+  assert.equal(res.confirmedDead, true, "the helper profile VERIFIES death");
+  assert.equal(pidAlive(sentinelPid), false, "orphan reaped");
+
+  // Error/no-op path: reaping an already-dead pid short-circuits.
+  const again = await reapPidGroupEscalated(sentinelPid, { hupWaitMs: 100, termWaitMs: 0 });
+  assert.equal(again.stage, "already-dead", "verification of a dead grandchild is a no-op");
+  console.log("[oc/c] PASS — orphan reproduced, then reaped by the helper-side escalation");
+});
+
+// ── reap module happy path: an obedient child needs NO escalation ─────────────
+test("reap module: a SIGHUP-obedient child dies at the SIGHUP stage — no escalation", { timeout: 15_000 }, async (t) => {
+  const mark = newMark();
+  const child = spawn("sleep", [mark], { detached: true, stdio: "ignore" }); // own group, like spawn-helper's setsid
+  child.unref();
+  t.after(() => killHard(child.pid));
+  await waitFor(() => pidAlive(child.pid), 5_000, "obedient sentinel up");
+
+  const stages = [];
+  const res = await reapPidGroupEscalated(child.pid, {
+    hupWaitMs: 1000,
+    termWaitMs: 500,
+    onStage: (s) => stages.push(s),
+  });
+  assert.equal(res.stage, "SIGHUP", "plain SIGHUP suffices for an obedient child");
+  assert.equal(res.confirmedDead, true);
+  assert.deepEqual(stages, [], "no escalation stages were needed");
+  console.log("[oc/reap] PASS — obedient child: SIGHUP only, verified");
+});
+
+// ── reap module group sweep: children of the PTY child die too ────────────────
+test("reap module: the SIGKILL stage sweeps the child's OWN children via the process group", { timeout: 15_000 }, async (t) => {
+  const mark = newMark();
+  const subMark = newMark();
+  // detached:true → setsid, exactly how spawn-helper isolates the PTY child.
+  // The leader ignores HUP+TERM and carries a background child in its group —
+  // the shape of `claude` having spawned an MCP server.
+  const child = spawn(
+    "bash",
+    ["-c", `trap '' HUP TERM; sleep ${subMark} & exec sleep ${mark}`],
+    { detached: true, stdio: "ignore" },
+  );
+  child.unref();
+  t.after(() => killHard(child.pid));
+
+  const leaderPid = await findSentinel(mark);
+  assert.equal(leaderPid, child.pid, "the exec'd leader keeps its pid");
+  const subPid = await waitFor(
+    async () => (await pgrepPids(`^sleep ${subMark}$`))[0] ?? null,
+    5_000,
+    "background group member",
+    100,
+  );
+  t.after(() => { try { process.kill(subPid, "SIGKILL"); } catch { /* ignore */ } });
+
+  const res = await reapPidGroupEscalated(leaderPid, { hupWaitMs: 300, termWaitMs: 300 });
+  assert.equal(res.stage, "SIGKILL", "immune leader forces the SIGKILL stage");
+  assert.equal(res.confirmedDead, true);
+  await waitFor(() => !pidAlive(subPid), 3_000, "group member death", 50);
+  assert.equal(pidAlive(leaderPid), false, "leader dead");
+  console.log("[oc/group] PASS — group SIGKILL swept the child's own children");
+});
+
+// ── final sweep: NOTHING may survive this suite ───────────────────────────────
+after(async () => {
+  const strays = await pgrepPids(SWEEP_PREFIX);
+  for (const pid of strays) killHard(pid); // clean up before failing loudly
+  assert.deepEqual(strays, [], `stray sentinel processes leaked: ${strays.join(", ")}`);
+  console.log("[oc/sweep] PASS — final ps sweep clean");
+});

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"


### PR DESCRIPTION
## Problem (HIGH severity)
Orphaned `claude` processes accumulated after terminal sessions (field: 15 at once, ~2–4GB RSS + live auth sessions). Root cause: teardown rested on **one unverified SIGHUP** — node-pty's `term.kill()` fired it and the bridge hard-exited 200ms later; spawn-helper's `setsid` makes the PTY child its own session/group leader, so nothing else could reach it. Empirical matrix: **every** teardown path leaked with a HUP-immune child.

## Fix (mechanism, not symptom)
- **`terminal/shared/reap.mjs`** — verified-kill primitive: SIGHUP → SIGTERM → SIGKILL (group sweep), returns confirmed-dead.
- **Bridge**: shutdown rewritten around it (no exit until confirmed, 5s cap); IPC parent-death detection; pty-pid reported to helper; token check before spawn; ws keepalive (dead links die ≤90s, not 8h).
- **Helper**: verifies grandchild death on bridge exit + holds `before-quit` until every grandchild is reaped.
- **7 new regression tests** (SIGHUP-immune sentinels) + serial `npm test`.

## Verification
Full Bug Fix workflow (Reproduce → Fix → **independent** Verify → Sign-off, human-approved). All matrix rows reap with pid evidence; **real dev-Electron helper** reaps a `kill -9`'d bridge's grandchild in ~1s and holds quit until reaped; healthy-child teardown stays ~71ms; falsification attempts held. Known inherent limit: a descendant that re-`setsid`s escapes (no cgroups) — docs note.

## Rollout
No `src/` changes — **nothing deploys from this merge**. Ships in the next **batched notarized helper release** (with bootstrap-prompt bridge changes + relay-host pinning `c5f9d86b`), gated on a 4-item packaged-helper QA checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)