### PR TITLE
fix(terminal): dock liveness watchdog — app-level heartbeat detects silent link death

### DIFF
--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -57,16 +57,21 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 import type { FitAddon as XFitAddon } from "@xterm/addon-fit";
 import {
   CONNECT_TIMEOUT_MS,
+  HEARTBEAT_INTERVAL_MS,
+  LINK_SILENT_CHECK_MS,
   RECONNECT_GRACE_MS,
   buildRelayUrl,
+  encodeHeartbeatFrame,
   encodeResizeMessage,
   initialConnectionState,
+  isHeartbeatAckFrame,
   isInputEnabled,
   isPeerDegradedFrame,
   isPeerReattachedFrame,
   isTerminalEnabled,
   mapCloseCode,
   relayBaseUrl,
+  shouldDeclareLinkSilent,
   terminalReducer,
   type TerminalConnectionState,
   type TerminalStatus,
@@ -233,6 +238,14 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   const degradeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pairRef = useRef<PairInfo | null>(null);
   const scheduleReconnectRef = useRef<() => void>(() => {});
+  // Silent-link watchdog bookkeeping (fix/terminal-dock-heartbeat).
+  // `lastInboundAtRef` is stamped on EVERY inbound frame (PTY bytes, control
+  // frames, hb-acks); `hbArmedRef` is a PER-SOCKET latch set on the socket's first
+  // hb-ack — an old relay never acks, so the watchdog stays disarmed there and the
+  // pre-watchdog behaviour is unchanged (version-skew gate). Both are reset in
+  // openBrowserLeg when a fresh socket is opened.
+  const lastInboundAtRef = useRef(0);
+  const hbArmedRef = useRef(false);
   // The compact bootstrap prompt (head/tail parts) the LAST launch-bus event
   // carried — i.e. what the launch button resolved. Dock-initiated launches with
   // no bus payload (paired auto-connect on open, Retry) fall back to building the
@@ -541,6 +554,10 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       }
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
+      // Fresh socket → fresh watchdog: disarm until ITS first hb-ack and restart
+      // the silence clock (an inherited stale stamp must never condemn a new leg).
+      hbArmedRef.current = false;
+      lastInboundAtRef.current = Date.now();
 
       if (!reconnect) {
         connectTimerRef.current = setTimeout(() => {
@@ -554,9 +571,18 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
         dispatch({ type: "relay-open" });
       };
       ws.onmessage = (ev) => {
+        // ANY inbound frame proves the link carried something just now — feed the
+        // silent-link watchdog before any classification.
+        lastInboundAtRef.current = Date.now();
         // TEXT = relay control frame on the BROWSER leg. The grace-window notices
         // arrive here (the R1 `attached` frame goes to the bridge leg only).
         if (typeof ev.data === "string") {
+          if (isHeartbeatAckFrame(ev.data)) {
+            // The relay's liveness echo — arm the watchdog for THIS socket. Never
+            // written to the xterm and never logged as content.
+            hbArmedRef.current = true;
+            return;
+          }
           if (isPeerDegradedFrame(ev.data)) {
             // Our peer (the bridge) dropped; the relay is HOLDING the session. Keep
             // the terminal, show a subtle hint, and bound the wait to the grace window.
@@ -652,6 +678,74 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     }, delay);
   }, [openBrowserLeg, clearReconnectTimer, clearDegradeTimer]);
   scheduleReconnectRef.current = scheduleReconnect;
+
+  // ── silent-link watchdog (fix/terminal-dock-heartbeat) ─────────────────────
+  // The watchdog verdict landed: the socket still LOOKS open but nothing inbound
+  // (PTY bytes or hb-acks) arrived for the whole silence threshold — a silent link
+  // death (wifi off / network switch; macOS never RSTs, so no close event ever
+  // fires). Tear down the ZOMBIE socket exactly like teardownSocket's socket step
+  // — null the handlers FIRST so its eventual close can't double-drive the state —
+  // then route into the EXISTING reattach machinery: disconnected + the
+  // grace-window reconnect loop (same sid, retained token, no re-mint).
+  const declareLinkSilent = useCallback(() => {
+    const ws = wsRef.current;
+    wsRef.current = null;
+    if (ws) {
+      ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+    }
+    clearDegradeTimer();
+    setPeerDegraded(false);
+    dispatch({ type: "link-silent" });
+    scheduleReconnectRef.current();
+  }, [clearDegradeTimer]);
+
+  // While CONNECTED: probe the relay with the app-level heartbeat every
+  // HEARTBEAT_INTERVAL_MS and run the silence check every LINK_SILENT_CHECK_MS.
+  // The check computes WALL-CLOCK elapsed (a hidden tab's clamped timers can only
+  // delay a tick, never fake recency) and re-runs immediately when the tab becomes
+  // visible or the browser flips online/offline — the moments a silent death is
+  // most likely to be discovered.
+  useEffect(() => {
+    if (!enabled || state.status !== "connected") return;
+
+    const sendHeartbeat = () => {
+      const ws = wsRef.current;
+      if (ws && ws.readyState === WebSocket.OPEN) ws.send(encodeHeartbeatFrame());
+    };
+    const check = () => {
+      if (statusRef.current !== "connected") return;
+      if (shouldDeclareLinkSilent(lastInboundAtRef.current, Date.now(), hbArmedRef.current)) {
+        logger.warn("Terminal link silent — declaring dead, reattaching", {
+          silentMs: Date.now() - lastInboundAtRef.current,
+        });
+        declareLinkSilent();
+      }
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") check();
+    };
+
+    // Probe immediately so the watchdog ARMS on the first ack instead of waiting a
+    // whole interval (matters when a drop happens right after connecting).
+    sendHeartbeat();
+    const sendTimer = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS);
+    const checkTimer = setInterval(check, LINK_SILENT_CHECK_MS);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("online", check);
+    window.addEventListener("offline", check);
+    return () => {
+      clearInterval(sendTimer);
+      clearInterval(checkTimer);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("online", check);
+      window.removeEventListener("offline", check);
+    };
+  }, [enabled, state.status, declareLinkSilent]);
 
   // ── connect (browser leg) ───────────────────────────────────────────────────
   // `autoLaunch` = the same-machine path: after minting, fire the vibecodes:// deep

