### PR TITLE
fix(terminal): same-owner bridge preemption — silent-drop reconnect no longer dies on DUP_BRIDGE

### DIFF
--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -178,7 +178,15 @@ const BRIDGE_RECONNECT_MS = Number(process.env.BRIDGE_RECONNECT_MS || 90000);
 const RECONNECT_ATTEMPT_TIMEOUT_MS = Number(process.env.BRIDGE_RECONNECT_ATTEMPT_TIMEOUT_MS || 10000);
 // Relay close codes that are TERMINAL for the bridge — never reconnect on these
 // (auth / duplicate failures cannot succeed on retry). Mirrors pairing.js → CLOSE.
-const TERMINAL_CLOSE_CODES = new Set([4002 /* DUP_BRIDGE */, 4005 /* OWNER_MISMATCH */, 4006 /* BAD_TOKEN */]);
+// 4001 (PREEMPTED) is terminal too (fix/terminal-bridge-zombie-preemption): a
+// newer same-owner bridge attach replaced this leg — reconnecting would only
+// steal the session back and flap, so the losing helper shuts down cleanly.
+const TERMINAL_CLOSE_CODES = new Set([
+  4001 /* PREEMPTED */,
+  4002 /* DUP_BRIDGE */,
+  4005 /* OWNER_MISMATCH */,
+  4006 /* BAD_TOKEN */,
+]);
 const NORMAL_CLOSURE = 1000;
 
 const [file, ...cmdArgs] = shellSplit(CMD);

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -215,11 +215,12 @@ export class TerminalRelay {
       return new Response(null, { status: 101, webSocket: client });
     }
 
-    // 2b) Same-owner browser PREEMPTION (fix/terminal-dock-heartbeat): decideAttach
-    //     accepted this leg OVER a still-registered browser socket — after a silent
-    //     link death (wifi off; macOS never RSTs) the dead socket lingers OPEN
-    //     forever and used to block every reattach with DUP_BROWSER. Close the
-    //     stale leg(s) BEFORE accepting the new one so single-attach holds
+    // 2b) Same-owner PREEMPTION (browser: fix/terminal-dock-heartbeat; bridge:
+    //     fix/terminal-bridge-zombie-preemption): decideAttach accepted this leg
+    //     OVER a still-registered socket of the same role — after a silent link
+    //     death (wifi off; macOS never RSTs) the dead socket lingers OPEN forever
+    //     and used to block every reattach with DUP_BROWSER / DUP_BRIDGE. Close
+    //     the stale leg(s) BEFORE accepting the new one so single-attach holds
     //     post-swap; handleDetach sees the pair still whole and skips the grace
     //     hold. Foreign owners never reach here (owner check above).
     if (decision.preempt) {
@@ -228,7 +229,7 @@ export class TerminalRelay {
           stale.close(CLOSE.PREEMPTED.code, CLOSE.PREEMPTED.reason);
         } catch { /* already closing */ }
       }
-      this.log("stale browser leg preempted", { session, role });
+      this.log("stale leg preempted", { session, role });
     }
 
     // 3) Accept into HIBERNATION. Tag by role (+ sub) so the peer is findable and

--- a/terminal/relay/src/pairing.js
+++ b/terminal/relay/src/pairing.js
@@ -22,10 +22,11 @@ export const CLOSE = Object.freeze({
   // SLICE 2 — auth + ownership:
   OWNER_MISMATCH: { code: 4005, reason: "owner mismatch — token is for a different user" },
   BAD_TOKEN: { code: 4006, reason: "invalid, tampered, or expired session token" },
-  // Same-owner browser preemption (fix/terminal-dock-heartbeat): the close the
-  // STALE browser leg receives when a newer same-owner browser attach replaces it.
-  // Reuses the DUP_BROWSER code (4001) — a dock that receives it maps to the
-  // existing "duplicate" copy — with a distinct reason for logs and tests.
+  // Same-owner preemption: the close a STALE leg receives when a newer same-owner
+  // attach of the same role replaces it (browser: fix/terminal-dock-heartbeat;
+  // bridge: fix/terminal-bridge-zombie-preemption). Reuses the DUP_BROWSER code
+  // (4001) — a dock that receives it maps to the existing "duplicate" copy, and
+  // the bridge treats it as terminal — with a distinct reason for logs and tests.
   PREEMPTED: { code: 4001, reason: "preempted" },
 });
 
