### PR TITLE
fix(terminal): allowlist the relay host — block malicious vibecodes:// links from hijacking the PTY

### DIFF
--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -40,6 +40,7 @@ import { createRequire } from "node:module";
 import WebSocket from "ws";
 import { parseControlMessage } from "./framing.js";
 import { parseLaunchDeepLink, redactDeepLinkToken } from "../../shared/deep-link.mjs";
+import { isRelayHostAllowed } from "../../shared/relay-allowlist.mjs";
 import { isAttachedFrame } from "../../shared/control-frames.mjs";
 import { reapPidGroupEscalated } from "../../shared/reap.mjs";
 
@@ -100,6 +101,25 @@ if (LAUNCH_URL) {
 }
 
 const RELAY = launched?.relay || args.relay || process.env.RELAY_URL || "ws://localhost:8787";
+
+// ── relay-host ALLOWLIST (load-bearing security gate) ─────────────────────────
+// `vibecodes://launch?relay=<HOST>` is fired by ANY web page, and `relay=` is the
+// highest-precedence source of RELAY above. Before this gate the bridge dialled
+// whatever host it named — an attacker relay then verifies its OWN token, passes
+// the R1 `{"t":"attached"}` gate, and streams keystrokes into the spawned `claude`
+// PTY (see the Reproduce & Investigate step). Pin the dial target HERE, before
+// `new WebSocket()` and before ANY pty.spawn on every path (promptless spawn-first
+// AND prompt-deferred). Loopback is allowed only when NOT packaged (dev/tests dial
+// the Node stand-in on ws://127.0.0.1:<port>); the packaged helper sets
+// VIBECODES_PACKAGED=1, so loopback + any non-prod host are rejected in production.
+// On reject: log the HOST ONLY (never the token) and exit cleanly, zero spawn.
+const ALLOW_LOOPBACK_RELAY = process.env.VIBECODES_PACKAGED !== "1";
+if (!isRelayHostAllowed(RELAY, { allowLoopback: ALLOW_LOOPBACK_RELAY })) {
+  let host = "unparseable";
+  try { host = new URL(RELAY).host; } catch { /* never echo the raw url — may carry a token */ }
+  log("error", "relay host not allowed", { host });
+  process.exit(1);
+}
 const SESSION = launched?.session || args.session || process.env.SESSION_ID || `dev-${Math.random().toString(36).slice(2, 10)}`;
 const TOKEN = launched?.token || args.token || process.env.BRIDGE_TOKEN || "";
 const CMD = args.cmd || process.env.BRIDGE_CMD || "claude";

--- a/terminal/helper/main.js
+++ b/terminal/helper/main.js
@@ -41,6 +41,10 @@ const SHARED_REAP = app.isPackaged
   ? path.join(process.resourcesPath, "shared", "reap.mjs")
   : path.resolve(__dirname, "..", "shared", "reap.mjs");
 
+const SHARED_ALLOWLIST = app.isPackaged
+  ? path.join(process.resourcesPath, "shared", "relay-allowlist.mjs")
+  : path.resolve(__dirname, "..", "shared", "relay-allowlist.mjs");
+
 // ── logging (metadata only — NEVER log the deep-link token) ───────────────────
 const t0 = Date.now();
 function log(level, msg, extra) {
@@ -60,6 +64,14 @@ let _reap = null;
 async function reapMod() {
   if (!_reap) _reap = await import(pathToFileURL(SHARED_REAP).href);
   return _reap;
+}
+
+// Lazily import the shared relay-host allowlist (same module + predicate the
+// bridge's own gate uses — single source of truth).
+let _allowlist = null;
+async function allowlistMod() {
+  if (!_allowlist) _allowlist = await import(pathToFileURL(SHARED_ALLOWLIST).href);
+  return _allowlist;
 }
 
 // ── child-bridge bookkeeping + idle quit ─────────────────────────────────────
@@ -139,6 +151,20 @@ async function handleLaunchUrl(rawUrl) {
     });
     return;
   }