--- a/src/lib/terminal/connection.test.ts
+++ b/src/lib/terminal/connection.test.ts
@@ -2,12 +2,17 @@ import { describe, it, expect } from "vitest";
 import {
   RELAY_CLOSE,
   RECONNECT_GRACE_MS,
+  HEARTBEAT_INTERVAL_MS,
+  LINK_SILENT_AFTER_MS,
   initialConnectionState,
   terminalReducer,
   mapCloseCode,
   isInputEnabled,
   isPeerDegradedFrame,
   isPeerReattachedFrame,
+  encodeHeartbeatFrame,
+  isHeartbeatAckFrame,
+  shouldDeclareLinkSilent,
   buildRelayUrl,
   encodeResizeMessage,
   type TerminalConnectionState,
@@ -18,6 +23,9 @@ import {
   encodeAttachedFrame,
   encodePeerDegradedFrame,
   encodePeerReattachedFrame,
+  encodeHeartbeatFrame as encodeSharedHeartbeatFrame,
+  encodeHeartbeatAckFrame as encodeSharedHeartbeatAckFrame,
+  isHeartbeatFrame as isSharedHeartbeatFrame,
 } from "../../../terminal/shared/control-frames.mjs";
 
 // Helper: fold a sequence of events through the reducer from the initial state.
@@ -268,5 +276,72 @@ describe("grace-window reconnect (fix/terminal-reconnect-reattach)", () => {
     expect(isPeerReattachedFrame(encodeAttachedFrame())).toBe(false);
     expect(isPeerDegradedFrame("")).toBe(false);
     expect(isPeerDegradedFrame('{"t":"peer-degraded"' /* truncated */)).toBe(false);
+  });
+});
+
+describe("silent-link watchdog (fix/terminal-dock-heartbeat)", () => {
+  const connected = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+
+  it("link-silent from connected → disconnected (recoverable, feeds the reattach loop)", () => {
+    const s = terminalReducer(connected, { type: "link-silent" });
+    expect(s.status).toBe("disconnected");
+    expect(s.errorKind).toBeNull();
+    expect(s.endedReason).toBeNull();
+  });
+
+  it("link-silent is ignored in every non-connected state", () => {
+    const nonConnected: TerminalConnectionState[] = [
+      initialConnectionState, // idle
+      run([{ type: "connect" }]), // connecting
+      run([{ type: "connect" }, { type: "relay-open" }]), // waiting-to-pair
+      terminalReducer(connected, { type: "closed", code: RELAY_CLOSE.PEER_GONE }), // disconnected (already reconnecting)
+      terminalReducer(connected, { type: "user-end" }), // session-ended
+      run([{ type: "connect" }, { type: "session-mint-failed" }]), // error
+    ];
+    for (const state of nonConnected) {
+      expect(terminalReducer(state, { type: "link-silent" })).toBe(state);
+    }
+  });
+
+  // The heartbeat frame + ack detector are duplicated from
+  // terminal/shared/control-frames.mjs (plain .mjs outside the TS build graph).
+  // Pin BOTH directions byte-for-byte against the real shared encoders — the relay
+  // auto-response matches the request string EXACTLY, so any drift breaks liveness.
+  it("the probe frame is byte-for-byte the shared encoder's (relay auto-response matches exactly)", () => {
+    expect(encodeHeartbeatFrame()).toBe(encodeSharedHeartbeatFrame());
+    expect(isSharedHeartbeatFrame(encodeHeartbeatFrame())).toBe(true);
+  });
+
+  it("detects the shared hb-ack frame the relay actually echoes", () => {
+    expect(isHeartbeatAckFrame(encodeSharedHeartbeatAckFrame())).toBe(true);
+  });
+
+  it("the ack detector is strict to its tag (disjoint from every other control frame)", () => {
+    expect(isHeartbeatAckFrame(encodeSharedHeartbeatFrame())).toBe(false);
+    expect(isHeartbeatAckFrame(encodeAttachedFrame())).toBe(false);
+    expect(isHeartbeatAckFrame(encodePeerDegradedFrame())).toBe(false);
+    expect(isHeartbeatAckFrame(encodePeerReattachedFrame())).toBe(false);
+    expect(isHeartbeatAckFrame("")).toBe(false);
+    expect(isHeartbeatAckFrame('{"t":"hb-ack"' /* truncated */)).toBe(false);
+    // The other detectors must not claim the ack either.
+    expect(isPeerDegradedFrame(encodeSharedHeartbeatAckFrame())).toBe(false);
+    expect(isPeerReattachedFrame(encodeSharedHeartbeatAckFrame())).toBe(false);
+  });
+
+  it("shouldDeclareLinkSilent: exactly the threshold is NOT yet dead; strictly beyond is", () => {
+    const last = 1_000_000;
+    expect(shouldDeclareLinkSilent(last, last + LINK_SILENT_AFTER_MS, true)).toBe(false);
+    expect(shouldDeclareLinkSilent(last, last + LINK_SILENT_AFTER_MS + 1, true)).toBe(true);
+    expect(shouldDeclareLinkSilent(last, last, true)).toBe(false);
+  });
+
+  it("shouldDeclareLinkSilent: unarmed (no ack ever — old relay) never declares dead", () => {
+    const last = 1_000_000;
+    expect(shouldDeclareLinkSilent(last, last + LINK_SILENT_AFTER_MS * 100, false)).toBe(false);
+  });
+
+  it("the silence threshold tolerates lost acks (≥ 2 probe intervals of headroom)", () => {
+    // One dropped ack must never be a false alarm; three probes fit in the window.
+    expect(LINK_SILENT_AFTER_MS).toBeGreaterThanOrEqual(HEARTBEAT_INTERVAL_MS * 3);
   });
 });

--- a/src/lib/terminal/connection.ts
+++ b/src/lib/terminal/connection.ts
@@ -80,6 +80,7 @@ export type TerminalEvent =
   | { type: "user-end" }
   | { type: "connect-timeout" }
   | { type: "reconnect-exhausted" }
+  | { type: "link-silent" }
   | { type: "closed"; code: number; reason?: string }
   | { type: "reset" };
 
