### PR TITLE
feat(workflows): per-step model tiering (frontier/standard/cheap)

### DIFF
--- a/docs/spikes/claude-model-tiering-prototype.md
+++ b/docs/spikes/claude-model-tiering-prototype.md
@@ -1,0 +1,132 @@
+# Prototype — Claude Code orchestrator/subagent model tiering
+
+**Status:** SPIKE PROTOTYPE (not production). Sketch to make the mechanism concrete
+and reviewable. See the Step 2 research findings for the honest assessment of
+whether the saving accrues to VibeCodes at all (spoiler: today it accrues to the
+*user*, because the launched Claude Code runs on the user's own auth).
+
+Spike card: Technical Spike — Claude Code model tiering. Author: full-stack persona, Step 2.
+
+---
+
+## What this prototype demonstrates
+
+The tiering pattern that Claude Code actually supports:
+
+- **Orchestrator (main loop)** stays on ONE model for the whole session (keeps the
+  prompt cache warm — switching the main-loop model mid-session invalidates it).
+- **Implementation is delegated to subagents** whose definitions carry a
+  `model:` frontmatter field, so the heavy generation/exploration tokens land on a
+  cheaper model (Sonnet) while the orchestrator reasons/reviews on the pricier one.
+
+Two independent levers, set independently:
+
+| Lever | Sets | Where |
+| --- | --- | --- |
+| Session model selection (`/model`, settings `model`, launch flag) | orchestrator (main loop) | user's global/session config |
+| `.claude/agents/*.md` `model:` frontmatter + per-spawn Task `model` override | subagents | project `.claude/` dir OR in-prompt instruction |
+
+---
+
+## The three artefacts VibeCodes *could* preload
+
+> IMPORTANT: The launched Claude Code runs in the **user's own project directory**
+> (their clone / a fresh `~/projects/<slug>`), NOT the VibeCodes repo. VibeCodes
+> has no direct filesystem write to that dir. The ONLY channel VibeCodes controls
+> at launch is the **bootstrap prompt** carried in the deep link
+> (`claude-cli://open?q=…` or `vibecodes://launch?…&prompt=…`). So "preload" here
+> means: the bootstrap prompt instructs the agent to (a) delegate to a Sonnet
+> subagent this session, and (b) optionally write the subagent definition + a
+> CLAUDE.md profile note so future sessions inherit it. Files only take effect on
+> the NEXT session; the in-prompt instruction is what tiers the CURRENT one.
+
+### 1. Subagent definition — `.claude/agents/vibecodes-implementer.md`
+
+The agent writes this into the project on first launch (same channel it already
+uses to write `CLAUDE.md` and `.vibecodes/`). Read by Claude Code at session start.
+
+```markdown
+---
+name: vibecodes-implementer
+description: >-
+  Implements a frozen, well-specified coding task — writes and edits code, runs
+  the build/tests, and reports back. Delegate mechanical implementation here to
+  keep the orchestrator's context small and cheap. NOT for architecture,
+  ambiguous scope, or board/workflow decisions — those stay with the orchestrator.
+model: sonnet
+---
+
+You implement a single, already-specified task. The orchestrator has frozen the
+spec — do not redesign it. Steps:
+1. Read only the files named in the spec (plus their direct imports).
+2. Make the change. Match existing patterns, naming, and file structure.
+3. Run `npm run lint` and `npx tsc --noEmit`; run the relevant tests.
+4. Report: files changed, test results, and anything the spec got wrong.
+Never touch the VibeCodes board (no MCP `move_task`/`complete_step`) — the
+orchestrator owns board state and identity.
+```
+
+### 2. Orchestrator profile note — appended to the project `CLAUDE.md`
+
+Written by the agent alongside the subagent def. Instructs the main loop to
+delegate. (This is the soft, prompt-level equivalent of the
+`Rylaa/fable5-orchestrator` profile — we do NOT need the full plugin.)
+
+```markdown
+## Model tiering (cost)
+
+Stay on your launched model as the orchestrator. Delegate mechanical
+implementation to the `vibecodes-implementer` subagent (runs on Sonnet) via the
+Task tool. Keep architecture, spec-writing, board/workflow orchestration, and
+review on the orchestrator. Freeze the spec before delegating so the subagent
+does not have to explore. Batch independent sub-tasks into parallel Task calls.
+```
+
+### 3. In-prompt instruction — appended to the launch bootstrap prompt
+
+This is the ONLY part that tiers the CURRENT session. It would be a new terse
+clause in the compact bootstrap builder
+(`src/lib/launch-claude-code.ts` → `buildCompactBootstrapPromptParts`). Sketch of
+the clause (kept short — the compact prompt has a hard URL budget):
+
+```
+Delegate implementation to a Sonnet subagent (Task tool, model: "sonnet"); keep
+planning, review and board ops on your main model.
+```
+
+Production note: this clause costs ~120 encoded chars against the
+`MAX_DEEP_LINK_URL_LENGTH` (1900) / vibecodes:// budget. It is trimmable tail, so
+it must sit AFTER the load-bearing MCP-connect + `record_project_path` steps, or
+be dropped first under truncation. Do not put it in the protected head.
+
+---
+
+## What is a sketch vs what is production-ready
+
+| Element | State |
+| --- | --- |
+| `.claude/agents/vibecodes-implementer.md` content | Sketch — needs iteration on when delegation actually helps vs adds latency |
+| CLAUDE.md profile note | Sketch — wording only |
+| Bootstrap-prompt clause | Sketch — real change is ~5 lines in `buildCompactBootstrapPromptParts`; needs a URL-budget test |
+| Per-spawn Task `model` override | Real Claude Code feature, no VibeCodes code needed |
+| Any settings.json / SessionStart hook injection | NOT possible — VibeCodes never writes to the user's machine; see findings |
+
+---
+
+## Honest caveats
+
+1. **VibeCodes cannot force the model.** No `--model` flag, `ANTHROPIC_MODEL` env,
+   or settings.json is injected by the launcher (verified — see findings). Every
+   artefact above is advisory; the user's own config/CLAUDE.md/`/model` wins.
+2. **The saving is the user's, not VibeCodes'.** The launched Claude Code bills to
+   the user's Claude subscription or their own API key on their machine. VibeCodes
+   pays nothing for these tokens today, so tiering them saves the user money and
+   is a UX/goodwill feature, not a VibeCodes COGS reduction.
+3. **Where tiering WOULD save VibeCodes money** is the separate in-app AI SDK path
+   (`resolveAiProvider` / platform credits / BYOK) — a different surface that this
+   prototype does not touch.
+4. **A Fable orchestrator is not the cost-optimal orchestrator.** Because Fable is
+   ~2× Opus per token, an Opus-orchestrator + Sonnet-subagents split is cheaper
+   than Fable-orchestrator + Sonnet-subagents (see cost table). Keep Fable on the
+   orchestrator only if orchestration quality demonstrably needs the frontier model.
+```

--- a/docs/spikes/claude-model-tiering-recommendation.md
+++ b/docs/spikes/claude-model-tiering-recommendation.md
@@ -1,0 +1,230 @@
+# Recommendation — Claude model tiering for VibeCodes workflows
+
+**Spike card:** Technical Spike — Claude model tiering ("Investigate Claude usages").
+**Step:** 3 of 4 — Write Recommendation. **Author:** full-stack persona.
+**Status:** Decision-grade. Next step is human approval (Step 4).
+
+**Inputs this builds on (do not re-read in full):**
+- **Step 1 — Define Research Questions:** the brief and success criteria (can we tier
+  models to cut cost/usage without hurting quality; what is the concrete introduction
+  mechanism; who actually saves).
+- **Step 2 — Research & Prototype:** findings + the prototype at
+  [`docs/spikes/claude-model-tiering-prototype.md`](./claude-model-tiering-prototype.md).
+  Key Step 2 conclusions carried forward: the two independent levers (orchestrator
+  model vs. subagent `model:`), the launch-bootstrap caveats, and risks **D1–D4**.
+
+This document **corrects one Step 2 framing** (the mechanism is server-side data in the
+MCP response, not the launch deep-link) and **adds Anthropic's own measured validation**.
+
+---
+
+## 1. Recommendation (go / no-go)
+
+### GO — Path A now. Treat Path B (server-side CMA) as a validated strategic follow-up. Ship the Haiku-matching quick win independently.
+
+**Preferred approach: Path A — per-step `model` hint in the workflow data returned by
+`claim_next_step`.** Add a recommended model to each workflow step / persona role; the
+orchestrator (the user's Claude Code) reads it and spawns that step's persona subagent
+on the named model. Fable/Opus stays on the orchestrator; Sonnet does implementation;
+Haiku does mechanical steps.
+
+**Why Path A wins as the first move:**
+
+1. **It is on-brand for the card.** The task is "Investigate Claude **usages**." Path A
+   makes each user's Claude subscription / API budget stretch **~2.5× further** (Anthropic's
+   own measured figure, §3) before hitting rate/usage limits — a direct, visible user
+   benefit that is exactly what "usages" points at.
+2. **The mechanism already exists — we're adding one field.** `claim_next_step`
+   (`mcp-server/src/tools/workflows.ts`) already returns `agent_role`, `bot_id`, the
+   `available_agents` roster, and a **mandatory** instruction to *"SPAWN a fresh subagent
+   whose system prompt IS that persona prompt"* per step (lines 729–738). The tiering lever
+   Step 2 identified (per-spawn Task `model` override) is a **real, shipping Claude Code
+   feature** that needs **zero** VibeCodes code. All we add is the *recommendation* of which
+   model, carried in data we already send.
+3. **No user-machine access required.** This was Step 2's central blocker for the
+   launch-bootstrap framing. Path A sidesteps it entirely: the model hint is server-side
+   data, re-sent on **every** claim, so it survives session restarts, compaction, and
+   config drift. Nothing is written to the user's disk.
+4. **Anthropic themselves ship and measure this exact coordinator/worker split** (§3) — we
+   are not betting on an unproven pattern.
+
+**Why NOT Path B first:** Path B (VibeCodes runs the workflow server-side on Managed
+Agents, billing our own key) is where the saving becomes a **VibeCodes COGS reduction**
+rather than a user benefit — genuinely attractive — but it is a **large** build (new
+server-side agent runner, environments, vaults, event streaming, billing integration) on a
+**beta** API (CMA). It is the right *strategic* direction, now de-risked by Anthropic's
+measured results, but it is not the cheapest high-value first move. Sequence it after Path A.
+
+**Independent of both:** the in-app AI path is hardcoded to `claude-sonnet-4-6`
+(`src/lib/ai-helpers.ts:7`, `AI_MODEL`), including the keyword-gated **workflow-matching
+adjudication** which has a standing "move to Haiku" intent
+(`src/lib/workflow-matching.ts:39–46`). Dropping that one call to a Haiku-tier model is a
+**standalone COGS win** that touches neither path and can ship this week. **Caveat (newly
+verified):** the plain `claude-haiku-4-5` alias was already tried and **rejected by the
+Anthropic API on the resolved key**, silently falling back to the heuristic in prod — so
+the quick win must use a **dated Haiku model id** and verify against the platform key
+before merge, not the bare alias.
+
+---
+
+## 2. Introduction mechanism (concrete)
+
+### Named mechanism: a `model` (a.k.a. `model_tier`) field per workflow step / persona role, surfaced in the `claim_next_step` MCP response.
+
+This **corrects Step 2's launch-bootstrap framing.** Step 2 was right that the launch
+deep-link *cannot* set the model (it only carries a prompt). The right lever is **not** the
+launcher — it is the **server-side workflow data VibeCodes already fully controls and
+already returns on every claim.**
+
+**The founder's mental model, confirmed against the code:** Claude Code *is* the
+orchestrator. It connects to VibeCodes, picks up a task, and runs the workflow step by
+step, and it **already spawns a fresh persona subagent per step** — the `claim_next_step`
+instruction literally mandates *"this step MUST be executed by a FRESH SUBAGENT that you
+spawn with your Agent/Task tool"* and *"SPAWN a fresh subagent whose system prompt IS that
+persona prompt"* (`workflows.ts:730,734`). Because each subagent runs in **isolated
+context**, choosing its model per spawn does **not** invalidate the orchestrator's prompt
+cache. So the founder's question — *"if we start with Fable, can we kick off the workflow
+steps in agents that use Sonnet?"* — answers **yes, cleanly.**
+
+**How the field rides the existing response.** `claim_next_step` already returns per step:
+`agent_role`, `bot_id`, the matched persona, the `available_agents` roster, prior-step
+`context`, and the spawn instruction. We add **one recommended model per step/role** and
+**one clause** to the instruction text: *"spawn this step's agent with `model=<x>`."* The
+prototype's §"in-prompt instruction" sketch
+([prototype.md](./claude-model-tiering-prototype.md)) becomes redundant for the *current*
+session — the hint is now authoritative data, re-sent every claim, not a trimmable tail
+clause fighting the deep-link URL budget.
+
+**Model → role mapping (natural fit to existing persona roles):**
+
+| Workflow step / role | Recommended tier | Rationale |
+| --- | --- | --- |
+| Orchestrator (main Claude Code loop) | **Fable / Opus** | Plans, sequences, reviews, owns board state. Frontier reasoning where it counts; stays on one model to keep prompt cache warm. |
+| Product Owner · "Review & Decide" · approval / synthesis steps | **Fable / Opus** (orchestrator tier) | Judgement-heavy, low-token — the frontier model earns its rate here. |
+| Full Stack · Front End · implementation steps | **Sonnet** | Token-heavy generation/editing — the bulk of billed tokens, at worker rate. |
+| QA · "run tests" · mechanical / mostly-deterministic steps | **Haiku** | Cheapest tier for low-judgement, high-volume mechanical work. |
+
+**Board-identity safety constraint (carried from Step 2, still binding).**
+Identity-bearing board mutations — `complete_step` / `fail_step`, and holding the
+`claim_token` — **stay with the orchestrator / identity holder**, never the cheap worker
+subagent. The existing instruction already enforces this (*"Keep the claim_token … do NOT
+pass it to the subagent"* and *"YOU (the orchestrator) call complete_step"*,
+`workflows.ts:732,735`). Tiering changes **only which model does the step's work**; it must
+not move who is accountable for the step. Step attribution keys on `step.bot_id`
+independent of the worker's model, so this holds by construction.
+
+**What actually gets built for Path A:**
+- A `model` (nullable text) column on the workflow-step / persona-role schema, plus mapping
+  in the platform workflow templates (default null → orchestrator picks).
+- The extra clause in the `claim_next_step` instruction builder (`workflows.ts`) that names
+  the step's model when present.
+- Advisory by nature — as Step 2 stressed, VibeCodes cannot *force* the model; the user's
+  `/model` and config always win. That is acceptable: the default path is the good path.
+
+---
+
+## 3. Cost
+
+**Lead with Anthropic's own measured numbers — the credible external anchor.** Anthropic's
+Cookbook *"plan big, execute small"*
+(`anthropics/claude-cookbooks/managed_agents/CMA_plan_big_execute_small.ipynb`) ships the
+*exact* coordinator/worker split we are proposing — verbatim
+`COORDINATOR_MODEL = "claude-fable-5"`, `WORKER_MODEL = "claude-sonnet-5"` — where the
+frontier model plans and synthesizes and **never touches raw data**, while cheap workers do
+all the token-heavy reading. On a 20-fact / 10-park verification task, measured:
+
+| Metric | Solo Fable | Split team (Fable coord + Sonnet workers) | Delta |
+| --- | --- | --- | --- |
+| Cost | **$4.00** | **$1.61** | **2.5× cheaper** |
+| Wall-clock | 608 s | 194 s | **3× faster** |
+| Input tokens billed at worker rate | — | **84–98%** | bulk of tokens move to the cheap tier |
+
+This is first-party, measured confirmation from Anthropic of the saving pattern — not a
+projection. It maps directly onto VibeCodes workflows: judgement (orchestrator/Product
+Owner) is low-token and stays frontier; implementation/QA is high-token and moves to
+Sonnet/Haiku.
+
+**Step 2's per-token cost table (carried forward) — note who pays:**
+
+| Split | Orchestrator tokens | Worker tokens | Who pays | Effect |
+| --- | --- | --- | --- | --- |
+| Solo Fable (today, local) | Fable | Fable | **User** | Baseline — most expensive |
+| **Path A: Fable/Opus orch + Sonnet/Haiku workers** | Fable/Opus (low volume) | Sonnet/Haiku (high volume) | **User** | ~2.5× more headroom on the user's own budget/limits. **VibeCodes COGS unchanged.** |
+| **Path B: server-side CMA, same split** | Fable/Opus | Sonnet/Haiku | **VibeCodes** | Same ~2.5× — but here it is a **real VibeCodes COGS reduction** on our API key. |
+| Opus orch + Sonnet workers | Opus (cheaper than Fable) | Sonnet | either | Cheapest orchestrator option — Fable is ~2× Opus/token, so only keep Fable on the orchestrator if orchestration quality demonstrably needs the frontier model (Step 2 caveat D-note). |
+
+**Segmentation — the crux, stated plainly:**
+- **Path A → the *user* saves.** The launched Claude Code bills to the user's Claude
+  subscription / their own API key. VibeCodes pays nothing for these tokens today, so
+  tiering them is a **UX / goodwill / usage-headroom** feature, not a COGS line. This is
+  fine — and it is precisely what a card titled "usages" is asking for.
+- **Path B → *VibeCodes* saves.** Only when VibeCodes runs the workflow server-side on its
+  own key does the 2.5× hit our P&L. That is the prize that justifies the larger build
+  later.
+- **Haiku-matching quick win → *VibeCodes* saves,** small but immediate: it is on the
+  in-app platform-key path (`resolveAiProvider` / platform credits), independent of A/B.
+
+---
+
+## 4. Risks (Step 2 D1–D4 carried, re-adjudicated, plus CMA-specific)
+
+| # | Risk | Disposition | Notes |
+| --- | --- | --- | --- |
+| **D1** | VibeCodes cannot *force* the model — the hint is advisory; user config/`/model` wins. | **Accepted** | Inherent to Path A. Default path is the good path; no correctness dependency on it. Not blocking. |
+| **D2** | Sonnet/Haiku quality on real VibeCodes implementation/QA steps is unproven — could hurt output quality. | **Mitigated, but flagged unverified** | Anthropic's measured task held quality with 84–98% tokens at worker rate, but that is *their* task, not ours. Mitigation: default hints conservative (implementation→Sonnet only; Haiku reserved for genuinely mechanical steps), field is per-step so we can dial back any step, and it is opt-in via template mapping. **Real Sonnet-vs-Opus quality on VibeCodes tasks is the top open unknown — see §6.** |
+| **D3** | Saving accrues to the user, not VibeCodes (Path A). | **Accepted / reframed** | Not a defect — it is the intended benefit for a "usages" card. Path B is the COGS lever when we want it. |
+| **D4** | Board-identity / claim_token must not leak to the cheap subagent. | **Mitigated (already enforced)** | Existing `claim_next_step` instruction keeps token + `complete_step`/`fail_step` on the orchestrator; attribution keys on `step.bot_id`. Tiering does not touch this. Not blocking. |
+| **D5 (new)** | **CMA is beta** (Path B). | **Blocking for Path B only** | API surface can change; not a basis to build production COGS on yet. Reinforces "Path B later." No effect on Path A. |
+| **D6 (new)** | **CMA limits vs. our workflow shape** (Path B): one level of delegation (depth > 1 ignored), max 20 unique roster agents, 25 concurrent threads. | **Accepted with a design note (Path B)** | Our workflows are single-level (orchestrator → per-step persona), so depth-1 fits. But a long workflow could exceed **25 concurrent threads** / **20 unique roster agents** if run fully parallel — Path B design must cap concurrency / reuse roster agents across steps. Not relevant to Path A (local Claude Code has no such caps). |
+| **D7 (new)** | **Haiku alias rejection** (quick win). | **Mitigated, must verify** | `claude-haiku-4-5` alias was rejected by the API on the resolved key and silently fell back to heuristic in prod (`workflow-matching.ts:39–46`). Use a **dated Haiku id** and verify against the platform key in a preview before merge. |
+
+**Nothing here is blocking for the recommended first move (Path A + quick win).** D5/D6
+gate only Path B, which we are deliberately deferring.
+
+---
+
+## 5. Build-effort t-shirt sizes
+
+| Work item | Size | What it entails |
+| --- | --- | --- |
+| **Path A — per-step `model` hint in `claim_next_step`** | **S** | One nullable `model` column on workflow-step/role schema; populate the platform templates with the role→tier mapping; add one clause to the `claim_next_step` instruction builder (`workflows.ts`); update `src/types/database.ts` (+ `Relationships`). No user-machine access, no new services. Per-spawn Task `model` override is already a shipping Claude Code feature. |
+| **Haiku-for-matching quick win** | **XS** | Swap `WORKFLOW_MATCHING_MODEL` (and consider the `role_matching` adjudication) to a **dated Haiku id**; verify against the platform key in preview (D7). ~1 line + a verification pass. Independent of A/B; can ship first. |
+| **Path B — server-side CMA workflow runner** | **L (XL if billing-integrated)** | New server-side agent runner on Managed Agents (Fable/Opus coordinator + Sonnet/Haiku roster mapped to existing `bot_profiles` / `idea_agents`), environments, vaults, event streaming, concurrency capping for D6, and integration with the platform-credit / billing surface. On a **beta** API. Strategic follow-up, not now. |
+
+---
+
+## 6. Decision & next steps (for Step 4 — human approval)
+
+**Recommended decision:** **Approve Path A + the Haiku-matching quick win. Log Path B as a
+tracked strategic follow-up (do not build yet).**
+
+**If approved, the actionable next steps:**
+1. **Ship the Haiku-matching quick win (XS).** New task: switch workflow-matching (and
+   optionally role-matching) adjudication to a **dated Haiku id**, verify against the
+   platform key in a preview deploy (respect D7 — do **not** reuse the bare `claude-haiku-4-5`
+   alias). Immediate, independent VibeCodes COGS win.
+2. **Build Path A (S).** New task: add the `model` column + template mapping + the
+   `claim_next_step` instruction clause, with the role→tier table from §2 as the default
+   mapping and board-identity constraint (D4) preserved. Keep hints conservative (Haiku only
+   for mechanical steps).
+3. **Resolve the top open unknown (D2) with a cheap experiment before over-committing tiers:**
+   run one representative VibeCodes workflow twice — orchestrator+Sonnet workers vs.
+   all-Opus — and compare deliverable quality and cost/latency. This tells us how aggressive
+   the default mapping should be. Do this *alongside* shipping Path A's conservative default.
+4. **File Path B (L/XL) as a strategic epic**, explicitly gated on: CMA leaving beta (D5),
+   a concurrency/roster design for the 25-thread / 20-agent / depth-1 limits (D6), and
+   billing integration. Cite the Anthropic Cookbook measured result (2.5× / 3×) as the
+   business case anchor.
+
+**Still explicitly unverified (flagged honestly):**
+- **Real Sonnet-vs-Opus quality on VibeCodes' own tasks** — the load-bearing unknown behind
+  the tier mapping (D2). Step 3 recommends the mapping *conservatively* precisely because
+  this is untested; step 3 experiment above closes it.
+- **Repo is on Sonnet 4.6, not Sonnet 5.** Anthropic's cookbook figures use `claude-sonnet-5`
+  / `claude-fable-5`; our in-app path pins `claude-sonnet-4-6` and `WORKFLOW_MATCHING_MODEL`
+  the same. Any Path B / quick-win work should confirm the intended concrete model ids at
+  build time rather than assume the cookbook's aliases resolve on our key (see D7 — an alias
+  already failed once in prod).
+- **Path A saving is real but accrues to the user, not VibeCodes** (D3) — restated so Step 4
+  does not mistake it for a COGS reduction. The COGS reduction is Path B (and the small
+  quick win).

--- a/docs/spikes/p1-ux-assessment.html
+++ b/docs/spikes/p1-ux-assessment.html
@@ -1,0 +1,114 @@
+<!-- P1 UX Assessment: Route in-app workflow-matching to Haiku -->
+<title>UX Assessment — Route workflow-matching to Haiku (No UI Surface)</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    font: 15px/1.6 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    max-width: 760px; margin: 2.5rem auto; padding: 0 1.25rem;
+    color: #1a1a1a; background: #fff;
+  }
+  h1 { font-size: 1.5rem; line-height: 1.25; margin: 0 0 .25rem; }
+  h2 { font-size: 1.05rem; margin: 2rem 0 .5rem; }
+  .sub { color: #666; margin: 0 0 1.5rem; font-size: .9rem; }
+  .verdict {
+    border-left: 3px solid #10b981; padding: .75rem 1rem; margin: 1.25rem 0;
+    background: rgba(16,185,129,.08); border-radius: 0 6px 6px 0;
+  }
+  .verdict strong { color: #0f9d6b; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .85em;
+    background: rgba(127,127,127,.15); padding: .1em .35em; border-radius: 4px; }
+  table { border-collapse: collapse; width: 100%; margin: .75rem 0; font-size: .9rem; }
+  th, td { text-align: left; padding: .5rem .6rem; border-bottom: 1px solid rgba(127,127,127,.25); vertical-align: top; }
+  th { font-weight: 600; color: #444; }
+  td:first-child code { white-space: nowrap; }
+  ul { margin: .4rem 0; padding-left: 1.2rem; }
+  li { margin: .3rem 0; }
+  .risk { border-left: 3px solid #f59e0b; padding: .75rem 1rem; margin: 1rem 0;
+    background: rgba(245,158,11,.08); border-radius: 0 6px 6px 0; }
+  footer { margin-top: 2.5rem; padding-top: 1rem; border-top: 1px solid rgba(127,127,127,.25);
+    color: #777; font-size: .82rem; }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e6e6e6; background: #111; }
+    h1 { color: #f5f5f5; }
+    .sub, th { color: #9aa0a6; }
+    .verdict strong { color: #34d399; }
+    footer { color: #888; }
+  }
+</style>
+
+<h1>UX Assessment — No UI Surface</h1>
+<p class="sub">Step 2 (UX Design) · P1: Route in-app workflow-matching to Haiku · <code>src/lib/workflow-matching.ts</code></p>
+
+<div class="verdict">
+  <strong>Designer's verdict: no UI deliverable.</strong> This is a backend model-constant swap
+  (<code>WORKFLOW_MATCHING_MODEL</code>: <code>claude-sonnet-4-6</code> → <code>claude-haiku-4-5-20251001</code>).
+  The workflow-matching adjudication runs entirely server-side. It has no view, no control, no copy.
+  The correct UX outcome is that this change is <em>invisible</em> to users. Do not invent UI where none is needed.
+</div>
+
+<h2>1. There is no user-facing surface</h2>
+<p>
+  The adjudicator (<code>adjudicateWorkflowMatch()</code>) is a data/logic-layer function called during
+  auto-rule application. Its <em>output</em> feeds the existing workflow-suggestion experience, but the
+  <em>model choice</em> behind that output is never surfaced — no model name, latency badge, or "powered by"
+  string is shown to the user. Swapping the constant changes which API the server calls and nothing else.
+</p>
+
+<h2>2. UX non-regression requirement (the real deliverable)</h2>
+<p>
+  Because the change is invisible <em>by design</em>, the sign-off is a non-regression assertion: the
+  workflow-suggestion panel must look and behave identically before and after. Same thresholds
+  (<code>WORKFLOW_AI_AUTOAPPLY_THRESHOLD = 0.85</code>), same in-flight timing, same keep/replace/remove
+  controls, same mismatch-reason text. Each state below must render pixel- and copy-identical to today.
+</p>
+
+<table>
+  <thead>
+    <tr><th>State</th><th>What the user sees</th><th>Must remain</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>in-flight / checking</code></td>
+      <td>"Checking…" affordance while adjudication resolves</td>
+      <td>Same spinner/label, same perceived latency band — no new "slow" feeling</td>
+    </tr>
+    <tr>
+      <td><code>suggested</code></td>
+      <td>Suggestion panel with mismatch reason + keep / replace / remove controls</td>
+      <td>Same layout, same reason copy, same controls (not colour-only)</td>
+    </tr>
+    <tr>
+      <td><code>auto-applied</code></td>
+      <td>High-confidence match (≥ 0.85) applied silently, no interruption</td>
+      <td>Same silent behaviour — no new toast, banner, or confirmation</td>
+    </tr>
+    <tr>
+      <td><code>dismissed</code></td>
+      <td>User keeps existing workflow; suggestion clears</td>
+      <td>Same dismissal path and persistence</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>3. The one indirect risk: silent backend degradation</h2>
+<div class="risk">
+  The adjudicator <strong>always resolves</strong> — if the model is unavailable, errors, times out, or
+  returns invalid output, it falls back to the deterministic keyword heuristic
+  (<code>source: 'heuristic'</code>). If the Haiku model id were silently rejected, every suspect case would
+  quietly drop to the heuristic: users would get <em>worse or no</em> AI suggestions, with <strong>no visible
+  error state</strong>. This is a telemetry concern, not a UI one — there is intentionally no user-facing
+  "AI unavailable" surface here.
+</div>
+<ul>
+  <li><strong>Not a UI state:</strong> do not add an error banner — degradation is meant to be graceful and invisible.</li>
+  <li><strong>Observable via telemetry only:</strong> watch the <code>source: 'ai'</code> vs <code>source: 'heuristic'</code>
+      ratio and adjudication error/timeout rates after rollout. A spike in <code>heuristic</code> is the real "error state."</li>
+  <li><strong>Acceptance for this step:</strong> suggestion quality (which suggestions appear / auto-apply) is
+      indistinguishable to users; only cost and latency change behind the scenes.</li>
+</ul>
+
+<footer>
+  Sign-off: no new UI. Protect the existing workflow-suggestion UX (four states above) as a non-regression
+  checklist; treat a rise in heuristic-fallback rate as the only "error" to watch — via telemetry, not the interface.
+  Feeds Step 3 (Design Review / human approval).
+</footer>

--- a/docs/spikes/p2-model-tier-design.html
+++ b/docs/spikes/p2-model-tier-design.html
@@ -1,0 +1,730 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>P2 · Per-step Model Tiering — UX Design</title>
+<style>
+  /* ── Tokens (VibeCodes dark theme: Tailwind Zinc, shadcn New York) ── */
+  :root{
+    --bg:#09090b;            /* zinc-950 — app background            */
+    --card:#101013;          /* doc section card                     */
+    --popover:#18181b;       /* zinc-900 — popover / dropdown        */
+    --border:#27272a;        /* zinc-800 — border / input            */
+    --muted:#27272a;         /* zinc-800                             */
+    --muted-20:rgba(39,39,42,.20);
+    --muted-30:rgba(39,39,42,.30);
+    --muted-60:rgba(39,39,42,.60);
+    --fg:#fafafa;            /* zinc-50                              */
+    --muted-fg:#a1a1aa;      /* zinc-400                             */
+    --faint-fg:#71717a;      /* zinc-500 — placeholders              */
+    --ring:#d4d4d8;          /* zinc-300 — focus ring                */
+    --emerald:#34d399; --emerald-b:rgba(16,185,129,.35); --emerald-bg:rgba(16,185,129,.08);
+    --violet:#a78bfa;  --violet-b:rgba(139,92,246,.25);  --violet-bg:rgba(139,92,246,.15);
+    --pink:#f472b6;    --pink-b:rgba(236,72,153,.25);    --pink-bg:rgba(236,72,153,.15);
+    --blue:#60a5fa;    --blue-b:rgba(59,130,246,.25);    --blue-bg:rgba(59,130,246,.15);
+    --cyan:#22d3ee;    --cyan-b:rgba(6,182,212,.25);     --cyan-bg:rgba(6,182,212,.15);
+    --amber:#fbbf24;   --amber-b:rgba(245,158,11,.25);   --amber-bg:rgba(245,158,11,.15);
+    --zincbadge:#a1a1aa; --zincbadge-b:rgba(113,113,122,.25); --zincbadge-bg:rgba(113,113,122,.15);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{
+    background:var(--bg);color:var(--fg);
+    font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+    font-size:15px;line-height:1.6;-webkit-font-smoothing:antialiased;
+  }
+  a{color:var(--fg)}
+  code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:.85em;background:var(--muted-30);border:1px solid var(--border);border-radius:4px;padding:1px 5px;color:#e4e4e7}
+
+  /* ── Page chrome ── */
+  .wrap{max-width:980px;margin:0 auto;padding:0 24px 120px}
+  header.hero{padding:56px 0 28px;border-bottom:1px solid var(--border)}
+  .kicker{display:inline-flex;gap:8px;align-items:center;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--emerald);margin-bottom:14px}
+  .kicker .dot{width:6px;height:6px;border-radius:99px;background:var(--emerald)}
+  h1{font-size:32px;line-height:1.2;font-weight:700;letter-spacing:-.02em}
+  .sub{margin-top:12px;color:var(--muted-fg);max-width:64ch}
+  .meta{margin-top:18px;display:flex;flex-wrap:wrap;gap:8px}
+  .meta span{font-size:11px;color:var(--muted-fg);border:1px solid var(--border);border-radius:99px;padding:3px 10px;background:var(--muted-20)}
+
+  nav.toc{position:sticky;top:0;z-index:50;background:rgba(9,9,11,.85);backdrop-filter:blur(8px);border-bottom:1px solid var(--border);margin:0 -24px;padding:10px 24px;display:flex;gap:4px;overflow-x:auto;white-space:nowrap}
+  nav.toc a{font-size:12px;color:var(--muted-fg);text-decoration:none;padding:5px 10px;border-radius:6px}
+  nav.toc a:hover{color:var(--fg);background:var(--muted-30)}
+  nav.toc a b{color:var(--emerald);font-weight:600;margin-right:5px}
+
+  section{margin-top:56px;scroll-margin-top:64px}
+  h2{font-size:21px;font-weight:650;letter-spacing:-.01em;display:flex;align-items:baseline;gap:12px}
+  h2 .num{color:var(--emerald);font-size:14px;font-weight:700}
+  h3{font-size:14px;font-weight:600;margin:26px 0 10px;color:#e4e4e7}
+  section>p{margin-top:10px;color:var(--muted-fg);max-width:70ch}
+  section>p strong, li strong{color:var(--fg);font-weight:600}
+  ul.notes{margin:12px 0 0 18px;color:var(--muted-fg)}
+  ul.notes li{margin-top:7px;max-width:72ch}
+  ul.notes li::marker{color:var(--faint-fg)}
+
+  /* ── Mockup frames ── */
+  .frame{margin-top:16px;border:1px solid var(--border);border-radius:12px;background:var(--card);overflow:hidden}
+  .frame .bar{display:flex;align-items:center;gap:8px;padding:8px 14px;border-bottom:1px solid var(--border);background:var(--muted-20)}
+  .frame .bar .fdot{width:9px;height:9px;border-radius:99px;background:var(--border)}
+  .frame .bar .flabel{font-size:11px;color:var(--muted-fg);margin-left:6px}
+  .frame .stage{padding:26px;background:
+    radial-gradient(circle at 1px 1px,rgba(255,255,255,.035) 1px,transparent 0) 0 0/22px 22px, var(--bg)}
+  .cols{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px}
+  @media(max-width:760px){.cols{grid-template-columns:1fr}}
+  .tag{display:inline-flex;align-items:center;gap:6px;font-size:10px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;border-radius:99px;padding:3px 10px;margin-bottom:12px}
+  .tag.now{color:var(--muted-fg);border:1px solid var(--border);background:var(--muted-20)}
+  .tag.new{color:var(--emerald);border:1px solid var(--emerald-b);background:var(--emerald-bg)}
+  .caption{font-size:12px;color:var(--faint-fg);margin-top:12px;max-width:70ch}
+  .caption b{color:var(--muted-fg);font-weight:600}
+
+  /* ── shadcn-style primitives (mock) ── */
+  .dialog{background:var(--bg);border:1px solid var(--border);border-radius:10px;box-shadow:0 20px 50px rgba(0,0,0,.55);padding:20px;max-width:512px;margin:0 auto}
+  .dlg-title{font-size:16px;font-weight:600;margin-bottom:16px}
+  .lbl{display:block;font-size:12px;font-weight:500;margin-bottom:6px}
+  .inp{display:flex;align-items:center;height:28px;padding:0 8px;flex:1 1 auto;min-width:0;border:1px solid var(--border);border-radius:6px;background:transparent;font-size:12px;color:var(--fg);white-space:nowrap;overflow:hidden}
+  .inp.ph{color:var(--faint-fg)}
+  .inp.h8{height:32px;font-size:13px}
+  .flab{font-size:10px;color:var(--muted-fg);white-space:nowrap}
+  .steprow{display:flex;align-items:flex-start;gap:8px;border:1px solid var(--border);background:var(--muted-20);border-radius:6px;padding:8px}
+  .arrows{display:flex;flex-direction:column;gap:2px;padding-top:4px;color:var(--muted-fg)}
+  .arrows svg{display:block;padding:2px}
+  .r{display:flex;align-items:center;gap:8px;min-width:0}
+  .r+.r{margin-top:6px}
+  .r.cont{padding-left:28px;gap:12px}
+  .grow{flex:1 1 auto;min-width:0;display:flex;align-items:center;gap:8px}
+  .numchip{display:flex;height:20px;width:20px;flex:none;align-items:center;justify-content:center;border-radius:99px;background:var(--muted);font-size:10px;font-weight:600;color:var(--muted-fg)}
+  .numchip.lg{height:24px;width:24px;font-size:12px}
+  .trash{color:var(--muted-fg);padding:4px;margin-top:4px}
+  .sw{position:relative;width:24px;height:14px;flex:none;border-radius:99px;background:var(--muted);border:1px solid var(--border)}
+  .sw::after{content:"";position:absolute;top:1px;left:1px;width:10px;height:10px;border-radius:99px;background:var(--faint-fg)}
+  .sw.on{background:var(--fg)}
+  .sw.on::after{left:auto;right:1px;background:var(--bg)}
+
+  /* select trigger */
+  .sel{display:inline-flex;align-items:center;justify-content:space-between;gap:6px;height:28px;padding:0 8px;border:1px solid var(--border);border-radius:6px;background:transparent;font-size:12px;color:var(--fg);flex:none;white-space:nowrap}
+  .sel .cue{color:var(--faint-fg);display:flex}
+  .sel.big{height:36px;padding:0 12px;font-size:13px;width:260px}
+  .sel.focus{outline:2px solid var(--ring);outline-offset:2px}
+  .helper{font-size:10px;color:var(--muted-fg);line-height:1.45}
+  .helper.big{font-size:12px;margin-top:6px}
+
+  /* listbox */
+  .listbox{width:300px;margin-top:6px;background:var(--popover);border:1px solid var(--border);border-radius:8px;box-shadow:0 12px 32px rgba(0,0,0,.5);padding:4px}
+  .opt{display:flex;align-items:flex-start;justify-content:space-between;gap:10px;padding:8px 10px;border-radius:6px}
+  .opt .name{font-size:13px;font-weight:500}
+  .opt .gloss{font-size:11px;color:var(--muted-fg);margin-top:1px}
+  .opt.active{background:var(--muted-60)}
+  .opt .chk{color:var(--fg);flex:none;margin-top:3px;visibility:hidden}
+  .opt.selected .chk{visibility:visible}
+
+  /* badges */
+  .badge{display:inline-flex;align-items:center;gap:4px;flex:none;border-radius:99px;border:1px solid var(--border);padding:1px 8px;font-size:10px;font-weight:500;line-height:1.6;color:var(--fg);white-space:nowrap}
+  .badge.role-v{background:var(--violet-bg);color:var(--violet);border-color:var(--violet-b)}
+  .badge.role-p{background:var(--pink-bg);color:var(--pink);border-color:var(--pink-b)}
+  .badge.role-b{background:var(--blue-bg);color:var(--blue);border-color:var(--blue-b)}
+  .badge.role-c{background:var(--cyan-bg);color:var(--cyan);border-color:var(--cyan-b)}
+  .badge.st-zinc{background:var(--zincbadge-bg);color:var(--zincbadge);border-color:var(--zincbadge-b)}
+  .badge.st-blue{background:var(--blue-bg);color:var(--blue);border-color:var(--blue-b)}
+  .badge.st-green{background:var(--emerald-bg);color:var(--emerald);border-color:var(--emerald-b)}
+  .badge.st-amber{background:var(--amber-bg);color:var(--amber);border-color:var(--amber-b)}
+  .badge.tier{background:transparent;color:#e4e4e7;border-color:#3f3f46}
+  .badge.tier .tk{color:var(--faint-fg);font-weight:400}
+
+  /* board step card */
+  .stepcard{display:flex;align-items:center;gap:12px;border:1px solid var(--border);background:var(--muted-30);border-radius:6px;padding:10px 12px}
+  .stepcard+.stepcard{margin-top:6px}
+  .stepcard .title{flex:1 1 auto;min-width:0;font-size:13px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .stepcard .chev{color:var(--faint-fg);flex:none;opacity:.5}
+
+  /* annotation */
+  .annot{position:relative;border:1.5px dashed var(--emerald-b);border-radius:8px;padding:6px;margin:6px -6px -6px}
+  .annot .pin{position:absolute;top:-9px;left:10px;font-size:9px;font-weight:700;letter-spacing:.08em;background:var(--emerald);color:#04231a;border-radius:99px;padding:1px 8px}
+
+  /* phone frame */
+  .phone{width:375px;max-width:100%;margin:0 auto;border:1px solid #3f3f46;border-radius:24px;background:var(--bg);box-shadow:0 24px 60px rgba(0,0,0,.5);overflow:hidden}
+  .phone .notch{height:26px;display:flex;align-items:center;justify-content:center}
+  .phone .notch i{display:block;width:110px;height:16px;border-radius:99px;background:#18181b}
+  .phone .screen{padding:14px 12px 22px}
+  .phone .r,.phone .r.cont{flex-wrap:wrap;row-gap:6px;padding-left:0}
+  .phone .r.cont{gap:8px}
+  .phone .full{flex:1 1 100%}
+  .phone .sel.mob{width:100%;height:36px;justify-content:space-between}
+
+  /* tables */
+  table{width:100%;border-collapse:collapse;margin-top:16px;font-size:13px}
+  th{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint-fg);text-align:left;font-weight:600;padding:8px 12px;border-bottom:1px solid var(--border)}
+  td{padding:10px 12px;border-bottom:1px solid var(--border);color:var(--muted-fg);vertical-align:top}
+  td:first-child{color:var(--fg)}
+  .tablewrap{overflow-x:auto;border:1px solid var(--border);border-radius:10px;background:var(--card);padding:0 4px 4px;margin-top:16px}
+  .tablewrap table{margin-top:0}
+  .tablewrap tr:last-child td{border-bottom:0}
+
+  .note{margin-top:16px;border:1px solid var(--amber-b);background:var(--amber-bg);border-radius:8px;padding:12px 14px;font-size:13px;color:var(--muted-fg)}
+  .note b{color:var(--amber)}
+  .note.green{border-color:var(--emerald-b);background:var(--emerald-bg)}
+  .note.green b{color:var(--emerald)}
+
+  /* mock buttons + textarea (task step edit dialog) */
+  .btn{display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 12px;border-radius:6px;font-size:12px;font-weight:500;border:1px solid transparent}
+  .btn.primary{background:var(--fg);color:var(--bg)}
+  .btn.ghost{background:transparent;color:var(--fg)}
+  .ta{display:block;min-height:60px;padding:6px 8px;border:1px solid var(--border);border-radius:6px;background:transparent;font-size:12px;color:var(--fg);line-height:1.5}
+  .ta.ph{color:var(--faint-fg)}
+
+  /* propagation diagram */
+  .flowrow{display:flex;align-items:stretch;gap:12px;flex-wrap:wrap}
+  .flowcard{border:1px solid var(--border);background:var(--muted-30);border-radius:8px;padding:10px 12px;font-size:12px;min-width:0}
+  .flowcard .fc-t{font-size:10px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;color:var(--faint-fg);margin-bottom:5px}
+  .flowcard.src{border-color:var(--emerald-b);background:var(--emerald-bg)}
+  .flowcard.hit{border-color:var(--emerald-b)}
+  .flowcol{display:flex;flex-direction:column;gap:8px;flex:1 1 240px;min-width:220px}
+  .flowarrow{align-self:center;color:var(--faint-fg);flex:none}
+  .fc-note{font-size:11px;color:var(--muted-fg);margin-top:3px}
+  .fc-note.ok{color:var(--emerald)}
+
+  .kbd{display:inline-block;font-family:ui-monospace,monospace;font-size:11px;border:1px solid #3f3f46;border-bottom-width:2px;border-radius:5px;padding:0 6px;background:var(--popover);color:#e4e4e7}
+  footer{margin-top:72px;padding-top:20px;border-top:1px solid var(--border);font-size:12px;color:var(--faint-fg)}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="hero">
+  <div class="kicker"><span class="dot"></span>Feature Development · Step 2 — UX Design (Rework)</div>
+  <h1>Per-step Model Tiering</h1>
+  <p class="sub">A per-step <strong style="color:var(--fg)">Model tier</strong> hint on workflow templates — <em>Auto / Frontier / Standard / Cheap</em> — that the orchestrator uses to pick which Claude model runs each step's agent — plus a per-task override on any task's still-pending steps. Cheap steps on cheap models stretch Claude usage roughly 2.5×. This document shows the full UI: the shared control, all five mounts (four template editors + the per-task step edit dialog), the read-only badge, edit-propagation rules, mobile, and accessibility.</p>
+  <div class="meta">
+    <span>P2 · Advisory hint — never blocks execution</span>
+    <span>Default: Auto (stored as <code style="border:none;background:none;padding:0">null</code>)</span>
+    <span>5 mounts — 4 template editors + 1 per-task dialog · 2 badge surfaces</span>
+    <span>Dark-first · matches shadcn New York / Zinc</span>
+  </div>
+</header>
+
+<nav class="toc" aria-label="Sections">
+  <a href="#s1"><b>1</b>Control</a>
+  <a href="#s2"><b>2</b>Editor before/after</a>
+  <a href="#s3"><b>3</b>Board badge</a>
+  <a href="#s4"><b>4</b>Task step edit</a>
+  <a href="#s5"><b>5</b>Mobile 375px</a>
+  <a href="#s6"><b>6</b>Tier seeding</a>
+  <a href="#s7"><b>7</b>Editing a tier</a>
+  <a href="#s8"><b>8</b>Interaction &amp; flow</a>
+  <a href="#s9"><b>9</b>Accessibility</a>
+  <a href="#s10"><b>10</b>Rationale</a>
+</nav>
+
+<!-- ══════════════════════ 1. SHARED CONTROL ══════════════════════ -->
+<section id="s1">
+  <h2><span class="num">01</span>The shared <code>ModelTierSelect</code> control</h2>
+  <p>One component, mounted identically in five places — the four template editors plus the task-view step edit dialog (§04). It is a standard shadcn <code>Select</code> — same trigger chrome as every other select in the app — with a two-line option layout (name + gloss) so users never have to recall what a tier means. The helper line is <strong>always visible</strong>, not a tooltip.</p>
+
+  <div class="cols">
+    <div class="frame">
+      <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Closed — default value</span></div>
+      <div class="stage">
+        <label class="lbl" for="m1">Model tier</label>
+        <div class="sel big" role="combobox" aria-expanded="false" id="m1">
+          <span>Auto <span style="color:var(--faint-fg)">(recommended)</span></span>
+          <span class="cue"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span>
+        </div>
+        <p class="helper big" id="tier-help">Advisory — helps stretch your Claude usage; the orchestrator can override.</p>
+      </div>
+    </div>
+
+    <div class="frame">
+      <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Open — listbox, “Standard” highlighted</span></div>
+      <div class="stage">
+        <label class="lbl">Model tier</label>
+        <div class="sel big focus" role="combobox" aria-expanded="true">
+          <span>Auto <span style="color:var(--faint-fg)">(recommended)</span></span>
+          <span class="cue"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span>
+        </div>
+        <div class="listbox" role="listbox" aria-label="Model tier">
+          <div class="opt selected" role="option" aria-selected="true">
+            <div><div class="name">Auto <span style="color:var(--faint-fg);font-weight:400">(recommended)</span></div><div class="gloss">Orchestrator picks the best model</div></div>
+            <span class="chk"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
+          </div>
+          <div class="opt" role="option">
+            <div><div class="name">Frontier</div><div class="gloss">Highest quality — decisions &amp; review</div></div>
+            <span class="chk"></span>
+          </div>
+          <div class="opt active" role="option">
+            <div><div class="name">Standard</div><div class="gloss">Balanced — most build steps</div></div>
+            <span class="chk"></span>
+          </div>
+          <div class="opt" role="option">
+            <div><div class="name">Cheap</div><div class="gloss">Fast &amp; low-cost — mechanical steps</div></div>
+            <span class="chk"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p class="caption"><b>Touch target:</b> the trigger renders <code>h-9</code> (36px) on desktop pointer and <code>min-h-11</code> (44px) under <code>@media (pointer: coarse)</code>; in compact step rows the visual is <code>h-7</code> to match sibling inputs, with the hit area extended to 44px via an invisible <code>before:-inset-y-2</code> overlay on touch devices. <b>Selection cue:</b> check icon + text, never colour alone. Fixed option order (Auto → Frontier → Standard → Cheap) matches the cost gradient, so position is meaningful and learnable.</p>
+</section>
+
+<!-- ══════════════════════ 2. EDITOR BEFORE / AFTER ══════════════════════ -->
+<section id="s2">
+  <h2><span class="num">02</span>Template step editor — before / after</h2>
+  <p>The Create Workflow Template dialog (<code>create-template-dialog.tsx</code>). Each step row currently has three field rows: <em>Title + Role</em>, <em>Description + Approval</em>, <em>Deliverables</em>. The tier control becomes a <strong>fourth row in the same pattern</strong> — 10px inline label, <code>h-7</code> compact select, helper text filling the remaining width. Nothing else moves; existing muscle memory is untouched.</p>
+
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Create Workflow Template — dialog (current → proposed)</span></div>
+    <div class="stage">
+      <div class="dialog">
+        <div class="dlg-title">Create Workflow Template</div>
+
+        <label class="lbl">Template Name</label>
+        <div class="inp h8" style="margin-bottom:14px">Feature Development</div>
+
+        <label class="lbl">Steps</label>
+
+        <div class="tag now" style="margin:2px 0 8px">Before — current step row</div>
+        <div class="steprow">
+          <div class="arrows">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+          </div>
+          <div style="flex:1;min-width:0">
+            <div class="r"><span class="numchip">3</span><span class="flab">Title</span><div class="inp">Implement feature</div><span class="flab">Role</span><div class="sel" style="width:128px"><span style="overflow:hidden;text-overflow:ellipsis">Full Stack Dev…</span><span class="cue"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div></div>
+            <div class="r cont"><span class="flab">Description</span><div class="inp ph">Description (optional)</div><span class="sw"></span><span class="flab">Approval</span></div>
+            <div class="r cont"><span class="flab">Deliverables</span><div class="inp ph">Deliverables (optional) — e.g. HTML mockups, API spec</div></div>
+          </div>
+          <span class="trash"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></span>
+        </div>
+
+        <div class="tag new" style="margin:18px 0 8px">After — Model tier as fourth field row</div>
+        <div class="steprow">
+          <div class="arrows">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+          </div>
+          <div style="flex:1;min-width:0">
+            <div class="r"><span class="numchip">3</span><span class="flab">Title</span><div class="inp">Implement feature</div><span class="flab">Role</span><div class="sel" style="width:128px"><span style="overflow:hidden;text-overflow:ellipsis">Full Stack Dev…</span><span class="cue"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div></div>
+            <div class="r cont"><span class="flab">Description</span><div class="inp ph">Description (optional)</div><span class="sw"></span><span class="flab">Approval</span></div>
+            <div class="r cont"><span class="flab">Deliverables</span><div class="inp ph">Deliverables (optional) — e.g. HTML mockups, API spec</div></div>
+            <div class="annot"><span class="pin">New</span>
+              <div class="r cont" style="margin-top:0">
+                <span class="flab">Model tier</span>
+                <div class="sel" style="width:150px"><span>Auto <span style="color:var(--faint-fg)">(rec.)</span></span><span class="cue"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div>
+                <span class="helper" style="flex:1;min-width:0">Advisory — helps stretch your Claude usage; the orchestrator can override.</span>
+              </div>
+            </div>
+          </div>
+          <span class="trash"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p class="caption"><b>Placement rationale:</b> row 1 (Title + Role) is already full; squeezing a third select there shrinks the title input below usability. A fourth <code>pl-7</code> row keeps the established label-left / control-right rhythm, keeps Role and Tier vertically adjacent (they're read together), and gives the mandatory helper line a natural home in the leftover width.</p>
+
+  <h3>State: a chosen tier (Standard)</h3>
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Step row — tier explicitly set</span></div>
+    <div class="stage">
+      <div class="dialog" style="padding:14px">
+        <div class="steprow">
+          <div class="arrows">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+          </div>
+          <div style="flex:1;min-width:0">
+            <div class="r"><span class="numchip">3</span><span class="flab">Title</span><div class="inp">Implement feature</div><span class="flab">Role</span><div class="sel" style="width:128px"><span style="overflow:hidden;text-overflow:ellipsis">Full Stack Dev…</span><span class="cue"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div></div>
+            <div class="r cont"><span class="flab">Description</span><div class="inp">Build endpoint + UI per the approved design</div><span class="sw on"></span><span class="flab">Approval</span></div>
+            <div class="r cont"><span class="flab">Deliverables</span><div class="inp">PR link, migration file</div></div>
+            <div class="r cont">
+              <span class="flab">Model tier</span>
+              <div class="sel" style="width:150px"><span>Standard</span><span class="cue"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div>
+              <span class="helper" style="flex:1;min-width:0">Advisory — helps stretch your Claude usage; the orchestrator can override.</span>
+            </div>
+          </div>
+          <span class="trash"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h3>State: read-only preview (platform template, “Add Template” dialog)</h3>
+  <p>Where steps are shown read-only — the expanded platform-template card and the template detail panel (<code>StepRow</code>) — the tier renders as the <strong>static badge</strong>, never a disabled select. Auto shows nothing.</p>
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Platform template preview — read-only step list</span></div>
+    <div class="stage">
+      <div class="dialog" style="padding:14px;max-width:460px">
+        <div class="stepcard"><span class="numchip lg">1</span><span class="title">Requirements &amp; acceptance criteria</span><span class="badge tier"><span class="tk">tier:</span>Frontier</span><span class="badge role-b">Business Analyst</span></div>
+        <div class="stepcard"><span class="numchip lg">2</span><span class="title">UX design</span><span class="badge tier"><span class="tk">tier:</span>Frontier</span><span class="badge role-p">UX Designer</span></div>
+        <div class="stepcard"><span class="numchip lg">3</span><span class="title">Implement feature</span><span class="badge tier"><span class="tk">tier:</span>Standard</span><span class="badge role-v">Full Stack Developer</span></div>
+        <div class="stepcard"><span class="numchip lg">4</span><span class="title">Verify build &amp; tests</span><span class="badge tier"><span class="tk">tier:</span>Cheap</span><span class="badge role-c">QA Engineer</span></div>
+      </div>
+    </div>
+  </div>
+  <p class="caption">All four steps ship seeded per the map in §06 — note <b>UX design carries Frontier</b>: design is judgement-heavy work. A step left on <b>Auto (null)</b> renders no badge at all, exactly as on the board (§03, row 1). The tier badge sits immediately left of the role badge in every read-only surface, so the pair always reads “<i>tier, then who</i>”.</p>
+</section>
+
+<!-- ══════════════════════ 3. BOARD BADGE ══════════════════════ -->
+<section id="s3">
+  <h2><span class="num">03</span>Step-card badge on the board</h2>
+  <p>Board task → workflow section (<code>task-workflow-section.tsx</code>). Step rows already carry role + status badges (<code>text-[10px]</code>, outline variant). The tier badge joins the cluster <strong>before the role badge</strong>, monochrome outline (<code>border-zinc-700 text-zinc-200</code>) so it never competes with the colour-coded role and status badges. The literal prefix <code>tier:</code> disambiguates it from a role at a glance. <strong>Auto/null renders no badge at all</strong> — silence is the default, so the badge only appears when someone made a deliberate choice.</p>
+
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Task card → Workflow section — step rows</span></div>
+    <div class="stage">
+      <div style="max-width:560px;margin:0 auto">
+        <div class="stepcard" style="border-color:rgba(16,185,129,.3)">
+          <span class="numchip lg" style="background:rgba(16,185,129,.2);color:var(--emerald)"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
+          <span class="title">UX design</span>
+          <span class="badge role-p">UX Designer</span>
+          <span class="badge st-green"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Done</span>
+          <span class="chev"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span>
+        </div>
+        <div class="stepcard">
+          <span class="numchip lg">3</span>
+          <span class="title">Implement feature</span>
+          <span class="badge tier" aria-label="Model tier: Standard"><span class="tk">tier:</span>Standard</span>
+          <span class="badge role-v">Full Stack Developer</span>
+          <span class="badge st-zinc">Pending</span>
+          <span class="chev"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span>
+        </div>
+        <div class="stepcard">
+          <span class="numchip lg">4</span>
+          <span class="title">Verify build &amp; tests</span>
+          <span class="badge tier" aria-label="Model tier: Cheap"><span class="tk">tier:</span>Cheap</span>
+          <span class="badge role-c">QA Engineer</span>
+          <span class="badge st-zinc">Pending</span>
+          <span class="chev"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span>
+        </div>
+      </div>
+      <p class="caption" style="max-width:560px;margin:12px auto 0">Row 1 (“UX design”) was set back to <b>Auto</b> for this task (a per-task override — §04, §07) → no tier badge; the row is identical to today. On narrow cards the tier badge is the first badge to truncate-collapse into the step-detail dialog (title keeps priority) — it is informational, and the full cluster is always available one click away.</p>
+    </div>
+  </div>
+
+  <h3>Step detail dialog — header badge cluster</h3>
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Step Detail — header (step-detail-dialog.tsx)</span></div>
+    <div class="stage">
+      <div class="dialog" style="max-width:448px;padding:20px 20px 24px">
+        <div style="display:flex;align-items:center;gap:12px">
+          <span class="numchip" style="height:32px;width:32px;font-size:14px;font-weight:700">3</span>
+          <div style="min-width:0;flex:1">
+            <p style="font-size:15px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">Implement feature</p>
+            <div style="display:flex;align-items:center;gap:8px;margin-top:4px;flex-wrap:wrap">
+              <span class="badge st-zinc">Pending</span>
+              <span class="badge">Full Stack Developer</span>
+              <span class="badge tier" aria-label="Model tier: Standard"><span class="tk">tier:</span>Standard</span>
+              <span style="display:inline-flex;align-items:center;gap:6px;font-size:11px;color:var(--muted-fg)"><span style="width:16px;height:16px;border-radius:99px;background:var(--violet-bg);color:var(--violet);display:inline-flex;align-items:center;justify-content:center;font-size:8px;font-weight:700">D</span>DevBot</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p class="caption">Header order: <b>status → role → tier → agent</b> (status and role already exist in this order at <code>step-detail-dialog.tsx:390-402</code>; tier slots after role). Hovering/focusing the tier badge shows a tooltip: “Advisory model tier for this step. The orchestrator may override.” On <b>pending</b> steps this dialog's pencil icon opens edit mode, where the tier becomes editable per task — §04.</p>
+</section>
+
+<!-- ══════════════════════ 4. TASK-VIEW STEP EDIT DIALOG ══════════════════════ -->
+<section id="s4">
+  <h2><span class="num">04</span>Task view — step edit dialog (per-task override)</h2>
+  <p>The fifth mount of the shared control. In a task's Workflow section, opening a step and pressing the pencil icon (shown on <strong>pending</strong> steps only) flips <code>step-detail-dialog.tsx</code> into edit mode: stacked full-width fields — Title, Description, Agent Role, Expected Deliverables, approval toggle — with Save / Cancel and Comments below. The tier select is inserted <strong>between Agent Role and Expected Deliverables</strong>: it is the same <code>ModelTierSelect</code> — same four options, same glosses, same always-visible helper — rendered full-width in this dialog's stacked layout rather than the compact template-editor row.</p>
+
+  <div class="cols">
+    <div class="frame">
+      <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Step Detail — edit mode, tier at Auto (default)</span></div>
+      <div class="stage">
+        <div class="dialog" style="max-width:420px;padding:20px">
+          <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px">
+            <span class="numchip" style="height:32px;width:32px;font-size:14px;font-weight:700">3</span>
+            <div style="min-width:0;flex:1">
+              <p style="font-size:15px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">Implement feature</p>
+              <div style="display:flex;align-items:center;gap:8px;margin-top:4px;flex-wrap:wrap">
+                <span class="badge st-zinc">Pending</span>
+                <span class="badge">Full Stack Developer</span>
+              </div>
+            </div>
+          </div>
+
+          <label class="lbl">Title</label>
+          <div class="inp h8" style="margin-bottom:12px">Implement feature</div>
+
+          <label class="lbl">Description</label>
+          <div class="ta" style="margin-bottom:12px">Build endpoint + UI per the approved design</div>
+
+          <label class="lbl">Agent Role</label>
+          <div class="sel" style="width:100%;height:32px;font-size:13px;display:flex"><span>Full Stack Developer</span><span class="cue"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div>
+          <p class="helper" style="font-size:11px;margin:5px 0 12px">Matched against agents when template is applied</p>
+
+          <div class="annot" style="margin:0 0 12px"><span class="pin">New</span>
+            <label class="lbl">Model tier</label>
+            <div class="sel" style="width:100%;height:32px;font-size:13px;display:flex"><span>Auto <span style="color:var(--faint-fg)">(recommended)</span></span><span class="cue"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div>
+            <p class="helper" style="font-size:11px;margin-top:5px">Advisory — helps stretch your Claude usage; the orchestrator can override.</p>
+          </div>
+
+          <label class="lbl">Expected Deliverables</label>
+          <div class="inp h8 ph" style="margin-bottom:12px">Comma-separated, e.g. Design doc, API schema</div>
+
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:14px">
+            <span class="sw"></span><span class="lbl" style="margin:0">Requires human approval</span>
+          </div>
+
+          <div style="display:flex;gap:8px">
+            <span class="btn primary">Save</span>
+            <span class="btn ghost">Cancel</span>
+          </div>
+
+          <div style="border-top:1px solid var(--border);margin-top:16px;padding-top:12px;display:flex;align-items:center;gap:8px;font-size:12px;color:var(--muted-fg)">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+            Comments (2)
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="frame">
+      <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Edit mode — tier chosen (Frontier) · cropped</span></div>
+      <div class="stage">
+        <div class="dialog" style="max-width:420px;padding:20px">
+          <p style="font-size:11px;color:var(--faint-fg);text-align:center;margin-bottom:12px">⋯ Title · Description ⋯</p>
+
+          <label class="lbl">Agent Role</label>
+          <div class="sel" style="width:100%;height:32px;font-size:13px;display:flex"><span>UX Designer</span><span class="cue"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div>
+          <p class="helper" style="font-size:11px;margin:5px 0 12px">Matched against agents when template is applied</p>
+
+          <label class="lbl">Model tier</label>
+          <div class="sel" style="width:100%;height:32px;font-size:13px;display:flex"><span>Frontier</span><span class="cue"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div>
+          <p class="helper" style="font-size:11px;margin:5px 0 12px">Advisory — helps stretch your Claude usage; the orchestrator can override.</p>
+
+          <label class="lbl">Expected Deliverables</label>
+          <div class="inp h8" style="margin-bottom:12px">HTML mockups, design doc</div>
+
+          <p style="font-size:11px;color:var(--faint-fg);text-align:center;margin-top:4px">⋯ Approval toggle · Save / Cancel · Comments ⋯</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p class="caption"><b>Semantics — per-task override:</b> changes made here apply to <b>this task's step only, not the template</b>. <b>Persistence:</b> the existing <code>update_step</code> server action / MCP tool gains <code>model_tier</code> (<code>frontier</code> / <code>standard</code> / <code>cheap</code> or <code>null</code> for Auto), accepted on <b>pending steps only</b> — the same guard the rest of this edit form already has. Field order, label sizes (<code>text-xs</code>), input heights, and helper styling all match the dialog's current edit mode; the tier field is the only addition.</p>
+
+  <h3>State: in-progress / completed steps — no select, badge only</h3>
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Step Detail — step in progress (read-only tier)</span></div>
+    <div class="stage">
+      <div class="dialog" style="max-width:420px;padding:20px">
+        <div style="display:flex;align-items:center;gap:12px">
+          <span class="numchip" style="height:32px;width:32px;font-size:14px;font-weight:700;background:var(--blue-bg);color:var(--blue)">3</span>
+          <div style="min-width:0;flex:1">
+            <p style="font-size:15px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">Implement feature</p>
+            <div style="display:flex;align-items:center;gap:8px;margin-top:4px;flex-wrap:wrap">
+              <span class="badge st-blue">In Progress</span>
+              <span class="badge">Full Stack Developer</span>
+              <span class="badge tier" aria-label="Model tier: Standard"><span class="tk">tier:</span>Standard</span>
+              <span style="display:inline-flex;align-items:center;gap:6px;font-size:11px;color:var(--muted-fg)"><span style="width:16px;height:16px;border-radius:99px;background:var(--violet-bg);color:var(--violet);display:inline-flex;align-items:center;justify-content:center;font-size:8px;font-weight:700">D</span>DevBot</span>
+            </div>
+          </div>
+        </div>
+        <p style="font-size:13px;color:var(--muted-fg);margin-top:14px">Build endpoint + UI per the approved design</p>
+      </div>
+    </div>
+  </div>
+  <p class="caption">Once a step is <b>in progress, completed, failed, or awaiting approval</b>, the pencil icon is not rendered (today's behaviour — edit is pending-only), so the tier select never appears; the tier surfaces only as the read-only <code>tier:</code> badge in the header. No disabled control, no dead-looking form — the absence of the pencil already communicates “this step has started” everywhere in the dialog.</p>
+</section>
+
+<!-- ══════════════════════ 5. MOBILE 375px ══════════════════════ -->
+<section id="s5">
+  <h2><span class="num">05</span>Mobile — 375px</h2>
+  <p>Inside the dialog at 375px the step row's flex rows gain <code>flex-wrap</code>. Title and Role already share a line uncomfortably at this width; with tier added we let each control take the full row: labels sit above their control, selects go full-width (<code>w-full</code>), and the helper wraps beneath the select. Touch targets grow to 44px (<code>min-h-11</code> via <code>pointer: coarse</code>). Nothing overflows horizontally.</p>
+
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">iPhone SE / small Android — 375 × content</span></div>
+    <div class="stage">
+      <div class="phone">
+        <div class="notch"><i></i></div>
+        <div class="screen">
+          <div class="dlg-title" style="font-size:15px">Create Workflow Template</div>
+          <label class="lbl">Steps</label>
+          <div class="steprow" style="flex-direction:column;gap:8px">
+            <div style="display:flex;align-items:center;gap:8px;width:100%">
+              <span class="numchip">3</span>
+              <span class="flab" style="font-size:11px">Step 3</span>
+              <span style="flex:1"></span>
+              <span class="arrows" style="flex-direction:row;padding-top:0;gap:6px">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+              </span>
+              <span class="trash" style="margin-top:0;padding:2px"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></span>
+            </div>
+            <div class="full"><span class="flab">Title</span><div class="inp" style="height:36px;margin-top:4px">Implement feature</div></div>
+            <div class="full"><span class="flab">Role</span><div class="sel mob" style="margin-top:4px;display:flex"><span>Full Stack Developer</span><span class="cue"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div></div>
+            <div class="full"><span class="flab">Description</span><div class="inp ph" style="height:36px;margin-top:4px">Description (optional)</div></div>
+            <div class="full" style="display:flex;align-items:center;gap:8px"><span class="sw on"></span><span class="flab">Approval required</span></div>
+            <div class="full"><span class="flab">Deliverables</span><div class="inp ph" style="height:36px;margin-top:4px">Deliverables (optional)</div></div>
+            <div class="annot" style="margin:0;width:100%"><span class="pin">New</span>
+              <div class="full"><span class="flab">Model tier</span>
+                <div class="sel mob" style="margin-top:4px;display:flex"><span>Standard</span><span class="cue"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg></span></div>
+                <p class="helper" style="margin-top:5px">Advisory — helps stretch your Claude usage; the orchestrator can override.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p class="caption"><b>Breakpoint behaviour:</b> the stacked layout applies below <code>sm</code> (640px) via the same responsive classes the dialog already uses. The 375px frame above is worst-case; at 640px+ the compact four-row desktop layout from §02 applies. The select popover renders as a full-width sheet-style dropdown anchored to the trigger — options keep their two-line name+gloss layout, each option row ≥44px.</p>
+</section>
+
+<!-- ══════════════════════ 6. SEEDING TABLE ══════════════════════ -->
+<section id="s6">
+  <h2><span class="num">06</span>Default role → tier seeding</h2>
+  <p>When platform library templates ship tier values, defaults come from the step's role using the same regex families as <code>getRoleBadgeClasses</code>. Seeding is a one-time fill of the select — the user can change any value; it never overwrites an explicit choice. <strong>Scope (v1): platform library templates only.</strong> A “suggest tiers” affordance for user-authored templates was considered and cut in Design Review as over-reach — user templates simply default every step to Auto.</p>
+
+  <div class="tablewrap">
+    <table>
+      <thead><tr><th>Role family</th><th>Example roles</th><th>Seeded tier</th><th>Why</th></tr></thead>
+      <tbody>
+        <tr>
+          <td><span class="badge role-b">Product / Analysis</span></td>
+          <td>Product Owner, Business Analyst, PM — plus any step gated by <em>review</em> / <em>approval</em> / decision-making</td>
+          <td><span class="badge tier"><span class="tk">tier:</span>Frontier</span></td>
+          <td>Judgement-heavy; errors compound downstream</td>
+        </tr>
+        <tr>
+          <td><span class="badge role-p">Design</span></td>
+          <td>UX Designer — plus design and design-review steps</td>
+          <td><span class="badge tier"><span class="tk">tier:</span>Frontier</span></td>
+          <td>Design work is judgement-heavy; a weak design compounds through every build step after it</td>
+        </tr>
+        <tr>
+          <td><span class="badge role-v">Build</span></td>
+          <td>Full Stack Developer, Front End Developer, Back End Developer (build steps)</td>
+          <td><span class="badge tier"><span class="tk">tier:</span>Standard</span></td>
+          <td>Balanced quality/cost for most implementation work</td>
+        </tr>
+        <tr>
+          <td><span class="badge role-c">QA / Mechanical</span></td>
+          <td>QA Engineer (verify steps), lint/format passes, changelog &amp; docs housekeeping</td>
+          <td><span class="badge tier"><span class="tk">tier:</span>Cheap</span></td>
+          <td>Deterministic, checkable work — biggest usage win</td>
+        </tr>
+        <tr>
+          <td><span class="badge st-zinc">Unknown / custom</span></td>
+          <td>Any role that matches no family</td>
+          <td><span class="badge st-zinc" style="background:transparent">Auto (no badge)</span></td>
+          <td>Never guess — let the orchestrator decide</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="note green"><b>Usage story:</b> a typical 4-step Feature Development run seeded this way sends two steps to Frontier (requirements, UX design), one to Standard, one to Cheap — the judgement-heavy steps keep the best model while build and verify still run markedly more workflow cycles per Claude usage window than everything on Frontier.</div>
+</section>
+
+<!-- ══════════════════════ 7. EDIT PROPAGATION ══════════════════════ -->
+<section id="s7">
+  <h2><span class="num">07</span>What happens when you edit a tier</h2>
+  <p>Two edit surfaces, two blast radii. The rules are the same ones role and description edits already follow — no new mental model to learn.</p>
+
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Propagation — template edit vs. per-task edit</span></div>
+    <div class="stage">
+      <div class="flowrow">
+        <div class="flowcol">
+          <div class="flowcard src">
+            <div class="fc-t">Edit on a template step</div>
+            Step 3 · Model tier: <span class="badge tier"><span class="tk">tier:</span>Standard</span> → <span class="badge tier"><span class="tk">tier:</span>Frontier</span>
+            <div class="fc-note">via <code>propagateTemplateEdits</code> — same path as role edits</div>
+          </div>
+          <span class="flowarrow"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="m19 12-7 7-7-7"/></svg></span>
+          <div class="flowcard hit">Task A · step 3 <span class="badge st-zinc">Pending</span><div class="fc-note ok">✓ updated → Frontier</div></div>
+          <div class="flowcard">Task B · step 3 <span class="badge st-blue">In Progress</span><div class="fc-note">untouched — never rewritten</div></div>
+          <div class="flowcard">Task C · step 3 <span class="badge st-green">Completed</span><div class="fc-note">untouched — never rewritten</div></div>
+        </div>
+        <div class="flowcol">
+          <div class="flowcard src">
+            <div class="fc-t">Edit on a task's step (§04 dialog)</div>
+            Task A · step 3 · Model tier → <span class="badge tier"><span class="tk">tier:</span>Cheap</span>
+            <div class="fc-note">per-task override</div>
+          </div>
+          <span class="flowarrow"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="m19 12-7 7-7-7"/></svg></span>
+          <div class="flowcard hit">Task A · step 3<div class="fc-note ok">✓ this task's step only</div></div>
+          <div class="flowcard">The template<div class="fc-note">untouched</div></div>
+          <div class="flowcard">Every other task<div class="fc-note">untouched</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <ul class="notes">
+    <li><strong>Edit on a template step</strong> flows through to workflows already attached to tasks — but <strong>only to steps still pending</strong>, on the same propagation path role and description edits use today (<code>propagateTemplateEdits</code>). In-progress, completed, failed, and awaiting-approval steps are never rewritten: what ran is what history shows.</li>
+    <li><strong>Edit on a task's step</strong> (the §04 dialog) is a <strong>per-task override</strong> — it changes that one task's step and nothing else. The template is never modified from the task view.</li>
+    <li><strong>Overrides vs. later template edits — the simple rule:</strong> template edits propagate to pending steps exactly as today, <strong>last write wins</strong> — consistent with how role edits behave. So if you override a tier on a still-pending step and someone later edits that step on the template, the template value replaces your override. Once the step starts, nothing rewrites it either way. No merge logic, no “locked” flags — one rule, stated plainly.</li>
+  </ul>
+</section>
+
+<!-- ══════════════════════ 8. INTERACTION & FLOW ══════════════════════ -->
+<section id="s8">
+  <h2><span class="num">08</span>Interaction &amp; flow notes</h2>
+
+  <h3>Where the control appears — one shared component, five mounts</h3>
+  <div class="tablewrap">
+    <table>
+      <thead><tr><th>Surface</th><th>File</th><th>Mount point</th></tr></thead>
+      <tbody>
+        <tr><td>Create Workflow Template dialog</td><td><code>src/components/board/create-template-dialog.tsx</code></td><td>Fourth <code>pl-7</code> row of each step row (after Deliverables, ~L295)</td></tr>
+        <tr><td>Add Template → “Create New” tab</td><td><code>src/components/board/add-template-dialog.tsx</code></td><td>Same fourth row inside <code>renderCreateForm()</code> (~L812)</td></tr>
+        <tr><td>Workflows sidebar — inline edit</td><td><code>src/components/board/workflows-tab.tsx</code></td><td>Same fourth row in <code>StepEditor</code> (~L243); read-only <code>StepRow</code> gains the static badge</td></tr>
+        <tr><td>Admin platform library editor</td><td><code>src/components/admin/template-editor-dialog.tsx</code></td><td>Same fourth row (~L324) — identical layout, so platform authors see what users see</td></tr>
+        <tr><td>Task view — step edit dialog (per-task override, §04)</td><td><code>src/components/board/step-detail-dialog.tsx</code></td><td>Full-width field between Agent Role and Expected Deliverables (~L490) — pending steps only; edit saves via <code>update_step</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p>The four template editors are copies of the same compact-row layout today; the tier row is added identically in each. The step-detail dialog is the one stacked-layout mount (§04). The control itself lives once in <code>src/components/ui/model-tier-select.tsx</code> and adapts to both layouts.</p>
+
+  <h3>Keyboard &amp; focus order</h3>
+  <ul class="notes">
+    <li><strong>Tab order per step row:</strong> move-up → move-down → Title → Role → Description → Approval switch → Deliverables → <strong>Model tier</strong> → Delete step. The tier select is appended, so existing users' tab rhythm is unchanged.</li>
+    <li><strong>Open:</strong> <span class="kbd">Enter</span> / <span class="kbd">Space</span> / <span class="kbd">↓</span> on the trigger. <strong>Navigate:</strong> <span class="kbd">↑</span><span class="kbd">↓</span>; type-ahead by first letter (<span class="kbd">c</span> → Cheap). <strong>Commit:</strong> <span class="kbd">Enter</span>. <strong>Dismiss:</strong> <span class="kbd">Esc</span> restores prior value and returns focus to the trigger (Radix Select default behaviour — no custom key handling).</li>
+    <li><strong>Board badge:</strong> not focusable in the step row (whole row is the button, as today); in the step-detail header its tooltip is reachable by keyboard focus per the existing <code>Tooltip</code> pattern.</li>
+  </ul>
+
+  <h3>States</h3>
+  <ul class="notes">
+    <li><strong>Default / empty:</strong> new steps start at <em>Auto</em>; stored as <code>null</code> (no migration back-fill needed; absent key = Auto). No badge anywhere while Auto.</li>
+    <li><strong>Error — invalid value from API:</strong> if a template's <code>model_tier</code> is not one of the four values (hand-edited JSON, older client), the select renders <em>Auto</em> and behaves normally. On save, the normalised value is written and a single toast explains: <em>“Model tier reset to Auto — the saved value wasn't recognised.”</em> Never a blocking validation error; the field is advisory.</li>
+    <li><strong>Loading:</strong> template editors receive steps synchronously from already-loaded template JSON, so the select never shows an indeterminate state. In the workflows sidebar detail panel, the existing step-list skeleton simply gains a third 40px pill placeholder where the tier badge will sit.</li>
+    <li><strong>Read-only contexts</strong> (platform preview, read-only board): static badge only — a disabled select would imply an action that isn't available and would need adjacent explanation; the badge doesn't.</li>
+    <li><strong>Partial:</strong> mixed templates (some steps tiered, some Auto) are the expected steady state — no warning, no nudge to “complete” tiering.</li>
+  </ul>
+</section>
+
+<!-- ══════════════════════ 9. ACCESSIBILITY ══════════════════════ -->
+<section id="s9">
+  <h2><span class="num">09</span>Accessibility (WCAG 2.1 AA)</h2>
+  <div class="tablewrap">
+    <table>
+      <thead><tr><th>Element</th><th>Colours (dark)</th><th>Contrast</th><th>Requirement</th></tr></thead>
+      <tbody>
+        <tr><td>Select value / option names</td><td>zinc-50 <code>#fafafa</code> on zinc-950</td><td>≈ 18.6 : 1</td><td>4.5 : 1 ✓</td></tr>
+        <tr><td>Helper line, field labels, glosses</td><td>zinc-400 <code>#a1a1aa</code> on zinc-950 / zinc-900</td><td>≈ 7.6 : 1 / 7.0 : 1</td><td>4.5 : 1 ✓</td></tr>
+        <tr><td>Tier badge text</td><td>zinc-200 <code>#e4e4e7</code> on zinc-950, border zinc-700</td><td>≈ 15.4 : 1</td><td>4.5 : 1 ✓</td></tr>
+        <tr><td>Focus ring</td><td>zinc-300 <code>#d4d4d8</code> ring on zinc-950</td><td>≈ 13 : 1</td><td>3 : 1 (non-text) ✓</td></tr>
+        <tr><td>Role badges (existing)</td><td>e.g. violet-400 on zinc-950</td><td>≈ 7.3 : 1</td><td>4.5 : 1 ✓ (unchanged)</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <ul class="notes">
+    <li><strong>Visible label:</strong> “Model tier” is a real <code>&lt;Label htmlFor&gt;</code> in the full control and a visible 10px inline label in compact rows (same as Title/Role/Deliverables today) — never placeholder-only.</li>
+    <li><strong>Programmatic wiring:</strong> trigger has <code>aria-describedby</code> → the helper line; listbox options expose name + gloss as the accessible name/description; selection is announced via <code>aria-selected</code>.</li>
+    <li><strong>Badge screen-reader text:</strong> <code>aria-label="Model tier: Standard"</code> on the badge, so “Standard” is never announced as a bare mystery word next to the role.</li>
+    <li><strong>Keyboard:</strong> fully operable (Radix Select) — see §08. No pointer-only or hover-only behaviour: the badge is always rendered, the helper is always visible, tooltips are focus-triggered too.</li>
+    <li><strong>No colour-only meaning:</strong> the tier is conveyed by the word itself (badge and select value). Tier badges are deliberately monochrome — colour is reserved for role/status where it already carries redundant-coded meaning.</li>
+    <li><strong>Touch:</strong> 44px minimum target on coarse pointers for the trigger and every option row (§01, §05).</li>
+  </ul>
+  <div class="note"><b>Light theme:</b> all tokens are semantic (<code>border-border</code>, <code>text-muted-foreground</code>, <code>bg-muted/20</code>…), so the light variant is automatic: white background, zinc-200 borders, zinc-950 text, tier badge <code>border-zinc-300 text-zinc-700</code> (≈ 6.4 : 1 on white). No bespoke light styles are needed beyond the badge border token.</div>
+</section>
+
+<!-- ══════════════════════ 10. RATIONALE ══════════════════════ -->
+<section id="s10">
+  <h2><span class="num">10</span>Design rationale</h2>
+  <p>Four options is the ceiling for a scan-and-pick decision (<strong>Hick's law</strong>) — each option carries a one-line gloss so choosing takes seconds and requires no documentation. The control deliberately mirrors the existing Role select in the same step row (<strong>Jakob's law</strong> — internal consistency): same compact height, same inline-label pattern, same popover chrome, so it reads as a native part of a form users already know. Downstream, the <code>tier:</code> badge on step cards means the choice is visible where its consequence plays out (<strong>recognition over recall</strong>) — nobody has to reopen the template editor to remember what a step will cost — while rendering nothing for Auto keeps the default state exactly as quiet as today. Because the whole feature is advisory, the UI never blocks, warns, or demands completeness: it is a hint you can sprinkle onto expensive workflows and ignore everywhere else.</p>
+  <footer>P2 · Per-step Model Tiering — UX Design (Step 2, rework) · VibeCodes · Prepared for founder review · docs/spikes/p2-model-tier-design.html</footer>
+</section>
+
+</div>
+</body>
+</html>

--- a/docs/spikes/p2-ux-assessment.html
+++ b/docs/spikes/p2-ux-assessment.html
@@ -1,0 +1,187 @@
+<!-- P2 UX Assessment: Per-step model tiering (model_tier on workflow steps) -->
+<title>UX Assessment — Per-step model tiering (No UI Surface)</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    font: 15px/1.6 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    max-width: 780px; margin: 2.5rem auto; padding: 0 1.25rem;
+    color: #1a1a1a; background: #fff;
+  }
+  h1 { font-size: 1.5rem; line-height: 1.25; margin: 0 0 .25rem; }
+  h2 { font-size: 1.05rem; margin: 2rem 0 .5rem; }
+  h3 { font-size: .95rem; margin: 1.25rem 0 .35rem; }
+  .sub { color: #666; margin: 0 0 1.5rem; font-size: .9rem; }
+  .verdict {
+    border-left: 3px solid #10b981; padding: .75rem 1rem; margin: 1.25rem 0;
+    background: rgba(16,185,129,.08); border-radius: 0 6px 6px 0;
+  }
+  .verdict strong { color: #0f9d6b; }
+  .future {
+    border-left: 3px solid #6366f1; padding: .75rem 1rem; margin: 1.25rem 0;
+    background: rgba(99,102,241,.09); border-radius: 0 6px 6px 0;
+  }
+  .future strong { color: #4f46e5; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .85em;
+    background: rgba(127,127,127,.15); padding: .1em .35em; border-radius: 4px; }
+  table { border-collapse: collapse; width: 100%; margin: .75rem 0; font-size: .9rem; }
+  th, td { text-align: left; padding: .5rem .6rem; border-bottom: 1px solid rgba(127,127,127,.25); vertical-align: top; }
+  th { font-weight: 600; color: #444; }
+  td:first-child code { white-space: nowrap; }
+  ul { margin: .4rem 0; padding-left: 1.2rem; }
+  li { margin: .3rem 0; }
+  .badge { display: inline-block; font: 600 .72rem/1 ui-monospace, monospace;
+    padding: .25em .5em; border-radius: 5px; letter-spacing: .02em;
+    background: rgba(99,102,241,.16); color: #4f46e5; border: 1px solid rgba(99,102,241,.35); }
+  pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82rem;
+    line-height: 1.45; background: rgba(127,127,127,.10); border: 1px solid rgba(127,127,127,.22);
+    border-radius: 8px; padding: 1rem; overflow-x: auto; margin: .75rem 0; }
+  .tag { display: inline-block; font: 600 .7rem/1 system-ui, sans-serif; text-transform: uppercase;
+    letter-spacing: .04em; padding: .3em .55em; border-radius: 5px; vertical-align: middle;
+    background: rgba(245,158,11,.16); color: #b45309; border: 1px solid rgba(245,158,11,.4); }
+  footer { margin-top: 2.5rem; padding-top: 1rem; border-top: 1px solid rgba(127,127,127,.25);
+    color: #777; font-size: .82rem; }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e6e6e6; background: #111; }
+    h1 { color: #f5f5f5; }
+    .sub, th { color: #9aa0a6; }
+    .verdict strong { color: #34d399; }
+    .future strong { color: #a5b4fc; }
+    .badge { background: rgba(129,140,248,.20); color: #c7d2fe; border-color: rgba(129,140,248,.45); }
+    .tag { background: rgba(245,158,11,.18); color: #fcd34d; border-color: rgba(245,158,11,.45); }
+    footer { color: #888; }
+  }
+</style>
+
+<h1>UX Assessment — No UI Surface</h1>
+<p class="sub">Step 2 (UX Design) · P2: Per-step model tiering — add <code>model_tier</code> to workflow steps, surfaced in <code>claim_next_step</code></p>
+
+<div class="verdict">
+  <strong>Designer's verdict: no UI deliverable in this slice.</strong> This is a backend/data change —
+  a nullable <code>model_tier</code> (<code>frontier</code> / <code>standard</code> / <code>cheap</code>) added to
+  workflow steps, threaded template&nbsp;→&nbsp;step, and echoed back in the <code>claim_next_step</code> MCP
+  response so the orchestrator spawns each persona subagent on the recommended model. Per Requirements <strong>NG6</strong>,
+  human-authoring UI is explicitly out of scope: authoring is seed-SQL + API pass-through only. The correct UX
+  outcome is that this change is <em>invisible</em> to end users. No view, control, or copy changes.
+</div>
+
+<h2>1. There is no user-facing surface</h2>
+<p>
+  All existing rows default to <code>model_tier = null</code>, and <code>null</code> means "orchestrator decides"
+  — identical behaviour to today. The tier is a hint carried on the data layer and consumed by the orchestrating
+  agent; it never renders. The board, the template detail view, and the workflow-suggestion panel all draw the
+  same pixels they draw now. Do not invent UI where none is needed.
+</p>
+
+<h2>2. Non-regression checklist (the real deliverable)</h2>
+<p>
+  Because the change is invisible <em>by design</em>, sign-off is a non-regression assertion. For every step
+  where <code>model_tier</code> is null — which is <strong>all existing data</strong> — these surfaces must render
+  and behave pixel- and copy-identically to today:
+</p>
+
+<table>
+  <thead>
+    <tr><th>Surface</th><th>Component</th><th>Must remain identical</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Workflow step cards</td>
+      <td><code>task-workflow-section.tsx</code></td>
+      <td>Same step rows, order, status pills, claim/complete controls — no new tier badge, column, or icon</td>
+    </tr>
+    <tr>
+      <td>Step detail</td>
+      <td><code>step-detail-dialog.tsx</code></td>
+      <td>Same fields, comments, agent identity, and rework controls — no <code>model_tier</code> field shown or editable</td>
+    </tr>
+    <tr>
+      <td>Active agent / model display</td>
+      <td>step + claim UI (if any)</td>
+      <td>Whatever "who's running this" affordance exists today is unchanged — no model-name or tier surfaced</td>
+    </tr>
+    <tr>
+      <td>Template detail view</td>
+      <td><code>workflows-tab.tsx</code>, template dialogs</td>
+      <td>Same step list and metadata — no tier picker, no tier column in the template editor</td>
+    </tr>
+    <tr>
+      <td>Suggestion panel</td>
+      <td><code>workflow-suggestion-panel.tsx</code></td>
+      <td>Same match/keep/replace copy and controls — tier is never part of a suggestion</td>
+    </tr>
+    <tr>
+      <td>Apply / resync template</td>
+      <td><code>apply_workflow_template</code>, resync</td>
+      <td>Copies <code>model_tier</code> through silently; a null-tier template produces null-tier steps as before</td>
+    </tr>
+  </tbody>
+</table>
+
+<p style="font-size:.9rem;color:#888;">
+  Acceptance: a user with only existing (null-tier) workflows sees zero difference anywhere in the product.
+  The only observable effect of a <em>non-null</em> tier is which model the orchestrator picks — a backend concern,
+  not a rendered one.
+</p>
+
+<h2>3. Fast-follow: per-step model-tier authoring <span class="tag">Out of scope · proposed</span></h2>
+
+<div class="future">
+  <strong>Future slice, not this one.</strong> Requirements NG6 deliberately deferred human authoring. Capturing the
+  design here so the opportunity isn't lost. <em>None of the below ships in P2.</em> Once tiers are proven useful via
+  seed-SQL, a follow-up could let humans set a per-step tier in the template step editor — turning an invisible
+  backend hint into an intentional, cost-aware authoring control.
+</div>
+
+<h3>Where it lives</h3>
+<p>
+  A single compact <code>&lt;select&gt;</code> on each <strong>template step editor row</strong> (the natural authoring
+  home — where step name, persona/agent, and human-check already live). Not a modal; inline with the row, consistent
+  with the rest of the template editor. Recognition over recall: the resolved tier also appears as a subtle read-only
+  badge on the <strong>workflow step card</strong> so authored intent is visible without opening the editor.
+</p>
+
+<h3>The control (Hick's-law-minimal: 4 options)</h3>
+<pre>  Template step editor — row control
+  ┌──────────────────────────────────────────────────────────┐
+  │  Step 3 · Implementation            Persona: [ Builder ▾] │
+  │                                                          │
+  │  Model tier  ┌───────────────┐                           │
+  │              │ Auto        ▾ │   ← default = null        │
+  │              └───────────────┘                           │
+  │                • Auto      (orchestrator decides)         │
+  │                • Frontier  (hardest reasoning)            │
+  │                • Standard  (most steps)                   │
+  │                • Cheap     (simple / mechanical)          │
+  │                                                          │
+  │  ⓘ Auto lets the orchestrator choose; cheaper tiers      │
+  │     save your Claude usage on simpler steps.             │
+  └──────────────────────────────────────────────────────────┘
+
+  Workflow step card — resolved badge (read-only)
+  ┌──────────────────────────────────────────────────────────┐
+  │  ● Step 3 · Implementation      In progress              │
+  │    Builder                        [ tier: Standard ]      │
+  └──────────────────────────────────────────────────────────┘
+  (Auto/null renders NO badge — keeps default cards clean.)</pre>
+
+<h3>Design rules it must honour</h3>
+<ul>
+  <li><strong>Auto = null = default:</strong> the first option is "Auto", maps to <code>model_tier = null</code>,
+      preserving today's "orchestrator decides" behaviour. Authoring is purely additive.</li>
+  <li><strong>Four options only</strong> (Hick's law): Auto + three abstract tiers. Abstract tiers (not raw model
+      ids) keep the choice durable as underlying models change.</li>
+  <li><strong>Inline helper, always visible:</strong> "Auto lets the orchestrator choose; cheaper tiers save your
+      Claude usage on simpler steps." Explains the value without a tooltip-only dependency.</li>
+  <li><strong>Recognition over recall:</strong> resolved tier shows as a subtle badge on the step card; a null/Auto
+      step shows no badge, so existing boards stay visually quiet.</li>
+  <li><strong>Never colour alone (WCAG 2.1 AA):</strong> the badge always carries the tier word
+      (<code>tier: Standard</code>), not just a hue; the select uses text labels, not swatches.</li>
+  <li><strong>No hover-only actions, no modal:</strong> the control is a persistently visible inline select.</li>
+  <li><strong>Graceful degradation:</strong> unknown/legacy tier values fall back to Auto rendering — never an error state.</li>
+</ul>
+
+<footer>
+  Sign-off: no new UI in P2. Protect the six surfaces in the non-regression checklist (all identical for null-tier
+  steps, i.e. all existing data). The per-step tier-authoring select + card badge is a deliberate, captured
+  fast-follow — <strong>out of scope for this slice</strong>. Feeds Step 3 (Design Review / human approval).
+</footer>

--- a/mcp-server/src/register-tools.ts
+++ b/mcp-server/src/register-tools.ts
@@ -1088,7 +1088,7 @@ export function registerTools(
 
   server.tool(
     "create_workflow_template",
-    "Create a workflow template with ordered steps. Each step has a title, role (BA, UX, Dev, QA, Human), and optional approval gate.",
+    "Create a workflow template with ordered steps. Each step has a title, role (BA, UX, Dev, QA, Human), an optional approval gate, and an optional advisory model_tier hint (frontier | standard | cheap; omit for Auto) telling the orchestrator which model to run that step on.",
     createWorkflowTemplateSchema.shape,
     async (args: Record<string, unknown>, extra: ServerExtra) => {
       try {
@@ -1102,7 +1102,7 @@ export function registerTools(
 
   server.tool(
     "update_workflow_template",
-    "Update a workflow template's name, description, or steps. Only changed fields need to be provided. When steps are updated, changes are automatically propagated to pending steps in active workflow runs (structural changes with different step counts are skipped).",
+    "Update a workflow template's name, description, or steps. Only changed fields need to be provided. Each step may carry an optional advisory model_tier (frontier | standard | cheap; omit for Auto). When steps are updated, changes (including model_tier) are automatically propagated to pending steps in active workflow runs (structural changes with different step counts are skipped).",
     updateWorkflowTemplateSchema.shape,
     async (args: Record<string, unknown>, extra: ServerExtra) => {
       try {
@@ -1221,7 +1221,7 @@ export function registerTools(
 
   server.tool(
     "update_step",
-    "Edit a workflow step that is still in pending status. Use this to customise step titles, descriptions, roles, deliverables, or approval gates for a specific task. Only pending steps can be edited.",
+    "Edit a workflow step that is still in pending status. Use this to customise step titles, descriptions, roles, deliverables, approval gates, or the advisory model_tier (frontier | standard | cheap, or null to clear back to Auto) for a specific task. Only pending steps can be edited.",
     updateStepSchema.shape,
     async (args: Record<string, unknown>, extra: ServerExtra) => {
       try {

--- a/mcp-server/src/tools/workflows.test.ts
+++ b/mcp-server/src/tools/workflows.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import type { McpContext } from "../context";
 import { mintClaimToken, hashClaimToken } from "../claim-token";
 
+// AI role matching hits the network — stub it so applyWorkflowTemplate can run
+// against pure Supabase mocks. Only applyWorkflowTemplate uses it in this file.
+vi.mock("../../../src/lib/ai-role-matching", () => ({
+  matchRolesWithAiOrFuzzy: vi.fn(async () => ({})),
+}));
+
 // Shared valid claim token: post-cutover, every complete/fail needs one.
 const TCT = mintClaimToken();
 import {
@@ -15,6 +21,8 @@ import {
   failStepSchema,
   updateStep,
   updateStepSchema,
+  applyWorkflowTemplate,
+  modelTierClause,
 } from "./workflows";
 
 // ---------------------------------------------------------------------------
@@ -2058,6 +2066,57 @@ describe("updateStep", () => {
     });
   });
 
+  it("sets model_tier on a pending step", async () => {
+    let capturedPatch: Record<string, unknown> | null = null;
+    const ctx = makeContext(((table: string) => {
+      const chain = createChain(null);
+      chain.chain.update = vi.fn((data: unknown) => {
+        capturedPatch = data as Record<string, unknown>;
+        return chain.chain;
+      });
+      chain.chain.maybeSingle = vi.fn(() =>
+        Promise.resolve({ data: { id: STEP_ID, status: "pending", model_tier: "cheap" }, error: null })
+      );
+      return chain.chain;
+    }) as unknown as McpContext["supabase"]["from"]);
+
+    const result = await updateStep(ctx, { step_id: STEP_ID, model_tier: "cheap" });
+    expect((result as { model_tier: string }).model_tier).toBe("cheap");
+    expect(capturedPatch).toEqual({ model_tier: "cheap" });
+  });
+
+  it("clears model_tier back to Auto with null", async () => {
+    let capturedPatch: Record<string, unknown> | null = null;
+    const ctx = makeContext(((table: string) => {
+      const chain = createChain(null);
+      chain.chain.update = vi.fn((data: unknown) => {
+        capturedPatch = data as Record<string, unknown>;
+        return chain.chain;
+      });
+      chain.chain.maybeSingle = vi.fn(() =>
+        Promise.resolve({ data: { id: STEP_ID, status: "pending", model_tier: null }, error: null })
+      );
+      return chain.chain;
+    }) as unknown as McpContext["supabase"]["from"]);
+
+    await updateStep(ctx, { step_id: STEP_ID, model_tier: null });
+    expect(capturedPatch).toEqual({ model_tier: null });
+  });
+
+  it("rejects a model_tier edit when the step is not pending", async () => {
+    const ctx = makeContext(((table: string) => {
+      const chain = createChain(null);
+      chain.chain.maybeSingle = vi.fn(() =>
+        Promise.resolve({ data: null, error: null })
+      );
+      return chain.chain;
+    }) as unknown as McpContext["supabase"]["from"]);
+
+    await expect(
+      updateStep(ctx, { step_id: STEP_ID, model_tier: "frontier" })
+    ).rejects.toThrow("Step not found or is no longer pending");
+  });
+
   it("rejects update when step is not pending", async () => {
     const ctx = makeContext(((table: string) => {
       const chain = createChain(null);
@@ -2819,5 +2878,142 @@ describe("claimNextStep — subagent instruction (only mode)", () => {
     const instruction = (result as { instruction: string }).instruction;
 
     expect(instruction).toContain("RETRY or RESUME");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// modelTierClause — advisory spawn clause (P2)
+// ---------------------------------------------------------------------------
+
+describe("modelTierClause", () => {
+  it("returns empty string for null (byte-for-byte no-op)", () => {
+    expect(modelTierClause(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(modelTierClause(undefined)).toBe("");
+  });
+
+  it("returns an advisory clause naming the tier when set", () => {
+    for (const tier of ["frontier", "standard", "cheap"]) {
+      const clause = modelTierClause(tier);
+      expect(clause).toContain("RECOMMENDED MODEL TIER");
+      expect(clause).toContain(`\`${tier}\``);
+      expect(clause).toContain("Advisory only");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claimNextStep — model_tier advisory in the instruction (P2)
+// ---------------------------------------------------------------------------
+
+describe("claimNextStep — model_tier advisory", () => {
+  it("null model_tier leaves the instruction free of the tier clause", async () => {
+    const step = makeStepRow({ step_order: 1 });
+    const updatedStep = { ...step, status: "in_progress", claimed_by: USER_ID, model_tier: null };
+
+    const ctx = makeClaimContext({ pendingStep: step, updatedStep, priorSteps: [] });
+    const result = await claimNextStep(ctx, { task_id: TASK_ID });
+
+    const r = result as { instruction: string; step: { model_tier: string | null } };
+    expect(r.instruction).not.toContain("RECOMMENDED MODEL TIER");
+    expect(r.step.model_tier).toBeNull();
+  });
+
+  it("a set model_tier appends the advisory clause and surfaces on the step", async () => {
+    const step = makeStepRow({ step_order: 1 });
+    const updatedStep = { ...step, status: "in_progress", claimed_by: USER_ID, model_tier: "cheap" };
+
+    const ctx = makeClaimContext({ pendingStep: step, updatedStep, priorSteps: [] });
+    const result = await claimNextStep(ctx, { task_id: TASK_ID });
+
+    const r = result as { instruction: string; step: { model_tier: string | null } };
+    expect(r.instruction).toContain("RECOMMENDED MODEL TIER for this step: `cheap`");
+    expect(r.instruction).toContain("Advisory only");
+    expect(r.step.model_tier).toBe("cheap");
+  });
+
+  it("the null path is byte-for-byte identical to omitting model_tier entirely", async () => {
+    const stepA = makeStepRow({ step_order: 1 });
+    const nullCtx = makeClaimContext({
+      pendingStep: stepA,
+      updatedStep: { ...stepA, status: "in_progress", claimed_by: USER_ID, model_tier: null },
+      priorSteps: [],
+    });
+    const nullResult = (await claimNextStep(nullCtx, { task_id: TASK_ID })) as { instruction: string };
+
+    const stepB = makeStepRow({ step_order: 1 });
+    const absentCtx = makeClaimContext({
+      pendingStep: stepB,
+      updatedStep: { ...stepB, status: "in_progress", claimed_by: USER_ID },
+      priorSteps: [],
+    });
+    const absentResult = (await claimNextStep(absentCtx, { task_id: TASK_ID })) as { instruction: string };
+
+    expect(nullResult.instruction).toBe(absentResult.instruction);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyWorkflowTemplate — copies model_tier onto created steps (P2)
+// ---------------------------------------------------------------------------
+
+describe("applyWorkflowTemplate — model_tier", () => {
+  it("copies each template step's model_tier onto the inserted step (absent → null)", async () => {
+    const template = {
+      id: "00000000-0000-4000-a000-0000000000aa",
+      name: "Feature Dev",
+      idea_id: IDEA_ID,
+      usage_count: 0,
+      steps: [
+        { title: "Implement", role: "Full Stack Developer", model_tier: "standard" },
+        { title: "UX", role: "UX Designer" }, // no tier → null
+      ],
+    };
+
+    const insertedSteps: Record<string, unknown>[] = [];
+    const counts: Record<string, number> = {};
+
+    const ctx = makeContext(((table: string) => {
+      counts[table] = (counts[table] ?? 0) + 1;
+
+      if (table === "workflow_templates") {
+        return createChain(template).chain;
+      }
+      if (table === "board_tasks") {
+        return createChain({ id: TASK_ID, idea_id: IDEA_ID, title: "Task" }).chain;
+      }
+      if (table === "workflow_runs") {
+        // 1st call: active-run guard (maybeSingle → null). 2nd: insert run (single).
+        return counts[table] === 1
+          ? createChain(null).chain
+          : createChain({ id: RUN_ID, task_id: TASK_ID }).chain;
+      }
+      if (table === "idea_agents") {
+        return createChain([]).chain;
+      }
+      if (table === "task_workflow_steps") {
+        const chain = createChain({
+          id: "step-x", title: "x", agent_role: "y", bot_id: null,
+          status: "pending", position: 1000, step_order: 1, human_check_required: false,
+        });
+        chain.chain.insert = vi.fn((data: unknown) => {
+          insertedSteps.push(data as Record<string, unknown>);
+          return chain.chain;
+        });
+        return chain.chain;
+      }
+      if (table === "workflow_suggestions") {
+        return createChain([]).chain;
+      }
+      return createChain(null).chain;
+    }) as unknown as McpContext["supabase"]["from"]);
+
+    await applyWorkflowTemplate(ctx, { task_id: TASK_ID, template_id: template.id });
+
+    expect(insertedSteps).toHaveLength(2);
+    expect(insertedSteps[0].model_tier).toBe("standard");
+    expect(insertedSteps[1].model_tier).toBeNull();
   });
 });

--- a/mcp-server/src/tools/workflows.ts
+++ b/mcp-server/src/tools/workflows.ts
@@ -42,7 +42,22 @@ const templateStepSchema = z.object({
   requires_approval: z.boolean().optional().describe("Whether human approval is required after completion"),
   deliverables: z.array(z.string().max(100)).max(10).optional()
     .describe("Expected deliverables this step should produce (e.g. 'HTML mockups', 'requirements doc')"),
+  model_tier: z.enum(["frontier", "standard", "cheap"]).optional()
+    .describe("Advisory model tier hint (frontier | standard | cheap). Omit for Auto — the orchestrator picks the model. Never blocks execution."),
 });
+
+/**
+ * Advisory model-tier clause appended to a claimed step's spawn instruction.
+ * Returns "" for null/undefined so callers can add it unconditionally without
+ * changing the instruction byte-for-byte when no tier is set.
+ */
+export function modelTierClause(tier: string | null | undefined): string {
+  if (!tier) return "";
+  return (
+    `RECOMMENDED MODEL TIER for this step: \`${tier}\` — spawn this step's subagent on a \`${tier}\`-tier model if available. ` +
+    `Advisory only; does not change any other instruction.`
+  );
+}
 
 // ============================================================
 // Template Tools
@@ -172,6 +187,7 @@ export async function resyncWorkflowTemplate(
     role: String(s.role ?? ""),
     requires_approval: Boolean(s.requires_approval ?? false),
     deliverables: Array.isArray(s.deliverables) ? s.deliverables.map(String) : undefined,
+    model_tier: typeof s.model_tier === "string" ? s.model_tier : undefined,
   }));
 
   // Propagate edits to pending steps
@@ -332,6 +348,7 @@ export async function applyWorkflowTemplate(
         match_tier: matchedBotId ? (match?.tier ?? null) : null,
         human_check_required: Boolean(step.requires_approval ?? false),
         expected_deliverables: Array.isArray(step.deliverables) ? step.deliverables : [],
+        model_tier: typeof step.model_tier === "string" ? step.model_tier : null,
         position: (i + 1) * 1000,
         step_order: i + 1,
       })
@@ -390,7 +407,7 @@ export async function claimNextStep(
   // (docs/claim-token-protocol-design.html §3b).
   const { data: steps, error } = await ctx.supabase
     .from("task_workflow_steps")
-    .select("id, task_id, idea_id, run_id, title, description, agent_role, bot_id, claimed_by, human_check_required, status, position, step_order, output, comment_count, started_at, completed_at, created_at")
+    .select("id, task_id, idea_id, run_id, title, description, agent_role, bot_id, claimed_by, human_check_required, status, position, step_order, output, comment_count, started_at, completed_at, created_at, model_tier")
     .eq("task_id", params.task_id)
     .in("status", ["pending", "in_progress"])
     .order("step_order", { ascending: true, nullsFirst: false })
@@ -487,7 +504,7 @@ export async function claimNextStep(
     })
     .eq("id", step.id)
     .in("status", ["pending", "in_progress"])
-    .select("id, task_id, idea_id, run_id, title, description, agent_role, bot_id, claimed_by, human_check_required, status, position, step_order, output, expected_deliverables, comment_count, started_at, completed_at, created_at")
+    .select("id, task_id, idea_id, run_id, title, description, agent_role, bot_id, claimed_by, human_check_required, status, position, step_order, output, expected_deliverables, comment_count, started_at, completed_at, created_at, model_tier")
     .maybeSingle();
 
   if (updateError) throw new Error(`Failed to claim step: ${updateError.message}`);
@@ -829,7 +846,11 @@ export async function claimNextStep(
     `TASK DESCRIPTION: After calling complete_step, call update_task to append a summary of your deliverable to the task description under a markdown heading.`
   );
 
-  const instruction = [identityInstruction, skillsInstruction, ...contextParts].filter(Boolean).join("\n\n");
+  // Advisory model-tier clause — "" when model_tier is null, so .filter(Boolean)
+  // drops it and the instruction stays byte-for-byte identical to the Auto path.
+  const modelTierInstruction = modelTierClause(updated.model_tier);
+
+  const instruction = [identityInstruction, modelTierInstruction, skillsInstruction, ...contextParts].filter(Boolean).join("\n\n");
 
   return {
     done: false,
@@ -1170,6 +1191,8 @@ export const updateStepSchema = z.object({
   human_check_required: z.boolean().optional().describe("Whether human approval is required after completion"),
   expected_deliverables: z.array(z.string().max(200)).max(20).nullable().optional()
     .describe("Expected deliverables (null to clear)"),
+  model_tier: z.enum(["frontier", "standard", "cheap"]).nullish()
+    .describe("Advisory model tier hint (frontier | standard | cheap, or null to clear back to Auto). Applied to pending steps only."),
 });
 
 export async function updateStep(
@@ -1182,6 +1205,7 @@ export async function updateStep(
   if (params.agent_role !== undefined) patch.agent_role = params.agent_role;
   if (params.human_check_required !== undefined) patch.human_check_required = params.human_check_required;
   if (params.expected_deliverables !== undefined) patch.expected_deliverables = params.expected_deliverables ?? [];
+  if (params.model_tier !== undefined) patch.model_tier = params.model_tier ?? null;
 
   if (Object.keys(patch).length === 0) {
     throw new Error("No fields to update — provide at least one field to change");
@@ -1192,7 +1216,7 @@ export async function updateStep(
     .update(patch)
     .eq("id", params.step_id)
     .eq("status", "pending")
-    .select("id, task_id, run_id, title, description, agent_role, human_check_required, expected_deliverables, status")
+    .select("id, task_id, run_id, title, description, agent_role, human_check_required, expected_deliverables, model_tier, status")
     .maybeSingle();
 
   if (error) throw new Error(`Failed to update step: ${error.message}`);

--- a/src/actions/workflow-templates.ts
+++ b/src/actions/workflow-templates.ts
@@ -387,6 +387,7 @@ export async function applyWorkflowTemplateWithContext(
         agent_role: step.role,
         human_check_required: step.requires_approval ?? false,
         expected_deliverables: step.deliverables ?? [],
+        model_tier: step.model_tier ?? null,
         position: index * 1000,
         step_order: index + 1,
         status: "pending" as const,

--- a/src/actions/workflow.ts
+++ b/src/actions/workflow.ts
@@ -8,6 +8,7 @@ import {
   validateDeliverables,
   MAX_WORKFLOW_ROLE_LENGTH,
 } from "@/lib/validation";
+import { MODEL_TIER_VALUES } from "@/lib/constants";
 
 // ─── Workflow Steps ───
 
@@ -66,6 +67,7 @@ export async function updateWorkflowStep(
     human_check_required?: boolean;
     expected_deliverables?: string[];
     bot_id?: string | null;
+    model_tier?: string | null;
   }
 ) {
   const supabase = await createClient();
@@ -97,6 +99,13 @@ export async function updateWorkflowStep(
   if (updates.human_check_required !== undefined) patch.human_check_required = updates.human_check_required;
   if (updates.expected_deliverables !== undefined) patch.expected_deliverables = validateDeliverables(updates.expected_deliverables);
   if (updates.bot_id !== undefined) patch.bot_id = updates.bot_id;
+  if (updates.model_tier !== undefined) {
+    // Advisory hint: accept a valid tier or null (Auto); reject anything else.
+    if (updates.model_tier !== null && !MODEL_TIER_VALUES.has(updates.model_tier)) {
+      throw new Error("Invalid model tier — expected frontier, standard, or cheap");
+    }
+    patch.model_tier = updates.model_tier;
+  }
 
   const { data, error } = await supabase
     .from("task_workflow_steps")

--- a/src/components/admin/template-editor-dialog.tsx
+++ b/src/components/admin/template-editor-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dialog";
 import { createLibraryTemplate, updateLibraryTemplate } from "@/actions/admin-templates";
 import { RoleCombobox } from "@/components/ui/role-combobox";
+import { ModelTierSelect } from "@/components/shared/model-tier-select";
 import { LABEL_COLORS } from "@/lib/constants";
 import type { WorkflowTemplateStep } from "@/types/database";
 import type { WorkflowLibraryTemplate } from "@/types";
@@ -322,6 +323,10 @@ export function TemplateEditorDialog({
                       className="h-7 flex-1 text-xs"
                     />
                   </div>
+                  <ModelTierSelect
+                    value={step.model_tier ?? null}
+                    onChange={(v) => updateStep(idx, { model_tier: v ?? undefined })}
+                  />
                 </div>
 
                 <button

--- a/src/components/board/add-template-dialog.tsx
+++ b/src/components/board/add-template-dialog.tsx
@@ -36,6 +36,7 @@ import {
 import { listLibraryTemplates } from "@/actions/admin-templates";
 import { importTemplateWithLabel, createWorkflowTemplate } from "@/actions/workflow-templates";
 import { RoleCombobox, useRoleSuggestions } from "@/components/ui/role-combobox";
+import { ModelTierSelect } from "@/components/shared/model-tier-select";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -810,6 +811,10 @@ export function AddTemplateDialog({
                     className="h-7 flex-1 text-xs"
                   />
                 </div>
+                <ModelTierSelect
+                  value={step.model_tier ?? null}
+                  onChange={(v) => updateStep(idx, { model_tier: v ?? undefined })}
+                />
               </div>
 
               <button

--- a/src/components/board/create-template-dialog.tsx
+++ b/src/components/board/create-template-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dialog";
 import { createWorkflowTemplate } from "@/actions/workflow-templates";
 import { RoleCombobox, useRoleSuggestions } from "@/components/ui/role-combobox";
+import { ModelTierSelect } from "@/components/shared/model-tier-select";
 import { TEMPLATE_LABEL_SUGGESTIONS, LABEL_COLORS } from "@/lib/constants";
 import { Lightbulb } from "lucide-react";
 import type { WorkflowTemplateStep } from "@/types/database";
@@ -293,6 +294,10 @@ export function CreateTemplateDialog({
                       className="h-7 flex-1 text-xs"
                     />
                   </div>
+                  <ModelTierSelect
+                    value={step.model_tier ?? null}
+                    onChange={(v) => updateStep(idx, { model_tier: v ?? undefined })}
+                  />
                 </div>
 
                 <button

--- a/src/components/board/step-detail-dialog.tsx
+++ b/src/components/board/step-detail-dialog.tsx
@@ -32,6 +32,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { RoleCombobox } from "@/components/ui/role-combobox";
+import { ModelTierSelect, ModelTierBadge } from "@/components/shared/model-tier-select";
 import { Textarea } from "@/components/ui/textarea";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -143,6 +144,7 @@ export function StepDetailDialog({
   const [editDescription, setEditDescription] = useState("");
   const [editRole, setEditRole] = useState("");
   const [editDeliverables, setEditDeliverables] = useState("");
+  const [editModelTier, setEditModelTier] = useState<string | null>(null);
   const [editHumanCheck, setEditHumanCheck] = useState(false);
   const [saving, setSaving] = useState(false);
   const [assignedAgent, setAssignedAgent] = useState<{ name: string; avatar_url: string | null; role: string | null } | null>(null);
@@ -256,6 +258,7 @@ export function StepDetailDialog({
     setEditDescription(step.description ?? "");
     setEditRole(step.agent_role ?? "");
     setEditDeliverables((step.expected_deliverables ?? []).join(", "));
+    setEditModelTier(step.model_tier ?? null);
     setEditHumanCheck(step.human_check_required);
     setIsEditing(true);
   }
@@ -271,6 +274,7 @@ export function StepDetailDialog({
         title: editTitle,
         description: editDescription || null,
         agent_role: editRole || null,
+        model_tier: editModelTier,
         human_check_required: editHumanCheck,
         expected_deliverables: deliverables,
       });
@@ -401,6 +405,7 @@ export function StepDetailDialog({
                     {step.agent_role}
                   </Badge>
                 )}
+                <ModelTierBadge tier={step.model_tier} />
                 {step.bot_id && assignedAgent ? (
                   <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
                     <Avatar className="h-4 w-4">
@@ -487,6 +492,11 @@ export function StepDetailDialog({
                   helperText="Matched against agents when template is applied"
                 />
               </div>
+              <ModelTierSelect
+                variant="full"
+                value={editModelTier}
+                onChange={setEditModelTier}
+              />
               <div className="space-y-1.5">
                 <Label htmlFor="edit-deliverables" className="text-xs">Expected Deliverables</Label>
                 <Input

--- a/src/components/board/task-workflow-section.tsx
+++ b/src/components/board/task-workflow-section.tsx
@@ -63,6 +63,7 @@ import { StepDetailDialog } from "./step-detail-dialog";
 import { WorkflowSuggestionPanel } from "./workflow-suggestion-panel";
 import { TaskAutoOpenContext } from "./kanban-board";
 import { ApprovalLockIcon } from "./approval-lock-icon";
+import { ModelTierBadge } from "@/components/shared/model-tier-select";
 import type { TaskWorkflowStep, WorkflowRun, WorkflowTemplate } from "@/types";
 
 /** Map a role string to a color class for the role badge. */
@@ -572,6 +573,7 @@ export function TaskWorkflowSection({ taskId, ideaId, isReadOnly = false }: Task
                   </span>
                 )}
 
+                <ModelTierBadge tier={step.model_tier} />
                 {step.agent_role && (
                   <Badge
                     variant="outline"

--- a/src/components/board/workflows-tab.tsx
+++ b/src/components/board/workflows-tab.tsx
@@ -28,6 +28,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { RoleCombobox, useRoleSuggestions } from "@/components/ui/role-combobox";
+import { ModelTierSelect, ModelTierBadge } from "@/components/shared/model-tier-select";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -100,6 +101,7 @@ function StepRow({ step, index, matchTier }: { step: WorkflowTemplateStep; index
         {index + 1}
       </span>
       <span className="flex-1 truncate text-sm font-medium">{step.title}</span>
+      <ModelTierBadge tier={step.model_tier} />
       <span className="relative shrink-0">
         <Badge
           variant="outline"
@@ -241,6 +243,10 @@ function StepEditor({ steps, onChange, ideaId, poolRoles, userRoles }: StepEdito
                 className="h-7 flex-1 text-xs"
               />
             </div>
+            <ModelTierSelect
+              value={step.model_tier ?? null}
+              onChange={(v) => updateStep(idx, { model_tier: v ?? undefined })}
+            />
           </div>
 
           <button

--- a/src/components/shared/model-tier-select.tsx
+++ b/src/components/shared/model-tier-select.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import * as React from "react";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+import { Select as SelectPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { SelectContent } from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import {
+  MODEL_TIERS,
+  MODEL_TIER_AUTO_GLOSS,
+  MODEL_TIER_ADVISORY_HELPER,
+  modelTierLabel,
+} from "@/lib/constants";
+
+// Radix Select can't use "" as an item value, so Auto (null) uses this sentinel.
+const AUTO_VALUE = "__auto__";
+
+interface TierOption {
+  value: string;
+  label: React.ReactNode;
+  gloss: string;
+}
+
+const OPTIONS: TierOption[] = [
+  {
+    value: AUTO_VALUE,
+    label: (
+      <>
+        Auto <span className="font-normal text-muted-foreground">(recommended)</span>
+      </>
+    ),
+    gloss: MODEL_TIER_AUTO_GLOSS,
+  },
+  ...MODEL_TIERS.map((t) => ({ value: t.value, label: t.label, gloss: t.gloss })),
+];
+
+/**
+ * Two-line option (name + gloss). Only the name sits inside ItemText, so the
+ * closed trigger shows the name alone while the listbox shows name + gloss.
+ */
+function TierItem({ value, label, gloss }: TierOption) {
+  return (
+    <SelectPrimitive.Item
+      value={value}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default select-none flex-col items-start gap-0.5 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "[@media(pointer:coarse)]:min-h-11 [@media(pointer:coarse)]:justify-center",
+      )}
+    >
+      <span className="text-sm font-medium leading-tight">
+        <SelectPrimitive.ItemText>{label}</SelectPrimitive.ItemText>
+      </span>
+      <span className="text-[11px] text-muted-foreground leading-tight">{gloss}</span>
+      <span className="absolute right-2 top-1.5 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+    </SelectPrimitive.Item>
+  );
+}
+
+export interface ModelTierSelectProps {
+  value: string | null;
+  onChange: (value: string | null) => void;
+  disabled?: boolean;
+  /** "compact" = inline template-editor row; "full" = stacked dialog field. */
+  variant?: "compact" | "full";
+  id?: string;
+  className?: string;
+}
+
+/**
+ * Shared advisory model-tier control. Auto = null (stored as absent/NULL). Same
+ * four options, glosses, and always-visible helper in every mount; only the
+ * layout differs between the compact template-editor row and the full dialog field.
+ */
+export function ModelTierSelect({
+  value,
+  onChange,
+  disabled,
+  variant = "compact",
+  id,
+  className,
+}: ModelTierSelectProps) {
+  const reactId = React.useId();
+  const triggerId = id ?? `model-tier-${reactId}`;
+  const helperId = `${triggerId}-helper`;
+
+  const selectValue = value ?? AUTO_VALUE;
+  const handleChange = (v: string) => onChange(v === AUTO_VALUE ? null : v);
+
+  const displayLabel =
+    value === null || value === undefined ? (
+      <>
+        Auto <span className="font-normal text-muted-foreground">(recommended)</span>
+      </>
+    ) : (
+      modelTierLabel(value)
+    );
+
+  const listbox = (
+    <SelectContent aria-label="Model tier" className="min-w-[16rem]">
+      {OPTIONS.map((opt) => (
+        <TierItem key={opt.value} {...opt} />
+      ))}
+    </SelectContent>
+  );
+
+  // Shared trigger chrome (mirrors shadcn SelectTrigger) with a coarse-pointer
+  // 44px min height for touch.
+  const triggerClass = cn(
+    "border-input dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 flex items-center justify-between gap-2 rounded-md border bg-transparent text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:min-h-11",
+    "[&>span]:line-clamp-1 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  );
+
+  if (variant === "full") {
+    return (
+      <div className={cn("space-y-1.5", className)}>
+        <Label htmlFor={triggerId} className="text-xs">
+          Model tier
+        </Label>
+        <SelectPrimitive.Root value={selectValue} onValueChange={handleChange} disabled={disabled}>
+          <SelectPrimitive.Trigger
+            id={triggerId}
+            aria-describedby={helperId}
+            className={cn(triggerClass, "h-8 w-full px-3 text-sm")}
+          >
+            <SelectPrimitive.Value>{displayLabel}</SelectPrimitive.Value>
+            <SelectPrimitive.Icon asChild>
+              <ChevronDownIcon className="size-4 opacity-50" />
+            </SelectPrimitive.Icon>
+          </SelectPrimitive.Trigger>
+          {listbox}
+        </SelectPrimitive.Root>
+        <p id={helperId} className="text-[11px] text-muted-foreground">
+          {MODEL_TIER_ADVISORY_HELPER}
+        </p>
+      </div>
+    );
+  }
+
+  // Compact inline row — matches the sibling Title/Role/Deliverables rows.
+  return (
+    <div className={cn("flex flex-wrap items-center gap-x-3 gap-y-1.5 pl-7", className)}>
+      <Label htmlFor={triggerId} className="text-[10px] text-muted-foreground whitespace-nowrap">
+        Model tier
+      </Label>
+      <SelectPrimitive.Root value={selectValue} onValueChange={handleChange} disabled={disabled}>
+        <SelectPrimitive.Trigger
+          id={triggerId}
+          aria-describedby={helperId}
+          className={cn(triggerClass, "h-7 w-[150px] px-2 text-xs")}
+        >
+          <SelectPrimitive.Value>{displayLabel}</SelectPrimitive.Value>
+          <SelectPrimitive.Icon asChild>
+            <ChevronDownIcon className="size-3.5 opacity-50" />
+          </SelectPrimitive.Icon>
+        </SelectPrimitive.Trigger>
+        {listbox}
+      </SelectPrimitive.Root>
+      <span id={helperId} className="min-w-0 flex-1 text-[10px] text-muted-foreground">
+        {MODEL_TIER_ADVISORY_HELPER}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Read-only tier badge for step cards and dialog headers. Renders nothing for
+ * Auto (null) — silence is the default. Monochrome outline so it never competes
+ * with the colour-coded role/status badges.
+ */
+export function ModelTierBadge({
+  tier,
+  className,
+}: {
+  tier: string | null | undefined;
+  className?: string;
+}) {
+  if (!tier) return null;
+  const label = modelTierLabel(tier);
+  return (
+    <Badge
+      variant="outline"
+      aria-label={`Model tier: ${label}`}
+      className={cn(
+        "shrink-0 gap-0.5 text-[10px] font-normal border-zinc-300 text-zinc-700 dark:border-zinc-700 dark:text-zinc-200",
+        className,
+      )}
+    >
+      <span className="text-muted-foreground">tier:</span>
+      {label}
+    </Badge>
+  );
+}

--- a/src/lib/constants.test.ts
+++ b/src/lib/constants.test.ts
@@ -9,6 +9,7 @@ import {
   SORT_OPTIONS,
   BOT_ROLE_TEMPLATES,
   SUGGESTED_TAGS,
+  defaultTierForRole,
 } from "./constants";
 import type { IdeaStatus, CommentType } from "@/types";
 
@@ -217,3 +218,44 @@ describe("SUGGESTED_TAGS", () => {
   });
 });
 
+
+// ── defaultTierForRole (P2 model tiering) ─────────────────────────────
+
+describe("defaultTierForRole", () => {
+  it("maps canonical product/analysis roles to frontier", () => {
+    expect(defaultTierForRole("Product Owner")).toBe("frontier");
+    expect(defaultTierForRole("Business Analyst")).toBe("frontier");
+    expect(defaultTierForRole("Product Manager")).toBe("frontier");
+  });
+
+  it("maps design roles to frontier", () => {
+    expect(defaultTierForRole("UX Designer")).toBe("frontier");
+    expect(defaultTierForRole("UI Designer")).toBe("frontier");
+  });
+
+  it("maps build engineers to standard", () => {
+    expect(defaultTierForRole("Full Stack Developer")).toBe("standard");
+    expect(defaultTierForRole("Full Stack Engineer")).toBe("standard");
+    expect(defaultTierForRole("Front End Engineer")).toBe("standard");
+    expect(defaultTierForRole("Frontend Engineer")).toBe("standard");
+    expect(defaultTierForRole("Back End Engineer")).toBe("standard");
+    expect(defaultTierForRole("Backend Engineer")).toBe("standard");
+  });
+
+  it("maps QA / mechanical roles to cheap", () => {
+    expect(defaultTierForRole("QA Engineer")).toBe("cheap");
+    expect(defaultTierForRole("Tester")).toBe("cheap");
+  });
+
+  it("is case-insensitive and trims", () => {
+    expect(defaultTierForRole("  qa engineer  ")).toBe("cheap");
+    expect(defaultTierForRole("ux designer")).toBe("frontier");
+    expect(defaultTierForRole("FULL STACK DEVELOPER")).toBe("standard");
+  });
+
+  it("returns null for unknown / custom roles", () => {
+    expect(defaultTierForRole("Wizard")).toBeNull();
+    expect(defaultTierForRole("")).toBeNull();
+    expect(defaultTierForRole("Community Manager")).toBeNull();
+  });
+});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,6 +2,63 @@ import type { IdeaStatus, CommentType, SortOption } from "@/types";
 
 export const VIBECODES_USER_ID = "a0000000-0000-4000-a000-000000000001";
 
+// ─── Per-step model tiering (P2) ───
+// Advisory hint on workflow steps telling the orchestrator which Claude model to
+// run a step's subagent on. Auto = null (absent) = orchestrator decides — never
+// stored as a literal "auto".
+
+export type ModelTierValue = "frontier" | "standard" | "cheap";
+
+/** Selectable tiers with their labels + one-line glosses (fixed order = cost gradient). */
+export const MODEL_TIERS: { value: ModelTierValue; label: string; gloss: string }[] = [
+  { value: "frontier", label: "Frontier", gloss: "Highest quality — decisions & design" },
+  { value: "standard", label: "Standard", gloss: "Balanced — most build steps" },
+  { value: "cheap", label: "Cheap", gloss: "Fast & low-cost — mechanical steps" },
+];
+
+/** Gloss shown for the Auto (null) default option. */
+export const MODEL_TIER_AUTO_GLOSS = "Orchestrator picks the best model";
+
+/** Set of valid stored tier values (excludes Auto/null). */
+export const MODEL_TIER_VALUES: ReadonlySet<string> = new Set(
+  MODEL_TIERS.map((t) => t.value),
+);
+
+/** Always-visible helper text shown beneath the tier control. */
+export const MODEL_TIER_ADVISORY_HELPER =
+  "Advisory — helps stretch your Claude usage; the orchestrator can override.";
+
+/** Human label for a stored tier value; falls back to the raw value if unknown. */
+export function modelTierLabel(tier: string): string {
+  return MODEL_TIERS.find((t) => t.value === tier)?.label ?? tier;
+}
+
+/**
+ * Default advisory tier for a step's role (design §06). Tolerant of role-name
+ * variants and case. Returns null for unknown/custom roles — never guess, let the
+ * orchestrator decide. Shared by the library-seeding reference and any UI reuse.
+ */
+export function defaultTierForRole(role: string): ModelTierValue | null {
+  const r = role?.trim().toLowerCase() ?? "";
+  if (!r) return null;
+
+  // QA / mechanical → cheap (checked first: "QA Engineer" must not fall to build)
+  if (/\bqa\b|quality assurance|\btest\b|tester|testing/.test(r)) return "cheap";
+
+  // Design / UX → frontier (before build, so "UX Designer" wins over "engineer")
+  if (/\bux\b|\bui\b|designer|\bdesign\b/.test(r)) return "frontier";
+
+  // Product / analysis / decision / review → frontier
+  if (/\bproduct\b|\bowner\b|analyst|founder|\bceo\b|\bpm\b|\bba\b|review|approv|decision/.test(r))
+    return "frontier";
+
+  // Build engineers → standard
+  if (/engineer|developer|\bdev\b|programmer|architect|full[\s-]?stack|front|back|coder/.test(r))
+    return "standard";
+
+  return null;
+}
+
 export const STATUS_CONFIG: Record<
   IdeaStatus,
   { label: string; color: string; bgColor: string }

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  validateWorkflowTemplateSteps,
   validateTitle,
   validateDescription,
   validateOptionalDescription,
@@ -385,5 +386,52 @@ describe("validateTeamDescription", () => {
   it("accepts max length description", () => {
     const desc = "a".repeat(MAX_TEAM_DESCRIPTION_LENGTH);
     expect(validateTeamDescription(desc)).toHaveLength(MAX_TEAM_DESCRIPTION_LENGTH);
+  });
+});
+
+// ── validateWorkflowTemplateSteps — model_tier (P2) ──────────────────
+
+describe("validateWorkflowTemplateSteps — model_tier", () => {
+  const base = { title: "Implement feature", role: "Full Stack Developer" };
+
+  it("passes a valid tier through", () => {
+    const [step] = validateWorkflowTemplateSteps([{ ...base, model_tier: "standard" }]);
+    expect(step.model_tier).toBe("standard");
+  });
+
+  it("accepts each of frontier / standard / cheap", () => {
+    for (const tier of ["frontier", "standard", "cheap"] as const) {
+      const [step] = validateWorkflowTemplateSteps([{ ...base, model_tier: tier }]);
+      expect(step.model_tier).toBe(tier);
+    }
+  });
+
+  it("omits model_tier when absent", () => {
+    const [step] = validateWorkflowTemplateSteps([{ ...base }]);
+    expect("model_tier" in step).toBe(false);
+  });
+
+  it("omits model_tier when null", () => {
+    const [step] = validateWorkflowTemplateSteps([{ ...base, model_tier: null }]);
+    expect("model_tier" in step).toBe(false);
+  });
+
+  it("throws a ValidationError on an unrecognised tier value", () => {
+    expect(() =>
+      validateWorkflowTemplateSteps([{ ...base, model_tier: "ultra" }])
+    ).toThrow(ValidationError);
+  });
+
+  it("preserves other fields alongside a valid tier", () => {
+    const [step] = validateWorkflowTemplateSteps([
+      { ...base, description: "  do it  ", requires_approval: true, model_tier: "cheap" },
+    ]);
+    expect(step).toMatchObject({
+      title: "Implement feature",
+      role: "Full Stack Developer",
+      description: "do it",
+      requires_approval: true,
+      model_tier: "cheap",
+    });
   });
 });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -27,6 +27,8 @@ const VALID_LABEL_COLORS = [
   "rose", "zinc",
 ];
 
+const VALID_MODEL_TIERS = ["frontier", "standard", "cheap"];
+
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const GITHUB_URL_PATTERN = /^https:\/\/github\.com\/.+/;
@@ -238,9 +240,27 @@ export function validateDeliverables(deliverables: string[]): string[] {
   return unique;
 }
 
+type WorkflowTemplateStepInput = {
+  title: string;
+  description?: string;
+  role: string;
+  requires_approval?: boolean;
+  deliverables?: string[];
+  model_tier?: string | null;
+};
+
+type WorkflowTemplateStepOutput = {
+  title: string;
+  description?: string;
+  role: string;
+  requires_approval?: boolean;
+  deliverables?: string[];
+  model_tier?: string;
+};
+
 export function validateWorkflowTemplateSteps(
-  steps: { title: string; description?: string; role: string; requires_approval?: boolean; deliverables?: string[] }[]
-): { title: string; description?: string; role: string; requires_approval?: boolean; deliverables?: string[] }[] {
+  steps: WorkflowTemplateStepInput[]
+): WorkflowTemplateStepOutput[] {
   if (!steps || steps.length === 0) {
     throw new ValidationError("At least one step is required");
   }
@@ -255,12 +275,26 @@ export function validateWorkflowTemplateSteps(
     if (role.length > MAX_WORKFLOW_ROLE_LENGTH) {
       throw new ValidationError(`Step ${i + 1}: role must be ${MAX_WORKFLOW_ROLE_LENGTH} characters or less`);
     }
+
+    // model_tier is advisory: pass valid tiers through, omit absent/null, and
+    // reject any other value so a bad hand-edited JSON never persists silently.
+    let model_tier: string | undefined;
+    if (step.model_tier !== undefined && step.model_tier !== null) {
+      if (!VALID_MODEL_TIERS.includes(step.model_tier)) {
+        throw new ValidationError(
+          `Step ${i + 1}: invalid model tier "${step.model_tier}" (expected frontier, standard, or cheap)`
+        );
+      }
+      model_tier = step.model_tier;
+    }
+
     return {
       title,
       description: step.description?.trim() || undefined,
       role,
       requires_approval: step.requires_approval ?? false,
       deliverables: step.deliverables ? validateDeliverables(step.deliverables) : undefined,
+      ...(model_tier !== undefined ? { model_tier } : {}),
     };
   });
 }

--- a/src/lib/workflow-helpers.test.ts
+++ b/src/lib/workflow-helpers.test.ts
@@ -1112,3 +1112,69 @@ describe("resolveSuggestionOnApply", () => {
     expect(captured.updateEqs).not.toContainEqual(["id", "sug-A"]);
   });
 });
+
+// --- propagateTemplateEdits — model_tier (P2) ---
+
+/** Capturing mock: records the update payloads sent to pending steps. */
+function createTierCaptureSupabase(step: { id: string; status: string; step_order: number }) {
+  const updates: Record<string, unknown>[] = [];
+  const supabase = {
+    from: vi.fn((table: string) => {
+      if (table === "workflow_runs") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              not: vi.fn().mockResolvedValue({
+                data: [{ id: "run-1", task_id: "task-1" }],
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      // task_workflow_steps
+      let isUpdate = false;
+      let payload: Record<string, unknown> | null = null;
+      const chain: Record<string, unknown> = {
+        select: vi.fn(() => { isUpdate = false; return chain; }),
+        update: vi.fn((p: Record<string, unknown>) => { isUpdate = true; payload = p; return chain; }),
+        order: vi.fn(() => Promise.resolve({ data: [step], error: null })),
+        eq: vi.fn((col: string) => {
+          if (col === "status" && isUpdate) {
+            if (payload) updates.push(payload);
+            return Promise.resolve({ count: 1, error: null });
+          }
+          return chain;
+        }),
+      };
+      return chain;
+    }),
+  };
+  return { supabase, updates };
+}
+
+describe("propagateTemplateEdits — model_tier", () => {
+  it("copies a template step's model_tier onto pending steps", async () => {
+    const { supabase, updates } = createTierCaptureSupabase({ id: "s1", status: "pending", step_order: 1 });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await propagateTemplateEdits(supabase as any, "tmpl-1", [
+      { title: "Build", role: "Dev", model_tier: "standard" },
+    ]);
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0].model_tier).toBe("standard");
+  });
+
+  it("writes null model_tier when the template step has none (Auto)", async () => {
+    const { supabase, updates } = createTierCaptureSupabase({ id: "s1", status: "pending", step_order: 1 });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await propagateTemplateEdits(supabase as any, "tmpl-1", [
+      { title: "Build", role: "Dev" },
+    ]);
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0].model_tier).toBeNull();
+  });
+});

--- a/src/lib/workflow-helpers.ts
+++ b/src/lib/workflow-helpers.ts
@@ -532,6 +532,7 @@ export async function propagateTemplateEdits(
           agent_role: templateStep.role,
           human_check_required: templateStep.requires_approval ?? false,
           expected_deliverables: templateStep.deliverables ?? [],
+          model_tier: templateStep.model_tier ?? null,
         })
         .eq("id", step.id)
         .eq("status", "pending");

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -6,6 +6,8 @@ export interface WorkflowTemplateStep {
   role: string;
   requires_approval?: boolean;
   deliverables?: string[];
+  /** Advisory per-step model tier hint: 'frontier' | 'standard' | 'cheap'. Absent = Auto. */
+  model_tier?: string;
 }
 
 export type Database = {
@@ -866,6 +868,7 @@ export type Database = {
           created_at: string;
           expected_deliverables: string[];
           match_tier: string | null;
+          model_tier: string | null;
           updated_at: string;
         };
         Insert: {
@@ -886,6 +889,7 @@ export type Database = {
           human_check_required?: boolean;
           expected_deliverables?: string[];
           match_tier?: string | null;
+          model_tier?: string | null;
           comment_count?: number;
           started_at?: string | null;
           completed_at?: string | null;
@@ -910,6 +914,7 @@ export type Database = {
           human_check_required?: boolean;
           expected_deliverables?: string[];
           match_tier?: string | null;
+          model_tier?: string | null;
           comment_count?: number;
           started_at?: string | null;
           completed_at?: string | null;

--- a/supabase/migrations/00130_step_model_tier.sql
+++ b/supabase/migrations/00130_step_model_tier.sql
@@ -1,0 +1,15 @@
+-- P2: Per-step model tiering.
+-- Adds an advisory `model_tier` hint to workflow steps. The orchestrator uses it
+-- to decide which Claude model runs a step's subagent. Purely advisory — it never
+-- blocks execution. Default is NULL (= "Auto", orchestrator decides). Additive,
+-- nullable, no backfill.
+
+ALTER TABLE task_workflow_steps
+  ADD COLUMN model_tier TEXT;
+
+ALTER TABLE task_workflow_steps
+  ADD CONSTRAINT task_workflow_steps_model_tier_check
+  CHECK (model_tier IS NULL OR model_tier IN ('frontier', 'standard', 'cheap'));
+
+COMMENT ON COLUMN task_workflow_steps.model_tier IS
+  'Advisory per-step model tier hint (frontier | standard | cheap). NULL = Auto — the orchestrator picks the model. Never blocks execution.';

--- a/supabase/migrations/00131_seed_library_model_tiers.sql
+++ b/supabase/migrations/00131_seed_library_model_tiers.sql
@@ -1,0 +1,66 @@
+-- P2: Seed advisory model_tier defaults into the platform library templates.
+--
+-- Scope (v1): workflow_library_templates only. Per-idea templates and user
+-- templates default every step to Auto (absent). This is a one-time fill of the
+-- select's default value — it NEVER overwrites a step that already carries a
+-- model_tier, and users can change any value afterwards.
+--
+-- Role -> tier map (design §06), matched on each step's role AND title, tolerant
+-- of role-name variants and case:
+--   QA / mechanical  (QA Engineer, verify / run-tests / lint / format steps) -> cheap
+--   Design / UX      (UX Designer, design & design-review steps)             -> frontier
+--   Product / review (Product Owner, Business Analyst, PM, decision/review)  -> frontier
+--   Build engineers  (Full Stack / Front End / Back End Engineer/Developer)  -> standard
+--   everything else                                                          -> absent (Auto)
+
+DO $$
+DECLARE
+  tpl RECORD;
+  new_steps jsonb;
+  step jsonb;
+  role_txt text;
+  title_txt text;
+  tier text;
+BEGIN
+  FOR tpl IN SELECT id, steps FROM workflow_library_templates LOOP
+    -- Skip malformed / empty step arrays defensively.
+    IF tpl.steps IS NULL OR jsonb_typeof(tpl.steps) <> 'array' THEN
+      CONTINUE;
+    END IF;
+
+    new_steps := '[]'::jsonb;
+
+    FOR step IN SELECT * FROM jsonb_array_elements(tpl.steps) LOOP
+      -- Never overwrite an explicit choice already present on the step.
+      IF (step ? 'model_tier') AND (step->>'model_tier') IS NOT NULL THEN
+        new_steps := new_steps || step;
+        CONTINUE;
+      END IF;
+
+      role_txt := lower(coalesce(step->>'role', ''));
+      title_txt := lower(coalesce(step->>'title', ''));
+      tier := NULL;
+
+      IF role_txt ~ '\yqa\y|quality assurance|\ytest'
+         OR title_txt ~ '\yqa\y|verify|run tests|\ylint|\yformat|changelog' THEN
+        tier := 'cheap';
+      ELSIF role_txt ~ '\yux\y|\yui\y|design'
+         OR title_txt ~ 'design' THEN
+        tier := 'frontier';
+      ELSIF role_txt ~ 'product|owner|analyst|\ypm\y|\yba\y|founder|\yceo\y'
+         OR title_txt ~ 'review|approv|decision|requirement' THEN
+        tier := 'frontier';
+      ELSIF role_txt ~ 'engineer|developer|\ydev\y|programmer|architect|full.?stack|front|back' THEN
+        tier := 'standard';
+      END IF;
+
+      IF tier IS NOT NULL THEN
+        step := jsonb_set(step, '{model_tier}', to_jsonb(tier), true);
+      END IF;
+
+      new_steps := new_steps || step;
+    END LOOP;
+
+    UPDATE workflow_library_templates SET steps = new_steps WHERE id = tpl.id;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## What
Adds a per-step **Model tier** (`frontier` / `standard` / `cheap`, with **Auto = null = orchestrator decides** as default) to workflow steps. When the orchestrator claims a step, `claim_next_step` surfaces the tier + an **advisory** clause telling it which model to spawn that step's subagent on — frontier for judgement (design/decisions/review), standard for build, cheap for mechanical steps. Advisory only; nothing is enforced.

Board card **P2** from the "Investigate Claude usages" spike (approved). Full Feature Development workflow ran (Requirements → UX v3 → Design Review → Implementation → QA → Final Sign-off).

## User-configurable everywhere
Shared `ModelTierSelect` (glosses + always-visible advisory helper + a11y) mounted in **5 surfaces**: all four template step editors (create dialog, Add-Template "Create New", workflows-tab editor, admin editor) **+ the task-view step-detail edit dialog** (per-task override, pending steps only). Read-only `tier:` badge on board step rows + step-detail header (nothing when Auto).

## Safety
- **Null-path byte-for-byte:** the tier clause helper returns `""` for null and is dropped by `filter(Boolean)`, so an untier'd step produces the **exact same** `claim_next_step` instruction as today → in-flight workflows (incl. the one that built this) unaffected. Test-locked.
- **Fixed a latent bug:** `validateWorkflowTemplateSteps` rebuilt steps from a field allowlist and would have **silently stripped** `model_tier` on every save — now passes valid tiers through, rejects invalid.
- Identity/claim-token/ordering/approval-gates untouched. Advisory-only. `update_step` accepts the tier on **pending** steps only.

## Migrations (apply to prod)
- `00130` — `ADD COLUMN model_tier TEXT` (nullable, CHECK frontier/standard/cheap, no backfill).
- `00131` — seeds the default role→tier map into **platform library templates only**; QA-verified **idempotent** and **never overwrites** an existing tier.

## Verification
- `npx tsc --noEmit` clean · **232 unit tests green** · 0 new lint errors · QA 13/13 acceptance items PASS, no blockers.
- Post-deploy live checks (tracked in the board card): tiered template → claim shows advisory clause · per-task override persists · badge shows/hides · **legacy untier'd board unchanged**.

## Rollback
Advisory + additive-nullable; behavioural rollback = revert the code (column harmlessly remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)