@@ -73,17 +74,27 @@ export function isValidSession(session) {
  * ownership failure, not a duplicate. When `sub` is omitted (e.g. slice-1 callers /
  * unit tests of the bare state machine) owner-binding is skipped.
  *
- * Same-owner browser PREEMPTION (fix/terminal-dock-heartbeat): when the browser
- * leg dies SILENTLY (wifi off / network switch — macOS never RSTs), the dead
- * socket still counts as attached, so a legitimate same-owner reattach used to
- * bounce off DUP_BROWSER forever. For an owner-verified leg (`sub` present — a
- * foreign sub was already rejected above) the NEWER browser attach now wins:
- * `{ok: true, preempt: true}` tells the caller to close the stale browser leg
+ * Same-owner PREEMPTION (fix/terminal-dock-heartbeat for the browser leg,
+ * fix/terminal-bridge-zombie-preemption for the bridge leg): when a leg dies
+ * SILENTLY (wifi off / network switch — macOS never RSTs), the dead socket still
+ * counts as attached, so a legitimate same-owner reattach used to bounce off
+ * DUP_BROWSER / DUP_BRIDGE forever. For an owner-verified leg (`sub` present — a
+ * foreign sub was already rejected above) the NEWER attach now wins for BOTH
+ * roles: `{ok: true, preempt: true}` tells the caller to close the stale leg
  * (CLOSE.PREEMPTED, 4001 "preempted") before accepting this one, keeping the
- * single-attach invariant post-swap. Sub-less callers keep the old DUP_BROWSER
- * verdict, and a 2nd BRIDGE is still rejected — the bridge leg detects its own
- * link death via protocol pings and closes honestly, so a live duplicate there
- * is a real conflict, not a zombie.
+ * single-attach invariant post-swap. Sub-less callers keep the old DUP_* verdicts.
+ *
+ * The bridge was originally EXCLUDED from preemption on the theory that its
+ * protocol-ping keepalive closes a dead link honestly, so a live duplicate must be
+ * a real conflict. That theory fails after a silent death: the keepalive's
+ * ws.terminate() destroys the CLIENT side, but the RST never reaches Cloudflare
+ * (interface/NAT changed), so the RELAY keeps counting the zombie leg — the
+ * bridge's own grace-window reattach then hit DUP_BRIDGE, a code it rightly treats
+ * as terminal, and it gave up and reaped the PTY child. Net effect: a real-world
+ * wifi blip ended the session even though relay, dock, and bridge each behaved.
+ * A LIVE duplicate bridge (two helpers racing) now resolves latest-wins, same as
+ * the browser: the preempted helper sees 4001 (terminal for the bridge too) and
+ * shuts down instead of steal-back flapping.
  *
  * @param {AttachState} state - current attachment state for the session
  * @param {string} role - "bridge" | "browser"
@@ -102,6 +113,7 @@ export function decideAttach(state, role, sub) {
     return { ok: false, ...CLOSE.DUP_BROWSER };
   }
   if (role === "bridge" && state.bridge) {
+    if (sub !== undefined) return { ok: true, preempt: true };
     return { ok: false, ...CLOSE.DUP_BRIDGE };
   }
   return { ok: true };

--- a/terminal/relay/src/pairing.test.js
+++ b/terminal/relay/src/pairing.test.js
@@ -129,12 +129,34 @@ test("preemption: a foreign owner is still rejected OWNER_MISMATCH, never preemp
   assert.equal(d.code, CLOSE.OWNER_MISMATCH.code);
 });
 
