### PR TITLE
feat(terminal): reconnect re-attaches to the running session (grace-window reattach)

### DIFF
--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -57,11 +57,15 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 import type { FitAddon as XFitAddon } from "@xterm/addon-fit";
 import {
   CONNECT_TIMEOUT_MS,
+  RECONNECT_GRACE_MS,
   buildRelayUrl,
   encodeResizeMessage,
   initialConnectionState,
   isInputEnabled,
+  isPeerDegradedFrame,
+  isPeerReattachedFrame,
   isTerminalEnabled,
+  mapCloseCode,
   relayBaseUrl,
   terminalReducer,
   type TerminalConnectionState,
@@ -120,6 +124,11 @@ interface TerminalDockProps {
 interface PairInfo {
   sessionId: string;
   bridgeToken: string;
+  // Retained so a TRANSIENT drop can REATTACH to the SAME sid with no re-mint
+  // (grace-window reconnect). `browserToken` re-opens the browser leg; `expiresAt`
+  // (unix seconds) is the token-validity bound on how long reattach is possible.
+  browserToken: string;
+  expiresAt: number;
 }
 
 interface StatusMeta {
@@ -193,6 +202,10 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     resolveTerminalPlatform(readPlatformSignals()),
   );
   const [paired, setPaired] = useState<boolean>(() => isBrowserPaired());
+  // Grace-window degrade hint: the relay told us our peer (the bridge) dropped and
+  // it's HOLDING the session. The terminal stays visible; we show a subtle
+  // "reconnecting" hint until peer-reattached (or the window expires).
+  const [peerDegraded, setPeerDegraded] = useState(false);
 
   const wsRef = useRef<WebSocket | null>(null);
   const termRef = useRef<XTerm | null>(null);
@@ -208,6 +221,18 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // otherwise two sessions + two bridges race and the relay tears both down
   // (single-attach / peer-gone). This is the fix for the "connect fires twice" bug.
   const connectGenRef = useRef(0);
+  // Grace-window reconnect bookkeeping. `reconnectDeadlineRef.current === 0` means
+  // "healthy, not reconnecting"; it's set on the first transient drop and cleared
+  // once a byte proves the link healthy again. The pair (sid + retained tokens) is
+  // mirrored into a ref so the timer-driven reconnect loop reads current creds
+  // without re-binding. `scheduleReconnectRef` breaks the openBrowserLeg ⇄
+  // scheduleReconnect cycle. `degradeTimerRef` bounds the peer-degraded wait.
+  const reconnectDeadlineRef = useRef(0);
+  const reconnectAttemptRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const degradeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pairRef = useRef<PairInfo | null>(null);
+  const scheduleReconnectRef = useRef<() => void>(() => {});
   // The compact bootstrap prompt (head/tail parts) the LAST launch-bus event
   // carried — i.e. what the launch button resolved. Dock-initiated launches with
   // no bus payload (paired auto-connect on open, Retry) fall back to building the
@@ -223,6 +248,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   statusRef.current = state.status;
   readOnlyRef.current = readOnly;
   pairedRef.current = paired;
+  pairRef.current = pair;
 
   // ── lazy, client-only xterm init ────────────────────────────────────────────
   useEffect(() => {
@@ -333,6 +359,20 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     if (helperTimerRef.current) {
       clearTimeout(helperTimerRef.current);
       helperTimerRef.current = null;
+    }
+  }, []);
+
+  const clearReconnectTimer = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  }, []);
+
+  const clearDegradeTimer = useCallback(() => {
+    if (degradeTimerRef.current) {
+      clearTimeout(degradeTimerRef.current);
+      degradeTimerRef.current = null;
     }
   }, []);
 
@@ -461,6 +501,14 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
 
   const teardownSocket = useCallback(() => {
     clearConnectTimer();
+    // Cancel any in-flight grace-window reconnect loop / degrade wait, and reset the
+    // reconnect budget. Nulling the socket's handlers below means a teardown-initiated
+    // close never re-triggers the reconnect loop (only genuine drops do).
+    clearReconnectTimer();
+    clearDegradeTimer();
+    reconnectDeadlineRef.current = 0;
+    reconnectAttemptRef.current = 0;
+    setPeerDegraded(false);
     const ws = wsRef.current;
     wsRef.current = null;
     if (ws) {
@@ -471,7 +519,139 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
         /* already closing */
       }
     }
-  }, [clearConnectTimer]);
+  }, [clearConnectTimer, clearReconnectTimer, clearDegradeTimer]);
+
+  // Open (or RE-open) the BROWSER leg to the relay and wire its handlers. Shared by
+  // connect() (fresh session) and the grace-window reconnect loop (same sid, retained
+  // token — NO re-mint). `reconnect` skips the hard 30s connect-timeout→error: while
+  // reconnecting the grace-window scheduler bounds the retries instead.
+  const openBrowserLeg = useCallback(
+    (sessionId: string, browserToken: string, opts?: { reconnect?: boolean }) => {
+      const reconnect = opts?.reconnect ?? false;
+      const url = buildRelayUrl(relayBaseUrl(), sessionId, browserToken);
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(url);
+      } catch (err) {
+        logger.error("Terminal relay socket open failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        dispatch({ type: "closed", code: 1006 });
+        return;
+      }
+      ws.binaryType = "arraybuffer";
+      wsRef.current = ws;
+
+      if (!reconnect) {
+        connectTimerRef.current = setTimeout(() => {
+          dispatch({ type: "connect-timeout" });
+          teardownSocket();
+        }, CONNECT_TIMEOUT_MS);
+      }
+
+      ws.onopen = () => {
+        clearConnectTimer();
+        dispatch({ type: "relay-open" });
+      };
+      ws.onmessage = (ev) => {
+        // TEXT = relay control frame on the BROWSER leg. The grace-window notices
+        // arrive here (the R1 `attached` frame goes to the bridge leg only).
+        if (typeof ev.data === "string") {
+          if (isPeerDegradedFrame(ev.data)) {
+            // Our peer (the bridge) dropped; the relay is HOLDING the session. Keep
+            // the terminal, show a subtle hint, and bound the wait to the grace window.
+            setPeerDegraded(true);
+            if (!degradeTimerRef.current) {
+              degradeTimerRef.current = setTimeout(() => {
+                degradeTimerRef.current = null;
+                setPeerDegraded(false);
+                dispatch({ type: "reconnect-exhausted" });
+                try {
+                  wsRef.current?.close(1000, "reconnect-grace-expired");
+                } catch {
+                  /* already closing */
+                }
+              }, RECONNECT_GRACE_MS);
+            }
+          } else if (isPeerReattachedFrame(ev.data)) {
+            // The pair is whole again inside the window — resume. Proves the pipe is
+            // restored even before the next byte, so drop back to connected + reset
+            // the reconnect budget (a scenario-1 already-connected leg no-ops).
+            clearDegradeTimer();
+            setPeerDegraded(false);
+            reconnectDeadlineRef.current = 0;
+            reconnectAttemptRef.current = 0;
+            dispatch({ type: "data" });
+          }
+          return;
+        }
+        // BINARY = opaque PTY bytes → the bridge is streaming; the link is HEALTHY.
+        // Clear the launch nudges, mark paired on first success, and reset every
+        // reconnect/degrade timer + budget so a later drop starts a fresh window.
+        clearHelperTimer();
+        removeLaunchIframe();
+        setLaunchPhase("idle");
+        clearDegradeTimer();
+        setPeerDegraded(false);
+        reconnectDeadlineRef.current = 0;
+        reconnectAttemptRef.current = 0;
+        if (!pairedRef.current) {
+          markBrowserPaired();
+          setPaired(true);
+        }
+        dispatch({ type: "data" });
+        termRef.current?.write(new Uint8Array(ev.data as ArrayBuffer));
+      };
+      ws.onerror = () => {
+        logger.warn("Terminal relay socket error", { sessionId });
+      };
+      ws.onclose = (ev) => {
+        clearConnectTimer();
+        wsRef.current = null;
+        dispatch({ type: "closed", code: ev.code, reason: ev.reason });
+        // Grace-window reconnect: a transient drop AFTER a live stream (PEER_GONE /
+        // abnormal 1006) is recoverable → keep reattaching within the window. Any
+        // terminal / clean-end code maps to a non-disconnected state and stops here.
+        // A teardown-initiated close nulled these handlers, so it never reaches this.
+        const mapped = mapCloseCode(ev.code, ev.reason, statusRef.current);
+        if (mapped.status === "disconnected") scheduleReconnectRef.current();
+      };
+    },
+    [teardownSocket, clearConnectTimer, clearHelperTimer, removeLaunchIframe, clearDegradeTimer],
+  );
+
+  // Drive the grace-window reconnect loop: reattach to the SAME sid with the retained
+  // browser token, with jittered exponential backoff, bounded by BOTH the grace window
+  // and the token validity. When either is spent with no reattach, end honestly
+  // (reconnect-exhausted → the calm "session ended, start a new one" overlay). No
+  // re-mint, no deep link — a bounded, silent reattach.
+  const scheduleReconnect = useCallback(() => {
+    clearDegradeTimer();
+    const p = pairRef.current;
+    const now = Date.now();
+    const tokenValid = !!p && p.expiresAt * 1000 > now + 1000;
+    if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
+    if (!p || !tokenValid || now >= reconnectDeadlineRef.current) {
+      reconnectDeadlineRef.current = 0;
+      reconnectAttemptRef.current = 0;
+      dispatch({ type: "reconnect-exhausted" });
+      return;
+    }
+    const attempt = reconnectAttemptRef.current++;
+    const delay = Math.min(1000 * 2 ** attempt, 8000) + Math.floor(Math.random() * 250);
+    clearReconnectTimer();
+    reconnectTimerRef.current = setTimeout(() => {
+      const pp = pairRef.current;
+      if (!pp || Date.now() >= reconnectDeadlineRef.current) {
+        reconnectDeadlineRef.current = 0;
+        reconnectAttemptRef.current = 0;
+        dispatch({ type: "reconnect-exhausted" });
+        return;
+      }
+      openBrowserLeg(pp.sessionId, pp.browserToken, { reconnect: true });
+    }, delay);
+  }, [openBrowserLeg, clearReconnectTimer, clearDegradeTimer]);
+  scheduleReconnectRef.current = scheduleReconnect;
 
   // ── connect (browser leg) ───────────────────────────────────────────────────
   // `autoLaunch` = the same-machine path: after minting, fire the vibecodes:// deep
@@ -492,7 +672,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     lastDimsRef.current = "";
     dispatch({ type: "connect" });
 
