### PR TITLE
fix(terminal): accept expired tokens for same-owner reattach to a live session — reconnect now works past the 5-min TTL

### DIFF
--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -130,10 +130,11 @@ interface PairInfo {
   sessionId: string;
   bridgeToken: string;
   // Retained so a TRANSIENT drop can REATTACH to the SAME sid with no re-mint
-  // (grace-window reconnect). `browserToken` re-opens the browser leg; `expiresAt`
-  // (unix seconds) is the token-validity bound on how long reattach is possible.
+  // (grace-window reconnect). `browserToken` re-opens the browser leg. Reattach is
+  // bounded purely by RECONNECT_GRACE_MS — the relay waives token expiry for a
+  // same-owner reattach to a live session (fix/terminal-expired-reattach), so no
+  // client-side expiry gate exists here.
   browserToken: string;
-  expiresAt: number;
 }
 
 interface StatusMeta {
@@ -647,17 +648,18 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   );
 
   // Drive the grace-window reconnect loop: reattach to the SAME sid with the retained
-  // browser token, with jittered exponential backoff, bounded by BOTH the grace window
-  // and the token validity. When either is spent with no reattach, end honestly
-  // (reconnect-exhausted → the calm "session ended, start a new one" overlay). No
-  // re-mint, no deep link — a bounded, silent reattach.
+  // browser token, with jittered exponential backoff, bounded purely by the grace
+  // window (the relay waives token expiry for a same-owner reattach to a live
+  // session, so an AGED session reconnects too — fix/terminal-expired-reattach).
+  // When the window is spent with no reattach, end honestly (reconnect-exhausted →
+  // the calm "session ended, start a new one" overlay). No re-mint, no deep link —
+  // a bounded, silent reattach.
   const scheduleReconnect = useCallback(() => {
     clearDegradeTimer();
     const p = pairRef.current;
     const now = Date.now();
-    const tokenValid = !!p && p.expiresAt * 1000 > now + 1000;
     if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
-    if (!p || !tokenValid || now >= reconnectDeadlineRef.current) {
+    if (!p || now >= reconnectDeadlineRef.current) {
       reconnectDeadlineRef.current = 0;
       reconnectAttemptRef.current = 0;
       dispatch({ type: "reconnect-exhausted" });
@@ -798,13 +800,12 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     if (gen !== connectGenRef.current) return;
 
     dispatch({ type: "session-created", sessionId: data.sessionId });
-    // Retain the browser token + expiry too, so a transient drop can REATTACH to
-    // this same sid with no re-mint (grace-window reconnect).
+    // Retain the browser token too, so a transient drop can REATTACH to this same
+    // sid with no re-mint (grace-window reconnect).
     setPair({
       sessionId: data.sessionId,
       bridgeToken: data.bridgeToken,
       browserToken: data.browserToken,
-      expiresAt: data.expiresAt,
     });
     // A fresh mint starts a fresh reconnect budget.
     reconnectDeadlineRef.current = 0;
@@ -819,15 +820,14 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
 
   // Manual "Reconnect now" — force an immediate reattach attempt (skip the backoff
   // wait) using the retained token, or fall back to a clean fresh launch if the
-  // token/window is spent. Fixes the old button, which minted an EMPTY session with
+  // grace window is spent. Fixes the old button, which minted an EMPTY session with
   // no autoLaunch and timed out after 30s.
   const reconnectNow = useCallback(() => {
     const p = pairRef.current;
     const now = Date.now();
-    const tokenValid = !!p && p.expiresAt * 1000 > now + 1000;
     const withinWindow =
       reconnectDeadlineRef.current === 0 || now < reconnectDeadlineRef.current;
-    if (p && tokenValid && withinWindow) {
+    if (p && withinWindow) {
       clearReconnectTimer();
       if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
       openBrowserLeg(p.sessionId, p.browserToken, { reconnect: true });

--- a/src/lib/terminal/connection.test.ts
+++ b/src/lib/terminal/connection.test.ts
@@ -255,9 +255,12 @@ describe("encodeResizeMessage", () => {
 });
 
 describe("grace-window reconnect (fix/terminal-reconnect-reattach)", () => {
-  it("the reconnect window stays strictly inside the token TTL (no re-mint)", () => {
-    // The whole point: original tokens must still be valid for the entire window, so
-    // a reattach never needs a fresh mint. Keep a safety margin below the 300s TTL.
+  it("the grace window is the sole reattach bound; TTL only bounds establishment", () => {
+    // fix/terminal-expired-reattach: the relay waives token expiry for a same-owner
+    // reattach to a LIVE session, so reattach is bounded purely by the grace window —
+    // the dock keeps NO client-side expiry gate. The window still sits below the TTL
+    // so a FIRST attach (never waived — no bound owner yet) always has a live token
+    // for the whole launch flow.
     expect(RECONNECT_GRACE_MS).toBeLessThan(DEFAULT_TTL_SECONDS * 1000);
   });
 

--- a/src/lib/terminal/connection.ts
+++ b/src/lib/terminal/connection.ts
@@ -20,10 +20,12 @@ export const CONNECT_TIMEOUT_MS = 30_000;
 /**
  * Reconnect grace window (ms). THE ONE SHARED NUMBER — equal to the relay grace
  * (terminal/relay/src/pairing.js → RECONNECT_GRACE_MS) and the bridge budget
- * (terminal/bridge/src/index.js → BRIDGE_RECONNECT_MS), and deliberately < the 300s
- * token TTL so the ORIGINAL browser token is still valid for the whole window — a
- * transient drop REATTACHES to the same sid with no re-mint. Beyond the window the
- * session ends honestly and the UX falls back to a clean fresh launch.
+ * (terminal/bridge/src/index.js → BRIDGE_RECONNECT_MS). This window is the SOLE
+ * bound on reattach: a transient drop REATTACHES to the same sid with the ORIGINAL
+ * browser token, no re-mint — the relay waives token expiry for a same-owner
+ * reattach to a live session (fix/terminal-expired-reattach), so even a session
+ * older than the 300s token TTL reconnects. Beyond the window the session ends
+ * honestly and the UX falls back to a clean fresh launch.
  */
 export const RECONNECT_GRACE_MS = 90_000;
 

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -179,11 +179,18 @@ export class TerminalRelay {
 
     // 1) Authenticate the leg: verify the app-minted token's signature + expiry and
     //    that its `sid`/`role` claims match THIS connection. Never log the token.
+    //    The durable owner binding is read FIRST and handed to authorizeAttach so a
+    //    same-owner reattach to a LIVE session is accepted even after the token's
+    //    TTL lapsed (fix/terminal-expired-reattach) — establishment (no bound
+    //    owner) and foreign subs still require an unexpired token.
+    const boundOwner = (await this.state.storage.get("owner")) ?? null;
     const auth = await authorizeAttach({
       token,
       secret: this.env.TERMINAL_SESSION_SECRET,
       session,
       role,
+      boundOwner,
+      maxSessionMs: this.maxMs(),
     });
     if (!auth.ok) {
       this.log("attach rejected (auth)", { session, role, reason: auth.reason, code: CLOSE.BAD_TOKEN.code });
@@ -192,6 +199,10 @@ export class TerminalRelay {
       server.accept();
       server.close(CLOSE.BAD_TOKEN.code, CLOSE.BAD_TOKEN.reason);
       return new Response(null, { status: 101, webSocket: client });
+    }
+    if (auth.expired) {
+      // Metadata only — never token material.
+      this.log("attach authorized with expired token (reattach waiver)", { session, role });
     }
 
     // 2) Owner-binding + single-attach (pure), fed from LIVE sockets + durable owner.

--- a/terminal/relay/src/pairing.js
+++ b/terminal/relay/src/pairing.js
@@ -155,15 +155,20 @@ export function peerRole(role) {
 // THE ONE SHARED NUMBER. When a single leg drops, the relay does NOT tear the
 // session down; it holds the owner binding + the surviving socket and arms a
 // grace alarm for this long, waiting for the dropped role to re-attach (same sid
-// + same owner + still-valid token) so the pair can resume with no re-mint. The
-// three reconnect budgets are deliberately equal and MUST stay < the token TTL
-// (DEFAULT_TTL_SECONDS = 300s in ../../shared/session-token.mjs) so the ORIGINAL
-// tokens are still valid for the whole window — no token re-mint, ever:
+// + same owner) so the pair can resume with no re-mint. The three reconnect
+// budgets are deliberately equal:
 //   - relay grace       → RECONNECT_GRACE_MS (here)
 //   - bridge reconnect  → BRIDGE_RECONNECT_MS (bridge/src/index.js)
 //   - client reconnect  → RECONNECT_GRACE_MS  (src/lib/terminal/connection.ts)
-// BEYOND the window the session is torn down honestly (survivor gets PEER_GONE,
-// state cleared) and the UX falls back to a clean fresh launch.
+// Token expiry does NOT bound reattach (fix/terminal-expired-reattach): the token
+// TTL (DEFAULT_TTL_SECONDS = 300s in ../../shared/session-token.mjs) bounds
+// session ESTABLISHMENT only. For a reattach to a session the relay is still
+// holding, authorizeAttach waives expiry IFF the token's sub matches the bound
+// owner (belt-and-braces capped at the max session age) — so an AGED session
+// (attached long ago, dropped past its TTL) reconnects inside the grace window
+// with the ORIGINAL tokens, no re-mint ever. BEYOND the window the session is
+// torn down honestly (survivor gets PEER_GONE, owner binding + state cleared, so
+// the waiver dies with it) and the UX falls back to a clean fresh launch.
 export const RECONNECT_GRACE_MS = 90_000;
 
 /** Default idle cap: 30 minutes of no traffic. Overridable via env TERMINAL_IDLE_MS. */

--- a/terminal/shared/session-token.mjs
+++ b/terminal/shared/session-token.mjs
@@ -19,6 +19,15 @@
 //
 // The signing secret NEVER lives in code. It is read from the environment by each
 // caller (TERMINAL_SESSION_SECRET) and passed in. This module is pure crypto.
+//
+// Expiry semantics (fix/terminal-expired-reattach): the TTL bounds session
+// ESTABLISHMENT — a first attach (no bound owner yet) always needs a live token.
+// REATTACH to a session the relay is still holding is bounded by the reconnect
+// grace window + the live-session owner binding instead: `authorizeAttach` waives
+// expiry ONLY when the caller supplies the session's bound owner (`boundOwner`)
+// and the token's `sub` matches it — signature, shape, sid and role checks are
+// never waived, and a belt-and-braces cap rejects tokens older than the max
+// session age. `verifyToken` itself stays strict (expired is always a failure).
 
 /** @typedef {"bridge"|"browser"} Role */
 
@@ -34,6 +43,15 @@
 
 /** Default token lifetime: short-lived (5 minutes) — enough to open both legs. */
 export const DEFAULT_TTL_SECONDS = 300;
+
+/**
+ * Belt-and-braces cap on the expiry waiver: even for a same-owner reattach to a
+ * live session, a token whose `iat` is older than this can never be a legitimate
+ * reattach — the relay's max-duration cap (same default, see
+ * relay/src/pairing.js → DEFAULT_MAX_MS) would have ended the session already.
+ * Callers pass the relay's configured maxMs; this default (4h) applies if absent.
+ */
+export const DEFAULT_MAX_SESSION_MS = 4 * 60 * 60 * 1000;
 
 const ROLES = Object.freeze(["bridge", "browser"]);
 const enc = new TextEncoder();
@@ -85,15 +103,17 @@ export async function signToken(payload, secret) {
 }
 
 /**
- * Verify a token's signature and expiry. Constant-time signature check via
- * `crypto.subtle.verify`. Does NOT check sid/role binding — see {@link authorizeAttach}.
+ * Internal verifier: signature + shape checks are ALWAYS enforced; expiry is
+ * REPORTED (`expired`) rather than rejected, so {@link authorizeAttach} can apply
+ * the reattach waiver. Never exported — external callers go through the strict
+ * {@link verifyToken} or {@link authorizeAttach}.
  *
  * @param {unknown} token
  * @param {string} secret
  * @param {{ now?: number }} [opts] - `now` in unix seconds (defaults to wall clock)
- * @returns {Promise<{ ok: true, claims: SessionClaims } | { ok: false, reason: string }>}
+ * @returns {Promise<{ ok: true, claims: SessionClaims, expired: boolean } | { ok: false, reason: string }>}
  */
-export async function verifyToken(token, secret, opts = {}) {
+async function verifyTokenInternal(token, secret, opts = {}) {
   const now = opts.now ?? Math.floor(Date.now() / 1000);
   if (typeof token !== "string" || token.length === 0) {
     return { ok: false, reason: "missing token" };
@@ -126,7 +146,6 @@ export async function verifyToken(token, secret, opts = {}) {
   if (typeof claims.iat !== "number" || typeof claims.exp !== "number") {
     return { ok: false, reason: "missing iat/exp" };
   }
-  if (now >= claims.exp) return { ok: false, reason: "expired" };
   if (typeof claims.sub !== "string" || claims.sub.length === 0) {
     return { ok: false, reason: "missing sub" };
   }
@@ -135,7 +154,25 @@ export async function verifyToken(token, secret, opts = {}) {
   }
   if (!ROLES.includes(claims.role)) return { ok: false, reason: "bad role" };
 
-  return { ok: true, claims };
+  return { ok: true, claims, expired: now >= claims.exp };
+}
+
+/**
+ * Verify a token's signature and expiry. Constant-time signature check via
+ * `crypto.subtle.verify`. Does NOT check sid/role binding — see {@link authorizeAttach}.
+ * STRICT: an expired token always fails here (the reattach waiver lives ONLY in
+ * `authorizeAttach`, gated on the live session's bound owner).
+ *
+ * @param {unknown} token
+ * @param {string} secret
+ * @param {{ now?: number }} [opts] - `now` in unix seconds (defaults to wall clock)
+ * @returns {Promise<{ ok: true, claims: SessionClaims } | { ok: false, reason: string }>}
+ */
+export async function verifyToken(token, secret, opts = {}) {
+  const res = await verifyTokenInternal(token, secret, opts);
+  if (!res.ok) return res;
+  if (res.expired) return { ok: false, reason: "expired" };
+  return { ok: true, claims: res.claims };
 }
 
 /**
@@ -145,15 +182,50 @@ export async function verifyToken(token, secret, opts = {}) {
  *
  * Shared by the Cloudflare relay and the Node stand-in so both enforce identically.
  *
- * @param {{ token: unknown, secret: string, session: unknown, role: unknown, now?: number }} args
- * @returns {Promise<{ ok: true, sub: string, claims: SessionClaims } | { ok: false, reason: string }>}
+ * REATTACH EXPIRY WAIVER (fix/terminal-expired-reattach): when the relay is still
+ * holding a session (owner bound), the caller passes that owner as `boundOwner`.
+ * An EXPIRED token is then accepted IFF its `sub` matches `boundOwner` — i.e. the
+ * waiver applies only to the session's rightful owner reattaching to a LIVE
+ * session; establishment (no bound owner) always needs an unexpired token. A
+ * foreign expired token fails with the SAME reason as plain expiry so a rejected
+ * caller learns nothing about session liveness. Signature, shape, sid and role
+ * checks are NEVER waived. Belt-and-braces: a waived token older than
+ * `maxSessionMs` (the relay's max session age) is rejected — no legitimate
+ * session can outlive it. Waived results carry `expired: true` for logging.
+ *
+ * @param {{ token: unknown, secret: string, session: unknown, role: unknown,
+ *           now?: number, boundOwner?: string|null, maxSessionMs?: number }} args
+ *   `boundOwner` — the live session's bound owner (`sub`), or null when the
+ *   session has no owner binding (virgin / already torn down). Default null.
+ *   `maxSessionMs` — the relay's max session age; bounds the waiver (default 4h).
+ * @returns {Promise<{ ok: true, sub: string, claims: SessionClaims, expired?: true } | { ok: false, reason: string }>}
  */
-export async function authorizeAttach({ token, secret, session, role, now }) {
-  const res = await verifyToken(token, secret, { now });
+export async function authorizeAttach({
+  token,
+  secret,
+  session,
+  role,
+  now,
+  boundOwner = null,
+  maxSessionMs = DEFAULT_MAX_SESSION_MS,
+}) {
+  const res = await verifyTokenInternal(token, secret, { now });
   if (!res.ok) return res;
   const c = res.claims;
   if (c.sid !== session) return { ok: false, reason: "sid mismatch" };
   if (c.role !== role) return { ok: false, reason: "role mismatch" };
+  if (res.expired) {
+    // The waiver: only the LIVE session's bound owner may attach on an expired
+    // token. Everything else fails exactly like plain expiry (no liveness leak).
+    if (boundOwner == null || c.sub !== boundOwner) {
+      return { ok: false, reason: "expired" };
+    }
+    const nowSec = now ?? Math.floor(Date.now() / 1000);
+    if ((nowSec - c.iat) * 1000 > maxSessionMs) {
+      return { ok: false, reason: "expired" };
+    }
+    return { ok: true, sub: c.sub, claims: c, expired: true };
+  }
   return { ok: true, sub: c.sub, claims: c };
 }
 

--- a/terminal/shared/session-token.test.mjs
+++ b/terminal/shared/session-token.test.mjs
@@ -88,6 +88,107 @@ test("authorizeAttach binds sid + role to the connection", async () => {
   assert.equal(roleBad.reason, "role mismatch");
 });
 
+// ── reattach expiry waiver (fix/terminal-expired-reattach) ─────────────────────
+// authorizeAttach accepts an EXPIRED token IFF the caller passes the live session's
+// bound owner and the token's sub matches it. Everything else about an expired
+// token fails exactly like plain expiry, and no other check is ever waived.
+
+const AFTER_EXP = NOW + DEFAULT_TTL_SECONDS + 60; // 60s past the token's expiry
+
+test("expired token + matching boundOwner is accepted with expired:true (reattach waiver)", async () => {
+  const token = await signToken(baseClaims(), SECRET);
+  const res = await authorizeAttach({
+    token, secret: SECRET, session: "sess-1", role: "browser", now: AFTER_EXP, boundOwner: "user-A",
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.sub, "user-A");
+  assert.equal(res.expired, true, "waived attaches must be flagged expired for logging");
+});
+
+test("an unexpired attach never carries the expired flag", async () => {
+  const token = await signToken(baseClaims(), SECRET);
+  const res = await authorizeAttach({
+    token, secret: SECRET, session: "sess-1", role: "browser", now: NOW, boundOwner: "user-A",
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.expired, undefined);
+});
+
+test("expired token with NO bound owner (establishment / torn-down session) is rejected", async () => {
+  const token = await signToken(baseClaims(), SECRET);
+  // boundOwner omitted (defaults to null) and explicit null both reject.
+  const omitted = await authorizeAttach({ token, secret: SECRET, session: "sess-1", role: "browser", now: AFTER_EXP });
+  assert.equal(omitted.ok, false);
+  assert.equal(omitted.reason, "expired");
+  const explicit = await authorizeAttach({
+    token, secret: SECRET, session: "sess-1", role: "browser", now: AFTER_EXP, boundOwner: null,
+  });
+  assert.equal(explicit.ok, false);
+  assert.equal(explicit.reason, "expired");
+});
+
+test("expired token whose sub is NOT the bound owner fails with the SAME reason as plain expiry", async () => {
+  // No session-liveness signal leak: a foreign expired token must be indistinguishable
+  // from an expired token against a dead session.
+  const token = await signToken(baseClaims({ sub: "user-EVIL" }), SECRET);
+  const res = await authorizeAttach({
+    token, secret: SECRET, session: "sess-1", role: "browser", now: AFTER_EXP, boundOwner: "user-A",
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "expired");
+});
+
+test("tampered signature is rejected even with a matching boundOwner (never waived)", async () => {
+  const token = await signToken(baseClaims(), SECRET);
+  const [payloadB64] = token.split(".");
+  const forged = `${payloadB64}.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`;
+  const res = await authorizeAttach({
+    token: forged, secret: SECRET, session: "sess-1", role: "browser", now: AFTER_EXP, boundOwner: "user-A",
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "bad signature");
+});
+
+test("sid / role binding is enforced on a waived (expired, owner-matching) token", async () => {
+  const token = await signToken(baseClaims(), SECRET); // sid sess-1, role browser
+  const sidBad = await authorizeAttach({
+    token, secret: SECRET, session: "sess-OTHER", role: "browser", now: AFTER_EXP, boundOwner: "user-A",
+  });
+  assert.equal(sidBad.ok, false);
+  assert.equal(sidBad.reason, "sid mismatch");
+  const roleBad = await authorizeAttach({
+    token, secret: SECRET, session: "sess-1", role: "bridge", now: AFTER_EXP, boundOwner: "user-A",
+  });
+  assert.equal(roleBad.ok, false);
+  assert.equal(roleBad.reason, "role mismatch");
+});
+
+test("waiver belt-and-braces: a token older than maxSessionMs is rejected despite an owner match", async () => {
+  const token = await signToken(baseClaims(), SECRET); // iat = NOW
+  const maxSessionMs = 60 * 60 * 1000; // 1h cap for the test
+  // 1h + 1s after iat → past the cap → rejected like plain expiry.
+  const tooOld = await authorizeAttach({
+    token, secret: SECRET, session: "sess-1", role: "browser",
+    now: NOW + 3601, boundOwner: "user-A", maxSessionMs,
+  });
+  assert.equal(tooOld.ok, false);
+  assert.equal(tooOld.reason, "expired");
+  // Expired but still inside the cap → waived.
+  const inside = await authorizeAttach({
+    token, secret: SECRET, session: "sess-1", role: "browser",
+    now: NOW + 3599, boundOwner: "user-A", maxSessionMs,
+  });
+  assert.equal(inside.ok, true);
+  assert.equal(inside.expired, true);
+});
+
+test("verifyToken stays strict: expired is a failure regardless of any waiver in authorizeAttach", async () => {
+  const token = await signToken(baseClaims(), SECRET);
+  const res = await verifyToken(token, SECRET, { now: AFTER_EXP });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "expired");
+});
+
 test("mintSessionTokens mints both legs sharing one sid + sub", async () => {
   const out = await mintSessionTokens({ sub: "user-A", idea: "idea-1", secret: SECRET, now: NOW });
   assert.match(out.sid, /[0-9a-f-]{36}/);

--- a/terminal/test/expired-reattach.test.mjs
+++ b/terminal/test/expired-reattach.test.mjs
@@ -1,0 +1,217 @@
+// Expired-token reattach — regression proof (fix/terminal-expired-reattach).
+//
+// ROOT CAUSE (Reproduce & Investigate step): the token TTL (300s) bounded EVERY
+// attach, including grace-window reattaches. A session older than the TTL (attach
+// long ago → drop later) could never reconnect: authorizeAttach rejected the
+// original — now expired — tokens and BOTH legs closed 4006, even though the relay
+// was faithfully holding the session for exactly that reattach.
+//
+// THE FIX under test: authorizeAttach now takes the held session's bound owner
+// (`boundOwner`) and waives EXPIRY ONLY — never signature/shape/sid/role — when the
+// expired token's sub matches it (belt-and-braces capped at the max session age).
+// So: TTL bounds session ESTABLISHMENT; reattach is bounded by the grace window +
+// the live-session owner binding. Establishment on a virgin sid, foreign subs, and
+// reattach after the grace teardown (owner binding released) all still fail 4006.
+//
+// All cases run against the Node stand-in relay, which passes the SAME boundOwner
+// into the SAME shared authorizeAttach the Cloudflare DO uses. Tokens are aged for
+// real (short TTL via the shared mint + a wall-clock wait) — no clock mocking, so
+// this exercises the exact seconds-based expiry math the relay runs.
+//
+// Run: cd terminal/test && node --test expired-reattach.test.mjs   (or: npm test)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens } from "../shared/session-token.mjs";
+import { isPeerReattachedFrame } from "../shared/control-frames.mjs";
+
+const SECRET = "expired-reattach-test-secret";
+
+// ── generic waiters (same idioms as reconnect-reattach.test.mjs) ───────────────
+async function waitFor(pred, ms, label, pollMs = 25) {
+  const started = Date.now();
+  for (;;) {
+    const v = await pred();
+    if (v) return v;
+    if (Date.now() - started > ms) throw new Error(`timed out after ${ms}ms waiting for ${label}`);
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Open a raw ws leg and collect its TEXT control frames + binary bytes. */
+async function openRawLeg(relayUrl, session, role, token) {
+  const ws = new WebSocket(`${relayUrl}/?session=${session}&role=${role}&token=${encodeURIComponent(token)}`);
+  const leg = { ws, texts: [], binary: "", closed: null };
+  ws.on("message", (data, isBinary) => {
+    if (isBinary) leg.binary += Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+    else leg.texts.push(Buffer.isBuffer(data) ? data.toString("utf8") : String(data));
+  });
+  ws.on("close", (code, reasonBuf) => { leg.closed = [code, reasonBuf ? reasonBuf.toString() : ""]; });
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${role} open timeout`)), 5000)),
+  ]);
+  return leg;
+}
+
+const hasFrame = (leg, pred) => leg.texts.some(pred);
+
+/** Mint a token pair with a tiny TTL, then wait until it is PROVABLY expired. */
+async function mintAndAge({ sub, sid }) {
+  const tokens = await mintSessionTokens({ sub, idea: "idea-ER", sid, secret: SECRET, ttlSeconds: 1 });
+  return {
+    tokens,
+    ageOut: async () => {
+      // exp = floor(mint-time)+1; 1.6s later floor(now) >= exp is guaranteed.
+      await sleep(1600);
+      assert.ok(Math.floor(Date.now() / 1000) >= tokens.exp, "tokens must be past exp before the reattach");
+    },
+  };
+}
+
+// ── (1) aged reattach succeeds on BOTH legs ────────────────────────────────────
+test("(1) aged session: BOTH legs drop past the TTL, reattach with the SAME expired tokens → whole + bytes resume", { timeout: 20000 }, async (t) => {
+  const session = `er-1-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 8000 });
+  t.after(() => relay.close());
+  const { tokens, ageOut } = await mintAndAge({ sub: owner, sid: session });
+
+  // Establish while the tokens are still live (TTL bounds establishment).
+  let browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  let bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+
+  // Age the session past the token TTL, then drop BOTH legs (sleep-style 1006).
+  await ageOut();
+  browser.ws.terminate();
+  bridge.ws.terminate();
+  await waitFor(() => relay.sessions.get(session)?.bridge == null && relay.sessions.get(session)?.browser == null, 5000, "both legs dropped");
+  assert.ok(relay.sessions.has(session), "session held (grace window) after both legs dropped");
+
+  // Reattach BOTH legs with the ORIGINAL — now expired — tokens, inside grace.
+  browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+  bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
+
+  await waitFor(() => hasFrame(browser, isPeerReattachedFrame), 5000, "peer-reattached to browser");
+  await waitFor(() => hasFrame(bridge, isPeerReattachedFrame), 5000, "peer-reattached to bridge");
+  assert.equal(browser.closed, null, "reattached browser leg was NOT closed (no 4006)");
+  assert.equal(bridge.closed, null, "reattached bridge leg was NOT closed (no 4006)");
+
+  // Bytes flow again through the re-paired session.
+  const tok = `AGED-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+  bridge.ws.send(Buffer.from(tok, "utf8"), { binary: true });
+  await waitFor(() => browser.binary.includes(tok), 5000, "post-reattach byte flow");
+  console.log("[er/1] PASS — aged reattach accepted on both legs, bytes resumed");
+});
+
+// ── (2) establishment on a virgin sid still requires a live token ─────────────
+test("(2) first-attach with an expired token on a virgin sid → 4006 (TTL bounds establishment)", { timeout: 15000 }, async (t) => {
+  const session = `er-2-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 8000 });
+  t.after(() => relay.close());
+
+  // Signed correctly for this sid, but expired ~59 min ago — no session exists, so
+  // there is no bound owner and the waiver must NOT apply.
+  const past = Math.floor(Date.now() / 1000) - 3600;
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-ER", sid: session, secret: SECRET, now: past, ttlSeconds: 60 });
+
+  const leg = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  await waitFor(() => leg.closed != null, 5000, "expired first-attach close");
+  assert.equal(leg.closed[0], 4006, "virgin-sid establishment with an expired token must close 4006");
+  assert.equal(relay.sessions.has(session), false, "no session state was created");
+  console.log("[er/2] PASS — expired token cannot ESTABLISH a session");
+});
+
+// ── (3) foreign-owner expired reattach → 4006 ──────────────────────────────────
+test("(3) foreign-owner EXPIRED token against a held session → 4006; survivor untouched", { timeout: 15000 }, async (t) => {
+  const session = `er-3-${Math.random().toString(36).slice(2, 8)}`;
+  const ownerA = `user-A-${Math.random().toString(36).slice(2, 8)}`;
+  const ownerB = `user-B-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 8000 });
+  t.after(() => relay.close());
+
+  // Owner A establishes normally, then the bridge drops → session held for A.
+  const a = await mintSessionTokens({ sub: ownerA, idea: "idea-ER", sid: session, secret: SECRET });
+  const browser = await openRawLeg(relay.url, session, "browser", a.browser);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+  const bridge = await openRawLeg(relay.url, session, "bridge", a.bridge);
+  bridge.ws.terminate();
+  await waitFor(() => relay.sessions.get(session)?.bridge == null, 5000, "bridge slot freed (held)");
+
+  // Owner B presents an EXPIRED (signature-valid, sid/role-correct) token: the
+  // waiver requires sub === boundOwner, so this fails like plain expiry → 4006,
+  // NOT 4005 — a foreign expired token must not learn the session is live.
+  const past = Math.floor(Date.now() / 1000) - 3600;
+  const b = await mintSessionTokens({ sub: ownerB, idea: "idea-ER", sid: session, secret: SECRET, now: past, ttlSeconds: 60 });
+  const intruder = await openRawLeg(relay.url, session, "bridge", b.bridge);
+  await waitFor(() => intruder.closed != null, 5000, "intruder close");
+  assert.equal(intruder.closed[0], 4006, "foreign expired reattach must be rejected 4006 (same as plain expiry)");
+  assert.equal(browser.ws.readyState, WebSocket.OPEN, "the held owner-A survivor is untouched");
+  assert.ok(relay.sessions.has(session), "session still held for the rightful owner");
+  console.log("[er/3] PASS — foreign-owner expired token rejected without a liveness leak");
+});
+
+// ── (4) after the grace teardown, expired tokens are dead for good ─────────────
+test("(4) reattach after grace expiry (session reaped, owner released) → 4006", { timeout: 15000 }, async (t) => {
+  const session = `er-4-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 250 });
+  t.after(() => relay.close());
+  const { tokens, ageOut } = await mintAndAge({ sub: owner, sid: session });
+
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+
+  // Drop both and let the tiny grace window elapse → old teardown, owner released.
+  browser.ws.terminate();
+  bridge.ws.terminate();
+  await waitFor(() => !relay.sessions.has(session), 5000, "session reaped after grace expiry");
+
+  // Ensure the tokens are past exp, then try to come back: with the owner binding
+  // gone there is nothing to waive against → establishment rules → 4006.
+  await ageOut();
+  const late = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  await waitFor(() => late.closed != null, 5000, "late reattach close");
+  assert.equal(late.closed[0], 4006, "expired reattach after the grace teardown must close 4006");
+  console.log("[er/4] PASS — the waiver dies with the session (owner binding released)");
+});
+
+// ── (5) expired same-owner browser preemption of a zombie leg ──────────────────
+test("(5) aged session: same-owner browser with the EXPIRED token preempts its zombie leg (stale gets 4001 preempted)", { timeout: 20000 }, async (t) => {
+  const session = `er-5-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET, graceMs: 8000 });
+  t.after(() => relay.close());
+  const { tokens, ageOut } = await mintAndAge({ sub: owner, sid: session });
+
+  const zombie = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
+
+  // Age past the TTL. The first browser leg is now a ZOMBIE (still registered
+  // server-side, e.g. after a silent link death) and the token is expired.
+  await ageOut();
+  const fresh = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  t.after(() => { try { fresh.ws.terminate(); } catch { /* */ } });
+
+  // The stale leg is preempted (4001 "preempted"); the fresh leg takes the slot.
+  await waitFor(() => zombie.closed != null, 5000, "zombie browser closed");
+  assert.equal(zombie.closed[0], 4001, "stale leg must be closed with the preempted/duplicate code 4001");
+  assert.match(zombie.closed[1], /preempted/, "close reason says preempted");
+  assert.equal(fresh.closed, null, "the preempting (expired-token, same-owner) leg was accepted");
+
+  // The swapped-in leg is live: bridge bytes reach it.
+  const tok = `SWAP-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+  bridge.ws.send(Buffer.from(tok, "utf8"), { binary: true });
+  await waitFor(() => fresh.binary.includes(tok), 5000, "post-preemption byte flow");
+  assert.equal(fresh.ws.readyState, WebSocket.OPEN, "fresh browser leg stays live");
+  console.log("[er/5] PASS — expired same-owner preemption: zombie out, fresh leg live");
+});

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs ../shared/session-token.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/prompt-launch.test.mjs
+++ b/terminal/test/prompt-launch.test.mjs
@@ -193,7 +193,10 @@ test("prompt launch with an expired or foreign-owner token spawns NOTHING", { ti
   }
 
   // (a) expired token — fails authorizeAttach (relay close 4006).
-  const past = Math.floor(Date.now() / 1000) - 3600;
+  // fix/terminal-expired-reattach: a same-owner expired token against a LIVE
+  // session is now waived for reattach, so age this one past the max session age
+  // (default 4h) — beyond the belt-and-braces cap the reject path still holds.
+  const past = Math.floor(Date.now() / 1000) - 5 * 3600;
   const expired = await signToken(
     { sub: ownerA, sid: session, idea: "idea-P", role: "bridge", iat: past, exp: past + 60 },
     SECRET,

--- a/terminal/test/roundtrip.test.mjs
+++ b/terminal/test/roundtrip.test.mjs
@@ -171,8 +171,12 @@ test("bridge <-> relay <-> browser round-trip + single-attach + owner-binding", 
   }
 
   // (e) a browser with an EXPIRED token is rejected (bad/expired token).
+  // fix/terminal-expired-reattach: a same-owner expired token against a LIVE
+  // session is now WAIVED (that is the fix), so this fixture ages the token past
+  // the max session age (default 4h) — beyond the belt-and-braces cap no waiver
+  // ever applies, and the reject path stays covered end-to-end.
   {
-    const past = Math.floor(Date.now() / 1000) - 3600;
+    const past = Math.floor(Date.now() / 1000) - 5 * 3600;
     const expired = await signToken(
       { sub: ownerA, sid: session, idea: "idea-X", role: "browser", iat: past, exp: past + 60 },
       SECRET,

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -121,11 +121,24 @@ export function startStandinRelay(opts = {}) {
     }
 
     // Authenticate the leg with the SAME shared verifier the real relay uses.
-    const auth = await authorizeAttach({ token, secret, session, role });
+    // Mirrors the Cloudflare DO (fix/terminal-expired-reattach): the held
+    // session's bound owner + the max session age are handed to authorizeAttach
+    // so a same-owner reattach to a LIVE session is waived past the token TTL.
+    const auth = await authorizeAttach({
+      token,
+      secret,
+      session,
+      role,
+      boundOwner: sessions.get(session)?.owner ?? null,
+      maxSessionMs: maxMs,
+    });
     if (!auth.ok) {
       log("attach rejected (auth)", { session, role, reason: auth.reason });
       ws.close(CLOSE.BAD_TOKEN.code, CLOSE.BAD_TOKEN.reason);
       return;
+    }
+    if (auth.expired) {
+      log("attach authorized with expired token (reattach waiver)", { session, role });
     }
 
     if (!sessions.has(session)) {

--- a/terminal/test/verify-against-relay.mjs
+++ b/terminal/test/verify-against-relay.mjs
@@ -102,8 +102,11 @@ try {
   }
 
   // (e) expired token: refused with BAD_TOKEN.
+  // fix/terminal-expired-reattach: a same-owner expired token against a LIVE
+  // session is now waived for reattach, so age this one past the max session age
+  // (default 4h) — beyond the belt-and-braces cap the reject path still holds.
   {
-    const past = Math.floor(Date.now() / 1000) - 3600;
+    const past = Math.floor(Date.now() / 1000) - 5 * 3600;
     const expired = await signToken(
       { sub: ownerA, sid: session, idea: "idea-X", role: "browser", iat: past, exp: past + 60 },
       SECRET,


### PR DESCRIPTION
## Bug

An **aged terminal session could never reconnect**. The 300s session-token TTL bounded *every* attach, including grace-window reattaches. A session live longer than 5 minutes that then dropped (Wi-Fi blip, sleep, network switch) hit **4006 on both legs**: the relay was faithfully holding the session for exactly that reattach, but `authorizeAttach` rejected the original — now expired — tokens, and the dock's client-side `expiresAt` gate gave up without even trying. The step-1 (Sentinel) design verified this with a deterministic repro: drop both legs past the TTL but inside grace → both reattaches close 4006.

## Fix

New invariant: **the TTL bounds session ESTABLISHMENT; reattach is bounded by the grace window + the live-session owner binding.**

- `terminal/shared/session-token.mjs` — `authorizeAttach` gains `boundOwner` (default `null`) + `maxSessionMs` (default 4h). Expiry is waived **iff** the session is live (owner bound) **and** the token's `sub` matches that owner. Signature / shape / sid / role checks are never waived. Waived results carry `expired: true`. `verifyToken` stays strict.
- `terminal/relay/src/index.js` — reads the durable `owner` binding before auth, passes it + the configured `maxMs` into `authorizeAttach`, and logs waived attaches distinctly (metadata only, no token material). Post-grace teardown clears the owner binding, so the waiver dies with the session by construction.
- `terminal/test/standin-relay.mjs` — mirrors the DO exactly (same shared verifier, same inputs).
- `src/components/board/terminal-dock.tsx` — client-side `expiresAt` gates removed from `scheduleReconnect` / `reconnectNow`; reattach is bounded purely by `RECONNECT_GRACE_MS`. `PairInfo.expiresAt` deleted (unused after the gates went).
- `terminal/relay/src/pairing.js` / `src/lib/terminal/connection.ts` — stale "grace < TTL so tokens stay valid" comment blocks rewritten to the new invariant. `decideAttach` logic unchanged.
- **Bridge + helper: no changes** — the bridge always retried with its original token; the relay now accepts it for aged sessions too.

## Security trade-off (explicit)

A stolen bridge/browser token is now usable past its TTL — but **only** while its exact session is still alive or grace-held, **only** for the sid+role it was minted for, **only** by the session's bound owner (`sub` match), and never past the max session age (belt-and-braces: waived tokens older than the relay's `maxMs`, default 4h, are rejected). A foreign expired token fails with the **same reason as plain expiry**, so a rejected caller learns nothing about session liveness. Establishing a session on a fresh sid still requires an unexpired token.

## Tests

- **New `terminal/test/expired-reattach.test.mjs`** (registered in the suite): (1) aged reattach succeeds on both legs + bytes resume; (2) expired first-attach on a virgin sid → 4006; (3) foreign-owner expired reattach → 4006 (no liveness leak), survivor untouched; (4) reattach after grace teardown → 4006; (5) expired same-owner browser preemption of a zombie leg → stale leg 4001 "preempted", fresh leg live.
- **`terminal/shared/session-token.test.mjs`** — full `boundOwner` matrix (waived + `expired:true`, null-owner reject, foreign-sub reject, tampered-sig reject, sid/role mismatch reject, `iat`-past-`maxSessionMs` reject + inside-cap boundary, `verifyToken` strictness pin). Now also wired into `terminal/test`'s npm test run.
- Fixture updates: `roundtrip.test.mjs (e)`, `prompt-launch.test.mjs pl4 (a)`, `verify-against-relay.mjs (e)` aged their expired tokens past the 4h cap — their old same-owner-1h-expired fixtures are precisely the case this fix legalises.
- `connection.test.ts` TTL pin re-documented (window < TTL now only guarantees establishment-time liveness).

**Results:** terminal suite 68/68 · relay 17/17 · `npx tsc --noEmit` clean · lint identical to master baseline (84 problems, all pre-existing) · full vitest 1506/1506.

## Deploy order

**Relay first (wrangler), then web.** Old relay + new dock: expired reattaches are retried and still get 4006 — harmless, identical to today. New relay + old dock: the old client-side gate just keeps the old behaviour. No bridge/helper rollout needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)