### PR TITLE
fix(terminal): dev helper no longer steals the vibecodes:// handler — opt-in dev protocol registration

### DIFF
--- a/terminal/helper/BUILD-AND-SIGN.md
+++ b/terminal/helper/BUILD-AND-SIGN.md
@@ -126,6 +126,13 @@ scheme and resource layout:
 
 ## Prove the end-to-end chain (against the LIVE relay)
 
+> **Launch Services hazard (dev runs):** dev runs (`electron main.js`, including
+> `verify-helper-launch.mjs`) do **not** touch the OS `vibecodes://` handler by
+> default. macOS **ignores** `setAsDefaultProtocolClient`'s path/args, so the
+> opt-in dev registration (`VIBECODES_DEV_PROTO_REG=1`) registers the raw
+> Electron bundle (`com.github.Electron`) and **steals the scheme from the
+> installed app**. Repair: launch `/Applications/VibeCodes.app` once.
+
 `verify-helper-launch.mjs` mints owner-bound tokens with the relay's
 `TERMINAL_SESSION_SECRET` (read from `terminal/relay/.dev.vars`), attaches a browser
 leg to the **deployed** relay, then drives the helper with a real

--- a/terminal/helper/main.js
+++ b/terminal/helper/main.js
@@ -22,6 +22,8 @@ const { app } = require("electron");
 const { fork } = require("node:child_process");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- CJS Electron main, matches the requires above
+const { shouldRegisterProtocolInDev } = require("./proto-reg");
 
 const LAUNCH_PREFIX = "vibecodes://";
 