@@ -201,6 +202,17 @@ export function terminalReducer(
       if (state.status === "session-ended") return state;
       return { ...state, status: "session-ended", endedReason: "reconnect-failed", errorKind: null };
 
+    case "link-silent":
+      // The heartbeat watchdog declared the link DEAD: nothing inbound (PTY bytes
+      // or hb-acks) for the whole silence threshold while the socket still LOOKS
+      // open — silent link death (wifi off / network switch; macOS never RSTs).
+      // Same recoverable outcome as a visible drop → disconnected, so the existing
+      // grace-window reattach machinery takes over. Only meaningful from a live
+      // stream; every other state already has an honest story (the watchdog only
+      // runs while connected anyway — this guard is defence-in-depth).
+      if (state.status !== "connected") return state;
+      return { ...state, status: "disconnected", errorKind: null, endedReason: null };
+
     case "closed": {
       // A user-initiated end already produced the terminal state; the socket's own
       // close event must not clobber it back to a generic disconnect.
@@ -287,4 +299,58 @@ export function isPeerDegradedFrame(text: string): boolean {
 /** The pair is whole again inside the window — resume. */
 export function isPeerReattachedFrame(text: string): boolean {
   return isControlFrame(text, "peer-reattached");
+}
+
+// ── app-level heartbeat + silent-link watchdog (fix/terminal-dock-heartbeat) ──
+//
+// macOS never RSTs a socket when the network silently dies (wifi off / network
+// switch), and the dock only left "connected" on SOCKET events — so a silent link
+// death froze the pill on "Connected" forever. The protocol-level pings the bridge
+// relies on are invisible to browser JS, so the dock probes at the APP level:
+// while connected it sends `{"t":"hb"}` every HEARTBEAT_INTERVAL_MS and the relay
+// echoes `{"t":"hb-ack"}` to the probing leg only (hibernation-safe auto-response;
+// never forwarded, never extends the relay's idle clock). The watchdog declares
+// the link dead when NOTHING inbound — PTY bytes or acks — has arrived for
+// LINK_SILENT_AFTER_MS, but ONLY once ARMED by the socket's first ack: an OLD
+// relay never acks, so the watchdog stays disarmed there and pre-watchdog
+// behaviour is unchanged (version-skew gate).
+//
+// The frame is duplicated (not imported) from terminal/shared/control-frames.mjs
+// for the same reason RELAY_CLOSE is — that module is plain .mjs outside the app's
+// TS build graph. connection.test.ts pins both directions byte-for-byte against
+// the real .mjs encoders, so any drift fails there.
+
+/** Cadence of the dock's `{"t":"hb"}` probe while connected. */
+export const HEARTBEAT_INTERVAL_MS = 15_000;
+
+/**
+ * Silence threshold: nothing inbound for LONGER than this (strictly) → the link is
+ * declared dead. Three heartbeat intervals — one lost ack is never a false alarm.
+ */
+export const LINK_SILENT_AFTER_MS = 45_000;
+
+/**
+ * Watchdog poll cadence. Each check computes WALL-CLOCK elapsed, so a hidden tab's
+ * timer clamping can only DELAY detection, never fake recency; the dock also
+ * re-checks immediately on visibilitychange→visible and online/offline.
+ */
+export const LINK_SILENT_CHECK_MS = 5_000;
+
+/** The exact TEXT frame the dock sends as its liveness probe (mirrors encodeHeartbeatFrame in the .mjs). */
+export function encodeHeartbeatFrame(): string {
+  return JSON.stringify({ t: "hb" });
+}
+
+/** The relay's heartbeat echo — proof the link is alive. NEVER content: not written to the xterm, not logged. */
+export function isHeartbeatAckFrame(text: string): boolean {
+  return isControlFrame(text, "hb-ack");
+}
+
+/**
+ * The watchdog verdict, pure so the boundary is unit-tested: dead only when ARMED
+ * (this socket has acked at least once) AND the silence STRICTLY exceeds the
+ * threshold. Unarmed → never (old-relay skew gate).
+ */
+export function shouldDeclareLinkSilent(lastInboundAt: number, now: number, armed: boolean): boolean {
+  return armed && now - lastInboundAt > LINK_SILENT_AFTER_MS;
 }

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -46,6 +46,9 @@ import {
   encodeAttachedFrame,
   encodePeerDegradedFrame,
   encodePeerReattachedFrame,
+  encodeHeartbeatFrame,
+  encodeHeartbeatAckFrame,
+  isHeartbeatFrame,
 } from "../../shared/control-frames.mjs";
 
 /** Normal WebSocket closure code used for clean, server-initiated session ends. */
@@ -96,6 +99,22 @@ export class TerminalRelay {
     // NOTE (hibernation): do NOT keep session state in instance fields — the DO
     // can be evicted between messages. Live sockets + state.storage are the only
     // durable sources, read on demand below.
+
+    // App-level HEARTBEAT echo (fix/terminal-dock-heartbeat): answer the browser
+    // dock's `{"t":"hb"}` liveness probe with `{"t":"hb-ack"}` WITHOUT waking the
+    // DO (hibernation-safe auto-response). Deliberately NOT routed through
+    // webSocketMessage: a heartbeat is never forwarded to the peer and never
+    // stamps lastActivityAt, so the 30-min idle cap is unaffected by an
+    // open-but-idle dock. If the runtime lacks auto-response, the belt-and-braces
+    // intercept in webSocketMessage below still answers (with a DO wake).
+    try {
+      const Pair = globalThis.WebSocketRequestResponsePair;
+      if (Pair) {
+        this.state.setWebSocketAutoResponse(new Pair(encodeHeartbeatFrame(), encodeHeartbeatAckFrame()));
+      }
+    } catch (e) {
+      this.log("heartbeat auto-response unavailable", { err: String(e) });
+    }
   }
 
   /** @param {string} msg @param {object} [extra] */
@@ -185,6 +204,22 @@ export class TerminalRelay {
       return new Response(null, { status: 101, webSocket: client });
     }
 
+    // 2b) Same-owner browser PREEMPTION (fix/terminal-dock-heartbeat): decideAttach
+    //     accepted this leg OVER a still-registered browser socket — after a silent
+    //     link death (wifi off; macOS never RSTs) the dead socket lingers OPEN
+    //     forever and used to block every reattach with DUP_BROWSER. Close the
+    //     stale leg(s) BEFORE accepting the new one so single-attach holds
+    //     post-swap; handleDetach sees the pair still whole and skips the grace
+    //     hold. Foreign owners never reach here (owner check above).
+    if (decision.preempt) {
+      for (const stale of this.state.getWebSockets(`role:${role}`)) {
+        try {
+          stale.close(CLOSE.PREEMPTED.code, CLOSE.PREEMPTED.reason);
+        } catch { /* already closing */ }
+      }
+      this.log("stale browser leg preempted", { session, role });
+    }
+
     // 3) Accept into HIBERNATION. Tag by role (+ sub) so the peer is findable and
     //    single-attach is re-derivable after the DO is evicted from memory.
     this.state.acceptWebSocket(server, [`role:${role}`, `sub:${auth.sub}`]);
@@ -249,6 +284,18 @@ export class TerminalRelay {
    * @param {string|ArrayBuffer} message
    */
   async webSocketMessage(ws, message) {
+    // HEARTBEAT intercept (belt-and-braces): normally the auto-response pair set
+    // in the constructor answers `{"t":"hb"}` without this handler ever running.
+    // If auto-response is unavailable at runtime, echo the ack here — BEFORE the
+    // forward (a heartbeat never reaches the peer) and BEFORE the activity stamp
+    // (heartbeats must not extend the idle clock).
+    if (typeof message === "string" && isHeartbeatFrame(message)) {
+      try {
+        ws.send(encodeHeartbeatAckFrame());
+      } catch { /* leg already closing */ }
+      return;
+    }
+
     const att = ws.deserializeAttachment() || {};
     const role = att.role;
     if (role !== "bridge" && role !== "browser") return;
@@ -306,6 +353,27 @@ export class TerminalRelay {
     } catch { /* attachment may be gone */ }
     this.log("detached", { role, why, ...extra });
 
+    // Survivors, excluding the closing socket (it may still appear in the list).
+    const surviving = { bridge: false, browser: false };
+    const survivorSockets = [];
+    for (const peer of this.state.getWebSockets()) {
+      if (peer === ws) continue;
+      survivorSockets.push(peer);
+      try {
+        const peerRole = peer.deserializeAttachment()?.role;
+        if (peerRole === "bridge" || peerRole === "browser") surviving[peerRole] = true;
+      } catch { /* attachment may be gone */ }
+    }
+
+    // PREEMPTION swap (fix/terminal-dock-heartbeat): the closing socket was
+    // already REPLACED — a same-owner attach closed it and both roles are still
+    // live. Nothing dropped, so there is nothing to hold a grace window for;
+    // opening one here would wrongly suspend the idle cap for the whole window.
+    if (surviving.bridge && surviving.browser) {
+      this.log("detach superseded — pair still whole", { role, why });
+      return;
+    }
+
     const now = Date.now();
     // Open (or keep) the grace hold; the grace alarm governs teardown from here.
     if ((await this.state.storage.get("graceDeadline")) == null) {
@@ -313,17 +381,14 @@ export class TerminalRelay {
     }
     await this.armAlarm(now);
 
-    // Tell any SURVIVING peer we're holding (the closing socket may still appear
-    // in the list, so skip it). We do NOT close survivors during the window.
-    let survivors = 0;
-    for (const peer of this.state.getWebSockets()) {
-      if (peer === ws) continue;
-      survivors++;
+    // Tell any SURVIVING peer we're holding. We do NOT close survivors during
+    // the window.
+    for (const peer of survivorSockets) {
       try {
         peer.send(encodePeerDegradedFrame());
       } catch { /* already closing */ }
     }
-    this.log("holding session for reconnect", { droppedRole: role, survivors, graceMs: this.graceMs() });
+    this.log("holding session for reconnect", { droppedRole: role, survivors: survivorSockets.length, graceMs: this.graceMs() });
   }
 
   // ── Idle / max-duration via DO alarms ────────────────────────────────────────

--- a/terminal/relay/src/pairing.js
+++ b/terminal/relay/src/pairing.js
@@ -22,6 +22,11 @@ export const CLOSE = Object.freeze({
   // SLICE 2 — auth + ownership:
   OWNER_MISMATCH: { code: 4005, reason: "owner mismatch — token is for a different user" },
   BAD_TOKEN: { code: 4006, reason: "invalid, tampered, or expired session token" },
+  // Same-owner browser preemption (fix/terminal-dock-heartbeat): the close the
+  // STALE browser leg receives when a newer same-owner browser attach replaces it.
+  // Reuses the DUP_BROWSER code (4001) — a dock that receives it maps to the
+  // existing "duplicate" copy — with a distinct reason for logs and tests.
+  PREEMPTED: { code: 4001, reason: "preempted" },
 });
 
 /**
@@ -68,10 +73,22 @@ export function isValidSession(session) {
  * ownership failure, not a duplicate. When `sub` is omitted (e.g. slice-1 callers /
  * unit tests of the bare state machine) owner-binding is skipped.
  *
+ * Same-owner browser PREEMPTION (fix/terminal-dock-heartbeat): when the browser
+ * leg dies SILENTLY (wifi off / network switch — macOS never RSTs), the dead
+ * socket still counts as attached, so a legitimate same-owner reattach used to
+ * bounce off DUP_BROWSER forever. For an owner-verified leg (`sub` present — a
+ * foreign sub was already rejected above) the NEWER browser attach now wins:
+ * `{ok: true, preempt: true}` tells the caller to close the stale browser leg
+ * (CLOSE.PREEMPTED, 4001 "preempted") before accepting this one, keeping the
+ * single-attach invariant post-swap. Sub-less callers keep the old DUP_BROWSER
+ * verdict, and a 2nd BRIDGE is still rejected — the bridge leg detects its own
+ * link death via protocol pings and closes honestly, so a live duplicate there
+ * is a real conflict, not a zombie.
+ *
  * @param {AttachState} state - current attachment state for the session
  * @param {string} role - "bridge" | "browser"
  * @param {string} [sub] - the owner id carried by the (already token-verified) leg
- * @returns {{ok: true} | {ok: false, code: number, reason: string}}
+ * @returns {{ok: true, preempt?: true} | {ok: false, code: number, reason: string}}
  */
 export function decideAttach(state, role, sub) {
   if (!ROLES.includes(role)) {
@@ -81,6 +98,7 @@ export function decideAttach(state, role, sub) {
     return { ok: false, ...CLOSE.OWNER_MISMATCH };
   }
   if (role === "browser" && state.browser) {
+    if (sub !== undefined) return { ok: true, preempt: true };
     return { ok: false, ...CLOSE.DUP_BROWSER };
   }
   if (role === "bridge" && state.bridge) {

--- a/terminal/relay/src/pairing.test.js
+++ b/terminal/relay/src/pairing.test.js
@@ -104,6 +104,45 @@ test("owner-binding: omitting sub skips the owner check (slice-1 compatibility)"
   assert.equal(decideAttach(s, "browser").ok, true);
 });
 
+// ── same-owner browser preemption (fix/terminal-dock-heartbeat) ──────────────
+
+test("preemption: an owner-verified 2nd browser is accepted with the preempt flag", () => {
+  let s = emptyState();
+  s = attach(s, "bridge", "user-A");
+  s = attach(s, "browser", "user-A"); // possibly a silently-dead zombie leg
+  const d = decideAttach(s, "browser", "user-A");
+  assert.deepEqual(d, { ok: true, preempt: true }, "the newer same-owner browser wins");
+});
+
+test("preemption: a sub-less 2nd browser keeps the old DUP_BROWSER rejection", () => {
+  const s = attach(emptyState(), "browser");
+  const d = decideAttach(s, "browser");
+  assert.equal(d.ok, false);
+  assert.equal(d.code, CLOSE.DUP_BROWSER.code);
+});
+
+test("preemption: a foreign owner is still rejected OWNER_MISMATCH, never preempts", () => {
+  let s = emptyState();
+  s = attach(s, "browser", "user-A");
+  const d = decideAttach(s, "browser", "user-B");
+  assert.equal(d.ok, false);
+  assert.equal(d.code, CLOSE.OWNER_MISMATCH.code);
+});
+
+test("preemption: never applies to the bridge role — a live 2nd bridge is a real conflict", () => {
+  let s = emptyState();
+  s = attach(s, "bridge", "user-A");
+  const d = decideAttach(s, "bridge", "user-A");
+  assert.equal(d.ok, false);
+  assert.equal(d.code, CLOSE.DUP_BRIDGE.code);
+});
+
+test("preemption: the stale-leg close reuses the DUP_BROWSER code with a distinct reason", () => {
+  assert.equal(CLOSE.PREEMPTED.code, CLOSE.DUP_BROWSER.code);
+  assert.equal(CLOSE.PREEMPTED.code, 4001);
+  assert.match(CLOSE.PREEMPTED.reason, /preempted/);
+});
+
 test("isValidSession accepts url-safe tokens and rejects junk", () => {
   assert.equal(isValidSession("a3f9"), true);
   assert.equal(isValidSession("dev-abc_123.4"), true);

--- a/terminal/shared/control-frames.mjs
+++ b/terminal/shared/control-frames.mjs
@@ -34,6 +34,21 @@
 // Both are skew-safe exactly like `attached`: an old bridge logs-and-ignores an
 // unknown control frame, and a browser dock that doesn't know them treats them
 // as a no-op.
+//
+// LINK-LIVENESS HEARTBEAT (fix/terminal-dock-heartbeat) adds a browser→relay probe
+// pair in the SAME `{"t":…}` namespace. macOS never RSTs a socket when the network
+// silently dies (wifi off / network switch), so the browser leg needs an app-level
+// echo to prove the link is alive — the protocol-level pings the bridge relies on
+// are invisible to browser JS:
+//   - `{"t":"hb"}`     — sent BY the browser dock every ~15s while connected.
+//   - `{"t":"hb-ack"}` — echoed BY the relay, to the SENDING leg only. Never
+//     forwarded to the peer and never counted as session activity (the 30-min
+//     idle cap is unaffected). On Cloudflare this is a hibernation-safe
+//     setWebSocketAutoResponse pair — zero DO wakes.
+// Skew-safe both ways: an OLD relay forwards the hb to the bridge, which
+// logs-and-ignores it as an unknown control frame; the dock's watchdog only ARMS
+// on the first hb-ack, so with an old relay (no ack, ever) the pre-watchdog
+// behaviour is unchanged.
 
 /** Detect any control TEXT frame with a given `t` tag. Cheap + strict + bounded. */
 function isControlFrame(text, tag) {
@@ -80,4 +95,24 @@ export function encodePeerReattachedFrame() {
 /** @param {unknown} text @returns {boolean} */
 export function isPeerReattachedFrame(text) {
   return isControlFrame(text, "peer-reattached");
+}
+
+/** TEXT frame the browser dock sends the relay as its app-level liveness probe. */
+export function encodeHeartbeatFrame() {
+  return JSON.stringify({ t: "hb" });
+}
+
+/** @param {unknown} text @returns {boolean} */
+export function isHeartbeatFrame(text) {
+  return isControlFrame(text, "hb");
+}
+
+/** TEXT frame the relay echoes back to the PROBING leg only (never forwarded). */
+export function encodeHeartbeatAckFrame() {
+  return JSON.stringify({ t: "hb-ack" });
+}
+
+/** @param {unknown} text @returns {boolean} */
+export function isHeartbeatAckFrame(text) {
+  return isControlFrame(text, "hb-ack");
 }

--- a/terminal/test/control-frames.test.mjs
+++ b/terminal/test/control-frames.test.mjs
@@ -15,6 +15,10 @@ import {
   isPeerDegradedFrame,
   encodePeerReattachedFrame,
   isPeerReattachedFrame,
+  encodeHeartbeatFrame,
+  isHeartbeatFrame,
+  encodeHeartbeatAckFrame,
+  isHeartbeatAckFrame,
 } from "../shared/control-frames.mjs";
 import { parseControlMessage } from "../bridge/src/framing.js";
 
@@ -34,6 +38,20 @@ test("grace-window frames encode ⇄ detect round-trip and stay mutually disjoin
   // Neither is a resize control frame.
   assert.equal(parseControlMessage(encodePeerDegradedFrame()), null);
   assert.equal(parseControlMessage(encodePeerReattachedFrame()), null);
+});
+
+test("heartbeat frames encode ⇄ detect round-trip and stay disjoint from everything else", () => {
+  assert.equal(isHeartbeatFrame(encodeHeartbeatFrame()), true);
+  assert.equal(isHeartbeatAckFrame(encodeHeartbeatAckFrame()), true);
+  // The probe and its echo never cross-match, nor match any other control frame.
+  assert.equal(isHeartbeatFrame(encodeHeartbeatAckFrame()), false);
+  assert.equal(isHeartbeatAckFrame(encodeHeartbeatFrame()), false);
+  assert.equal(isAttachedFrame(encodeHeartbeatFrame()), false);
+  assert.equal(isPeerDegradedFrame(encodeHeartbeatAckFrame()), false);
+  assert.equal(isHeartbeatFrame(encodeAttachedFrame()), false);
+  // Neither is a resize control frame (browser→bridge namespace stays disjoint).
+  assert.equal(parseControlMessage(encodeHeartbeatFrame()), null);
+  assert.equal(parseControlMessage(encodeHeartbeatAckFrame()), null);
 });
 
 test("rejects non-attached / malformed / hostile inputs", () => {

--- a/terminal/test/heartbeat.test.mjs
+++ b/terminal/test/heartbeat.test.mjs
@@ -1,0 +1,177 @@
+// Browser-leg liveness heartbeat + same-owner preemption — regression proof
+// (fix/terminal-dock-heartbeat).
+//
+// ROOT CAUSE (Reproduce & Investigate step): the dock only leaves "connected" on
+// SOCKET events, and macOS never RSTs a socket when the network silently dies
+// (wifi off / network switch) — so a silent link death froze the pill on
+// "Connected" forever. The bridge leg detects via protocol-level pings; browser
+// JS can't see those, so the dock needs an APP-level echo.
+//
+// THE FIX under test (relay side; the dock's watchdog is unit-tested in
+// src/lib/terminal/connection.test.ts):
+//   heartbeat   — the browser leg sends `{"t":"hb"}`; the relay echoes
+//                 `{"t":"hb-ack"}` to the PROBING leg only. Never forwarded to
+//                 the peer, and never counted as activity — an open-but-idle dock
+//                 must still idle-close on schedule.
+//   preemption  — a same-owner browser attach while a (possibly silently dead)
+//                 browser leg is still registered now WINS: the stale leg is
+//                 closed 4001 "preempted", the new leg goes live, and NO grace
+//                 window opens (the pair never stopped being whole).
+//
+// Runs against the Node stand-in relay, which shares the exact decision logic
+// (pairing.js) and mirrors the DO's hb intercept. Every wait is hard-timeout
+// guarded.
+//
+// Run: cd terminal/test && node --test heartbeat.test.mjs   (or: npm test)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens } from "../shared/session-token.mjs";
+import {
+  encodeHeartbeatFrame,
+  isHeartbeatFrame,
+  isHeartbeatAckFrame,
+  isAttachedFrame,
+  isPeerDegradedFrame,
+} from "../shared/control-frames.mjs";
+
+const SECRET = "heartbeat-test-secret";
+const HARD_TIMEOUT_MS = 10_000;
+
+// ── generic waiters (same idioms as reconnect-reattach.test.mjs) ──────────────
+async function waitFor(pred, ms, label, pollMs = 25) {
+  const started = Date.now();
+  for (;;) {
+    const v = await pred();
+    if (v) return v;
+    if (Date.now() - started > ms) throw new Error(`timed out after ${ms}ms waiting for ${label}`);
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+/** Open a raw ws leg and collect its TEXT control frames + binary bytes. */
+async function openRawLeg(relayUrl, session, role, token) {
+  const ws = new WebSocket(`${relayUrl}/?session=${session}&role=${role}&token=${encodeURIComponent(token)}`);
+  const leg = { ws, texts: [], binary: "", closed: null };
+  ws.on("message", (data, isBinary) => {
+    if (isBinary) leg.binary += Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+    else leg.texts.push(Buffer.isBuffer(data) ? data.toString("utf8") : String(data));
+  });
+  ws.on("close", (code, reasonBuf) => { leg.closed = [code, reasonBuf ? reasonBuf.toString() : ""]; });
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${role} open timeout`)), 5000)),
+  ]);
+  return leg;
+}
+
+const hasFrame = (leg, pred) => leg.texts.some(pred);
+
+// ── (a) hb → hb-ack to the probing leg only; the peer sees NOTHING ────────────
+test("(a) browser hb is acked to the browser only — never forwarded to the bridge", { timeout: 15000 }, async (t) => {
+  const session = `hb-a-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-HB", sid: session, secret: SECRET });
+
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+  t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
+
+  browser.ws.send(encodeHeartbeatFrame());
+  await waitFor(() => hasFrame(browser, isHeartbeatAckFrame), HARD_TIMEOUT_MS, "hb-ack to the probing browser leg");
+
+  // Let anything wrongly forwarded arrive, then assert the bridge saw NOTHING but
+  // its own R1 `attached` confirmation — no hb, no hb-ack, no bytes.
+  await new Promise((r) => setTimeout(r, 200));
+  const unexpected = bridge.texts.filter((f) => !isAttachedFrame(f));
+  assert.deepEqual(unexpected, [], "the bridge leg received no heartbeat traffic");
+  assert.equal(bridge.binary, "", "no bytes reached the bridge leg");
+  console.log("[hb/a] PASS — hb acked to sender only, peer untouched");
+});
+
+// ── (b) heartbeats do NOT extend the idle clock ───────────────────────────────
+test("(b) a session with ONLY heartbeat traffic still idle-closes on schedule", { timeout: 15000 }, async (t) => {
+  const session = `hb-b-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const idleMs = 500;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, idleMs });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-HB", sid: session, secret: SECRET });
+
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+
+  // Probe far faster than the idle cap. If heartbeats counted as activity the
+  // session would live forever; the fix requires it to end at ~idleMs regardless.
+  const probe = setInterval(() => {
+    if (browser.ws.readyState === WebSocket.OPEN) browser.ws.send(encodeHeartbeatFrame());
+  }, 100);
+  t.after(() => clearInterval(probe));
+
+  await waitFor(() => browser.closed != null && bridge.closed != null, HARD_TIMEOUT_MS, "idle close of both legs");
+  clearInterval(probe);
+  assert.equal(browser.closed[0], 1000, "idle end closes with the normal code");
+  assert.match(browser.closed[1], /idle/, "reason classifies as idle for the dock copy");
+  assert.match(bridge.closed[1], /idle/, "the bridge leg idle-closes too");
+  console.log(`[hb/b] PASS — hb-only session idle-closed (reason=${JSON.stringify(browser.closed[1])})`);
+});
+
+// ── (c) same-owner browser preemption: the newer leg wins, end-to-end ─────────
+test("(c) same-owner 2nd browser preempts the stale leg (4001 preempted) and goes live; no grace hold opens", { timeout: 15000 }, async (t) => {
+  const session = `hb-c-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-HB", sid: session, secret: SECRET });
+
+  // A "silently dead" browser leg: the socket is still registered server-side —
+  // exactly what a wifi-off dock looks like to the relay (no FIN/RST ever).
+  const stale = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
+
+  // The dock's watchdog fired and the reattach loop opens a NEW browser leg with
+  // the SAME owner-bound token (no re-mint) — this used to bounce off DUP_BROWSER.
+  const fresh = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  t.after(() => { try { fresh.ws.terminate(); } catch { /* */ } });
+
+  // The stale leg is closed 4001 "preempted"; the fresh one stays open.
+  await waitFor(() => stale.closed != null, HARD_TIMEOUT_MS, "stale browser leg closed");
+  assert.equal(stale.closed[0], 4001, "stale leg closed with the DUP_BROWSER/preempted code");
+  assert.match(stale.closed[1], /preempted/, "with the distinct preempted reason");
+  assert.equal(fresh.ws.readyState, WebSocket.OPEN, "the fresh leg is the live browser leg");
+
+  // Single-attach held post-swap AND the pair never stopped being whole: the
+  // bridge must NOT have been told its peer dropped (no grace hold for a swap).
+  await new Promise((r) => setTimeout(r, 200));
+  assert.equal(hasFrame(bridge, isPeerDegradedFrame), false, "no peer-degraded to the bridge on a preemption swap");
+  assert.ok(relay.sessions.has(session), "session retained across the swap");
+
+  // Live end-to-end both ways through the new leg.
+  const down = `DOWN-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+  bridge.ws.send(Buffer.from(down, "utf8"), { binary: true });
+  await waitFor(() => fresh.binary.includes(down), HARD_TIMEOUT_MS, "bridge → fresh browser bytes");
+  const up = `UP-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+  fresh.ws.send(Buffer.from(up, "utf8"), { binary: true });
+  await waitFor(() => bridge.binary.includes(up), HARD_TIMEOUT_MS, "fresh browser → bridge bytes");
+  assert.equal(stale.binary.includes(down), false, "the stale leg received none of the post-swap bytes");
+  console.log("[hb/c] PASS — same-owner preemption swapped legs cleanly, pipe live end-to-end");
+});
+
+// ── (d) skew safety: hb frames are inert outside the heartbeat protocol ───────
+test("(d) an hb frame is not a resize/attached/grace frame — an old peer logs-and-ignores it", { timeout: 5000 }, async () => {
+  // A NON-intercepting (old) relay would forward the hb to the bridge, which
+  // treats unknown TEXT control frames as a logged no-op (see bridge framing +
+  // control-frames tests). Pin the disjointness here so that skew story holds.
+  const { parseControlMessage } = await import("../bridge/src/framing.js");
+  assert.equal(parseControlMessage(encodeHeartbeatFrame()), null, "hb is not a bridge control frame");
+  assert.equal(isHeartbeatFrame('{"type":"resize","cols":80,"rows":24}'), false);
+  assert.equal(isAttachedFrame(encodeHeartbeatFrame()), false);
+  console.log("[hb/d] PASS — hb frame inert to an old bridge (logged no-op, zero PTY bytes)");
+});

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/roundtrip.test.mjs
+++ b/terminal/test/roundtrip.test.mjs
@@ -6,7 +6,9 @@
 // and asserts everything slice 2 must prove:
 //   (a) the browser leg receives the bridge's PTY output (the READY sentinel),
 //   (b) bytes sent from the browser leg reach the PTY and echo back (round-trip),
-//   (c) a 2nd browser attach (same user, valid token) is rejected (single-attach),
+//   (c) a 2nd browser attach (same user, valid token) PREEMPTS the first leg —
+//       the stale leg is closed 4001 "preempted" and the new leg goes live, so
+//       single-attach still holds post-swap (fix/terminal-dock-heartbeat),
 //   (d) a browser whose token is for a DIFFERENT user is rejected (owner-mismatch),
 //   (e) a browser with an EXPIRED token is rejected (bad/expired token).
 //
@@ -126,13 +128,36 @@ test("bridge <-> relay <-> browser round-trip + single-attach + owner-binding", 
     return [code, reasonBuf ? reasonBuf.toString() : ""];
   }
 
-  // (c) a 2nd browser (SAME user, valid token) is rejected (single-attach).
+  // (c) a 2nd browser (SAME user, valid token) PREEMPTS the first leg
+  // (fix/terminal-dock-heartbeat): after a silent link death the old socket
+  // lingers OPEN forever, so the newer same-owner attach must WIN — the stale
+  // leg is closed 4001 "preempted", the new one becomes the live browser, and
+  // single-attach holds post-swap.
   {
-    const [code, reason] = await expectClose(tokensA.browser, "2nd browser");
-    console.log(`[test] (c) 2nd browser (same user) closed code=${code} reason=${JSON.stringify(reason)}`);
-    assert.equal(code, 4001, "2nd browser must be rejected with single-attach close code 4001");
-    assert.match(reason, /single-attach/, "close reason should explain single-attach");
-    console.log("[test] (c) PASS — single-attach enforced");
+    const firstClosed = once(browser, "close");
+    const ws2 = new WebSocket(`${relay.url}/?session=${session}&role=browser&token=${encodeURIComponent(tokensA.browser)}`);
+    ws2.on("message", (data) => {
+      browserBuf += Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+    });
+    await Promise.race([
+      once(ws2, "open"),
+      new Promise((_, rej) => setTimeout(() => rej(new Error("2nd browser open timeout")), 5000)),
+    ]);
+    const [code, reasonBuf] = await Promise.race([
+      firstClosed,
+      new Promise((_, rej) => setTimeout(() => rej(new Error("preempted-close timeout")), 5000)),
+    ]);
+    const reason = reasonBuf ? reasonBuf.toString() : "";
+    console.log(`[test] (c) stale browser closed code=${code} reason=${JSON.stringify(reason)}`);
+    assert.equal(code, 4001, "the STALE browser must be closed with the preempted/duplicate code 4001");
+    assert.match(reason, /preempted/, "close reason should say preempted");
+    browser = ws2; // the new leg is the live browser from here on
+    // The swapped-in leg still round-trips — the pipe survived the preemption.
+    const swapTok = `SWAP-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+    browserBuf = "";
+    browser.send(Buffer.from(swapTok + "\n", "utf8"), { binary: true });
+    await waitForText(() => browserBuf, swapTok, HARD_TIMEOUT_MS, "post-preemption echo");
+    console.log("[test] (c) PASS — same-owner preemption: stale leg closed, new leg live");
   }
 
   // (d) a browser whose token is for a DIFFERENT user is rejected (owner-mismatch).
@@ -158,8 +183,8 @@ test("bridge <-> relay <-> browser round-trip + single-attach + owner-binding", 
     console.log("[test] (e) PASS — expired token rejected");
   }
 
-  // sanity: the original (authenticated) browser is still attached and live.
-  assert.equal(browser.readyState, WebSocket.OPEN, "first browser must remain connected");
+  // sanity: the live (post-preemption) browser is still attached and streaming.
+  assert.equal(browser.readyState, WebSocket.OPEN, "live browser must remain connected");
   console.log("[test] ALL ASSERTIONS PASSED");
 });
 

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -35,6 +35,8 @@ import {
   encodeAttachedFrame,
   encodePeerDegradedFrame,
   encodePeerReattachedFrame,
+  encodeHeartbeatAckFrame,
+  isHeartbeatFrame,
 } from "../shared/control-frames.mjs";
 
 const NORMAL_CLOSURE = 1000;
@@ -139,6 +141,18 @@ export function startStandinRelay(opts = {}) {
       return;
     }
 
+    // Same-owner browser PREEMPTION (fix/terminal-dock-heartbeat) — mirrors the
+    // Cloudflare DO: the stale browser leg (possibly silently dead) is closed 4001
+    // "preempted" and this attach takes its slot. Nulling the slot FIRST makes the
+    // stale socket's teardown a no-op (superseded), so no grace window opens for a
+    // swap that leaves the pair whole.
+    if (decision.preempt && legs[role]) {
+      const stale = legs[role];
+      legs[role] = null;
+      try { stale.close(CLOSE.PREEMPTED.code, CLOSE.PREEMPTED.reason); } catch { /* closing */ }
+      log("stale browser leg preempted", { session, role });
+    }
+
     const firstLeg = legs.bridge === null && legs.browser === null;
     if (legs.owner === null) legs.owner = auth.sub;
     legs[role] = ws;
@@ -171,6 +185,13 @@ export function startStandinRelay(opts = {}) {
     if (!legs.graceTimer) bumpIdle(session, legs);
 
     ws.on("message", (data, isBinary) => {
+      // HEARTBEAT intercept (fix/terminal-dock-heartbeat) — mirrors the Cloudflare
+      // DO's auto-response: echo the ack to the PROBING leg only, never forward,
+      // and never bump the idle clock (a heartbeat is not session activity).
+      if (!isBinary && isHeartbeatFrame(String(data))) {
+        try { ws.send(encodeHeartbeatAckFrame()); } catch { /* leg already gone */ }
+        return;
+      }
       const peer = role === "bridge" ? legs.browser : legs.bridge;
       if (peer && peer.readyState === peer.OPEN) {
         peer.send(data, { binary: isBinary }); // verbatim, opaque


### PR DESCRIPTION
## Bug (board card `7ba0b46f`)

Silent link death (wifi off / network switch) freezes the terminal dock on **"Connected" forever**. macOS never RSTs the socket, so no close/error event ever fires; the dock only left `connected` on socket events, and the protocol-level pings the bridge leg uses are invisible to browser JS. The grace-window reattach machinery already existed — it just never triggered. Worse, once the dead socket lingered server-side, a reattach bounced off `DUP_BROWSER 4001`.

## Fix

**App-level heartbeat + wall-clock watchdog, routed into the existing reattach loop (same sid, retained token, no re-mint):**

- **Shared frames** (`terminal/shared/control-frames.mjs`): `{"t":"hb"}` probe / `{"t":"hb-ack"}` echo in the existing bounded `{"t":…}` namespace. Skew-safe both directions: old bridge logs-and-ignores a forwarded hb; an old relay never acks → the watchdog never arms → pre-fix behaviour unchanged.
- **Relay DO** (`terminal/relay/src/index.js`): hibernation-safe `setWebSocketAutoResponse` answers probes with zero DO wakes — never forwarded, never stamps `lastActivityAt` (30-min idle cap unaffected). Belt-and-braces `webSocketMessage` intercept (echo + return before forward/activity) if auto-response is unavailable.
- **Same-owner browser preemption** (`pairing.js` + DO + stand-in): a same-owner browser attach while a stale browser leg is registered now wins — stale leg closed `4001 "preempted"`, new leg live, single-attach holds post-swap, no grace hold when the pair never stopped being whole. Foreign subs still `OWNER_MISMATCH`; 2nd bridge still `DUP_BRIDGE`.
- **Dock** (`src/lib/terminal/connection.ts` + `terminal-dock.tsx`): hb every 15s while connected; `lastInboundAt` stamped on every inbound frame (acks never reach the xterm); 5s watchdog on wall-clock silence >45s (3 probes — one lost ack is never a false alarm), armed only after the socket's first ack; immediate re-check on `visibilitychange`/`online`/`offline`; on declare-dead → zombie-socket teardown, new `link-silent` event (`connected → disconnected`, ignored elsewhere), existing `scheduleReconnect`.
- **No bridge/helper changes.**

## Tests

- `terminal/test` serial suite **47/47** — new `heartbeat.test.mjs` (ack-to-sender-only + peer sees nothing; hb-only session still idle-closes; preemption end-to-end; hb inert to an old bridge); `roundtrip.test.mjs` case (c) updated to the new preemption semantics.
- `terminal/relay` **17/17** (preemption verdicts in `pairing.test.js`).
- vitest `connection.test.ts` **40/40** incl. byte-for-byte drift pins against the shared .mjs encoders and `shouldDeclareLinkSilent` boundaries; full vitest **1506/1506**.
- `npx tsc --noEmit` clean; `npm run lint` adds no new errors (4 pre-existing errors in `terminal/helper/main.js`, untouched).

## Deploy order

1. **Relay first**: `cd terminal/relay && npx wrangler deploy` (skew-safe — an old dock ignores acks, an un-upgraded dock never probes).
2. Then merge this PR (web via Vercel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