-test("preemption: never applies to the bridge role — a live 2nd bridge is a real conflict", () => {
+// ── same-owner bridge preemption (fix/terminal-bridge-zombie-preemption) ──────
+// The bridge's keepalive terminate() after a SILENT link death never reaches
+// Cloudflare (interface/NAT changed — no RST delivered), so the relay keeps
+// counting the zombie leg and the bridge's own grace-window reattach bounced off
+// DUP_BRIDGE — a terminal code for the bridge, which then reaped the PTY child.
+// Bridge reattach now preempts exactly like the browser leg.
+
+test("preemption: an owner-verified 2nd bridge is accepted with the preempt flag", () => {
   let s = emptyState();
-  s = attach(s, "bridge", "user-A");
+  s = attach(s, "bridge", "user-A"); // possibly a silently-dead zombie leg
+  s = attach(s, "browser", "user-A");
   const d = decideAttach(s, "bridge", "user-A");
+  assert.deepEqual(d, { ok: true, preempt: true }, "the newer same-owner bridge wins");
+});
+
+test("preemption: a sub-less 2nd bridge keeps the old DUP_BRIDGE rejection", () => {
+  const s = attach(emptyState(), "bridge");
+  const d = decideAttach(s, "bridge");
   assert.equal(d.ok, false);
   assert.equal(d.code, CLOSE.DUP_BRIDGE.code);
+});
+
+test("preemption: a foreign owner bridge is still rejected OWNER_MISMATCH, never preempts", () => {
+  let s = emptyState();
+  s = attach(s, "bridge", "user-A");
+  const d = decideAttach(s, "bridge", "user-B");
+  assert.equal(d.ok, false);
+  assert.equal(d.code, CLOSE.OWNER_MISMATCH.code);
 });
 
 test("preemption: the stale-leg close reuses the DUP_BROWSER code with a distinct reason", () => {

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs ../shared/session-token.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs zombie-bridge-reattach.test.mjs ../shared/session-token.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -154,8 +154,9 @@ export function startStandinRelay(opts = {}) {
       return;
     }
 
-    // Same-owner browser PREEMPTION (fix/terminal-dock-heartbeat) — mirrors the
-    // Cloudflare DO: the stale browser leg (possibly silently dead) is closed 4001
+    // Same-owner PREEMPTION (browser: fix/terminal-dock-heartbeat; bridge:
+    // fix/terminal-bridge-zombie-preemption) — mirrors the Cloudflare DO: the
+    // stale leg of the same role (possibly silently dead) is closed 4001
     // "preempted" and this attach takes its slot. Nulling the slot FIRST makes the
     // stale socket's teardown a no-op (superseded), so no grace window opens for a
     // swap that leaves the pair whole.
@@ -163,7 +164,7 @@ export function startStandinRelay(opts = {}) {
       const stale = legs[role];
       legs[role] = null;
       try { stale.close(CLOSE.PREEMPTED.code, CLOSE.PREEMPTED.reason); } catch { /* closing */ }
-      log("stale browser leg preempted", { session, role });
+      log("stale leg preempted", { session, role });
     }
 
     const firstLeg = legs.bridge === null && legs.browser === null;

--- a/terminal/test/zombie-bridge-reattach.test.mjs
+++ b/terminal/test/zombie-bridge-reattach.test.mjs
@@ -1,0 +1,126 @@
+// Same-owner BRIDGE preemption — regression proof
+// (fix/terminal-bridge-zombie-preemption).
+//
+// ROOT CAUSE (Reproduce & Investigate step): after a SILENT link death (wifi
+// blip / network switch) the bridge's keepalive eventually ws.terminate()s its
+// dead socket, but the RST never reaches Cloudflare (interface/NAT changed), so
+// the RELAY still counts the zombie bridge leg. The bridge's own grace-window
+// reattach — same sid, same owner-bound token — then bounced off DUP_BRIDGE
+// (4002), a code the bridge rightly treats as TERMINAL, so it gave up and reaped
+// the PTY child. Proven against the PROD relay: browser reattach over a zombie
+// preempts (fix/terminal-dock-heartbeat), bridge reattach closed 4002 — the
+// asymmetry that made every real-world silent drop end the session.
+//
+// THE FIX under test: decideAttach now grants an owner-verified bridge the same
+// preempt verdict as the browser — the stale leg is closed 4001 "preempted", the
+// new leg takes its slot, and no grace hold opens (the pair never stopped being
+// whole). 4001 joins the bridge's TERMINAL_CLOSE_CODES so a genuinely duplicated
+// LIVE helper shuts down instead of steal-back flapping.
+//
+// Runs against the Node stand-in relay, which shares the exact decision logic
+// (pairing.js) and the DO's preemption block. Every wait is hard-timeout guarded.
+//
+// Run: cd terminal/test && node --test zombie-bridge-reattach.test.mjs   (or: npm test)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens } from "../shared/session-token.mjs";
+import { isPeerDegradedFrame, isAttachedFrame } from "../shared/control-frames.mjs";
+
+const SECRET = "zombie-bridge-test-secret";
+const HARD_TIMEOUT_MS = 10_000;
+
+async function waitFor(pred, ms, label, pollMs = 25) {
+  const started = Date.now();
+  for (;;) {
+    const v = await pred();
+    if (v) return v;
+    if (Date.now() - started > ms) throw new Error(`timed out after ${ms}ms waiting for ${label}`);
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+/** Open a raw ws leg and collect its TEXT control frames + binary bytes. */
+async function openRawLeg(relayUrl, session, role, token) {
+  const ws = new WebSocket(`${relayUrl}/?session=${session}&role=${role}&token=${encodeURIComponent(token)}`);
+  const leg = { ws, texts: [], binary: "", closed: null };
+  ws.on("message", (data, isBinary) => {
+    if (isBinary) leg.binary += Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+    else leg.texts.push(Buffer.isBuffer(data) ? data.toString("utf8") : String(data));
+  });
+  ws.on("close", (code, reason) => {
+    leg.closed = [code, String(reason)];
+  });
+  await new Promise((resolve, reject) => {
+    const to = setTimeout(() => reject(new Error(`${role} leg open timeout`)), HARD_TIMEOUT_MS);
+    ws.once("open", () => { clearTimeout(to); resolve(); });
+    ws.once("error", (e) => { clearTimeout(to); reject(e); });
+  });
+  return leg;
+}
+
+const hasFrame = (leg, pred) => leg.texts.some(pred);
+
+test("same-owner 2nd bridge preempts the zombie leg (4001 preempted) and goes live; no grace hold opens", { timeout: 15000 }, async (t) => {
+  const session = `zb-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-ZB", sid: session, secret: SECRET });
+
+  // A "silently dead" bridge leg: still registered server-side — exactly what a
+  // wifi-off helper looks like to the relay (no FIN/RST ever delivered).
+  const stale = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+
+  // The bridge's keepalive fired and its reconnect loop opens a NEW bridge leg
+  // with the SAME owner-bound token (no re-mint) — this used to bounce off
+  // DUP_BRIDGE (terminal for the bridge → PTY child reaped, session dead).
+  const fresh = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { fresh.ws.terminate(); } catch { /* */ } });
+
+  // The zombie leg is closed 4001 "preempted"; the fresh one stays open and gets
+  // its own attach confirmation (it is now THE bridge leg).
+  await waitFor(() => stale.closed != null, HARD_TIMEOUT_MS, "stale bridge leg closed");
+  assert.equal(stale.closed[0], 4001, "stale leg closed with the PREEMPTED code");
+  assert.match(stale.closed[1], /preempted/, "with the distinct preempted reason");
+  assert.equal(fresh.ws.readyState, WebSocket.OPEN, "the fresh leg is the live bridge leg");
+  await waitFor(() => hasFrame(fresh, isAttachedFrame), HARD_TIMEOUT_MS, "attach confirmation to the fresh bridge leg");
+
+  // Single-attach held post-swap AND the pair never stopped being whole: the
+  // browser must NOT have been told its peer dropped (no grace hold for a swap).
+  await new Promise((r) => setTimeout(r, 200));
+  assert.equal(hasFrame(browser, isPeerDegradedFrame), false, "no peer-degraded to the browser on a preemption swap");
+  assert.ok(relay.sessions.has(session), "session retained across the swap");
+
+  // Live end-to-end both ways through the new leg.
+  const down = `DOWN-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+  fresh.ws.send(Buffer.from(down, "utf8"), { binary: true });
+  await waitFor(() => browser.binary.includes(down), HARD_TIMEOUT_MS, "fresh bridge → browser bytes");
+  const up = `UP-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+  browser.ws.send(Buffer.from(up, "utf8"), { binary: true });
+  await waitFor(() => fresh.binary.includes(up), HARD_TIMEOUT_MS, "browser → fresh bridge bytes");
+  assert.equal(stale.binary.includes(up), false, "the zombie leg received none of the post-swap bytes");
+  console.log("[zb] PASS — same-owner bridge preemption swapped legs cleanly, pipe live end-to-end");
+});
+
+test("a foreign-owner bridge still cannot preempt a live session", { timeout: 15000 }, async (t) => {
+  const session = `zb-f-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const tokensA = await mintSessionTokens({ sub: owner, idea: "idea-ZB", sid: session, secret: SECRET });
+  const tokensB = await mintSessionTokens({ sub: `${owner}-evil`, idea: "idea-ZB", sid: session, secret: SECRET });
+
+  const bridgeA = await openRawLeg(relay.url, session, "bridge", tokensA.bridge);
+  t.after(() => { try { bridgeA.ws.terminate(); } catch { /* */ } });
+
+  const bridgeB = await openRawLeg(relay.url, session, "bridge", tokensB.bridge);
+  await waitFor(() => bridgeB.closed != null, HARD_TIMEOUT_MS, "foreign bridge rejected");
+  assert.equal(bridgeB.closed[0], 4005, "foreign owner rejected OWNER_MISMATCH, never preempts");
+  assert.equal(bridgeA.ws.readyState, WebSocket.OPEN, "the bound owner's leg is untouched");
+  console.log("[zb/f] PASS — owner binding still gates bridge preemption");
+});


### PR DESCRIPTION
## The bug (proven against the prod relay)

Nick re-tested the "reattach fails for any session older than 5 min" card and reconnect still failed in real use — even though fix/terminal-expired-reattach (#95) is deployed and works (verified live: an expired-token same-owner reattach to a held session is accepted by the prod relay).

The remaining failure is a **role asymmetry in preemption**. After a *silent* link death (Wi-Fi blip / network switch — macOS never RSTs):

1. The relay never hears a FIN/RST, so the dead sockets stay **registered at the DO** for minutes.
2. The dock's watchdog fires and its reattach **preempts** its zombie twin (fix/terminal-dock-heartbeat) — browser leg recovers. ✅
3. The bridge's keepalive fires (~60–90s), it terminates its dead socket (the RST never reaches Cloudflare across the changed interface/NAT) and reattaches with its original token — and bounces off **DUP_BRIDGE (4002)**, because its zombie twin still counts. 4002 is (rightly) terminal for the bridge → it gives up and **reaps the claude child**. Session dead. ❌

Reproduced against `wss://vibecodes-terminal-relay.nicholasmball.workers.dev`: same-owner browser reattach over a zombie → old leg closed `4001 preempted`, new leg accepted; same-owner bridge reattach over a zombie → closed `4002 bridge already attached for this session`.

## The fix

An owner-verified reattach now wins over a stale leg of the same role for **both** legs:

- `decideAttach` grants the bridge the same `{ok, preempt: true}` verdict as the browser (sub-less callers keep DUP_BRIDGE; foreign owners still hit OWNER_MISMATCH first). The DO's preempt block was already role-generic.
- `4001 PREEMPTED` joins the bridge's `TERMINAL_CLOSE_CODES`, so a genuinely duplicated *live* helper shuts down cleanly instead of steal-back flapping. Skew-safe: an old relay never sends 4001 to a bridge leg.

## Tests

- `pairing.test.js`: bridge preemption verdicts (same-owner / sub-less / foreign owner) — 19 pass
- New `zombie-bridge-reattach.test.mjs` (hermetic, stand-in relay): zombie closed 4001, fresh bridge gets the attach confirmation, **no grace hold opens**, byte pipe live both ways post-swap; foreign owner still can't preempt
- Full terminal suite: 72/72 pass; dock unit tests 40/40; `tsc --noEmit` and lint clean

## Deploy notes

- Relay redeploy required (wrangler) — doing it as part of this PR's verification
- Helper rebuild is optional: the relay-side preempt alone fixes the silent-drop reconnect for existing installs; the bridge's 4001-terminal change only matters for the rare two-live-helpers race

🤖 Generated with [Claude Code](https://claude.com/claude-code)