@@ -255,8 +257,12 @@ if (!gotLock) {
     // electron-builder `protocols`; this runtime call covers dev + (re)registration.
     if (app.isPackaged) {
       app.setAsDefaultProtocolClient(LAUNCH_PREFIX.replace("://", ""));
-    } else {
-      // Dev: point the registration at this Electron + project dir.
+    } else if (shouldRegisterProtocolInDev(process.env)) {
+      // Dev: OFF by default. On macOS setAsDefaultProtocolClient IGNORES the
+      // path/args below — Launch Services registers the running bundle, i.e.
+      // the raw Electron binary (com.github.Electron), stealing vibecodes://
+      // from the installed app. Opt in with VIBECODES_DEV_PROTO_REG=1; repair
+      // by launching /Applications/VibeCodes.app once.
       app.setAsDefaultProtocolClient(LAUNCH_PREFIX.replace("://", ""), process.execPath, [
         path.resolve(__dirname),
       ]);

--- a/terminal/helper/proto-reg.js
+++ b/terminal/helper/proto-reg.js
@@ -1,0 +1,17 @@
+// Dev-mode gate for registering the vibecodes:// scheme.
+//
+// On macOS, app.setAsDefaultProtocolClient IGNORES its path/args arguments —
+// Launch Services registers whichever bundle is currently running. In dev that
+// bundle is the raw Electron binary (com.github.Electron), so registering from
+// a dev run STEALS the vibecodes:// handler from the installed
+// /Applications/VibeCodes.app. Dev registration is therefore OFF by default
+// and opt-in only, via VIBECODES_DEV_PROTO_REG=1 (exactly "1").
+//
+// Pure CJS, no electron import — unit-testable under plain node
+// (terminal/test/proto-reg.test.mjs).
+
+function shouldRegisterProtocolInDev(env) {
+  return env?.VIBECODES_DEV_PROTO_REG === "1";
+}
+
+module.exports = { shouldRegisterProtocolInDev };

--- a/terminal/helper/verify-helper-launch.mjs
+++ b/terminal/helper/verify-helper-launch.mjs
@@ -101,13 +101,16 @@ try {
   const [bin, binArgs] = process.env.HELPER_BIN
     ? [process.env.HELPER_BIN, [launchUrl]]
     : [electronBin, [MAIN, launchUrl]];
+  const helperEnv = {
+    ...process.env,
+    BRIDGE_CMD: `${process.execPath} ${SENTINEL}`,
+    ELECTRON_DISABLE_SECURITY_WARNINGS: "1",
+  };
+  // The verify script must NEVER alter the OS vibecodes:// handler — strip any inherited opt-in.
+  delete helperEnv.VIBECODES_DEV_PROTO_REG;
   helper = spawn(bin, binArgs, {
     // Test seam: the bridge runs the sentinel instead of interactive `claude`.
-    env: {
-      ...process.env,
-      BRIDGE_CMD: `${process.execPath} ${SENTINEL}`,
-      ELECTRON_DISABLE_SECURITY_WARNINGS: "1",
-    },
+    env: helperEnv,
     stdio: ["ignore", "inherit", "inherit"],
   });
 

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs ../shared/session-token.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs ../shared/session-token.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/proto-reg.test.mjs
+++ b/terminal/test/proto-reg.test.mjs
@@ -1,0 +1,27 @@
+// Unit tests for the dev protocol-registration gate (terminal/helper/proto-reg.js).
+//
+// The gate keeps dev helper runs from stealing the OS vibecodes:// handler:
+// on macOS setAsDefaultProtocolClient ignores path/args and registers the raw
+// Electron bundle (com.github.Electron), so dev registration must be OFF for
+// everything except an explicit VIBECODES_DEV_PROTO_REG=1 opt-in.
+//
+// Run: cd terminal/test && node proto-reg.test.mjs   (or via `npm test`)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { shouldRegisterProtocolInDev } = require("../helper/proto-reg.js");
+
+test("dev registration is OFF for anything that is not exactly '1'", () => {
+  assert.equal(shouldRegisterProtocolInDev({}), false, "empty env");
+  assert.equal(shouldRegisterProtocolInDev({ VIBECODES_DEV_PROTO_REG: "0" }), false, '"0"');
+  assert.equal(shouldRegisterProtocolInDev({ VIBECODES_DEV_PROTO_REG: "" }), false, "empty string");
+  assert.equal(shouldRegisterProtocolInDev({ VIBECODES_DEV_PROTO_REG: "true" }), false, '"true"');
+  assert.equal(shouldRegisterProtocolInDev(undefined), false, "undefined env");
+});
+
+test("dev registration is ON only for the exact opt-in '1'", () => {
+  assert.equal(shouldRegisterProtocolInDev({ VIBECODES_DEV_PROTO_REG: "1" }), true);
+});


### PR DESCRIPTION
## Bug

Any dev run of the terminal helper (`electron main.js`, including `verify-helper-launch.mjs`) hijacked the OS-wide `vibecodes://` URL scheme from the installed `/Applications/VibeCodes.app`. After a dev run, clicking a signed deep link launched the raw Electron binary instead of the installed app. Field-confirmed twice.

## Mechanism

`terminal/helper/main.js` (dev branch of the registration, old lines 256-263) called `app.setAsDefaultProtocolClient(scheme, process.execPath, [projectDir])`, assuming the path/args point the registration at "this Electron + project dir". That is a **Windows/Linux-only** feature — on macOS those arguments are **ignored** and Launch Services registers the currently running bundle, i.e. the bare Electron shell (`com.github.Electron`). So every dev boot silently stole the scheme.

## Fix

- **`terminal/helper/proto-reg.js`** (new): pure-CJS seam, no electron import. `shouldRegisterProtocolInDev(env)` is true **only** for `VIBECODES_DEV_PROTO_REG === "1"`.
- **`terminal/helper/main.js`**: packaged (`app.isPackaged`) registration unchanged; the dev branch now registers only behind the explicit opt-in, with a corrected comment explaining the macOS behaviour and the repair (launch the installed app once).
- **`terminal/helper/verify-helper-launch.mjs`**: strips `VIBECODES_DEV_PROTO_REG` from the child env — the verify script must never alter the OS handler.
- **`terminal/helper/BUILD-AND-SIGN.md`**: hazard note near the verify section.

## Tests

- New `terminal/test/proto-reg.test.mjs` (node --test, registered in the suite): gate is false for `{}`, `"0"`, `""`, `"true"`, and `undefined` env; true only for exactly `"1"`.
- Full terminal suite: **70/70 pass**.
- `npx tsc --noEmit` clean; `npm run lint` byte-identical to baseline (no new errors — the one new `require()` in main.js carries a targeted disable matching the file's existing pre-existing-error pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)