-    let data: { sessionId: string; browserToken: string; bridgeToken: string };
+    let data: { sessionId: string; browserToken: string; bridgeToken: string; expiresAt: number };
     try {
       const res = await fetch("/api/terminal/session", {
         method: "POST",
@@ -524,64 +704,43 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     if (gen !== connectGenRef.current) return;
 
     dispatch({ type: "session-created", sessionId: data.sessionId });
-    setPair({ sessionId: data.sessionId, bridgeToken: data.bridgeToken });
+    // Retain the browser token + expiry too, so a transient drop can REATTACH to
+    // this same sid with no re-mint (grace-window reconnect).
+    setPair({
+      sessionId: data.sessionId,
+      bridgeToken: data.bridgeToken,
+      browserToken: data.browserToken,
+      expiresAt: data.expiresAt,
+    });
+    // A fresh mint starts a fresh reconnect budget.
+    reconnectDeadlineRef.current = 0;
+    reconnectAttemptRef.current = 0;
     termRef.current?.clear();
 
     // Same-machine: hand the bridge token to the local helper via the deep link.
     if (autoLaunch) fireLaunchDeepLink(data.sessionId, data.bridgeToken);
 
-    const url = buildRelayUrl(relayBaseUrl(), data.sessionId, data.browserToken);
-    let ws: WebSocket;
-    try {
-      ws = new WebSocket(url);
-    } catch (err) {
-      logger.error("Terminal relay socket open failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      dispatch({ type: "closed", code: 1006 });
-      return;
+    openBrowserLeg(data.sessionId, data.browserToken);
+  }, [ideaId, teardownSocket, clearHelperTimer, removeLaunchIframe, fireLaunchDeepLink, openBrowserLeg]);
+
+  // Manual "Reconnect now" — force an immediate reattach attempt (skip the backoff
+  // wait) using the retained token, or fall back to a clean fresh launch if the
+  // token/window is spent. Fixes the old button, which minted an EMPTY session with
+  // no autoLaunch and timed out after 30s.
+  const reconnectNow = useCallback(() => {
+    const p = pairRef.current;
+    const now = Date.now();
+    const tokenValid = !!p && p.expiresAt * 1000 > now + 1000;
+    const withinWindow =
+      reconnectDeadlineRef.current === 0 || now < reconnectDeadlineRef.current;
+    if (p && tokenValid && withinWindow) {
+      clearReconnectTimer();
+      if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
+      openBrowserLeg(p.sessionId, p.browserToken, { reconnect: true });
+    } else {
+      void connect({ autoLaunch: true });
     }
-    ws.binaryType = "arraybuffer";
-    wsRef.current = ws;
-
-    connectTimerRef.current = setTimeout(() => {
-      dispatch({ type: "connect-timeout" });
-      teardownSocket();
-    }, CONNECT_TIMEOUT_MS);
-
-    ws.onopen = () => {
-      clearConnectTimer();
-      dispatch({ type: "relay-open" });
-    };
-    ws.onmessage = (ev) => {
-      // BINARY = opaque PTY bytes → xterm. TEXT = control frame — none expected on
-      // the BROWSER leg (the relay's R1 `attached` confirmation goes to the bridge
-      // leg only); ignore so a frame never reaches the screen as garbage.
-      if (typeof ev.data === "string") return;
-      // The helper attached and is streaming — the launch succeeded; drop the
-      // "opening helper" nudge and clean up the probe iframe/timer.
-      clearHelperTimer();
-      removeLaunchIframe();
-      setLaunchPhase("idle");
-      // First successful connection on this browser → remember it so future opens
-      // auto-connect and skip the setup wall (criteria #5 / #6).
-      if (!pairedRef.current) {
-        markBrowserPaired();
-        setPaired(true);
-      }
-      dispatch({ type: "data" });
-      termRef.current?.write(new Uint8Array(ev.data as ArrayBuffer));
-    };
-    ws.onerror = () => {
-      // A 'close' with the real code follows; just log metadata here.
-      logger.warn("Terminal relay socket error", { sessionId: data.sessionId });
-    };
-    ws.onclose = (ev) => {
-      clearConnectTimer();
-      wsRef.current = null;
-      dispatch({ type: "closed", code: ev.code, reason: ev.reason });
-    };
-  }, [ideaId, teardownSocket, clearConnectTimer, clearHelperTimer, removeLaunchIframe, fireLaunchDeepLink]);
+  }, [openBrowserLeg, clearReconnectTimer, connect]);
 
   // Install-first entry gate. This is the ONE place a browser "open" is turned into
   // either a setup panel, a coming-soon panel, or an auto-connect — the deep link is
@@ -795,13 +954,26 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
               onCopyBridge={copyBridgeCommand}
             />
           )}
+          {/* Our OWN link dropped — we're actively REATTACHING to the same session
+              within the grace window (retained token, no re-mint). Copy only claims
+              what's true DURING the window: the agent is held/running locally and we
+              reconnect automatically; if the window lapses the overlay switches to the
+              honest "session ended" end state. */}
           {state.status === "disconnected" && (
             <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
-              <WifiOff className="mr-1 inline h-3 w-3" />
-              <b>Lost the connection.</b> Your machine may have slept or dropped Wi-Fi. The agent keeps running locally.
-              <button className="ml-2 underline hover:text-amber-200" onClick={() => void connect()}>
+              <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
+              <b>Reconnecting to your session…</b> Your machine may have slept or dropped Wi-Fi. Your agent keeps running locally while we reattach.
+              <button className="ml-2 underline hover:text-amber-200" onClick={reconnectNow}>
                 Reconnect now
               </button>
+            </div>
+          )}
+          {/* Peer (the bridge) dropped but our link is fine — the relay is HOLDING the
+              session. Keep the live terminal visible; just show a subtle hint. */}
+          {state.status === "connected" && peerDegraded && (
+            <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
+              <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
+              <b>Connection interrupted — reconnecting…</b> Your machine may have slept; we&apos;re holding your session and will resume automatically.
             </div>
           )}
         </div>
@@ -1073,6 +1245,8 @@ function endedTitle(state: TerminalConnectionState): string {
       return "Ended after being idle";
     case "max-duration":
       return "Reached the session time limit";
+    case "reconnect-failed":
+      return "This session ended";
     default:
       return "Session ended";
   }
@@ -1083,6 +1257,10 @@ function endedMessage(state: TerminalConnectionState): string {
     case "idle":
     case "max-duration":
       return "We closed the session to keep things tidy and safe. Nothing went wrong — your work on your machine is untouched.";
+    case "reconnect-failed":
+      // The grace window / token validity lapsed before the link came back. Honest,
+      // reassuring, and the "Launch again" button below starts a clean fresh session.
+      return "We couldn't reattach in time after the connection dropped. Your saved work is safe — start a new session to pick things back up.";
     default:
       return "Claude Code on your machine stopped. The scrollback above is kept.";
   }

--- a/src/lib/terminal/connection.test.ts
+++ b/src/lib/terminal/connection.test.ts
@@ -1,15 +1,24 @@
 import { describe, it, expect } from "vitest";
 import {
   RELAY_CLOSE,
+  RECONNECT_GRACE_MS,
   initialConnectionState,
   terminalReducer,
   mapCloseCode,
   isInputEnabled,
+  isPeerDegradedFrame,
+  isPeerReattachedFrame,
   buildRelayUrl,
   encodeResizeMessage,
   type TerminalConnectionState,
   type TerminalEvent,
 } from "./connection";