+
+  // RELAY-HOST ALLOWLIST (first-line reject, so we never fork on a hostile host).
+  // `relay=` is attacker-controllable — any web page can fire this deep link. Pin
+  // the dial target to the prod relay (loopback allowed only in dev). The forked
+  // bridge re-checks with the SAME predicate (single source of truth); this early
+  // reject just avoids spending a fork on a doomed launch. Log the HOST ONLY.
+  const { isRelayHostAllowed } = await allowlistMod();
+  if (!isRelayHostAllowed(parsed.relay, { allowLoopback: !app.isPackaged })) {
+    let host = "unparseable";
+    try { host = new URL(parsed.relay).host; } catch { /* never echo the token */ }
+    log("error", "relay host not allowed — refusing to launch bridge", { host });
+    return;
+  }
+
   log("info", "launching bridge for deep link", { url: redactDeepLinkToken(rawUrl) });
 
   // ELECTRON_RUN_AS_NODE=1 → the forked process is plain Node (Electron's bundled
@@ -146,7 +172,14 @@ async function handleLaunchUrl(rawUrl) {
   // through verbatim so test seams (e.g. BRIDGE_CMD) keep working; in production
   // the bridge defaults the spawned command to `claude`.
   const child = fork(BRIDGE_ENTRY, ["--launch-url", rawUrl], {
-    env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+    env: {
+      ...process.env,
+      ELECTRON_RUN_AS_NODE: "1",
+      // Signal the bridge's OWN allowlist gate whether we're packaged. Packaged
+      // → loopback + any non-prod host rejected; dev → loopback allowed. Keeps
+      // the two gates (helper here + bridge) in lockstep.
+      VIBECODES_PACKAGED: app.isPackaged ? "1" : "",
+    },
     stdio: ["ignore", "pipe", "pipe", "ipc"],
   });
   children.add(child);

--- a/terminal/shared/relay-allowlist.mjs
+++ b/terminal/shared/relay-allowlist.mjs
@@ -1,0 +1,99 @@
+// Shared relay-host allowlist — the SINGLE source of truth for "may the bridge
+// dial this relay?".
+//
+// THREAT (see the Reproduce & Investigate step): `vibecodes://launch?relay=<HOST>`
+// can be fired by ANY web page. Before this gate the bridge dialled WHATEVER host
+// `relay=` named, with zero validation — an attacker-controlled relay verifies its
+// OWN attacker-minted token against its OWN secret, passes the R1 `{"t":"attached"}`
+// gate, and then streams keystrokes into the spawned `claude` PTY (+ the one-shot
+// argv prompt). That is RCE-adjacent. This module pins the dial target so a hostile
+// `relay=` value can never reach `new WebSocket()` or `pty.spawn()`.
+//
+// Pure + dependency-free (only the global WHATWG `URL`), so it runs unchanged in
+// Node (bridge), Electron-as-Node (helper) and is trivially unit-testable.
+
+/**
+ * The ONE production relay host, matched EXACTLY (never substring/endsWith —
+ * `…workers.dev.evil.com` and `evil-…workers.dev` must both fail).
+ */
+export const PROD_RELAY_HOST = "vibecodes-terminal-relay.nicholasmball.workers.dev";
+
+/** Loopback hostnames permitted only when `allowLoopback` is set (dev/tests). */
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+
+/**
+ * Normalise a WHATWG-URL hostname for comparison: IPv6 hostnames arrive wrapped
+ * in brackets (`[::1]`), so strip them so `::1` compares cleanly.
+ *
+ * @param {string} hostname
+ * @returns {string}
+ */
+function bareHost(hostname) {
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}
+
+/**
+ * Whether the bridge is allowed to dial `relayUrl`.
+ *
+ * Rules:
+ *   - Not a parseable URL → false.
+ *   - Allowed iff EXACT `hostname === PROD_RELAY_HOST` AND `protocol === "wss:"`.
+ *     Exact-match also defeats userinfo tricks: `wss://real-host@evil.com` parses
+ *     to `hostname === "evil.com"`, so it is rejected here.
+ *   - When `allowLoopback` (dev + automated tests dial the Node stand-in relay on
+ *     `ws://127.0.0.1:<port>`): ALSO allow loopback hostnames with `ws:`|`wss:`
+ *     on any port. When NOT set (packaged helper), loopback is rejected.
+ *
+ * @param {unknown} relayUrl
+ * @param {{ allowLoopback?: boolean }} [opts]
+ * @returns {boolean}
+ */
+export function isRelayHostAllowed(relayUrl, { allowLoopback = false } = {}) {
+  if (typeof relayUrl !== "string" || relayUrl.length === 0) return false;
+  let url;
+  try {
+    url = new URL(relayUrl);
+  } catch {
+    return false;
+  }
+
+  const host = bareHost(url.hostname);
+
+  // Production relay: exact host + secure (wss) only.
+  if (host === PROD_RELAY_HOST && url.protocol === "wss:") return true;
+
+  // Dev/test loopback: any port, ws or wss.
+  if (
+    allowLoopback &&
+    LOOPBACK_HOSTS.has(host) &&
+    (url.protocol === "ws:" || url.protocol === "wss:")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Throwing convenience wrapper for call sites that want fail-closed semantics.
+ * The thrown message carries the HOST ONLY — never the token/query string.
+ *
+ * @param {unknown} relayUrl
+ * @param {{ allowLoopback?: boolean }} [opts]
+ * @returns {string} the validated relay URL
+ */
+export function assertRelayAllowed(relayUrl, opts) {
+  if (!isRelayHostAllowed(relayUrl, opts)) {
+    let host = "unparseable";
+    try {
+      host = new URL(String(relayUrl)).host;
+    } catch {
+      /* keep "unparseable" — never echo the raw string (may carry a token) */
+    }
+    throw new Error(`relay host not allowed: ${host}`);
+  }
+  return String(relayUrl);
+}

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/relay-allowlist.test.mjs
+++ b/terminal/test/relay-allowlist.test.mjs
@@ -1,0 +1,205 @@
+// Relay-host allowlist — the fix for the `vibecodes://launch?relay=<HOST>` RCE
+// vector (see the Reproduce & Investigate step). Two layers of proof:
+//
+//   1. UNIT — the pure `isRelayHostAllowed` predicate: prod wss ✅, prod ws ❌,
+//      loopback gated on `allowLoopback`, and a battery of bypass strings ❌
+//      (fake-suffix host, fake-prefix host, userinfo trick, wrong scheme, garbage).
+//   2. BRIDGE e2e — the load-bearing gate: with VIBECODES_PACKAGED=1 a loopback
+//      `relay=` is rejected → the bridge exits 1 with ZERO `spawning PTY`; the
+//      positive control (no VIBECODES_PACKAGED) dials the loopback stand-in and
+//      attaches + spawns normally, byte round-trip through the relay.
+//
+// Run: cd terminal/test && node relay-allowlist.test.mjs   (or via `npm test`)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import WebSocket from "ws";
+import {
+  isRelayHostAllowed,
+  assertRelayAllowed,
+  PROD_RELAY_HOST,
+} from "../shared/relay-allowlist.mjs";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens } from "../shared/session-token.mjs";
+import { buildLaunchDeepLink } from "../shared/deep-link.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BRIDGE_ENTRY = path.resolve(__dirname, "../bridge/src/index.js");
+const SENTINEL = path.resolve(__dirname, "./sentinel-cmd.mjs");
+const HARD_TIMEOUT_MS = 20000;
+const SECRET = "relay-allowlist-test-secret";
+const PROD_WSS = `wss://${PROD_RELAY_HOST}`;
+
+// ── UNIT: the pure predicate ───────────────────────────────────────────────────
+
+test("prod relay over wss is allowed (both allowLoopback modes)", () => {
+  assert.equal(isRelayHostAllowed(PROD_WSS, { allowLoopback: false }), true);
+  assert.equal(isRelayHostAllowed(PROD_WSS, { allowLoopback: true }), true);
+  assert.equal(isRelayHostAllowed(`${PROD_WSS}/?session=x&role=bridge`, { allowLoopback: false }), true);
+});
+
+test("prod relay over insecure ws is REJECTED (wss-only)", () => {
+  assert.equal(isRelayHostAllowed(`ws://${PROD_RELAY_HOST}`, { allowLoopback: false }), false);
+  assert.equal(isRelayHostAllowed(`ws://${PROD_RELAY_HOST}`, { allowLoopback: true }), false);
+});
+
+test("loopback is allowed ONLY when allowLoopback is set", () => {
+  for (const host of ["127.0.0.1", "localhost", "[::1]"]) {
+    assert.equal(isRelayHostAllowed(`ws://${host}:8787`, { allowLoopback: true }), true, `${host} ws dev`);
+    assert.equal(isRelayHostAllowed(`wss://${host}:8787`, { allowLoopback: true }), true, `${host} wss dev`);
+    assert.equal(isRelayHostAllowed(`ws://${host}:8787`, { allowLoopback: false }), false, `${host} packaged`);
+  }
+});
+
+test("bypass strings are all REJECTED", () => {
+  const bypass = [
+    "wss://evil.example",
+    // fake SUFFIX — endsWith() would have let this through
+    `wss://${PROD_RELAY_HOST}.evil.com`,
+    // fake PREFIX — substring/includes() would have let this through
+    `wss://evil-${PROD_RELAY_HOST}`,
+    // userinfo trick — real host in the userinfo, evil host is the authority
+    `wss://${PROD_RELAY_HOST}@evil.com`,
+    "wss://real@evil.com",
+    // wrong scheme entirely
+    `https://${PROD_RELAY_HOST}`,
+    `http://${PROD_RELAY_HOST}`,
+    // garbage / non-strings
+    "not a url",
+    "",
+    "://///",
+    null,
+    undefined,
+    42,
+    {},
+  ];
+  for (const b of bypass) {
+    assert.equal(isRelayHostAllowed(b, { allowLoopback: true }), false, `must reject: ${String(b)}`);
+    assert.equal(isRelayHostAllowed(b, { allowLoopback: false }), false, `must reject (packaged): ${String(b)}`);
+  }
+});
+
+test("assertRelayAllowed throws host-only (never the token) on reject", () => {
+  const withToken = `wss://evil.example/?token=SUPERSECRET&role=bridge`;
+  assert.throws(
+    () => assertRelayAllowed(withToken, { allowLoopback: false }),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.includes("evil.example"), "message names the host");
+      assert.ok(!err.message.includes("SUPERSECRET"), "message must NOT leak the token");
+      return true;
+    },
+  );
+  assert.equal(assertRelayAllowed(PROD_WSS, { allowLoopback: false }), PROD_WSS);
+});
+
+// ── BRIDGE e2e helpers (mirror prompt-launch.test.mjs) ─────────────────────────
+
+function spawnBridge(argv, env = {}) {
+  const child = spawn(process.execPath, [BRIDGE_ENTRY, ...argv], {
+    env: { PATH: process.env.PATH, BRIDGE_MAX_SECONDS: "60", ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (d) => { stderr += d; });
+  return { child, getStderr: () => stderr };
+}
+
+function waitForText(getBuf, text, ms, label) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const iv = setInterval(() => {
+      if (getBuf().includes(text)) { clearInterval(iv); resolve(Date.now() - started); }
+      else if (Date.now() - started > ms) { clearInterval(iv); reject(new Error(`timed out waiting for ${label}`)); }
+    }, 25);
+  });
+}
+
+async function waitForExit(child, ms, label) {
+  const [code] = await Promise.race([
+    once(child, "exit"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${label} exit timeout`)), ms)),
+  ]);
+  return { code };
+}
+
+async function connectBrowserLeg(relayUrl, session, browserToken) {
+  let buf = "";
+  const ws = new WebSocket(`${relayUrl}/?session=${session}&role=browser&token=${encodeURIComponent(browserToken)}`);
+  ws.on("message", (data) => { buf += Buffer.isBuffer(data) ? data.toString("utf8") : String(data); });
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error("browser ws open timeout")), 5000)),
+  ]);
+  return { ws, getBuf: () => buf };
+}
+
+// ── e2e NEGATIVE: packaged bridge + loopback relay ⇒ exit 1, ZERO spawn ────────
+test("packaged bridge (VIBECODES_PACKAGED=1) rejects a loopback relay before any spawn", { timeout: 60000 }, async (t) => {
+  const session = `ra-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = "user-RA-" + Math.random().toString(36).slice(2, 8);
+  let relay;
+  let bridge;
+
+  t.after(async () => {
+    if (bridge && bridge.exitCode === null) bridge.kill("SIGKILL");
+    if (relay) await relay.close();
+  });
+
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-RA", sid: session, secret: SECRET });
+  relay = await startStandinRelay({ port: 0, secret: SECRET });
+
+  // Loopback stand-in URL — allowed in dev, but VIBECODES_PACKAGED=1 pins to prod.
+  const launchUrl = buildLaunchDeepLink({ relay: relay.url, session, token: tokens.bridge });
+  const spawned = spawnBridge(
+    ["--launch-url", launchUrl, "--cmd", `${process.execPath} ${SENTINEL}`],
+    { VIBECODES_PACKAGED: "1" },
+  );
+  bridge = spawned.child;
+
+  const { code } = await waitForExit(spawned.child, HARD_TIMEOUT_MS, "packaged bridge");
+  const logs = spawned.getStderr();
+  assert.ok(logs.includes("relay host not allowed"), "bridge logs the allowlist rejection");
+  assert.ok(!logs.includes("spawning PTY"), "NO PTY spawn on a rejected relay host");
+  assert.ok(!logs.includes("connecting to relay"), "bridge must not even dial the relay");
+  assert.equal(code, 1, "a rejected relay host exits non-zero");
+  console.log("[test/ra] PASS — packaged + loopback relay ⇒ exit 1, zero spawn");
+});
+
+// ── e2e POSITIVE control: dev bridge + loopback relay ⇒ normal attach+spawn ─────
+test("dev bridge (no VIBECODES_PACKAGED) dials the loopback stand-in and spawns normally", { timeout: 60000 }, async (t) => {
+  const session = `rap-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = "user-RAP-" + Math.random().toString(36).slice(2, 8);
+  let relay;
+  let bridge;
+  let browser;
+
+  t.after(async () => {
+    try { browser?.terminate(); } catch { /* ignore */ }
+    if (bridge && bridge.exitCode === null) bridge.kill("SIGKILL");
+    if (relay) await relay.close();
+  });
+
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-RAP", sid: session, secret: SECRET });
+  relay = await startStandinRelay({ port: 0, secret: SECRET });
+
+  const leg = await connectBrowserLeg(relay.url, session, tokens.browser);
+  browser = leg.ws;
+
+  const launchUrl = buildLaunchDeepLink({ relay: relay.url, session, token: tokens.bridge });
+  const spawned = spawnBridge(["--launch-url", launchUrl, "--cmd", `${process.execPath} ${SENTINEL}`]);
+  bridge = spawned.child;
+
+  await waitForText(leg.getBuf, "READY", HARD_TIMEOUT_MS, "sentinel via relay");
+  const logs = spawned.getStderr();
+  assert.ok(!logs.includes("relay host not allowed"), "loopback relay is NOT rejected in dev");
+  assert.ok(logs.includes("spawning PTY"), "dev bridge spawns the PTY");
+  assert.ok(logs.includes("connecting to relay"), "dev bridge dials the loopback relay");
+  console.log("[test/rap] PASS — dev + loopback relay ⇒ normal attach + spawn");
+});


### PR DESCRIPTION
## Problem (HIGH, RCE-adjacent)
Any web page could fire `vibecodes://launch?relay=<attacker-host>&token=<attacker-minted>&prompt=…` and the bridge dialed **whatever host the link named, with zero validation**. The attacker's relay verifies its own token against its own secret, passes the R1 `{"t":"attached"}` gate, and streams keystrokes (+ a one-shot argv prompt) into the spawned `claude` PTY on the victim's machine. Confirmed with a localhost repro.

## Fix
Pin the relay host to an allowlist (`terminal/shared/relay-allowlist.mjs`): exact-match `vibecodes-terminal-relay.nicholasmball.workers.dev` over `wss:` (never substring); loopback allowed **only when not packaged**. Enforced as a **load-bearing gate in the bridge** before the socket and before any spawn on every path; helper adds a defense-in-depth early reject + injects `VIBECODES_PACKAGED` so the forked bridge's gate matches. Packaged build → only the real prod relay.

## Verification (Bug Fix workflow, human-approved)
Packaged-mode attack re-run with an independent driver: **exit 1, attacker relay never saw a socket, no spawn, browser leg got nothing.** Falsification battery (uppercase, trailing-dot, `:443`, punycode look-alikes, `@`/userinfo, protocol-relative, embedded newlines/tabs, fake prefix/suffix) → **no bypass**. `relay-allowlist` 7/7 · full serial `npm test` **34/34** · tsc clean · no `src/` changes.

## Rollout
Nothing deploys from this merge. **Third and final** helper-side change in the batched notarized helper release (with bootstrap-prompt + orphan-cleanup). Packaged-QA gate adds: `wss://evil.example` link refused; real in-app prod launch still works. Staging host intentionally not allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)