### PR TITLE
fix(terminal): exclude /api/terminal from edge middleware — stop recurring lost-response 500s on session mint

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,10 @@ jobs:
       # Required by src/lib/encryption.ts (GitHub connection token storage). Without it,
       # rendering connected-state in github-link.spec.ts throws and the suite goes red.
       API_KEY_ENCRYPTION_KEY: ${{ secrets.API_KEY_ENCRYPTION_KEY }}
+      # Dummy value, not a secret: without it /api/terminal/session short-circuits
+      # 503 "not configured" BEFORE its auth check, and the middleware-exclusion
+      # smoke in e2e/auth/middleware.spec.ts needs the route's real 401.
+      TERMINAL_SESSION_SECRET: e2e-dummy-terminal-session-secret
       TEST_USER_A_EMAIL: ${{ secrets.TEST_USER_A_EMAIL }}
       TEST_USER_A_PASSWORD: ${{ secrets.TEST_USER_A_PASSWORD }}
       TEST_USER_B_EMAIL: ${{ secrets.TEST_USER_B_EMAIL }}

--- a/.github/workflows/terminal-mint-probe.yml
+++ b/.github/workflows/terminal-mint-probe.yml
@@ -1,0 +1,35 @@
+# Recurrence detection for card b6e5c728: the terminal session mint endpoint
+# intermittently 500ed ("No response is returned from route handler") when the
+# edge-middleware -> nodejs response bridge lost the route's response after an
+# instance recycle. The fix excludes /api/terminal from the middleware matcher;
+# this probe catches any regression. An unauthenticated POST must reach the
+# route handler and come back as a clean 401 — anything else (500, 3xx, timeout)
+# means the response path is broken again. No secrets needed: the probe is
+# deliberately unauthenticated.
+name: Terminal Mint Probe
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mint-endpoint-health:
+    name: mint-endpoint-health
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Unauth POST /api/terminal/session must return 401
+        run: |
+          body=$(mktemp)
+          code=$(curl -sS -o "$body" -w "%{http_code}" --max-time 30 \
+            -X POST -H "Content-Type: application/json" -d '{}' \
+            https://vibecodes.co.uk/api/terminal/session)
+          if [ "$code" != "401" ]; then
+            echo "FAIL: expected HTTP 401, got $code (body: $(wc -c < "$body") bytes)"
+            exit 1
+          fi
+          echo "OK: 401 as expected"

--- a/e2e/auth/middleware.spec.ts
+++ b/e2e/auth/middleware.spec.ts
@@ -40,6 +40,20 @@ test.describe("Middleware — Route Protection", () => {
     });
   });
 