+import { DEFAULT_TTL_SECONDS } from "../../../terminal/shared/session-token.mjs";
+import {
+  encodeAttachedFrame,
+  encodePeerDegradedFrame,
+  encodePeerReattachedFrame,
+} from "../../../terminal/shared/control-frames.mjs";
 
 // Helper: fold a sequence of events through the reducer from the initial state.
 function run(events: TerminalEvent[], start = initialConnectionState): TerminalConnectionState {
@@ -98,6 +107,33 @@ describe("terminalReducer — ending & failures", () => {
     const s = run([{ type: "connect" }, { type: "session-mint-failed" }]);
     expect(s.status).toBe("error");
     expect(s.errorKind).toBe("session-mint-failed");
+  });
+
+  it("reconnect-exhausted → honest session-ended (reconnect-failed), from a live drop", () => {
+    // connect → live → drop (disconnected) → grace window / token lapses.
+    const dropped = run([
+      { type: "connect" },
+      { type: "relay-open" },
+      { type: "data" },
+      { type: "closed", code: RELAY_CLOSE.PEER_GONE },
+    ]);
+    expect(dropped.status).toBe("disconnected");
+    const ended = terminalReducer(dropped, { type: "reconnect-exhausted" });
+    expect(ended.status).toBe("session-ended");
+    expect(ended.endedReason).toBe("reconnect-failed");
+    expect(ended.errorKind).toBeNull();
+  });
+
+  it("reconnect-exhausted never clobbers an existing session-ended (e.g. a user-end)", () => {
+    const ended = run([
+      { type: "connect" },
+      { type: "relay-open" },
+      { type: "data" },
+      { type: "user-end" },
+    ]);
+    const after = terminalReducer(ended, { type: "reconnect-exhausted" });
+    expect(after.status).toBe("session-ended");
+    expect(after.endedReason).toBe("user");
   });
 
   it("reset returns to a fresh idle state", () => {
@@ -207,5 +243,30 @@ describe("encodeResizeMessage", () => {
     expect(encodeResizeMessage(120, -1)).toBeNull();
     expect(encodeResizeMessage(1.5, 30)).toBeNull();
     expect(encodeResizeMessage(120, 99999)).toBeNull();
+  });
+});
+
+describe("grace-window reconnect (fix/terminal-reconnect-reattach)", () => {
+  it("the reconnect window stays strictly inside the token TTL (no re-mint)", () => {
+    // The whole point: original tokens must still be valid for the entire window, so
+    // a reattach never needs a fresh mint. Keep a safety margin below the 300s TTL.
+    expect(RECONNECT_GRACE_MS).toBeLessThan(DEFAULT_TTL_SECONDS * 1000);
+  });
+
+  // The browser detectors are duplicated from terminal/shared/control-frames.mjs
+  // (that module is plain .mjs outside the app's TS build graph). This pins them to
+  // the REAL encoders the relay sends, so any drift fails here.
+  it("detects the shared peer-degraded / peer-reattached frames the relay actually sends", () => {
+    expect(isPeerDegradedFrame(encodePeerDegradedFrame())).toBe(true);
+    expect(isPeerReattachedFrame(encodePeerReattachedFrame())).toBe(true);
+  });
+
+  it("each detector is strict to its own tag (mutually + attached-frame disjoint)", () => {
+    expect(isPeerReattachedFrame(encodePeerDegradedFrame())).toBe(false);
+    expect(isPeerDegradedFrame(encodePeerReattachedFrame())).toBe(false);
+    expect(isPeerDegradedFrame(encodeAttachedFrame())).toBe(false);
+    expect(isPeerReattachedFrame(encodeAttachedFrame())).toBe(false);
+    expect(isPeerDegradedFrame("")).toBe(false);
+    expect(isPeerDegradedFrame('{"t":"peer-degraded"' /* truncated */)).toBe(false);
   });
 });

--- a/src/lib/terminal/connection.ts
+++ b/src/lib/terminal/connection.ts
@@ -17,6 +17,16 @@
 /** How long we wait for the relay handshake before declaring an error (≈30s). */
 export const CONNECT_TIMEOUT_MS = 30_000;
 
+/**
+ * Reconnect grace window (ms). THE ONE SHARED NUMBER — equal to the relay grace
+ * (terminal/relay/src/pairing.js → RECONNECT_GRACE_MS) and the bridge budget
+ * (terminal/bridge/src/index.js → BRIDGE_RECONNECT_MS), and deliberately < the 300s
+ * token TTL so the ORIGINAL browser token is still valid for the whole window — a
+ * transient drop REATTACHES to the same sid with no re-mint. Beyond the window the
+ * session ends honestly and the UX falls back to a clean fresh launch.
+ */
+export const RECONNECT_GRACE_MS = 90_000;
+
 /** Default dev relay (overridable via NEXT_PUBLIC_TERMINAL_RELAY_URL). */
 export const DEFAULT_RELAY_URL = "ws://127.0.0.1:8787";
 
@@ -50,7 +60,7 @@ export type TerminalErrorKind =
   | "session-mint-failed"
   | "unknown";
 
-export type EndedReason = "user" | "remote" | "idle" | "max-duration";
+export type EndedReason = "user" | "remote" | "idle" | "max-duration" | "reconnect-failed";
 
 export interface TerminalConnectionState {
   status: TerminalStatus;
@@ -69,6 +79,7 @@ export type TerminalEvent =
   | { type: "data" }
   | { type: "user-end" }
   | { type: "connect-timeout" }
+  | { type: "reconnect-exhausted" }
   | { type: "closed"; code: number; reason?: string }
   | { type: "reset" };
 
@@ -183,6 +194,13 @@ export function terminalReducer(
       if (!isHandshaking(state.status)) return state;
       return { ...state, status: "error", errorKind: "connect-timeout", closeCode: null };
 
+    case "reconnect-exhausted":
+      // The grace window / token validity elapsed while disconnected and no reattach
+      // landed → an HONEST end (not an error). The saved work on the machine is safe;
+      // the overlay offers a clean fresh launch. A user-end already terminal → keep it.
+      if (state.status === "session-ended") return state;
+      return { ...state, status: "session-ended", endedReason: "reconnect-failed", errorKind: null };
+
     case "closed": {
       // A user-initiated end already produced the terminal state; the socket's own
       // close event must not clobber it back to a generic disconnect.
@@ -239,4 +257,34 @@ export function isTerminalEnabled(): boolean {
 /** Relay base URL (public env), defaulting to the local dev relay. */
 export function relayBaseUrl(): string {
   return process.env.NEXT_PUBLIC_TERMINAL_RELAY_URL || DEFAULT_RELAY_URL;
+}
+
+// ── grace-window control frames (browser leg) ─────────────────────────────────
+//
+// The relay sends the SURVIVING leg TEXT control frames while it HOLDS a session
+// open for the reconnect grace window. These detectors mirror the shared
+// definitions in terminal/shared/control-frames.mjs (encodePeerDegradedFrame /
+// encodePeerReattachedFrame). Duplicated (not imported) for the same reason
+// RELAY_CLOSE is: that module is plain .mjs outside the app's TS build graph — the
+// drift is pinned by connection.test.ts, which imports the real encoders and checks
+// these detectors agree byte-for-byte.
+
+function isControlFrame(text: string, tag: string): boolean {
+  if (text.length === 0 || text.length > 64) return false;
+  try {
+    const msg = JSON.parse(text) as unknown;
+    return !!msg && typeof msg === "object" && (msg as { t?: unknown }).t === tag;
+  } catch {
+    return false;
+  }
+}
+
+/** The relay is HOLDING this session: our peer dropped and may re-attach — keep the stream. */
+export function isPeerDegradedFrame(text: string): boolean {
+  return isControlFrame(text, "peer-degraded");
+}
+
+/** The pair is whole again inside the window — resume. */
+export function isPeerReattachedFrame(text: string): boolean {
+  return isControlFrame(text, "peer-reattached");
 }

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -41,7 +41,11 @@ import WebSocket from "ws";
 import { parseControlMessage } from "./framing.js";
 import { parseLaunchDeepLink, redactDeepLinkToken } from "../../shared/deep-link.mjs";
 import { isRelayHostAllowed } from "../../shared/relay-allowlist.mjs";
-import { isAttachedFrame } from "../../shared/control-frames.mjs";
+import {
+  isAttachedFrame,
+  isPeerDegradedFrame,
+  isPeerReattachedFrame,
+} from "../../shared/control-frames.mjs";
 import { reapPidGroupEscalated } from "../../shared/reap.mjs";
 
 const require = createRequire(import.meta.url);
@@ -158,6 +162,25 @@ const SHUTDOWN_CAP_MS = 5000;
 const PING_INTERVAL_MS = Number(process.env.BRIDGE_PING_INTERVAL_MS || 30000);
 const PING_MAX_MISSED = 2;
 
+// ── reconnect budget (fix/terminal-reconnect-reattach) ────────────────────────
+// A TRANSIENT relay-link drop (sleep, Wi-Fi blip, missed pongs, a 1006 with no
+// FIN) must NOT reap a live `claude`. While the PTY child is alive AND within this
+// budget the bridge RECONNECTS to the SAME session (same relay URL + sid + the
+// still-valid bridge token) with jittered backoff (1s→2s→4s→8s cap), keeping claude
+// running across the gap and resuming the byte pipe on re-attach. THE ONE SHARED
+// NUMBER — equal to the relay grace window + the client budget, and < the 300s token
+// TTL so the ORIGINAL bridge token is still valid the whole window (no re-mint).
+// Reaping still happens on: budget exhausted, claude exits, a real shutdown (parent
+// disconnect / SIGTERM / before-quit), or a TERMINAL relay close code (below).
+const BRIDGE_RECONNECT_MS = Number(process.env.BRIDGE_RECONNECT_MS || 90000);
+// Per-attempt open timeout while reconnecting: a hung connect cycles to the next
+// attempt instead of stalling the whole budget.
+const RECONNECT_ATTEMPT_TIMEOUT_MS = Number(process.env.BRIDGE_RECONNECT_ATTEMPT_TIMEOUT_MS || 10000);
+// Relay close codes that are TERMINAL for the bridge — never reconnect on these
+// (auth / duplicate failures cannot succeed on retry). Mirrors pairing.js → CLOSE.
+const TERMINAL_CLOSE_CODES = new Set([4002 /* DUP_BRIDGE */, 4005 /* OWNER_MISMATCH */, 4006 /* BAD_TOKEN */]);
+const NORMAL_CLOSURE = 1000;
+
 const [file, ...cmdArgs] = shellSplit(CMD);
 const spawnArgs = PROMPT ? [...cmdArgs, PROMPT] : cmdArgs;
 
@@ -255,6 +278,15 @@ async function main() {
   let attachTimer = null;
   let pingTimer = null;
   let missedPongs = 0;
+  // Reconnect bookkeeping. `reconnectDeadline === 0` means "link healthy, not
+  // reconnecting"; it's set on the first transient drop and cleared once the link
+  // is proven healthy again (relay `attached` frame or the first byte).
+  let reconnectDeadline = 0;
+  let reconnectAttempt = 0;
+  let reconnectTimer = null;
+  // Whether the relay socket has opened at least once — distinguishes a first-connect
+  // failure (exit 1) from a post-connection drop (exit 0) at teardown.
+  let openedAtLeastOnce = false;
 
   function stopKeepalive() {
     if (pingTimer) {
@@ -274,6 +306,7 @@ async function main() {
     clearTimeout(connectTimer);
     clearTimeout(maxTimer);
     clearTimeout(attachTimer);
+    clearTimeout(reconnectTimer);
     stopKeepalive();
     log("info", "shutting down", { why, bytesOut, bytesIn });
     try { ws?.close(1000, why); } catch { /* ignore */ }
@@ -419,115 +452,225 @@ async function main() {
   const url =
     `${RELAY.replace(/\/$/, "")}/?session=${encodeURIComponent(SESSION)}` +
     `&role=bridge&token=${encodeURIComponent(TOKEN)}`;
-  // Log the URL WITHOUT the token (never log secrets).
-  log("info", "connecting to relay", { url: url.replace(/token=[^&]*/, "token=***"), host: os.hostname() });
-  ws = new WebSocket(url);
+  const redactedUrl = url.replace(/token=[^&]*/, "token=***");
 
-  // Hard timeouts so nothing hangs.
-  connectTimer = setTimeout(() => {
-    if (!open) {
-      log("error", "connect timeout — relay never opened", { ms: CONNECT_TIMEOUT_MS });
-      shutdown(1, "connect-timeout");
-    }
-  }, CONNECT_TIMEOUT_MS);
-
+  // The absolute max-duration cap is armed ONCE and spans reconnects (a link drop
+  // must never reset it). BRIDGE_MAX_SECONDS is preserved exactly.
   maxTimer = setTimeout(() => {
     log("warn", "max-duration cap reached — ending session", { seconds: MAX_SECONDS });
     shutdown(0, "max-duration");
   }, MAX_SECONDS * 1000);
 
-  // relay -> PTY
-  ws.on("message", (data, isBinary) => {
-    if (isBinary) {
-      // opaque keystroke bytes -> PTY stdin. While a prompt spawn is still
-      // gated there is no PTY; pre-auth keystrokes are dropped, never buffered.
-      bytesIn += data.length;
-      if (term) term.write(data.toString("utf8"));
-      return;
-    }
-    const text = data.toString("utf8");
-    // R1: the relay's post-auth confirmation — the ONLY signal that releases a
-    // prompt-carrying spawn. For promptless launches (already spawned) or an
-    // already-spawned PTY it is a harmless no-op.
-    if (isAttachedFrame(text)) {
-      clearTimeout(attachTimer);
-      attachTimer = null;
-      log("info", "relay confirmed attach", { session: SESSION });
-      if (PROMPT) spawnPty();
-      return;
-    }
-    // TEXT control frame (resize). Never written to the PTY as input.
-    const ctrl = parseControlMessage(text);
-    if (ctrl?.type === "resize") {
-      if (!term) {
-        pendingResize = ctrl; // applied right after the gated spawn
+  /** True while the PTY child (`claude`) is alive — the gate for reconnecting. */
+  function claudeAlive() {
+    return !!term && !ptyExited;
+  }
+
+  /**
+   * Decide what a relay close means. Only an ABNORMAL close (code 1006 — sleep, Wi-Fi
+   * drop, or the keepalive's own missed-pong ws.terminate(); i.e. NO close frame was
+   * received) is TRANSIENT: while claude is alive AND within the reconnect budget it
+   * RECONNECTS to the same session, keeping the child running. Every DELIBERATE relay
+   * close frame is terminal — the relay is ending the session, so reap, never retry:
+   *   - 1000                    → a clean end (idle / max / user).
+   *   - PEER_GONE 4004          → the relay's grace window elapsed (or an old relay's
+   *                               peer-gone) — the session is over.
+   *   - 4002 / 4005 / 4006      → duplicate / owner-mismatch / bad-token — cannot
+   *                               succeed on retry.
+   * (claude already gone, or the budget spent, also reap — see below.)
+   */
+  function handleRelayClose(code, reason) {
+    if (shuttingDown) return; // a real shutdown is already tearing down
+    stopKeepalive();
+    open = false;
+    const transient = code === 1006; // abnormal close = no deliberate frame from the relay
+    if (!transient) {
+      if (TERMINAL_CLOSE_CODES.has(code)) {
+        log("warn", "relay closed with a terminal code — not reconnecting", { code, reason });
+        shutdown(1, "ws-close-terminal");
         return;
       }
-      try {
-        term.resize(ctrl.cols, ctrl.rows);
-        log("debug", "resized PTY", { cols: ctrl.cols, rows: ctrl.rows });
-      } catch (e) {
-        log("warn", "resize failed", { err: String(e?.message || e) });
-      }
-    } else {
-      log("warn", "ignored unknown control frame");
+      // 1000 (clean end) or PEER_GONE 4004 (grace elapsed) — a deliberate session end.
+      shutdown(openedAtLeastOnce && !(PROMPT && !term) ? 0 : 1, "ws-close");
+      return;
     }
-  });
+    // Transient drop. Only worth reconnecting if there's a live child to preserve.
+    if (!claudeAlive()) {
+      shutdown(openedAtLeastOnce && !(PROMPT && !term) ? 0 : 1, "ws-close");
+      return;
+    }
+    const now = Date.now();
+    if (reconnectDeadline === 0) reconnectDeadline = now + BRIDGE_RECONNECT_MS;
+    if (now >= reconnectDeadline) {
+      log("warn", "reconnect budget exhausted — ending session", { budgetMs: BRIDGE_RECONNECT_MS });
+      shutdown(0, "reconnect-exhausted");
+      return;
+    }
+    scheduleReconnect(code);
+  }
 
-  // Keepalive: protocol-level ping every PING_INTERVAL_MS; the ws server (and
-  // Cloudflare's edge) auto-answers with pongs. A link that misses
-  // PING_MAX_MISSED pongs in a row is dead (sleep/network drop with no FIN) —
-  // terminate it so `close` fires and shutdown() reaps the PTY child, instead
-  // of the session holding a live `claude` for hours.
-  ws.on("pong", () => {
-    missedPongs = 0;
-  });
+  /** Schedule the next reconnect attempt with jittered exponential backoff, bounded
+   *  by the reconnect budget. */
+  function scheduleReconnect(code) {
+    const attempt = reconnectAttempt++;
+    const base = Math.min(1000 * 2 ** attempt, 8000); // 1s → 2s → 4s → 8s cap
+    const delay = base + Math.floor(Math.random() * 250); // jitter to de-sync retries
+    log("warn", "relay link dropped — will reconnect", {
+      code, attempt, delayMs: delay, budgetMsLeft: Math.max(0, reconnectDeadline - Date.now()),
+    });
+    clearTimeout(reconnectTimer);
+    reconnectTimer = setTimeout(() => {
+      if (shuttingDown) return;
+      if (Date.now() >= reconnectDeadline) {
+        log("warn", "reconnect budget exhausted — ending session", { budgetMs: BRIDGE_RECONNECT_MS });
+        shutdown(0, "reconnect-exhausted");
+        return;
+      }
+      openRelay();
+    }, delay);
+    reconnectTimer.unref?.();
+  }
 
-  ws.on("open", () => {
-    open = true;
+  /**
+   * Open (or RE-open) the bridge leg to the relay and wire its handlers. Called once
+   * initially and again for each reconnect attempt — the SAME url (relay + sid +
+   * token), which is why no re-mint is needed and the relay-allowlist gate (asserted
+   * once at startup on this exact RELAY) still holds for every attempt.
+   */
+  function openRelay() {
+    const reconnecting = reconnectDeadline !== 0;
+    log("info", reconnecting ? "reconnecting to relay" : "connecting to relay", {
+      url: redactedUrl, host: os.hostname(), attempt: reconnectAttempt,
+    });
+    ws = new WebSocket(url);
+
+    // Per-attempt open timeout. The FIRST connect failing is fatal; a RECONNECT
+    // attempt that won't open just cycles (terminate → close → next attempt/budget).
     clearTimeout(connectTimer);
-    log("info", "relay connected (bridge leg)", { session: SESSION });
-    missedPongs = 0;
-    pingTimer = setInterval(() => {
-      if (!ws || ws.readyState !== WebSocket.OPEN) return;
-      if (missedPongs >= PING_MAX_MISSED) {
-        log("warn", "keepalive: pongs missed — terminating dead relay link", { missed: missedPongs });
+    connectTimer = setTimeout(() => {
+      if (open) return;
+      if (reconnecting) {
+        log("warn", "reconnect attempt did not open in time — retrying", { ms: RECONNECT_ATTEMPT_TIMEOUT_MS });
         try { ws.terminate(); } catch { /* ignore */ }
+      } else {
+        log("error", "connect timeout — relay never opened", { ms: CONNECT_TIMEOUT_MS });
+        shutdown(1, "connect-timeout");
+      }
+    }, reconnecting ? RECONNECT_ATTEMPT_TIMEOUT_MS : CONNECT_TIMEOUT_MS);
+
+    // relay -> PTY
+    ws.on("message", (data, isBinary) => {
+      // Any inbound traffic proves the link is healthy again → reconnect complete.
+      if (reconnectDeadline !== 0) {
+        log("info", "relay link healthy again — reconnect complete", { attempts: reconnectAttempt });
+        reconnectDeadline = 0;
+        reconnectAttempt = 0;
+      }
+      if (isBinary) {
+        // opaque keystroke bytes -> PTY stdin. While a prompt spawn is still
+        // gated there is no PTY; pre-auth keystrokes are dropped, never buffered.
+        bytesIn += data.length;
+        if (term) term.write(data.toString("utf8"));
         return;
       }
-      missedPongs += 1;
-      try { ws.ping(); } catch { /* ignore */ }
-    }, PING_INTERVAL_MS);
-    pingTimer.unref?.();
-    // Prompt launches: arm the attach-confirmation window. An OLD relay never
-    // sends the frame → clean exit with NOTHING spawned (graceful skew; the
-    // dock's existing ~8s fallback covers the UX).
-    if (PROMPT && !term && !attachTimer) {
-      attachTimer = setTimeout(() => {
-        log("error", "no attach confirmation from relay — exiting without spawning", {
-          ms: ATTACH_CONFIRM_TIMEOUT_MS,
-        });
-        shutdown(1, "attach-confirm-timeout");
-      }, ATTACH_CONFIRM_TIMEOUT_MS);
-    }
-    // Flush any PTY output produced before the socket opened.
-    while (preOpenBuffer.length > 0) {
-      ws.send(preOpenBuffer.shift(), { binary: true });
-    }
-  });
+      const text = data.toString("utf8");
+      // R1: the relay's post-auth confirmation — the ONLY signal that releases a
+      // prompt-carrying spawn. Also sent on every (re)attach, so it doubles as the
+      // reconnect-complete proof above. For an already-spawned PTY it's a no-op.
+      if (isAttachedFrame(text)) {
+        clearTimeout(attachTimer);
+        attachTimer = null;
+        log("info", "relay confirmed attach", { session: SESSION });
+        if (PROMPT) spawnPty();
+        return;
+      }
+      // Grace-window notices (relay holding / pair restored). Informational for the
+      // bridge — the child keeps running regardless; recognised so they don't log as
+      // "unknown". Skew-safe: an old relay simply never sends them.
+      if (isPeerDegradedFrame(text)) {
+        log("debug", "relay reports peer degraded (holding session)");
+        return;
+      }
+      if (isPeerReattachedFrame(text)) {
+        log("debug", "relay reports pair reattached");
+        return;
+      }
+      // TEXT control frame (resize). Never written to the PTY as input.
+      const ctrl = parseControlMessage(text);
+      if (ctrl?.type === "resize") {
+        if (!term) {
+          pendingResize = ctrl; // applied right after the gated spawn
+          return;
+        }
+        try {
+          term.resize(ctrl.cols, ctrl.rows);
+          log("debug", "resized PTY", { cols: ctrl.cols, rows: ctrl.rows });
+        } catch (e) {
+          log("warn", "resize failed", { err: String(e?.message || e) });
+        }
+      } else {
+        log("warn", "ignored unknown control frame");
+      }
+    });
 
-  ws.on("close", (code, reasonBuf) => {
-    const reason = reasonBuf?.toString?.() || "";
-    log("info", "relay closed", { code, reason });
-    // A prompt launch whose spawn never got released (auth rejected / old relay)
-    // is a failure even though the socket technically opened.
-    shutdown(open && !(PROMPT && !term) ? 0 : 1, "ws-close");
-  });
+    // Keepalive: protocol-level ping every PING_INTERVAL_MS; the ws server (and
+    // Cloudflare's edge) auto-answers with pongs. A link that misses PING_MAX_MISSED
+    // pongs in a row is dead (sleep/network drop with no FIN) — terminate it so
+    // `close` fires and handleRelayClose() decides reconnect-vs-reap (within budget
+    // it now RECONNECTS rather than immediately reaping the child).
+    ws.on("pong", () => {
+      missedPongs = 0;
+    });
 
-  ws.on("error", (e) => {
-    log("error", "relay ws error", { err: String(e?.message || e) });
-    // 'close' will follow; shutdown there.
-  });
+    ws.on("open", () => {
+      open = true;
+      openedAtLeastOnce = true;
+      clearTimeout(connectTimer);
+      log("info", "relay connected (bridge leg)", { session: SESSION });
+      missedPongs = 0;
+      pingTimer = setInterval(() => {
+        if (!ws || ws.readyState !== WebSocket.OPEN) return;
+        if (missedPongs >= PING_MAX_MISSED) {
+          log("warn", "keepalive: pongs missed — terminating dead relay link", { missed: missedPongs });
+          try { ws.terminate(); } catch { /* ignore */ }
+          return;
+        }
+        missedPongs += 1;
+        try { ws.ping(); } catch { /* ignore */ }
+      }, PING_INTERVAL_MS);
+      pingTimer.unref?.();
+      // Prompt launches: arm the attach-confirmation window. An OLD relay never
+      // sends the frame → clean exit with NOTHING spawned (graceful skew; the
+      // dock's existing ~8s fallback covers the UX). Reconnects always have a live
+      // PTY (term set), so this never arms on a reconnect.
+      if (PROMPT && !term && !attachTimer) {
+        attachTimer = setTimeout(() => {
+          log("error", "no attach confirmation from relay — exiting without spawning", {
+            ms: ATTACH_CONFIRM_TIMEOUT_MS,
+          });
+          shutdown(1, "attach-confirm-timeout");
+        }, ATTACH_CONFIRM_TIMEOUT_MS);
+      }
+      // Flush any PTY output produced before the socket opened (incl. bytes buffered
+      // during a reconnect gap) — the pipe resumes seamlessly on re-attach.
+      while (preOpenBuffer.length > 0) {
+        ws.send(preOpenBuffer.shift(), { binary: true });
+      }
+    });
+
+    ws.on("close", (code, reasonBuf) => {
+      const reason = reasonBuf?.toString?.() || "";
+      log("info", "relay closed", { code, reason });
+      handleRelayClose(code, reason);
+    });
+
+    ws.on("error", (e) => {
+      log("error", "relay ws error", { err: String(e?.message || e) });
+      // 'close' will follow; handleRelayClose there.
+    });
+  }
+
+  openRelay();
 
   // Clean teardown on Ctrl-C / kill.
   for (const sig of ["SIGINT", "SIGTERM"]) {

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -36,12 +36,17 @@ import {
   CLOSE,
   DEFAULT_IDLE_MS,
   DEFAULT_MAX_MS,
+  RECONNECT_GRACE_MS,
   idleCloseReason,
   maxCloseReason,
   resolveMs,
 } from "./pairing.js";
 import { authorizeAttach } from "../../shared/session-token.mjs";
-import { encodeAttachedFrame } from "../../shared/control-frames.mjs";
+import {
+  encodeAttachedFrame,
+  encodePeerDegradedFrame,
+  encodePeerReattachedFrame,
+} from "../../shared/control-frames.mjs";
 
 /** Normal WebSocket closure code used for clean, server-initiated session ends. */
 const NORMAL_CLOSURE = 1000;
@@ -107,6 +112,20 @@ export class TerminalRelay {
   /** Max session age in ms (env override → default). */
   maxMs() {
     return resolveMs(this.env.TERMINAL_MAX_MS, DEFAULT_MAX_MS);
+  }
+
+  /** Reconnect grace window in ms (env override → shared default). */
+  graceMs() {
+    return resolveMs(this.env.TERMINAL_RECONNECT_GRACE_MS, RECONNECT_GRACE_MS);
+  }
+
+  /** Send a control frame to EVERY live leg (used for peer-reattached). */
+  broadcast(frame) {
+    for (const ws of this.state.getWebSockets()) {
+      try {
+        ws.send(frame);
+      } catch { /* leg already closing */ }
+    }
   }
 
   /** The live peer socket for the opposite role, or null. Tag-driven so it works post-hibernation. */
@@ -180,6 +199,21 @@ export class TerminalRelay {
       await this.state.storage.put("sessionStartedAt", now);
     }
     await this.state.storage.put("lastActivityAt", now);
+
+    // 4b) GRACE-WINDOW REATTACH reconciliation. If the session was being HELD open
+    //     for a dropped leg (graceDeadline set), this attach may complete the pair
+    //     again. When BOTH legs are present once more, clear the grace hold and
+    //     tell BOTH legs to resume (peer-reattached). If only one leg is back (the
+    //     both-legs-dropped case), keep holding and wait for the other. The owner
+    //     binding was never released, so decideAttach above already enforced
+    //     same-owner + single-attach on this reattach — a foreign sub was rejected.
+    const wasHeld = (await this.state.storage.get("graceDeadline")) != null;
+    const post = await this.computeAttachState();
+    const pairWhole = post.bridge && post.browser;
+    if (wasHeld && pairWhole) {
+      await this.state.storage.delete("graceDeadline");
+      this.log("reattached — pair whole again", { session, role });
+    }
     await this.armAlarm(now);
 
     // 5) R1 attach confirmation — BRIDGE leg only. A rejected leg is also
@@ -197,7 +231,14 @@ export class TerminalRelay {
       }
     }
 
-    this.log("attached", { session, role, ...(await this.computeAttachState()) });
+    // 6) If this attach restored the pair inside the grace window, tell BOTH legs
+    //    to resume. Sent AFTER the bridge's own `attached` frame; both are no-ops
+    //    for a leg that doesn't know them (skew-safe).
+    if (wasHeld && pairWhole) {
+      this.broadcast(encodePeerReattachedFrame());
+    }
+
+    this.log("attached", { session, role, ...post });
     return new Response(null, { status: 101, webSocket: client });
   }
 
@@ -242,8 +283,20 @@ export class TerminalRelay {
   }
 
   /**
-   * One leg went away. Tell the surviving peer (PEER_GONE) and drop it so the
-   * session id can be cleanly re-established, then release all session state.
+   * One leg went away. GRACE-WINDOW REATTACH (fix/terminal-reconnect-reattach):
+   * instead of tearing the whole session down on ANY single detach, HOLD it open
+   * for the reconnect grace window so the dropped role can re-attach (same sid +
+   * owner) and resume with no token re-mint. Two cases:
+   *
+   *   - a leg is STILL attached (the survivor) → mark the session degraded
+   *     (graceDeadline), keep the owner binding + the surviving socket, arm the
+   *     grace alarm, and tell the survivor via `peer-degraded` — do NOT close it.
+   *   - BOTH legs are now gone (e.g. sleep drops both 1006) → still keep the
+   *     session + owner + grace alarm for the window so EITHER leg can come back
+   *     and wait for the other.
+   *
+   * Only when the grace alarm fires still-incomplete does the old teardown run
+   * (survivor PEER_GONE + clearSessionState) — see alarm() → endGrace().
    * @param {WebSocket} ws @param {string} why @param {object} [extra]
    */
   async handleDetach(ws, why, extra = {}) {
@@ -253,45 +306,80 @@ export class TerminalRelay {
     } catch { /* attachment may be gone */ }
     this.log("detached", { role, why, ...extra });
 
-    // Close the surviving peer (the closing socket may still appear in the list).
+    const now = Date.now();
+    // Open (or keep) the grace hold; the grace alarm governs teardown from here.
+    if ((await this.state.storage.get("graceDeadline")) == null) {
+      await this.state.storage.put("graceDeadline", now + this.graceMs());
+    }
+    await this.armAlarm(now);
+
+    // Tell any SURVIVING peer we're holding (the closing socket may still appear
+    // in the list, so skip it). We do NOT close survivors during the window.
+    let survivors = 0;
     for (const peer of this.state.getWebSockets()) {
       if (peer === ws) continue;
+      survivors++;
       try {
-        peer.close(CLOSE.PEER_GONE.code, CLOSE.PEER_GONE.reason);
+        peer.send(encodePeerDegradedFrame());
       } catch { /* already closing */ }
     }
-    // The session is now empty → release the owner binding + lifecycle state so a
-    // fresh authorized owner can re-establish the id.
-    await this.clearSessionState();
+    this.log("holding session for reconnect", { droppedRole: role, survivors, graceMs: this.graceMs() });
   }
 
   // ── Idle / max-duration via DO alarms ────────────────────────────────────────
 
-  /** Arm the alarm to the nearest of (idle deadline, max-duration deadline). */
+  /**
+   * Arm the ONE alarm to the earliest live deadline: idle, max-duration, and — while
+   * a reconnect grace window is open — the grace deadline. ONE alarm handler, earliest
+   * deadline wins (coexists with the idle/max caps). Reads lastActivityAt from storage
+   * so it stays correct whether called on fresh activity (now === last) or a defensive
+   * re-arm (stored last is older).
+   */
   async armAlarm(now) {
     const started = (await this.state.storage.get("sessionStartedAt")) ?? now;
-    const next = Math.min(now + this.idleMs(), started + this.maxMs());
-    await this.state.storage.setAlarm(next);
+    const last = (await this.state.storage.get("lastActivityAt")) ?? now;
+    const grace = await this.state.storage.get("graceDeadline");
+    const candidates = [last + this.idleMs(), started + this.maxMs()];
+    if (grace != null) candidates.push(grace);
+    await this.state.storage.setAlarm(Math.min(...candidates));
   }
 
-  /** Hibernation-compatible alarm: enforce the lifecycle caps or re-arm. */
+  /** Hibernation-compatible alarm: enforce the lifecycle caps / grace expiry, or re-arm. */
   async alarm() {
     const now = Date.now();
     const started = await this.state.storage.get("sessionStartedAt");
     const last = await this.state.storage.get("lastActivityAt");
+    const grace = await this.state.storage.get("graceDeadline");
 
     if (started != null && now - started >= this.maxMs()) {
       this.log("session ended", { why: "max-duration", ageMs: now - started });
       return this.endSession(maxCloseReason(this.maxMs()));
     }
-    if (last != null && now - last >= this.idleMs()) {
+
+    // Reconnect grace expiry: the held-open session never became whole again inside
+    // the window → the OLD teardown (survivor PEER_GONE + clearSessionState).
+    if (grace != null && now >= grace) {
+      const st = await this.computeAttachState();
+      if (st.bridge && st.browser) {
+        // Defensive: became whole without fetch clearing the hold — recover, don't tear.
+        await this.state.storage.delete("graceDeadline");
+        await this.armAlarm(now);
+        return;
+      }
+      this.log("reconnect grace expired — tearing down", { });
+      return this.endGrace();
+    }
+
+    // Idle only governs a WHOLE session; a held (degraded) session has stale activity
+    // by definition and is governed by the grace deadline above instead.
+    if (grace == null && last != null && now - last >= this.idleMs()) {
       this.log("session ended", { why: "idle-timeout", idleMs: now - last });
       return this.endSession(idleCloseReason(this.idleMs()));
     }
-    // Activity happened since the alarm was set (or no legs) → re-arm defensively.
-    if (started != null || last != null) {
-      const next = Math.min((last ?? now) + this.idleMs(), (started ?? now) + this.maxMs());
-      await this.state.storage.setAlarm(next);
+
+    // Nothing due yet → re-arm to the next earliest deadline.
+    if (started != null || last != null || grace != null) {
+      await this.armAlarm(now);
     }
   }
 
@@ -305,9 +393,20 @@ export class TerminalRelay {
     await this.clearSessionState();
   }
 
-  /** Release owner binding + lifecycle bookkeeping + any pending alarm. */
+  /** Grace window elapsed without a full reattach → the original teardown: any
+   *  survivor gets PEER_GONE (4004) and all session state is released. */
+  async endGrace() {
+    for (const ws of this.state.getWebSockets()) {
+      try {
+        ws.close(CLOSE.PEER_GONE.code, CLOSE.PEER_GONE.reason);
+      } catch { /* already closing */ }
+    }
+    await this.clearSessionState();
+  }
+
+  /** Release owner binding + lifecycle bookkeeping + grace hold + any pending alarm. */
   async clearSessionState() {
-    await this.state.storage.delete(["owner", "sessionStartedAt", "lastActivityAt"]);
+    await this.state.storage.delete(["owner", "sessionStartedAt", "lastActivityAt", "graceDeadline"]);
     await this.state.storage.deleteAlarm();
   }
 }

--- a/terminal/relay/src/pairing.js
+++ b/terminal/relay/src/pairing.js
@@ -132,6 +132,22 @@ export function peerRole(role) {
 // src/lib/terminal/connection.ts → parseEndedReason): it looks for the substrings
 // "idle" / "max", so these builders and that classifier are in lock-step.
 
+// ── Reconnect grace window (fix/terminal-reconnect-reattach) ──────────────────
+//
+// THE ONE SHARED NUMBER. When a single leg drops, the relay does NOT tear the
+// session down; it holds the owner binding + the surviving socket and arms a
+// grace alarm for this long, waiting for the dropped role to re-attach (same sid
+// + same owner + still-valid token) so the pair can resume with no re-mint. The
+// three reconnect budgets are deliberately equal and MUST stay < the token TTL
+// (DEFAULT_TTL_SECONDS = 300s in ../../shared/session-token.mjs) so the ORIGINAL
+// tokens are still valid for the whole window — no token re-mint, ever:
+//   - relay grace       → RECONNECT_GRACE_MS (here)
+//   - bridge reconnect  → BRIDGE_RECONNECT_MS (bridge/src/index.js)
+//   - client reconnect  → RECONNECT_GRACE_MS  (src/lib/terminal/connection.ts)
+// BEYOND the window the session is torn down honestly (survivor gets PEER_GONE,
+// state cleared) and the UX falls back to a clean fresh launch.
+export const RECONNECT_GRACE_MS = 90_000;
+
 /** Default idle cap: 30 minutes of no traffic. Overridable via env TERMINAL_IDLE_MS. */
 export const DEFAULT_IDLE_MS = 30 * 60 * 1000;
 /** Default hard cap on total session age: 4 hours. Overridable via env TERMINAL_MAX_MS. */

--- a/terminal/shared/control-frames.mjs
+++ b/terminal/shared/control-frames.mjs
@@ -21,6 +21,30 @@
 // logged no-op — so sending this unconditionally is skew-safe in both
 // directions. The key `t` (not `type`) keeps it disjoint from the browser→
 // bridge control namespace (`{"type":"resize",…}`).
+//
+// GRACE-WINDOW REATTACH (fix/terminal-reconnect-reattach) adds two more relay→leg
+// TEXT control frames in the SAME `{"t":…}` namespace, sent instead of a hard
+// PEER_GONE close while a session is held open for the reconnect grace window:
+//   - `{"t":"peer-degraded"}`   — sent to the SURVIVING leg the moment its peer
+//     drops. "Your peer went away; I'm holding the session — keep your stream,
+//     it may resume." The survivor is NOT closed.
+//   - `{"t":"peer-reattached"}` — sent to BOTH legs once the dropped peer
+//     re-attaches (same sid + owner) inside the window and the pair is whole
+//     again. "Resume — the pairing is restored."
+// Both are skew-safe exactly like `attached`: an old bridge logs-and-ignores an
+// unknown control frame, and a browser dock that doesn't know them treats them
+// as a no-op.
+
+/** Detect any control TEXT frame with a given `t` tag. Cheap + strict + bounded. */
+function isControlFrame(text, tag) {
+  if (typeof text !== "string" || text.length === 0 || text.length > 64) return false;
+  try {
+    const msg = JSON.parse(text);
+    return !!msg && typeof msg === "object" && msg.t === tag;
+  } catch {
+    return false;
+  }
+}
 
 /** The exact TEXT frame the relay sends the bridge leg on successful attach. */
 export function encodeAttachedFrame() {
@@ -35,11 +59,25 @@ export function encodeAttachedFrame() {
  * @returns {boolean}
  */
 export function isAttachedFrame(text) {
-  if (typeof text !== "string" || text.length === 0 || text.length > 64) return false;
-  try {
-    const msg = JSON.parse(text);
-    return !!msg && typeof msg === "object" && msg.t === "attached";
-  } catch {
-    return false;
-  }
+  return isControlFrame(text, "attached");
+}
+
+/** TEXT frame the relay sends the SURVIVOR when its peer drops (grace window opened). */
+export function encodePeerDegradedFrame() {
+  return JSON.stringify({ t: "peer-degraded" });
+}
+
+/** @param {unknown} text @returns {boolean} */
+export function isPeerDegradedFrame(text) {
+  return isControlFrame(text, "peer-degraded");
+}
+
+/** TEXT frame the relay sends BOTH legs once the pair is whole again inside the window. */
+export function encodePeerReattachedFrame() {
+  return JSON.stringify({ t: "peer-reattached" });
+}
+
+/** @param {unknown} text @returns {boolean} */
+export function isPeerReattachedFrame(text) {
+  return isControlFrame(text, "peer-reattached");
 }

--- a/terminal/test/control-frames.test.mjs
+++ b/terminal/test/control-frames.test.mjs
@@ -8,11 +8,32 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { encodeAttachedFrame, isAttachedFrame } from "../shared/control-frames.mjs";
+import {
+  encodeAttachedFrame,
+  isAttachedFrame,
+  encodePeerDegradedFrame,
+  isPeerDegradedFrame,
+  encodePeerReattachedFrame,
+  isPeerReattachedFrame,
+} from "../shared/control-frames.mjs";
 import { parseControlMessage } from "../bridge/src/framing.js";
 
 test("encode ⇄ detect round-trips", () => {
   assert.equal(isAttachedFrame(encodeAttachedFrame()), true);
+});
+
+test("grace-window frames encode ⇄ detect round-trip and stay mutually disjoint", () => {
+  assert.equal(isPeerDegradedFrame(encodePeerDegradedFrame()), true);
+  assert.equal(isPeerReattachedFrame(encodePeerReattachedFrame()), true);
+  // Each detector is strict to its own tag — no cross-matching between the frames.
+  assert.equal(isPeerReattachedFrame(encodePeerDegradedFrame()), false);
+  assert.equal(isPeerDegradedFrame(encodePeerReattachedFrame()), false);
+  assert.equal(isAttachedFrame(encodePeerDegradedFrame()), false);
+  assert.equal(isAttachedFrame(encodePeerReattachedFrame()), false);
+  assert.equal(isPeerDegradedFrame(encodeAttachedFrame()), false);
+  // Neither is a resize control frame.
+  assert.equal(parseControlMessage(encodePeerDegradedFrame()), null);
+  assert.equal(parseControlMessage(encodePeerReattachedFrame()), null);
 });
 
 test("rejects non-attached / malformed / hostile inputs", () => {

--- a/terminal/test/lifecycle.test.mjs
+++ b/terminal/test/lifecycle.test.mjs
@@ -22,19 +22,24 @@ const SECRET = "lifecycle-test-secret";
 /** Open a leg and resolve once it's connected. */
 async function openLeg(relayUrl, session, role, token) {
   const ws = new WebSocket(`${relayUrl}/?session=${session}&role=${role}&token=${encodeURIComponent(token)}`);
+  // Clear the loser timer on settle — an orphaned ref'd setTimeout survives the
+  // race and later fires an unhandled rejection that node's runner misattributes
+  // to whichever concurrent test is still open (source of the lifecycle flake).
+  let timer;
   await Promise.race([
     once(ws, "open"),
-    new Promise((_, rej) => setTimeout(() => rej(new Error(`${role} open timeout`)), 5000)),
-  ]);
+    new Promise((_, rej) => { timer = setTimeout(() => rej(new Error(`${role} open timeout`)), 5000); }),
+  ]).finally(() => clearTimeout(timer));
   return ws;
 }
 
 /** Wait for a close and resolve [code, reason]. */
 async function closeOf(ws, label) {
+  let timer;
   const [code, reasonBuf] = await Promise.race([
     once(ws, "close"),
-    new Promise((_, rej) => setTimeout(() => rej(new Error(`${label} close timeout`)), 5000)),
-  ]);
+    new Promise((_, rej) => { timer = setTimeout(() => rej(new Error(`${label} close timeout`)), 5000); }),
+  ]).finally(() => clearTimeout(timer));
   return [code, reasonBuf ? reasonBuf.toString() : ""];
 }
 
@@ -52,8 +57,14 @@ test("idle-timeout closes BOTH legs with code 1000 + an 'idle' reason", { timeou
   // One message proves activity tracking (the idle clock starts from the LAST byte).
   bridge.send(Buffer.from("READY\n", "utf8"), { binary: true });
 
-  const [bCode, bReason] = await closeOf(browser, "browser");
-  const [gCode, gReason] = await closeOf(bridge, "bridge");
+  // Register BOTH close waiters BEFORE awaiting either. The two legs close
+  // near-simultaneously, so attaching the bridge listener only after the browser
+  // close has resolved can miss an already-fired 'close' → a spurious 5s
+  // "bridge close timeout" (the intermittent lifecycle flake).
+  const browserClosed = closeOf(browser, "browser");
+  const bridgeClosed = closeOf(bridge, "bridge");
+  const [bCode, bReason] = await browserClosed;
+  const [gCode, gReason] = await bridgeClosed;
 
   assert.equal(bCode, 1000, "browser leg must close with normal code 1000");
   assert.equal(gCode, 1000, "bridge leg must close with normal code 1000");
@@ -79,8 +90,13 @@ test("max-duration closes BOTH legs with code 1000 + a 'max' reason", { timeout:
   }, 50);
   t.after(() => clearInterval(chatter));
 
-  const [bCode, bReason] = await closeOf(browser, "browser");
-  const [gCode, gReason] = await closeOf(bridge, "bridge");
+  // Register BOTH close waiters before awaiting either (see idle test) — at
+  // maxMs=350 both legs close together, so the late-attached bridge listener
+  // was the source of the intermittent "bridge close timeout".
+  const browserClosed = closeOf(browser, "browser");
+  const bridgeClosed = closeOf(bridge, "bridge");
+  const [bCode, bReason] = await browserClosed;
+  const [gCode, gReason] = await bridgeClosed;
   clearInterval(chatter);
 
   assert.equal(bCode, 1000, "browser leg must close with normal code 1000");

--- a/terminal/test/orphan-cleanup.test.mjs
+++ b/terminal/test/orphan-cleanup.test.mjs
@@ -153,7 +153,12 @@ async function startSession(t, relayOpts = {}) {
 
 // ── (a) ws-close teardown must reap even a HUP+TERM-immune child ──────────────
 test("(a) ws-close: escalation reaches SIGKILL(+group) and the bridge exits only after the child is confirmed dead", { timeout: 40_000 }, async (t) => {
-  const { session, tokens, relay, browser } = await startSession(t);
+  // Grace-window reattach (fix/terminal-reconnect-reattach): a single-leg drop no
+  // longer tears the session down immediately — the relay HOLDS it for the grace
+  // window, then (no reattach) closes the survivor with PEER_GONE. A tiny graceMs
+  // keeps this fast; the bridge treats that deliberate PEER_GONE as a session end and
+  // runs the SAME verified-kill teardown under test here.
+  const { session, tokens, relay, browser } = await startSession(t, { graceMs: 300 });
   const mark = newMark();
   const spawned = spawnBridge({
     relayUrl: relay.url,
@@ -167,7 +172,8 @@ test("(a) ws-close: escalation reaches SIGKILL(+group) and the bridge exits only
   t.after(() => killHard(sentinelPid));
   console.log(`[oc/a] sentinel pid=${sentinelPid}`);
 
-  // Browser leg leaves → relay closes the bridge leg (peer-gone) → teardown.
+  // Browser leg leaves → relay holds, then (grace expiry) closes the bridge leg with
+  // PEER_GONE → the bridge's verified-kill teardown reaps the child.
   browser.close();
   const { code } = await waitForExit(spawned.child, HARD_TIMEOUT_MS, "bridge (ws-close)");
 

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/reconnect-reattach.test.mjs
+++ b/terminal/test/reconnect-reattach.test.mjs
@@ -1,0 +1,310 @@
+// Reconnect / grace-window reattach — regression proof (fix/terminal-reconnect-reattach).
+//
+// ROOT CAUSE (Reproduce & Investigate step): the relay tore the WHOLE session down
+// on ANY single-leg detach (handleDetach → survivor PEER_GONE 4004 + clearSessionState),
+// so a reconnecting browser/bridge had nothing to reattach to; and the bridge reaped
+// `claude` ~90s after the link froze with ZERO reconnect logic. A same-owner browser
+// could NOT re-pair because owner+peer no longer existed.
+//
+// THE FIX under test:
+//   relay  — a single-leg detach now HOLDS the session for a grace window (owner +
+//            surviving socket kept, `peer-degraded` sent, no PEER_GONE); a same-sid +
+//            owner reattach inside the window re-pairs both legs (`peer-reattached`);
+//            only a still-incomplete grace expiry runs the old teardown.
+//   bridge — a TRANSIENT relay-link drop while `claude` is alive reconnects to the
+//            SAME session (no re-mint) within a budget instead of reaping; budget
+//            exhausted / real shutdown still reaps the pty group (no leak).
+//
+// The relay-level cases (a–e) run against the Node stand-in (shares the exact grace
+// logic with the Cloudflare DO). The bridge-level case (f) drives the real bridge
+// process. Every wait is hard-timeout guarded; a final ps sweep proves no pty leak.
+//
+// Run: cd terminal/test && node --test reconnect-reattach.test.mjs   (or: npm test)
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, execFile } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens } from "../shared/session-token.mjs";
+import { isPeerDegradedFrame, isPeerReattachedFrame } from "../shared/control-frames.mjs";
+import { pidAlive } from "../shared/reap.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BRIDGE_ENTRY = path.resolve(__dirname, "../bridge/src/index.js");
+const SECRET = "reconnect-reattach-test-secret";
+const HARD_TIMEOUT_MS = 25_000;
+
+// ── generic waiters ───────────────────────────────────────────────────────────
+async function waitFor(pred, ms, label, pollMs = 25) {
+  const started = Date.now();
+  for (;;) {
+    const v = await pred();
+    if (v) return v;
+    if (Date.now() - started > ms) throw new Error(`timed out after ${ms}ms waiting for ${label}`);
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+/** Open a raw ws leg and collect its TEXT control frames + binary bytes. */
+async function openRawLeg(relayUrl, session, role, token) {
+  const ws = new WebSocket(`${relayUrl}/?session=${session}&role=${role}&token=${encodeURIComponent(token)}`);
+  const leg = { ws, texts: [], binary: "", closed: null };
+  ws.on("message", (data, isBinary) => {
+    if (isBinary) leg.binary += Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+    else leg.texts.push(Buffer.isBuffer(data) ? data.toString("utf8") : String(data));
+  });
+  ws.on("close", (code, reasonBuf) => { leg.closed = [code, reasonBuf ? reasonBuf.toString() : ""]; });
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${role} open timeout`)), 5000)),
+  ]);
+  return leg;
+}
+
+const hasFrame = (leg, pred) => leg.texts.some(pred);
+
+// ── (a) single-leg drop → survivor gets peer-degraded, NOT closed; state retained ──
+test("(a) single-leg drop holds the session: survivor gets peer-degraded, is NOT closed", { timeout: 15000 }, async (t) => {
+  const session = `ra-a-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 5000 });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-RA", sid: session, secret: SECRET });
+
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+
+  // Drop the bridge leg.
+  bridge.ws.terminate();
+
+  // The SURVIVOR (browser) receives peer-degraded and stays OPEN.
+  await waitFor(() => hasFrame(browser, isPeerDegradedFrame), 5000, "peer-degraded to survivor");
+  assert.equal(browser.ws.readyState, WebSocket.OPEN, "survivor must NOT be closed");
+  assert.equal(browser.closed, null, "survivor received no close");
+  assert.ok(relay.sessions.has(session), "session state is retained during the grace window");
+  console.log("[ra/a] PASS — survivor held + notified, session retained");
+});
+
+// ── (b) reattach same sid+owner within grace → re-paired, both resume ─────────
+test("(b) dropped leg reattaches (same sid+owner) within grace → both get peer-reattached and resume", { timeout: 15000 }, async (t) => {
+  const session = `ra-b-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 5000 });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-RA", sid: session, secret: SECRET });
+
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  let bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+
+  bridge.ws.terminate();
+  await waitFor(() => hasFrame(browser, isPeerDegradedFrame), 5000, "degraded");
+
+  // Reattach the bridge with the SAME sid + owner token.
+  bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
+
+  await waitFor(() => hasFrame(browser, isPeerReattachedFrame), 5000, "peer-reattached to browser");
+  await waitFor(() => hasFrame(bridge, isPeerReattachedFrame), 5000, "peer-reattached to bridge");
+
+  // Bytes flow again through the re-paired session.
+  const tok = `RESUME-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+  bridge.ws.send(Buffer.from(tok, "utf8"), { binary: true });
+  await waitFor(() => browser.binary.includes(tok), 5000, "post-reattach byte flow");
+  assert.equal(browser.ws.readyState, WebSocket.OPEN, "browser stayed live throughout");
+  console.log("[ra/b] PASS — reattached within grace, both resumed");
+});
+
+// ── (c) grace expires with no reattach → old teardown (survivor PEER_GONE + cleared) ──
+test("(c) grace expiry with no reattach → survivor closed PEER_GONE 4004 + state cleared", { timeout: 15000 }, async (t) => {
+  const session = `ra-c-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 250 });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-RA", sid: session, secret: SECRET });
+
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+
+  bridge.ws.terminate(); // no reattach — let the tiny grace window elapse
+
+  await waitFor(() => browser.closed != null, 5000, "survivor close after grace");
+  assert.equal(browser.closed[0], 4004, "survivor closed with PEER_GONE 4004 after grace expiry");
+  await waitFor(() => !relay.sessions.has(session), 3000, "session state cleared");
+  console.log(`[ra/c] PASS — grace expired: survivor PEER_GONE, state cleared (reason=${JSON.stringify(browser.closed[1])})`);
+});
+
+// ── (d) both legs drop, then one returns within grace → held, waits for the other ──
+test("(d) both legs drop then one returns within grace → session held, waits; whole again on the second", { timeout: 15000 }, async (t) => {
+  const session = `ra-d-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 5000 });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-RA", sid: session, secret: SECRET });
+
+  let browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  let bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+
+  // Sleep drops BOTH legs (1006).
+  browser.ws.terminate();
+  bridge.ws.terminate();
+  await waitFor(() => relay.sessions.get(session)?.bridge == null && relay.sessions.get(session)?.browser == null, 5000, "both legs dropped");
+  assert.ok(relay.sessions.has(session), "session held after BOTH legs dropped");
+
+  // One leg returns → still held, NOT whole, no reattached broadcast yet.
+  browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+  await new Promise((r) => setTimeout(r, 200));
+  assert.equal(browser.ws.readyState, WebSocket.OPEN, "returning leg stays open, waiting for its peer");
+  assert.equal(hasFrame(browser, isPeerReattachedFrame), false, "no reattach until the pair is whole");
+
+  // Second leg returns → whole again → peer-reattached to both.
+  bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
+  await waitFor(() => hasFrame(browser, isPeerReattachedFrame) && hasFrame(bridge, isPeerReattachedFrame), 5000, "reattached once whole");
+  console.log("[ra/d] PASS — held through both-legs-drop, resumed once the pair was whole");
+});
+
+// ── (e) reattach with a DIFFERENT owner sub → rejected (owner binding preserved) ──
+test("(e) reattach with a different owner sub is rejected OWNER_MISMATCH; the held survivor is untouched", { timeout: 15000 }, async (t) => {
+  const session = `ra-e-${Math.random().toString(36).slice(2, 8)}`;
+  const ownerA = `user-A-${Math.random().toString(36).slice(2, 8)}`;
+  const ownerB = `user-B-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 5000 });
+  t.after(() => relay.close());
+  const a = await mintSessionTokens({ sub: ownerA, idea: "idea-RA", sid: session, secret: SECRET });
+  const b = await mintSessionTokens({ sub: ownerB, idea: "idea-RA", sid: session, secret: SECRET });
+
+  const browser = await openRawLeg(relay.url, session, "browser", a.browser);
+  const bridge = await openRawLeg(relay.url, session, "bridge", a.bridge);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+
+  bridge.ws.terminate();
+  await waitFor(() => hasFrame(browser, isPeerDegradedFrame), 5000, "degraded");
+
+  // A DIFFERENT user tries to steal the held bridge slot with the SAME sid.
+  const intruder = new WebSocket(`${relay.url}/?session=${session}&role=bridge&token=${encodeURIComponent(b.bridge)}`);
+  const [code] = await Promise.race([
+    once(intruder, "close"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error("intruder close timeout")), 5000)),
+  ]);
+  assert.equal(code, 4005, "cross-owner reattach must be rejected OWNER_MISMATCH 4005");
+  assert.equal(browser.ws.readyState, WebSocket.OPEN, "the held owner-A survivor is untouched");
+  assert.ok(relay.sessions.has(session), "session still held for the rightful owner");
+  console.log("[ra/e] PASS — foreign-owner reattach rejected, owner binding preserved");
+});
+
+// ── (f) bridge-level: transient drop with claude alive → reconnect (no reap); budget exhausted → reap ──
+
+/** Spawn the real bridge (env-configured) with stderr capture, like orphan-cleanup. */
+function spawnBridge({ relayUrl, session, token, cmd, env = {} }) {
+  const child = spawn(process.execPath, [BRIDGE_ENTRY, "--cmd", cmd], {
+    env: { PATH: process.env.PATH, RELAY_URL: relayUrl, SESSION_ID: session, BRIDGE_TOKEN: token, BRIDGE_MAX_SECONDS: "60", ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (d) => { stderr += d; process.stderr.write(d); });
+  return { child, getStderr: () => stderr };
+}
+
+function pgrepPids(pattern) {
+  return new Promise((resolve) => {
+    execFile("pgrep", ["-f", pattern], (_err, stdout) =>
+      resolve(String(stdout || "").trim().split("\n").filter(Boolean).map(Number)));
+  });
+}
+function killHard(pid) {
+  try { process.kill(-pid, "SIGKILL"); } catch { /* */ }
+  try { process.kill(pid, "SIGKILL"); } catch { /* */ }
+}
+function newMark() { return String(47_000_000 + Math.floor(Math.random() * 1_000_000)); }
+/** A PTY command that ignores SIGHUP (like claude) so only a real reap escalation kills it. */
+const immuneCmd = (mark) => `bash -c "trap '' HUP; exec sleep ${mark}"`;
+async function findSentinel(mark) {
+  return waitFor(async () => {
+    const pids = await pgrepPids(`^sleep ${mark}$`);
+    return pids.length === 1 ? pids[0] : null;
+  }, 15_000, `sentinel "sleep ${mark}"`, 100);
+}
+
+test("(f1) transient relay drop with claude alive → bridge RECONNECTS to the same session, does NOT reap", { timeout: 40_000 }, async (t) => {
+  const session = `ra-f1-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 30_000 });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-RA", sid: session, secret: SECRET });
+
+  // Browser leg attaches first (relay has no buffering).
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+
+  // Real bridge running the echoing sentinel (stands in for a live `claude`).
+  const SENTINEL = path.resolve(__dirname, "./sentinel-cmd.mjs");
+  const spawned = spawnBridge({ relayUrl: relay.url, session, token: tokens.bridge, cmd: `${process.execPath} ${SENTINEL}` });
+  t.after(() => { if (spawned.child.exitCode === null) spawned.child.kill("SIGKILL"); });
+
+  await waitFor(() => browser.binary.includes("READY"), HARD_TIMEOUT_MS, "sentinel READY via relay");
+  const firstBridgeWs = await waitFor(() => relay.sessions.get(session)?.bridge ?? null, 5000, "bridge attached server-side");
+
+  // Force a TRANSIENT drop of the bridge's link (server-side terminate → client sees 1006).
+  firstBridgeWs.terminate();
+
+  // The bridge must RECONNECT (not reap): the relay re-pairs and broadcasts peer-reattached.
+  await waitFor(() => hasFrame(browser, isPeerReattachedFrame), 20_000, "bridge reconnected → peer-reattached");
+  assert.equal(spawned.child.exitCode, null, "bridge process did NOT exit across the drop");
+
+  // The pipe resumed: browser → relay → PTY → echo → browser (claude survived).
+  const tok = `AFTER-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+  browser.binary = "";
+  browser.ws.send(Buffer.from(tok + "\n", "utf8"), { binary: true });
+  await waitFor(() => browser.binary.includes(tok), HARD_TIMEOUT_MS, "round-trip after reconnect");
+  assert.doesNotMatch(spawned.getStderr(), /pty child confirmed dead|reconnect-exhausted/, "no reap happened on a transient drop");
+  console.log("[ra/f1] PASS — transient drop → bridge reconnected same session, claude survived, pipe resumed");
+});
+
+test("(f2) reconnect budget exhausted (relay stays down) → bridge reaps its child (no leak)", { timeout: 40_000 }, async (t) => {
+  const session = `ra-f2-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 30_000 });
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-RA", sid: session, secret: SECRET });
+
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+
+  const mark = newMark();
+  // Tiny reconnect budget → a couple of failed attempts against a dead relay, then reap.
+  const spawned = spawnBridge({
+    relayUrl: relay.url, session, token: tokens.bridge, cmd: immuneCmd(mark),
+    env: { BRIDGE_RECONNECT_MS: "1500" },
+  });
+  t.after(() => { if (spawned.child.exitCode === null) spawned.child.kill("SIGKILL"); });
+
+  const sentinelPid = await findSentinel(mark);
+  t.after(() => killHard(sentinelPid));
+
+  // Bring the WHOLE relay down so every reconnect attempt fails → budget exhausts.
+  await relay.close();
+
+  const [code] = await Promise.race([
+    once(spawned.child, "exit"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error("bridge exit timeout")), HARD_TIMEOUT_MS)),
+  ]);
+  assert.equal(pidAlive(sentinelPid), false, "the HUP-immune child was reaped (no leak) after the budget exhausted");
+  assert.match(spawned.getStderr(), /reconnect-exhausted|reconnect budget exhausted/, "the reconnect budget bounded the retries");
+  assert.equal(code, 0, "budget-exhausted teardown exits cleanly");
+  console.log("[ra/f2] PASS — reconnect budget bounded the retries, child reaped, no leak");
+});
+
+// ── final sweep: NOTHING may survive this suite ───────────────────────────────
+after(async () => {
+  const strays = await pgrepPids("^sleep 47");
+  for (const pid of strays) killHard(pid);
+  assert.deepEqual(strays, [], `stray sentinel processes leaked: ${strays.join(", ")}`);
+  console.log("[ra/sweep] PASS — final ps sweep clean");
+});

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -25,21 +25,27 @@ import {
   CLOSE,
   DEFAULT_IDLE_MS,
   DEFAULT_MAX_MS,
+  RECONNECT_GRACE_MS,
   idleCloseReason,
   maxCloseReason,
   resolveMs,
 } from "../relay/src/pairing.js";
 import { authorizeAttach } from "../shared/session-token.mjs";
-import { encodeAttachedFrame } from "../shared/control-frames.mjs";
+import {
+  encodeAttachedFrame,
+  encodePeerDegradedFrame,
+  encodePeerReattachedFrame,
+} from "../shared/control-frames.mjs";
 
 const NORMAL_CLOSURE = 1000;
 
 /**
  * @param {{ port?: number, secret?: string, idleMs?: number, maxMs?: number,
- *           sendAttachedFrame?: boolean,
+ *           graceMs?: number, sendAttachedFrame?: boolean,
  *           log?: (msg:string, extra?:object)=>void }} [opts]
  *   `secret` — TERMINAL_SESSION_SECRET used to verify leg tokens (defaults to env).
  *   `idleMs` / `maxMs` — lifecycle caps (default 30 min / 4 h); tests pass small values.
+ *   `graceMs` — reconnect grace window (default 90s); tests pass small values.
  *   `sendAttachedFrame` — default true (mirrors the real DO's R1 confirmation to
  *   the bridge leg); tests pass false to simulate an OLD relay for skew coverage.
  * @returns {Promise<{ url:string, port:number, close:()=>Promise<void>, sessions: Map }>}
@@ -49,9 +55,16 @@ export function startStandinRelay(opts = {}) {
   const secret = opts.secret ?? process.env.TERMINAL_SESSION_SECRET;
   const idleMs = resolveMs(opts.idleMs, DEFAULT_IDLE_MS);
   const maxMs = resolveMs(opts.maxMs, DEFAULT_MAX_MS);
+  const graceMs = resolveMs(opts.graceMs, RECONNECT_GRACE_MS);
   const sendAttachedFrame = opts.sendAttachedFrame !== false;
   // session id -> { bridge: ws|null, browser: ws|null, owner: string|null,
-  //                 idleTimer, maxTimer }
+  //                 idleTimer, maxTimer, graceTimer }
+  //
+  // GRACE-WINDOW REATTACH (fix/terminal-reconnect-reattach): faithfully mirrors the
+  // Cloudflare DO. On a single-leg detach we HOLD the session (owner + surviving
+  // socket kept, `peer-degraded` sent, no PEER_GONE) and arm a grace timer instead
+  // of tearing down. A same-sid+owner reattach inside the window re-pairs both legs
+  // (`peer-reattached`); the timer firing still-incomplete runs the OLD teardown.
   const sessions = new Map();
 
   const wss = new WebSocketServer({ port: opts.port ?? 0 });
@@ -62,9 +75,26 @@ export function startStandinRelay(opts = {}) {
     if (!legs) return;
     clearTimeout(legs.idleTimer);
     clearTimeout(legs.maxTimer);
+    clearTimeout(legs.graceTimer);
     for (const leg of [legs.bridge, legs.browser]) {
       if (leg && leg.readyState === leg.OPEN) {
         try { leg.close(NORMAL_CLOSURE, reason); } catch { /* closing */ }
+      }
+    }
+    sessions.delete(session);
+  }
+
+  /** Grace window elapsed without a full reattach → the OLD teardown: any survivor
+   *  gets PEER_GONE (4004) and the session is forgotten. */
+  function endGrace(session) {
+    const legs = sessions.get(session);
+    if (!legs) return;
+    clearTimeout(legs.idleTimer);
+    clearTimeout(legs.maxTimer);
+    clearTimeout(legs.graceTimer);
+    for (const leg of [legs.bridge, legs.browser]) {
+      if (leg && leg.readyState === leg.OPEN) {
+        try { leg.close(CLOSE.PEER_GONE.code, CLOSE.PEER_GONE.reason); } catch { /* closing */ }
       }
     }
     sessions.delete(session);
@@ -97,7 +127,7 @@ export function startStandinRelay(opts = {}) {
     }
 
     if (!sessions.has(session)) {
-      sessions.set(session, { bridge: null, browser: null, owner: null, idleTimer: null, maxTimer: null });
+      sessions.set(session, { bridge: null, browser: null, owner: null, idleTimer: null, maxTimer: null, graceTimer: null });
     }
     const legs = sessions.get(session);
 
@@ -120,12 +150,25 @@ export function startStandinRelay(opts = {}) {
       try { ws.send(encodeAttachedFrame()); } catch { /* leg already gone */ }
     }
 
-    // Arm the max-duration cap once, on the first leg; arm/refresh idle now.
-    if (firstLeg) {
+    // GRACE-WINDOW REATTACH reconciliation: if this session was being HELD for a
+    // dropped leg and BOTH legs are present again, cancel the grace hold and tell
+    // BOTH legs to resume. (Only one leg back → keep holding, wait for the other.)
+    if (legs.graceTimer && legs.bridge && legs.browser) {
+      clearTimeout(legs.graceTimer);
+      legs.graceTimer = null;
+      for (const leg of [legs.bridge, legs.browser]) {
+        try { leg.send(encodePeerReattachedFrame()); } catch { /* closing */ }
+      }
+      log("reattached — pair whole again", { session, role });
+    }
+
+    // Arm the max-duration cap once, on the first leg; arm/refresh idle now (unless
+    // still holding a grace window — a degraded session is governed by grace, not idle).
+    if (firstLeg && !legs.maxTimer) {
       legs.maxTimer = setTimeout(() => endSession(session, maxCloseReason(maxMs)), maxMs);
       legs.maxTimer.unref?.();
     }
-    bumpIdle(session, legs);
+    if (!legs.graceTimer) bumpIdle(session, legs);
 
     ws.on("message", (data, isBinary) => {
       const peer = role === "bridge" ? legs.browser : legs.bridge;
@@ -133,22 +176,26 @@ export function startStandinRelay(opts = {}) {
         peer.send(data, { binary: isBinary }); // verbatim, opaque
       }
       // Activity → push the idle deadline out (max-duration is untouched).
-      if (sessions.get(session) === legs) bumpIdle(session, legs);
+      if (sessions.get(session) === legs && !legs.graceTimer) bumpIdle(session, legs);
     });
 
+    // One leg went away → HOLD the session for the reconnect grace window instead of
+    // tearing it down. Keep the owner + any surviving socket; tell the survivor via
+    // `peer-degraded` (do NOT close it). endGrace() runs the old teardown if the
+    // window elapses still-incomplete.
     const teardown = () => {
-      if (legs[role] === ws) legs[role] = null;
+      if (legs[role] !== ws) return; // a superseding attach already owns this slot
+      legs[role] = null;
       log("detached", { session, role });
+      if (sessions.get(session) !== legs) return;
+      if (!legs.graceTimer) {
+        clearTimeout(legs.idleTimer); // idle is suspended while degraded
+        legs.graceTimer = setTimeout(() => endGrace(session), graceMs);
+        legs.graceTimer.unref?.();
+      }
       const peer = role === "bridge" ? legs.browser : legs.bridge;
       if (peer && peer.readyState === peer.OPEN) {
-        try { peer.close(CLOSE.PEER_GONE.code, CLOSE.PEER_GONE.reason); } catch { /* closing */ }
-      }
-      if (role === "bridge") legs.browser = null;
-      else legs.bridge = null;
-      if (!legs.bridge && !legs.browser) {
-        clearTimeout(legs.idleTimer);
-        clearTimeout(legs.maxTimer);
-        sessions.delete(session);
+        try { peer.send(encodePeerDegradedFrame()); } catch { /* closing */ }
       }
     };
 
@@ -168,6 +215,7 @@ export function startStandinRelay(opts = {}) {
             for (const legs of sessions.values()) {
               clearTimeout(legs.idleTimer);
               clearTimeout(legs.maxTimer);
+              clearTimeout(legs.graceTimer);
             }
             for (const client of wss.clients) {
               try { client.terminate(); } catch { /* ignore */ }


### PR DESCRIPTION
## Problem
A transient drop (Wi-Fi blip / laptop sleep) lost the live `claude` agent: the dock minted a brand-new session id on every reconnect (the "4 sessions" churn), the relay tore down owner+peer on any single-leg detach, and the bridge reaped `claude` ~90s after the link froze with zero reconnect logic — while the banner falsely promised "the agent keeps running locally". (Surfaced during the first successful live test.)

## Fix — grace-window reattach (shared 90s < 300s token TTL, no re-mint)
- **Relay DO:** single-leg detach *holds* owner+survivor for the window (hibernation-safe storage alarm), sends `{"t":"peer-degraded"}` instead of closing, and re-pairs a same-sid+owner reattach with `{"t":"peer-reattached"}`. Grace expiry → old teardown (PEER_GONE 4004 + clear).
- **Bridge:** only `1006` is transient → reconnect same session with backoff, `claude` stays alive, pipe resumes. `4004`/`4002`/`4005`/`4006` are terminal (reap, no retry-spin). Orphan-cleanup reaping intact on real shutdown.
- **Client:** retains `browserToken`+`expiresAt`, distinct reconnect path (same sid, no mint, bounded by grace **and** token validity), honest "session ended — your work is safe" + working fresh launch beyond the window (fixes the old broken "Reconnect now").
- **Shared:** skew-safe `peer-degraded`/`peer-reattached` frames (old peers log-and-ignore).

## Security (adversarially verified)
Foreign-owner reattach → `4005`, double-reattach → `DUP_BROWSER 4001`, expired token → `4006`; reconnect reuses the startup-validated relay URL so the host allowlist holds by construction.

## Also
Fixes a pre-existing race in `lifecycle.test.mjs` (late-attached close listener → spurious 5s timeout). **0 fails / 8 serial runs under 6-core CPU load** (was ~50%).

## Rollout (staged)
Relay via `wrangler deploy` (first, skew-safe) · web via Vercel on merge · **bridge-reconnect leg rides the next notarized helper build** — until then users get relay+web reattach with an honest degrade, never silent failure.

## Tests
reconnect-reattach 7/7 · full terminal serial suite 42/42 · vitest src/lib terminal 89/89 · tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)