### PR TITLE
perf(workflow-matching): route adjudication to Haiku 4.5 (COGS quick win)

### DIFF
--- a/src/lib/workflow-matching.ts
+++ b/src/lib/workflow-matching.ts
@@ -38,12 +38,14 @@ export { WORKFLOW_AI_ADJUDICATION_TIMEOUT_MS };
 
 /**
  * Model for the cheap workflow-matching adjudication (gated behind the keyword
- * pre-filter, tiny 3-field output). Uses the same model the rest of the app's AI
- * runs on — the `claude-haiku-4-5` alias was rejected by the Anthropic API on the
- * resolved key (adjudication silently fell back to heuristic in prod); the proven
- * model works. Revisit a Haiku-tier id (e.g. dated) later as a cost optimisation.
+ * pre-filter, tiny 3-field output) — runs on the dated Haiku 4.5 id, the cheapest
+ * tier and appropriate for this gated classification. Must stay the DATED id: the
+ * bare `claude-haiku-4-5` alias was rejected by the Anthropic API on the resolved
+ * platform key (adjudication silently fell back to heuristic in prod), so do NOT
+ * "simplify" this back to the alias. Only verifiable in prod via `ai_usage_log`
+ * (adjudication rows show `source:"ai"` rather than the heuristic fallback).
  */
-export const WORKFLOW_MATCHING_MODEL = "claude-sonnet-4-6";
+export const WORKFLOW_MATCHING_MODEL = "claude-haiku-4-5-20251001";
 
 const AI_TIMEOUT_MS = 30_000;
 


### PR DESCRIPTION
## What
Routes the in-app **workflow-suggestion adjudication** off `claude-sonnet-4-6` onto the dated Haiku id **`claude-haiku-4-5-20251001`**. Single-file change (`src/lib/workflow-matching.ts`): the model constant + its comment.

## Why
Adjudication is a gated, tiny 3-field classification — it doesn't need Sonnet-tier reasoning. This is one of the few surfaces VibeCodes pays for per token (platform-key / BYOK path), so Haiku ($1/$5) vs Sonnet ($3/$15) is ~3× cheaper per call at no meaningful quality cost.

Board card **P1** from the "Investigate Claude usages" spike (Decision Record, approved). Ran the full Feature Development workflow (Requirements → UX → Design Review ✅ → Implementation → QA ✅ → Final Sign-off ✅).

## Safety
- ⚠️ Uses the **dated** id on purpose — the bare `claude-haiku-4-5` alias was previously **rejected by the Anthropic API on the platform key** and silently fell back to the keyword heuristic. Comment warns against reverting to the alias.
- Graceful fallback, matching logic, thresholds, `chargeAiUsage`, and `AI_MODEL` all **untouched**.
- `npx tsc --noEmit` clean; `vitest run workflow-matching` 22/22 pass.

## Verification (post-deploy — the real gate)
Can't be tested locally (platform key not in local env; the call never throws, so a rejected id fails *silently* to heuristic). After deploy: trigger a *suspect* workflow-match → confirm an `ai_usage_log` row with `model=claude-haiku-4-5-20251001`, `key_type=platform`, and suggestion `source="ai"`. If it shows a heuristic fallback → revert this one line (org may lack Haiku 4.5 access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)