+  test.describe("Middleware-excluded API routes", () => {
+    // /api/terminal is excluded from the middleware matcher (card b6e5c728) and
+    // does its own auth. An unauthenticated mint must be answered by the ROUTE
+    // (clean 401 JSON) — a redirect, 500, or empty response means the exclusion
+    // regressed. Uses the built-in `request` fixture, which carries no auth state.
+    test("unauthenticated POST /api/terminal/session returns 401 from the route", async ({
+      request,
+    }) => {
+      const res = await request.post("/api/terminal/session", { data: {} });
+      expect(res.status()).toBe(401);
+      expect(await res.json()).toEqual({ error: "Not authenticated" });
+    });
+  });
+
   test.describe("Authenticated user", () => {
     test("should access /dashboard without redirect", async ({ userAPage: page }) => {
       await page.goto("/dashboard");

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,70 @@
+// Locks the middleware matcher's exclusion list. The edge-middleware -> nodejs
+// response bridge intermittently loses route responses after an instance
+// recycles (card b6e5c728 — three production outages on /api/terminal/session:
+// Jul 1, Jul 3, Jul 6 2026). Routes that do their own auth are excluded from
+// the matcher entirely; this test makes sure nobody re-includes them, and that
+// genuinely middleware-dependent routes stay matched.
+import { describe, it, expect } from "vitest";
+import { config } from "./middleware";
+
+// Next.js compiles matcher strings with path-to-regexp. Our single matcher is
+// `/` followed by one unnamed regex group (`/(...)`), which path-to-regexp
+// compiles to an anchored regex around that group. Simplification vs Next's
+// real compiler: we skip trailing-slash normalization and query/hash handling
+// — irrelevant for the plain pathnames asserted below.
+function compileMatcher(matcher: string): RegExp {
+  return new RegExp(`^${matcher}$`);
+}
+
+const matcherRegex = compileMatcher(config.matcher[0]);
+const matches = (pathname: string) => matcherRegex.test(pathname);
+
+describe("middleware matcher", () => {
+  it("has a single matcher entry", () => {
+    expect(config.matcher).toHaveLength(1);
+  });
+
+  describe("excluded paths (middleware must NOT run)", () => {
+    it("does not match /api/terminal/session (the b6e5c728 fix)", () => {
+      expect(matches("/api/terminal/session")).toBe(false);
+    });
+
+    it("does not match api/mcp routes", () => {
+      expect(matches("/api/mcp/anything")).toBe(false);
+    });
+
+    it("does not match api/oauth routes", () => {
+      expect(matches("/api/oauth/token")).toBe(false);
+    });
+
+    it("does not match /callback", () => {
+      expect(matches("/callback")).toBe(false);
+    });
+
+    it("does not match /monitoring", () => {
+      expect(matches("/monitoring")).toBe(false);
+    });
+
+    it("does not match ingest (PostHog reverse proxy)", () => {
+      expect(matches("/ingest/x")).toBe(false);
+    });
+  });
+
+  describe("matched paths (middleware MUST run)", () => {
+    it("matches /dashboard", () => {
+      expect(matches("/dashboard")).toBe(true);
+    });
+
+    it("matches idea board pages", () => {
+      expect(matches("/ideas/abc/board")).toBe(true);
+    });
+
+    it("matches /members", () => {
+      expect(matches("/members")).toBe(true);
+    });
+
+    it("matches non-excluded API routes (deliberate: only self-authing APIs are excluded)", () => {
+      expect(matches("/api/ai/generate")).toBe(true);
+    });
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,9 +16,15 @@ export const config = {
      * - .well-known (OAuth discovery endpoints)
      * - api/mcp (MCP endpoint - has its own auth via withMcpAuth)
      * - api/oauth (OAuth endpoints - handle their own auth)
+     * - api/terminal (terminal session mint - does its own supabase.auth.getUser();
+     *   the edge-middleware -> nodejs response bridge intermittently loses the
+     *   route's response after a function instance recycles, surfacing as
+     *   "No response is returned from route handler" 500s. Three production
+     *   outages: Jul 1, Jul 3, Jul 6 2026 — card b6e5c728. Excluded routes
+     *   (api/mcp, api/oauth) have never shown the error.)
      * - oauth (OAuth consent pages - handle their own auth)
      * - callback (auth callback - exchanges code for session, no getUser needed)
      */
-    "/((?!_next/static|_next/image|favicon.ico|sw\\.js|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$|\\.well-known|api/mcp|api/oauth|oauth|callback|monitoring|ingest).*)",
+    "/((?!_next/static|_next/image|favicon.ico|sw\\.js|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$|\\.well-known|api/mcp|api/oauth|api/terminal|oauth|callback|monitoring|ingest).*)",
   ],
 };


### PR DESCRIPTION
## Incident history (card b6e5c728)

Three production outages of terminal session minting — **Jul 1, Jul 3, Jul 6** — each surfacing as `500 "No response is returned from route handler"` on `POST /api/terminal/session`, each clearing on redeploy. Sentry showed the mint itself SUCCEEDING (the "Minted terminal session tokens" log line fired) before the 500 was returned.

## Root cause

The Next 16 **edge-middleware → nodejs response bridge** wedges after a function instance recycles and loses the nodejs route's response. Evidence:

- The route is already pinned `runtime = "nodejs"` / `force-dynamic` — the earlier fix for the route-level variant of this bug. The middleware wrapper is the remaining moving part.
- The middleware-**excluded** routes (`api/mcp`, `api/oauth`) have **never** shown this error.
- `/robots.txt` — also middleware-matched — fails identically.
- Failures correlate with instance recycles (post-idle cold paths), not with any code path in the route.

## The fix

Take middleware out of the request path entirely: add `api/terminal` to the matcher's exclusion group, pattern-identical to `api/mcp`.

**Why this is safe:** the route does its own `supabase.auth.getUser()` (401 unauthenticated, 403 non-team-member, zod-validated body) and never depended on the middleware — `updateSession` only refreshes cookies and redirects *page* routes. The terminal dock already handles 401s by prompting re-login.

## Changes

| File | Change |
|---|---|
| `middleware.ts` | `api/terminal` added to the exclusion group + comment documenting why |
| `middleware.test.ts` (new) | compiles the matcher to a regex; locks `api/terminal` + all existing exclusions OUT, and protected pages + non-excluded API routes (e.g. `/api/ai/generate`) IN |
| `e2e/auth/middleware.spec.ts` | unauth `POST /api/terminal/session` must return the route's own `401 {"error":"Not authenticated"}` — not a redirect/500 |
| `.github/workflows/e2e.yml` | dummy `TERMINAL_SESSION_SECRET` (not a real secret) so the route reaches its auth check in CI instead of 503ing "not configured" |
| `.github/workflows/terminal-mint-probe.yml` (new) | **recurrence detection**: every 30 min (+ manual dispatch), unauth POST to production; anything but a 401 fails the run. No secrets needed. |

## Validation

- `npx vitest run` — 1526 tests pass (11 new)
- `npx tsc --noEmit` — clean
- `npm run lint` — no findings in touched files (80 pre-existing warnings elsewhere, 0 errors)
- `npx playwright test e2e/auth/middleware.spec.ts --list` — spec parses (23 tests across both CI projects); the new test runs in CI's e2e job
- Both workflow YAMLs validate

## Suggested follow-up

`/robots.txt` exhibits the same lost-response failure and is still middleware-matched. Deliberately not touched here (separate concern) — worth its own card/PR to exclude it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)