### PR TITLE
feat(workflows): P2c — capture executed model + tier-adherence reporting

### DIFF
--- a/docs/spikes/p2c-tier-adherence-design.html
+++ b/docs/spikes/p2c-tier-adherence-design.html
@@ -1,0 +1,521 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>P2c · Tier Adherence — UX Design</title>
+<style>
+  /* ── Tokens (VibeCodes dark theme: Tailwind Zinc, shadcn New York) ── */
+  :root{
+    --bg:#09090b;            /* zinc-950 — app background            */
+    --card:#101013;          /* doc section card                     */
+    --popover:#18181b;       /* zinc-900 — popover / dropdown        */
+    --border:#27272a;        /* zinc-800 — border / input            */
+    --muted:#27272a;         /* zinc-800                             */
+    --muted-20:rgba(39,39,42,.20);
+    --muted-30:rgba(39,39,42,.30);
+    --muted-60:rgba(39,39,42,.60);
+    --fg:#fafafa;            /* zinc-50                              */
+    --muted-fg:#a1a1aa;      /* zinc-400                             */
+    --faint-fg:#71717a;      /* zinc-500 — placeholders              */
+    --ring:#d4d4d8;          /* zinc-300 — focus ring                */
+    --emerald:#34d399; --emerald-b:rgba(16,185,129,.35); --emerald-bg:rgba(16,185,129,.08);
+    --red:#f87171;     --red-b:rgba(239,68,68,.35);      --red-bg:rgba(239,68,68,.10);
+    --amber:#fbbf24;   --amber-b:rgba(245,158,11,.35);   --amber-bg:rgba(245,158,11,.12);
+    --blue:#60a5fa;    --blue-b:rgba(59,130,246,.25);    --blue-bg:rgba(59,130,246,.15);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{
+    background:var(--bg);color:var(--fg);
+    font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+    font-size:15px;line-height:1.6;-webkit-font-smoothing:antialiased;
+  }
+  a{color:var(--fg)}
+  code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:.85em;background:var(--muted-30);border:1px solid var(--border);border-radius:4px;padding:1px 5px;color:#e4e4e7}
+
+  .wrap{max-width:980px;margin:0 auto;padding:0 24px 120px}
+  header.hero{padding:56px 0 28px;border-bottom:1px solid var(--border)}
+  .kicker{display:inline-flex;gap:8px;align-items:center;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--emerald);margin-bottom:14px}
+  .kicker .dot{width:6px;height:6px;border-radius:99px;background:var(--emerald)}
+  h1{font-size:32px;line-height:1.2;font-weight:700;letter-spacing:-.02em}
+  .sub{margin-top:12px;color:var(--muted-fg);max-width:66ch}
+  .meta{margin-top:18px;display:flex;flex-wrap:wrap;gap:8px}
+  .meta span{font-size:11px;color:var(--muted-fg);border:1px solid var(--border);border-radius:99px;padding:3px 10px;background:var(--muted-20)}
+
+  nav.toc{position:sticky;top:0;z-index:50;background:rgba(9,9,11,.85);backdrop-filter:blur(8px);border-bottom:1px solid var(--border);margin:0 -24px;padding:10px 24px;display:flex;gap:4px;overflow-x:auto;white-space:nowrap}
+  nav.toc a{font-size:12px;color:var(--muted-fg);text-decoration:none;padding:5px 10px;border-radius:6px}
+  nav.toc a:hover{color:var(--fg);background:var(--muted-30)}
+  nav.toc a b{color:var(--emerald);font-weight:600;margin-right:5px}
+
+  section{margin-top:56px;scroll-margin-top:64px}
+  h2{font-size:21px;font-weight:650;letter-spacing:-.01em;display:flex;align-items:baseline;gap:12px}
+  h2 .num{color:var(--emerald);font-size:14px;font-weight:700}
+  h3{font-size:14px;font-weight:600;margin:26px 0 10px;color:#e4e4e7}
+  section>p{margin-top:10px;color:var(--muted-fg);max-width:70ch}
+  section>p strong, li strong, td strong{color:var(--fg);font-weight:600}
+  ul.notes{margin:12px 0 0 18px;color:var(--muted-fg)}
+  ul.notes li{margin-top:7px;max-width:72ch}
+  ul.notes li::marker{color:var(--faint-fg)}
+
+  /* ── Mockup frames ── */
+  .frame{margin-top:16px;border:1px solid var(--border);border-radius:12px;background:var(--card);overflow:hidden}
+  .frame .bar{display:flex;align-items:center;gap:8px;padding:8px 14px;border-bottom:1px solid var(--border);background:var(--muted-20)}
+  .frame .bar .fdot{width:9px;height:9px;border-radius:99px;background:var(--border)}
+  .frame .bar .flabel{font-size:11px;color:var(--muted-fg);margin-left:6px}
+  .frame .stage{padding:26px;background:
+    radial-gradient(circle at 1px 1px,rgba(255,255,255,.035) 1px,transparent 0) 0 0/22px 22px, var(--bg)}
+  .cols{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px}
+  @media(max-width:760px){.cols{grid-template-columns:1fr}}
+  .tag{display:inline-flex;align-items:center;gap:6px;font-size:10px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;border-radius:99px;padding:3px 10px;margin-bottom:12px}
+  .tag.now{color:var(--muted-fg);border:1px solid var(--border);background:var(--muted-20)}
+  .tag.new{color:var(--emerald);border:1px solid var(--emerald-b);background:var(--emerald-bg)}
+  .caption{font-size:12px;color:var(--faint-fg);margin-top:12px;max-width:70ch}
+  .caption b{color:var(--muted-fg);font-weight:600}
+
+  /* ── shadcn-style primitives (mock) ── */
+  .badge{display:inline-flex;align-items:center;gap:4px;flex:none;border-radius:99px;border:1px solid #3f3f46;padding:1px 8px;font-size:10px;font-weight:500;line-height:1.6;color:#e4e4e7;white-space:nowrap}
+  .badge .tk{color:var(--faint-fg);font-weight:400}
+  .badge.status-ok{color:var(--emerald);border-color:var(--emerald-b);background:var(--emerald-bg)}
+  .badge.role{color:var(--blue);border-color:var(--blue-b)}
+  .badge.warnfx{border-color:var(--amber-b)}
+  .badge.warnfx .fx{color:var(--amber);display:inline-flex;align-items:center;gap:3px}
+
+  /* step row */
+  .steprow{display:flex;align-items:center;gap:10px;border:1px solid var(--border);border-radius:8px;background:var(--muted-20);padding:9px 12px;margin-top:8px}
+  .steprow .n{flex:none;width:24px;height:24px;border-radius:99px;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:600;background:var(--emerald-bg);color:var(--emerald)}
+  .steprow .t{min-width:0;flex:1;font-size:13px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .steprow .ic{color:var(--blue);display:flex;flex:none}
+
+  /* dialog mock */
+  .dialog{background:var(--bg);border:1px solid var(--border);border-radius:10px;box-shadow:0 20px 50px rgba(0,0,0,.55);padding:20px;max-width:448px;margin:0 auto}
+  .dlg-num{flex:none;width:32px;height:32px;border-radius:99px;display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;background:var(--emerald-bg);color:var(--emerald)}
+  .dlg-head{display:flex;gap:12px;align-items:flex-start}
+  .dlg-title{font-size:15px;font-weight:600;line-height:1.3}
+  .badges{display:flex;flex-wrap:wrap;gap:6px;margin-top:6px;align-items:center}
+
+  /* adherence line (the new element) */
+  .adh{display:flex;align-items:flex-start;gap:8px;margin-top:12px;border:1px solid var(--border);border-radius:8px;padding:9px 12px;font-size:12.5px;background:var(--muted-20)}
+  .adh .aic{flex:none;display:flex;margin-top:2px}
+  .adh .amain{color:var(--fg);font-weight:500}
+  .adh .asub{color:var(--muted-fg);font-weight:400}
+  .adh .adis{display:block;font-size:11px;color:var(--faint-fg);margin-top:2px}
+  .adh.ok{border-color:var(--emerald-b)}
+  .adh.ok .aic{color:var(--emerald)}
+  .adh.bad{border-color:var(--amber-b);background:var(--amber-bg)}
+  .adh.bad .aic{color:var(--amber)}
+  .adh.bad .amain em{font-style:normal;color:var(--amber)}
+  .adh.unk{border-style:dashed}
+  .adh.unk .aic{color:var(--faint-fg)}
+  .adh.unk .amain{color:var(--muted-fg)}
+
+  /* comment mock */
+  .cmt{display:flex;gap:10px;margin-top:12px}
+  .cmt .av{flex:none;width:26px;height:26px;border-radius:99px;background:var(--muted-60);display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;color:var(--muted-fg)}
+  .cmt .body{flex:1;border:1px solid var(--border);border-radius:8px;padding:9px 12px;font-size:12.5px;background:var(--popover)}
+  .cmt .who{font-size:11px;color:var(--muted-fg);margin-bottom:4px}
+  .cmt .who b{color:var(--fg);font-weight:600}
+  .cmt.warn .body{border-color:var(--amber-b)}
+  .cmt.warn .body .lead{color:var(--amber);font-weight:600}
+
+  /* terminal / sql */
+  .term{margin-top:12px;border:1px solid var(--border);border-radius:8px;background:var(--popover);padding:14px 16px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;line-height:1.7;color:#d4d4d8;overflow-x:auto}
+  .term .hl{color:var(--emerald)}
+  .term .dim{color:var(--faint-fg)}
+  .term .warn{color:var(--amber)}
+  .term table{margin:6px 0 0;border-collapse:collapse;font-size:12px;font-family:inherit}
+  .term th,.term td{border:1px solid #3f3f46;padding:3px 10px;text-align:left;color:#d4d4d8;font-weight:400;text-transform:none;letter-spacing:0;font-size:12px}
+  .term th{color:var(--faint-fg)}
+
+  /* tooltip mock */
+  .tipwrap{position:relative;display:inline-block}
+  .tip{margin-top:8px;background:var(--fg);color:var(--bg);border-radius:6px;padding:7px 10px;font-size:11.5px;line-height:1.45;max-width:300px;box-shadow:0 8px 24px rgba(0,0,0,.4)}
+
+  /* tables */
+  table{width:100%;border-collapse:collapse;margin-top:16px;font-size:13px}
+  th{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint-fg);text-align:left;font-weight:600;padding:8px 12px;border-bottom:1px solid var(--border)}
+  td{padding:10px 12px;border-bottom:1px solid var(--border);color:var(--muted-fg);vertical-align:top}
+  td:first-child{color:var(--fg)}
+  .tablewrap{overflow-x:auto;border:1px solid var(--border);border-radius:10px;background:var(--card);padding:0 4px 4px;margin-top:16px}
+  .tablewrap table{margin-top:0}
+  .tablewrap tr:last-child td{border-bottom:0}
+  td code{white-space:normal}
+
+  .note{margin-top:16px;border:1px solid var(--amber-b);background:var(--amber-bg);border-radius:8px;padding:12px 14px;font-size:13px;color:var(--muted-fg);max-width:none}
+  .note b{color:var(--amber)}
+  .note.green{border-color:var(--emerald-b);background:var(--emerald-bg)}
+  .note.green b{color:var(--emerald)}
+
+  /* decision cards */
+  .dgrid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:14px;margin-top:18px}
+  @media(max-width:820px){.dgrid{grid-template-columns:1fr}}
+  .dcard{border:1px solid var(--emerald-b);background:var(--card);border-radius:10px;padding:16px}
+  .dcard .q{font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--emerald)}
+  .dcard .a{font-size:14px;font-weight:600;margin-top:6px;line-height:1.4}
+  .dcard .why{font-size:12px;color:var(--muted-fg);margin-top:8px;line-height:1.5}
+
+  .check{margin-top:14px}
+  .check li{display:flex;gap:10px;align-items:flex-start;padding:9px 0;border-bottom:1px solid var(--border);color:var(--muted-fg);font-size:13.5px;list-style:none;max-width:none}
+  .check li:last-child{border-bottom:0}
+  .check .box{flex:none;width:16px;height:16px;border:1.5px solid var(--faint-fg);border-radius:4px;margin-top:3px}
+  footer{margin-top:72px;padding-top:20px;border-top:1px solid var(--border);font-size:12px;color:var(--faint-fg)}
+
+  /* phone frame */
+  .phone{width:375px;max-width:100%;margin:0 auto;border:1px solid #3f3f46;border-radius:24px;background:var(--bg);box-shadow:0 24px 60px rgba(0,0,0,.5);overflow:hidden}
+  .phone .notch{height:26px;display:flex;align-items:center;justify-content:center}
+  .phone .notch i{display:block;width:110px;height:16px;border-radius:99px;background:#18181b}
+  .phone .screen{padding:16px 14px 24px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="hero">
+  <div class="kicker"><span class="dot"></span>Feature Development · Step 2 — UX Design</div>
+  <h1>P2c — Capture Executed Model &amp; Tier Adherence</h1>
+  <p class="sub">P2b made the model directive mandatory; P2c closes the loop by recording what the orchestrator <em>says</em> it ran (<code>executed_model</code>) and whether that honoured the step's tier (<code>tier_honored</code>). Almost all of P2c is backend — schema, capture params, <code>resolveModelTier</code> reuse, the <code>workflow_tier_adherence</code> view. This document designs the small user-visible surface that telemetry deserves, and decides the three open questions from the P2c Requirements deliverable. The governing principle throughout: <strong style="color:var(--fg)">this is self-reported data</strong> — every surface that shows adherence must say so, and <strong style="color:var(--fg)">unknown must never read as failure</strong> (NULL ≠ false is load-bearing in the schema; it is load-bearing in the UI too).</p>
+  <div class="meta">
+    <span>executed_model + tier_honored — both nullable (migration 00135)</span>
+    <span>NULL = unknown, never rendered as failure</span>
+    <span>Self-reported — not hard enforcement</span>
+    <span>Dark-first · shadcn New York / Zinc</span>
+  </div>
+</header>
+
+<nav class="toc" aria-label="Sections">
+  <a href="#s0"><b>0</b>Decisions</a>
+  <a href="#s1"><b>1</b>Surface map</a>
+  <a href="#s2"><b>2</b>Step detail — 3 states</a>
+  <a href="#s3"><b>3</b>Step row</a>
+  <a href="#s4"><b>4</b>Dishonored comment</a>
+  <a href="#s5"><b>5</b>Report — SQL view</a>
+  <a href="#s6"><b>6</b>All states</a>
+  <a href="#s7"><b>7</b>Copy strings</a>
+  <a href="#s8"><b>8</b>Mobile &amp; A11y</a>
+  <a href="#s9"><b>9</b>Review checklist</a>
+</nav>
+
+<!-- ══════════════════════ 0. DECISIONS ══════════════════════ -->
+<section id="s0">
+  <h2><span class="num">00</span>The three open questions — decided</h2>
+  <div class="dgrid">
+    <div class="dcard">
+      <div class="q">Q1 · v1 report surface</div>
+      <div class="a">SQL view + documented queries only. The admin “Tier adherence” card is a fast follow, not this card.</div>
+      <div class="why">Nick's intent — “so we'll be able to check it and run reports” — is fully satisfied by the view: he operates through Claude Code with direct Supabase access, and <code>select * from workflow_tier_adherence</code> is a one-liner there. Shipping an admin card <em>with</em> the capture would guarantee it launches into a permanent empty state (zero adherence rows exist until orchestrators adopt the new params). Requirements already marked the card a follow-up; agreeing keeps this card honest. Query shapes mocked in §05 so the view's columns are designed for the card that will consume them.</div>
+    </div>
+    <div class="dcard">
+      <div class="q">Q2 · Step-card indicator</div>
+      <div class="a">Yes — exception-only on the row, full three-state display in the step-detail dialog.</div>
+      <div class="why">Management by exception: the row (already carrying up to six chips) gains something <em>only</em> when <code>tier_honored = false</code> — an amber suffix inside the existing tier badge (§03). Honored and unknown rows look identical to today, matching <code>ModelTierBadge</code>'s silence-is-default philosophy. The step-detail dialog, where there is room, shows all three states with unknown rendered as a dashed, muted “Model not reported” — different icon, border style, <em>and</em> words from dishonored, so unknown can never be mistaken for failure (§02).</div>
+    </div>
+    <div class="dcard">
+      <div class="q">Q3 · Mismatch visibility</div>
+      <div class="a">Both: <code>logger.warn</code> <em>and</em> an auto step comment on dishonored completion.</div>
+      <div class="why"><code>logger.warn</code> lands in Vercel logs nobody reads in-product; Nick's “check it” happens on the board. <code>fail_step</code> already auto-posts a failure comment — reusing that exact machinery (plain <code>comment</code> type, no enum migration) gives free in-product visibility: the comment increments the row's existing comment-count chip and appears in the dialog's timeline (§04). Cost is one insert on a rare path. Dishonored only — honored and unknown post nothing (no noise).</div>
+    </div>
+  </div>
+  <p class="caption"><b>Scope deviation:</b> none pulled in, one nudged out — Q1 keeps the admin card <em>out</em> (agreeing with Requirements, against a maximal reading of Nick's quote); Q2/Q3 add two deliberately small in-product surfaces that reuse existing components (<code>ModelTierBadge</code>, step comments) rather than new ones. A follow-up board card for the admin “Tier adherence” tab section should be created at implementation time.</p>
+</section>
+
+<!-- ══════════════════════ 1. SURFACE MAP ══════════════════════ -->
+<section id="s1">
+  <h2><span class="num">01</span>Surface map — where adherence appears, and the honesty rule</h2>
+  <p>Four surfaces, in descending order of detail. Every one carries the self-reported disclosure — as visible caption where there is room (dialog, comment, SQL doc), as tooltip where there isn't (badges). No surface may use verification language (“verified”, “confirmed”, “enforced”); the vocabulary is <strong>reported / honored / not honored / not reported</strong>.</p>
+  <div class="tablewrap">
+    <table>
+      <thead><tr><th>Surface</th><th>Shows</th><th>Disclosure form</th><th>Section</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Step-detail dialog</strong></td><td>All three states — honored / not honored / not reported — with executed model name</td><td>Tooltip on the info affordance + one-line sub-text on the not-honored state</td><td>§02</td></tr>
+        <tr><td><strong>Step row</strong> (workflow section + workflows tab)</td><td>Dishonored only — amber suffix in the tier badge</td><td>Tooltip (full sentence incl. “self-reported”)</td><td>§03</td></tr>
+        <tr><td><strong>Auto step comment</strong></td><td>Dishonored only — posted at completion</td><td>In the comment body itself</td><td>§04</td></tr>
+        <tr><td><strong><code>workflow_tier_adherence</code> view</strong></td><td>Counts by user · tier · workflow · week + frontier drill-down</td><td>Header comment in the view's migration + documented queries</td><td>§05</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="note"><b>The canonical disclosure string</b> — one sentence, reused verbatim on every surface (a single constant, <code>TIER_ADHERENCE_DISCLOSURE</code>): <code style="white-space:normal">Self-reported by the orchestrator — VibeCodes records what the agent says it ran, and does not verify it.</code></div>
+</section>
+
+<!-- ══════════════════════ 2. STEP DETAIL — 3 STATES ══════════════════════ -->
+<section id="s2">
+  <h2><span class="num">02</span>Step-detail dialog — the three-state “Execution” line</h2>
+  <p>A single new element in <code>step-detail-dialog.tsx</code>: an <strong>Execution line</strong> rendered in the content area, above Output. It appears only when the step has a tier (Auto steps are exempt — <code>tier_honored</code> is NULL by design and showing anything would imply a promise Auto never made) <em>and</em> the step is <code>completed</code> or <code>failed</code>. Pending / in-progress steps show nothing — there is no execution to report yet.</p>
+
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">State 1 of 3 — honored (tier_honored = true)</span></div>
+    <div class="stage">
+      <div class="dialog">
+        <div class="dlg-head">
+          <span class="dlg-num"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
+          <div style="min-width:0;flex:1">
+            <p class="dlg-title">Design the settings dialog</p>
+            <div class="badges">
+              <span class="badge status-ok"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Completed</span>
+              <span class="badge role">designer</span>
+              <span class="badge"><span class="tk">tier:</span>Frontier</span>
+            </div>
+          </div>
+        </div>
+        <div class="adh ok">
+          <span class="aic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
+          <span>
+            <span class="amain">Ran on Fable</span> <span class="asub">· tier honored</span>
+            <span class="tipwrap" style="margin-left:4px;vertical-align:middle"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#71717a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg></span>
+          </span>
+        </div>
+        <div class="tip" style="margin-left:32px">The orchestrator reported running this step on Fable — the model mapped to its Frontier tier, or that tier's allowed fallback. Self-reported by the orchestrator — VibeCodes records what the agent says it ran, and does not verify it.</div>
+      </div>
+    </div>
+  </div>
+  <p class="caption"><b>Fallback counts as honored</b> — by Requirements, fallback-honored folds into <code>true</code>. The line always names the <em>executed</em> model, so a Frontier step that fell back reads “Ran on Opus · tier honored”, and the tooltip's “or that tier's allowed fallback” explains why the check is still green. The UI never recomputes exact-vs-fallback post hoc: the completing user's map at completion time isn't stored, so any recomputation could lie. Display what was stored, explain the rule.</p>
+
+  <div class="cols">
+    <div class="frame">
+      <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">State 2 of 3 — not honored (tier_honored = false)</span></div>
+      <div class="stage">
+        <div class="dialog" style="max-width:400px">
+          <div class="badges" style="margin-top:0">
+            <span class="badge status-ok"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Completed</span>
+            <span class="badge"><span class="tk">tier:</span>Frontier</span>
+          </div>
+          <div class="adh bad">
+            <span class="aic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4M12 17h.01"/></svg></span>
+            <span>
+              <span class="amain">Ran on <em>Sonnet</em></span> <span class="asub">· tier not honored</span>
+              <span class="adis">Frontier maps to Fable. Self-reported — not verified.</span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="frame">
+      <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">State 3 of 3 — unknown (tier_honored = NULL)</span></div>
+      <div class="stage">
+        <div class="dialog" style="max-width:400px">
+          <div class="badges" style="margin-top:0">
+            <span class="badge status-ok"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Completed</span>
+            <span class="badge"><span class="tk">tier:</span>Frontier</span>
+          </div>
+          <div class="adh unk">
+            <span class="aic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
+            <span>
+              <span class="amain">Model not reported</span>
+              <span class="adis">Not a failure — the orchestrator completed this step without saying which model ran it.</span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p class="caption"><b>Why unknown can never read as failure</b> — the two states differ on every channel at once: icon (help-circle vs warning-triangle), border (dashed zinc vs solid amber), fill (none vs amber tint), headline (“Model not reported” vs “Ran on Sonnet · tier not honored”), and sub-text (“Not a failure…” says it outright). Colour is the <em>least</em> load-bearing of the five. Every pre-P2c completion and every orchestrator that hasn't adopted the new params lands in unknown — which is most steps for months — so this state is calm, muted, and judgment-free by construction.</p>
+</section>
+
+<!-- ══════════════════════ 3. STEP ROW ══════════════════════ -->
+<section id="s3">
+  <h2><span class="num">03</span>Step row — exception-only amber suffix</h2>
+  <p>The compact rows in <code>task-workflow-section.tsx</code> and <code>workflows-tab.tsx</code> gain nothing for honored or unknown steps — they render exactly as today. Only <code>tier_honored = false</code> changes the row: <code>ModelTierBadge</code> grows optional <code>executedModel</code> / <code>tierHonored</code> props and, when dishonored, appends an amber triangle + “ran on &lt;Model&gt;” inside the existing badge (one chip, not two). Clicking the row opens the dialog with the full §02 line, per the section's existing behaviour.</p>
+
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Workflow step list — honored, dishonored, unknown rows side by side</span></div>
+    <div class="stage">
+      <div style="max-width:640px;margin:0 auto">
+        <div class="steprow">
+          <span class="n"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
+          <span class="t">Write the requirements document</span>
+          <span class="badge"><span class="tk">tier:</span>Frontier</span>
+          <span class="badge role">product owner</span>
+          <span class="badge status-ok">Completed</span>
+        </div>
+        <div class="steprow">
+          <span class="n"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
+          <span class="t">Design the settings dialog</span>
+          <span class="ic" title="Has output"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg></span>
+          <span class="badge warnfx"><span class="tk">tier:</span>Frontier <span class="fx"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4M12 17h.01"/></svg>ran on Sonnet</span></span>
+          <span class="badge role">designer</span>
+          <span class="badge status-ok">Completed</span>
+        </div>
+        <div class="steprow">
+          <span class="n"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
+          <span class="t">Implement the schema migration</span>
+          <span class="badge"><span class="tk">tier:</span>Standard</span>
+          <span class="badge role">developer</span>
+          <span class="badge status-ok">Completed</span>
+        </div>
+        <div class="tip" style="margin-left:44px;margin-top:10px">Tier not honored — this Frontier step maps to Fable, but the orchestrator reported running on Sonnet. Self-reported by the orchestrator — VibeCodes records what the agent says it ran, and does not verify it.</div>
+      </div>
+    </div>
+  </div>
+  <p class="caption"><b>Row 1 vs row 3:</b> row 1 is honored, row 3 is unknown — and they are deliberately indistinguishable at row level. The row answers “does anything need my attention?”, and for both the answer is no; the dialog carries the distinction (§02). <b>Amber, not red:</b> the tier badge suffix uses amber (warning) because a dishonored report is drift to investigate, not an execution failure — red stays reserved for the <code>Failed</code> status. The suffix is icon + words (“ran on Sonnet”), never a bare coloured dot. Full disclosure sentence lives in the badge's tooltip (shown above) and in <code>aria-label</code>: <code>Model tier Frontier — not honored: orchestrator reported Sonnet</code>.</p>
+</section>
+
+<!-- ══════════════════════ 4. DISHONORED COMMENT ══════════════════════ -->
+<section id="s4">
+  <h2><span class="num">04</span>Auto comment on dishonored completion (Q3)</h2>
+  <p>Mirrors <code>fail_step</code>'s auto-posted failure comment: when <code>complete_step</code> computes <code>tier_honored = false</code>, it inserts one step comment (existing <code>comment</code> type — no enum migration) attributed to the completing bot, then proceeds normally. The completion itself is <strong>never blocked or failed</strong> — this is telemetry, not enforcement. <code>logger.warn</code> fires alongside for ops-side aggregation.</p>
+
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">Step-detail dialog — comments timeline after a dishonored completion</span></div>
+    <div class="stage">
+      <div class="dialog">
+        <div class="cmt">
+          <span class="av">CD</span>
+          <div class="body">
+            <div class="who"><b>Compass</b> · designer · 2m ago</div>
+            Design doc delivered at docs/spikes/p2c-tier-adherence-design.html — three decisions inside.
+          </div>
+        </div>
+        <div class="cmt warn">
+          <span class="av">CD</span>
+          <div class="body">
+            <div class="who"><b>Compass</b> · designer · 2m ago</div>
+            <span class="lead">Tier not honored</span> — this step is set to Frontier but the orchestrator reported running on Sonnet. Self-reported by the orchestrator — VibeCodes records what the agent says it ran, and does not verify it.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p class="caption"><b>Why this beats logs alone:</b> the comment increments the step row's existing comment-count chip — so even without the §03 badge, a dishonored step already looks different on the board — and it survives in the step's permanent record for the Verify pass to read. Copy is generated server-side from one template (§07) so the wording matches the dialog and badge verbatim. Honored and unknown completions post <em>nothing</em>: a comment per completion would be pure noise, and unknown-as-comment would nag every legacy orchestrator.</p>
+</section>
+
+<!-- ══════════════════════ 5. REPORT — SQL VIEW ══════════════════════ -->
+<section id="s5">
+  <h2><span class="num">05</span>The report — <code>workflow_tier_adherence</code> + documented queries (Q1)</h2>
+  <p>v1's report surface <em>is</em> the view. Two documented queries — a summary and the frontier drill-down — live as a header comment in migration 00135 and a short “Checking tier adherence” subsection in <code>docs/release-process.md</code>'s monitoring area (or CLAUDE.md's AI section — implementer's choice, one place only). The shapes below are the design contract: the fast-follow admin card must be buildable from these two queries alone, with no further schema work.</p>
+
+  <h3>Query 1 — adherence summary (what Nick runs weekly)</h3>
+  <div class="term"><span class="dim">-- Tier adherence, last 30 days, by user and tier</span><br><span class="hl">select</span> week, user_email, tier, honored, dishonored, unknown, total<br><span class="hl">from</span> workflow_tier_adherence<br><span class="hl">where</span> week &gt;= now() - <span class="hl">interval</span> '30 days'<br><span class="hl">order by</span> week <span class="hl">desc</span>, dishonored <span class="hl">desc</span>;
+    <table>
+      <thead><tr><th>week</th><th>user_email</th><th>tier</th><th>honored</th><th>dishonored</th><th>unknown</th><th>total</th></tr></thead>
+      <tbody>
+        <tr><td>2026-07-06</td><td>ballathesenior@…</td><td>frontier</td><td>11</td><td class="warn">2</td><td>4</td><td>17</td></tr>
+        <tr><td>2026-07-06</td><td>ballathesenior@…</td><td>standard</td><td>23</td><td>0</td><td>9</td><td>32</td></tr>
+        <tr><td>2026-06-29</td><td>ballathesenior@…</td><td>frontier</td><td>8</td><td>0</td><td>12</td><td>20</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h3>Query 2 — frontier drill-down (“which steps didn't run on Fable?”)</h3>
+  <div class="term"><span class="dim">-- Frontier steps whose reported model was not fable (excludes unknown)</span><br><span class="hl">select</span> completed_at, task_title, step_title, executed_model, bot_name<br><span class="hl">from</span> workflow_tier_adherence_steps  <span class="dim">-- row-level companion of the view</span><br><span class="hl">where</span> tier = 'frontier' <span class="hl">and</span> tier_honored = <span class="hl">false</span><br><span class="hl">order by</span> completed_at <span class="hl">desc limit</span> 20;
+    <table>
+      <thead><tr><th>completed_at</th><th>task_title</th><th>step_title</th><th>executed_model</th><th>bot_name</th></tr></thead>
+      <tbody>
+        <tr><td>2026-07-07 14:02</td><td>P2c: Capture executed model…</td><td>UX Design</td><td class="warn">sonnet</td><td>Compass</td></tr>
+        <tr><td>2026-07-06 09:41</td><td>Fix relay session mint</td><td>Code Review</td><td class="warn">opus*</td><td>Sentinel</td></tr>
+      </tbody>
+    </table>
+  <span class="dim">* opus on frontier is dishonored only when it wasn't the allowed fallback at completion — the stored boolean is authoritative; never re-derive it in the query.</span></div>
+
+  <h3>Empty result — the documented interpretation</h3>
+  <div class="term"><span class="hl">select</span> * <span class="hl">from</span> workflow_tier_adherence;<br><span class="dim">(0 rows)</span><br><br><span class="dim">-- Doc note beside the query, verbatim:</span><br><span class="dim">-- 0 rows = no tiered steps completed yet. Rows appear after the first</span><br><span class="dim">-- completion of a step that has a model tier. All-unknown counts mean</span><br><span class="dim">-- steps are completing but orchestrators aren't reporting model_used yet.</span></div>
+
+  <ul class="notes">
+    <li><strong>Counts must be filterable to unknown-heavy.</strong> The summary always carries the <code>unknown</code> column next to honored/dishonored — an adherence rate quoted without its unknown denominator would be the numeric version of the colour-only sin. The doc'd note tells the reader how to interpret an all-unknown week.</li>
+    <li><strong>Fast-follow admin card (out of scope, shape agreed):</strong> a “Tier Adherence” section on the existing AI Usage tab — three <code>StatCard</code>s (Honored / Not honored / Not reported, each “n of total”), the frontier drill-down as a table, reusing the tab's existing From/To/user filter bar, with the canonical disclosure as the section's caption. It consumes Query 1 + Query 2 as-is.</li>
+    <li><strong>Disclosure in the doc:</strong> the documented-query section opens with the canonical disclosure sentence, so even the SQL surface carries it.</li>
+  </ul>
+</section>
+
+<!-- ══════════════════════ 6. ALL STATES ══════════════════════ -->
+<section id="s6">
+  <h2><span class="num">06</span>All states</h2>
+  <p>The in-product surface piggybacks entirely on data already loaded with the step row (<code>executed_model</code>, <code>tier_honored</code> ride the same select), so it introduces <strong>no new fetch, and therefore no new loading or error state</strong> — the workflow section's existing skeleton and error toast cover it. The states that do exist:</p>
+  <div class="tablewrap">
+    <table>
+      <thead><tr><th>State</th><th>Condition</th><th>Rendering</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Not applicable</strong></td><td>Step has no tier (Auto), or status is pending / in progress / awaiting approval</td><td>Nothing — no Execution line, no badge suffix. Auto made no promise; unstarted steps have nothing to report.</td></tr>
+        <tr><td><strong>Honored</strong></td><td><code>tier_honored = true</code>, completed/failed</td><td>Dialog: emerald check line “Ran on &lt;Model&gt; · tier honored”. Row: unchanged.</td></tr>
+        <tr><td><strong>Not honored</strong></td><td><code>tier_honored = false</code></td><td>Dialog: amber triangle line + sub-text. Row: amber badge suffix “ran on &lt;Model&gt;”. Plus the auto comment (§04).</td></tr>
+        <tr><td><strong>Unknown</strong></td><td><code>tier_honored IS NULL</code> on a tiered, completed step (legacy or non-reporting orchestrator)</td><td>Dialog: dashed muted “Model not reported” + “Not a failure” sub-text. Row: unchanged. Never amber, never red.</td></tr>
+        <tr><td><strong>Loading</strong></td><td>Workflow section fetching</td><td>Existing section skeleton — the Execution line renders only with resolved data, so no flash-of-wrong-state.</td></tr>
+        <tr><td><strong>Error</strong></td><td>Section fetch fails</td><td>Existing section error handling (toast, house rule: never silent). No adherence-specific error UI.</td></tr>
+        <tr><td><strong>Report empty</strong></td><td>View returns 0 rows</td><td>Documented interpretation beside the query (§05): “No tiered steps completed yet…”.</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ══════════════════════ 7. COPY STRINGS ══════════════════════ -->
+<section id="s7">
+  <h2><span class="num">07</span>Exact copy strings</h2>
+  <p>All adherence copy derives from one vocabulary — <strong>reported / honored / not honored / not reported</strong> — and one disclosure constant. <code>&lt;Model&gt;</code> is the display-cased executed model; <code>&lt;Tier&gt;</code> the step's tier label; <code>&lt;Mapped&gt;</code> the tier's platform-default model name (defaults are stable copy; per-user maps are not re-resolved post hoc).</p>
+  <div class="tablewrap">
+    <table>
+      <thead><tr><th>String</th><th>Exact copy</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Disclosure (canonical constant)</strong></td><td><code>Self-reported by the orchestrator — VibeCodes records what the agent says it ran, and does not verify it.</code></td></tr>
+        <tr><td><strong>Execution line · honored</strong></td><td><code>Ran on &lt;Model&gt; · tier honored</code> — tooltip: <code>The orchestrator reported running this step on &lt;Model&gt; — the model mapped to its &lt;Tier&gt; tier, or that tier's allowed fallback.</code> + disclosure.</td></tr>
+        <tr><td><strong>Execution line · not honored</strong></td><td><code>Ran on &lt;Model&gt; · tier not honored</code> — sub-text: <code>&lt;Tier&gt; maps to &lt;Mapped&gt;. Self-reported — not verified.</code></td></tr>
+        <tr><td><strong>Execution line · unknown</strong></td><td><code>Model not reported</code> — sub-text: <code>Not a failure — the orchestrator completed this step without saying which model ran it.</code></td></tr>
+        <tr><td><strong>Row badge suffix (dishonored only)</strong></td><td><code>ran on &lt;Model&gt;</code> — tooltip: <code>Tier not honored — this &lt;Tier&gt; step maps to &lt;Mapped&gt;, but the orchestrator reported running on &lt;Model&gt;.</code> + disclosure. <code>aria-label</code>: <code>Model tier &lt;Tier&gt; — not honored: orchestrator reported &lt;Model&gt;</code>.</td></tr>
+        <tr><td><strong>Auto comment body</strong></td><td><code>Tier not honored — this step is set to &lt;Tier&gt; but the orchestrator reported running on &lt;Model&gt;.</code> + disclosure sentence.</td></tr>
+        <tr><td><strong>Report · empty interpretation</strong></td><td><code>0 rows = no tiered steps completed yet. Rows appear after the first completion of a step that has a model tier.</code></td></tr>
+        <tr><td><strong><code>logger.warn</code> event</strong></td><td><code>"model tier not honored"</code> with <code>{ stepId, tier, executedModel, resolvedModel, botId }</code> — greppable constant string, details structured.</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ══════════════════════ 8. MOBILE & A11Y ══════════════════════ -->
+<section id="s8">
+  <h2><span class="num">08</span>Mobile (375px) &amp; accessibility — WCAG 2.1 AA</h2>
+  <p>No admin card in v1, so mobile work is confined to the step row and dialog. Below <code>sm</code>, the dishonored badge suffix drops its text and keeps the amber triangle — the row's chips already compete for 375px, and the triangle is a <em>shape</em>, not a colour, so the reduction stays non-colour-coded; the full wording is one tap away in the dialog, which the whole row already opens. The Execution line in the dialog wraps naturally (it is a flex row of text) and its tap targets (info tooltip trigger) get <code>min-h-11</code> under coarse pointers, matching <code>ModelTierSelect</code>'s existing treatment.</p>
+
+  <div class="frame">
+    <div class="bar"><span class="fdot"></span><span class="fdot"></span><span class="fdot"></span><span class="flabel">375px — dishonored row, icon-only suffix</span></div>
+    <div class="stage">
+      <div class="phone">
+        <div class="notch"><i></i></div>
+        <div class="screen">
+          <div class="steprow" style="min-height:44px">
+            <span class="n"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>
+            <span class="t">Design the settings dialog</span>
+            <span class="badge warnfx"><span class="tk">tier:</span>Frontier <span class="fx"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4M12 17h.01"/></svg></span></span>
+            <span class="badge status-ok">Done</span>
+          </div>
+          <p class="caption" style="margin-top:10px">Tap opens the step-detail dialog → full Execution line with wording and disclosure (§02).</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="tablewrap">
+    <table>
+      <thead><tr><th>Concern</th><th>Treatment</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Not colour-only</strong></td><td>Honored / not honored / unknown differ by icon shape (check / triangle / help-circle), border style (solid / solid / dashed), and — decisively — words (“tier honored” / “tier not honored” / “Model not reported”). The mobile icon-only suffix is a shape distinction, with full text in <code>aria-label</code> and one tap away.</td></tr>
+        <tr><td><strong>Programmatic names</strong></td><td>Execution line is a labelled group: <code>aria-label="Execution: ran on Sonnet, tier not honored"</code> etc. Row badge suffix carried in the badge's single <code>aria-label</code> (§07) — one announcement, not fragments. Tooltip content duplicated via <code>aria-describedby</code>, not hover-only.</td></tr>
+        <tr><td><strong>Tooltips accessible</strong></td><td>Info affordances follow the existing <code>match_tier</code> badge pattern (<code>cursor-help</code> + Radix Tooltip): keyboard-focusable trigger, tooltip on focus as well as hover, dismiss on Esc (WCAG 1.4.13).</td></tr>
+        <tr><td><strong>Contrast</strong></td><td>Amber <code>#fbbf24</code> on zinc-950 ≈ 10.9:1; emerald <code>#34d399</code> ≈ 9.9:1; muted <code>zinc-400</code> ≈ 7.5:1 — all clear 4.5:1 for text; icons clear 3:1 (non-text).</td></tr>
+        <tr><td><strong>Target size</strong></td><td>Row stays a single ≥44px tap target on coarse pointers (whole row opens dialog — the badge itself is not the target on mobile). Tooltip trigger in dialog ≥44px coarse.</td></tr>
+        <tr><td><strong>No new live regions</strong></td><td>Adherence is historical record, not a live event — nothing announces on render. The auto comment inherits the comment list's existing semantics.</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ══════════════════════ 9. REVIEW CHECKLIST ══════════════════════ -->
+<section id="s9">
+  <h2><span class="num">09</span>Design-review checklist</h2>
+  <p>For the Design Review step — each item maps to a decision or a Requirements clause.</p>
+  <ul class="check">
+    <li><span class="box"></span><span><strong>Q1:</strong> SQL view + documented queries as the v1 report; admin “Tier adherence” section deferred as a fast-follow card consuming Query 1 + Query 2 unchanged — approve the deferral and the two query shapes. (§00, §05)</span></li>
+    <li><span class="box"></span><span><strong>Q2:</strong> exception-only row suffix + full three-state Execution line in the dialog — approve the split, and specifically that honored and unknown rows are identical at row level. (§02, §03)</span></li>
+    <li><span class="box"></span><span><strong>Q3:</strong> auto comment on dishonored completion (plain <code>comment</code> type, completing-bot attribution, completion never blocked) alongside <code>logger.warn</code> — approve. (§04)</span></li>
+    <li><span class="box"></span><span><strong>NULL ≠ false in UI:</strong> unknown differs from dishonored on icon, border, tint, and words; “Not a failure” stated verbatim — confirm no surface lets unknown read as failure. (§02)</span></li>
+    <li><span class="box"></span><span><strong>Honesty framing:</strong> canonical disclosure constant appears on every surface (dialog tooltip/sub-text, badge tooltip, comment body, SQL doc header) and no string uses verification language — audit §07 copy table.</span></li>
+    <li><span class="box"></span><span><strong>Fallback display:</strong> “Ran on Opus · tier honored” for a fallback-honored Frontier step, with the tooltip's “or that tier's allowed fallback” — confirm this reads as correct, not contradictory. (§02)</span></li>
+    <li><span class="box"></span><span><strong>Amber not red:</strong> dishonored uses warning amber everywhere; red remains exclusive to the Failed status — confirm. (§03)</span></li>
+    <li><span class="box"></span><span><strong>States:</strong> not-applicable gating (Auto steps, pre-completion statuses show nothing), no new fetch/loading/error surface, report empty-interpretation — confirm the table in §06 is complete.</span></li>
+    <li><span class="box"></span><span><strong>Mobile:</strong> icon-only suffix below <code>sm</code> with full text in dialog + aria — accept, or require text at all widths. (§08)</span></li>
+    <li><span class="box"></span><span><strong>Out-of-scope guard:</strong> nothing here implies hard enforcement, external cross-check, backfill, or blocking completions — flag if any mockup or string suggests otherwise.</span></li>
+  </ul>
+</section>
+
+<footer>
+  P2c · Capture Executed Model &amp; Tier Adherence — UX Design · card <code>cc099a5a</code> · builds on “P2c Requirements” (self-reported telemetry, migration 00135, <code>workflow_tier_adherence</code>) and the approved P2b design (<code>docs/spikes/p2b-model-tier-enforcement-design.html</code>) · Compass, UX
+</footer>
+
+</div>
+</body>
+</html>

--- a/mcp-server/src/register-tools.ts
+++ b/mcp-server/src/register-tools.ts
@@ -1174,7 +1174,7 @@ export function registerTools(
 
   server.tool(
     "complete_step",
-    "Mark a workflow step as completed with optional output/deliverable. Pass the `claim_token` you received from claim_next_step — it proves you are the claimer; you must also be acting as the step's assigned bot (set_agent_identity). If the token is lost, call claim_next_step to re-claim and get a fresh one. The output is stored on the step's `output` column (primary source for context chaining to subsequent steps) and also as a step comment for UI display. If the step requires human approval, it moves to awaiting_approval instead.",
+    "Mark a workflow step as completed with optional output/deliverable. Pass the `claim_token` you received from claim_next_step — it proves you are the claimer; you must also be acting as the step's assigned bot (set_agent_identity). If the token is lost, call claim_next_step to re-claim and get a fresh one. The output is stored on the step's `output` column (primary source for context chaining to subsequent steps) and also as a step comment for UI display. If the step requires human approval, it moves to awaiting_approval instead. Pass `model_used` = the Task-tool model alias the step's subagent actually ran on (self-reported — VibeCodes records it but does not verify it).",
     completeStepSchema.shape,
     async (args: Record<string, unknown>, extra: ServerExtra) => {
       try {
@@ -1188,7 +1188,7 @@ export function registerTools(
 
   server.tool(
     "fail_step",
-    "Mark a workflow step as failed. Pass the `claim_token` from claim_next_step (not needed when rejecting an awaiting_approval step — human gate). Pass the failure reason in the `output` parameter (NOT `reason`). Use `reset_to_step_id` for cascade rejection — resets that step and all subsequent steps back to pending (and invalidates their claim tokens) so the workflow can be reworked from that point (the run stays 'running'). Without `reset_to_step_id`, the entire workflow run is marked as failed and stops. The `output` text is saved as a 'failure' comment on the step and becomes rework context when the step is later re-claimed via `claim_next_step`.",
+    "Mark a workflow step as failed. Pass the `claim_token` from claim_next_step (not needed when rejecting an awaiting_approval step — human gate). Pass the failure reason in the `output` parameter (NOT `reason`). Use `reset_to_step_id` for cascade rejection — resets that step and all subsequent steps back to pending (and invalidates their claim tokens) so the workflow can be reworked from that point (the run stays 'running'). Without `reset_to_step_id`, the entire workflow run is marked as failed and stops. The `output` text is saved as a 'failure' comment on the step and becomes rework context when the step is later re-claimed via `claim_next_step`. Pass `model_used` = the Task-tool model alias the step's subagent actually ran on (self-reported — VibeCodes records it but does not verify it).",
     failStepSchema.shape,
     async (args: Record<string, unknown>, extra: ServerExtra) => {
       try {

--- a/mcp-server/src/tools/workflows.test.ts
+++ b/mcp-server/src/tools/workflows.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import type { McpContext } from "../context";
 import { mintClaimToken, hashClaimToken } from "../claim-token";
+import { TIER_ADHERENCE_DISCLOSURE } from "../../../src/lib/constants";
 
 // AI role matching hits the network — stub it so applyWorkflowTemplate can run
 // against pure Supabase mocks. Only applyWorkflowTemplate uses it in this file.
@@ -24,6 +25,7 @@ import {
   applyWorkflowTemplate,
   modelTierClause,
   resolveModelTier,
+  resolveTierAdherence,
 } from "./workflows";
 
 // ---------------------------------------------------------------------------
@@ -182,6 +184,42 @@ describe("workflow schemas", () => {
     it("rejects invalid UUID", () => {
       expect(() =>
         completeStepSchema.parse({ step_id: "not-a-uuid" })
+      ).toThrow();
+    });
+
+    // P2c FR-1: model_used is optional (backward compatible) and constrained
+    // to the known Task-tool aliases + the "other"/"unknown" sentinels.
+    it("accepts a valid model_used alias", () => {
+      const result = completeStepSchema.parse({ step_id: STEP_ID, model_used: "fable" });
+      expect(result.model_used).toBe("fable");
+    });
+
+    it("accepts model_used omitted (backward compatible)", () => {
+      const result = completeStepSchema.parse({ step_id: STEP_ID });
+      expect(result.model_used).toBeUndefined();
+    });
+
+    it("rejects an unrecognised model_used value (e.g. 'gpt-4')", () => {
+      expect(() =>
+        completeStepSchema.parse({ step_id: STEP_ID, model_used: "gpt-4" })
+      ).toThrow();
+    });
+  });
+
+  describe("failStepSchema", () => {
+    it("accepts a valid model_used alias", () => {
+      const result = failStepSchema.parse({ step_id: STEP_ID, model_used: "opus" });
+      expect(result.model_used).toBe("opus");
+    });
+
+    it("accepts model_used omitted (backward compatible)", () => {
+      const result = failStepSchema.parse({ step_id: STEP_ID });
+      expect(result.model_used).toBeUndefined();
+    });
+
+    it("rejects an unrecognised model_used value (e.g. 'gpt-4')", () => {
+      expect(() =>
+        failStepSchema.parse({ step_id: STEP_ID, model_used: "gpt-4" })
       ).toThrow();
     });
   });
@@ -1088,6 +1126,185 @@ describe("completeStep", () => {
     await completeStep(ctx, { claim_token: TCT.token, step_id: STEP_ID });
 
     expect(commentInserted).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeStep — tier adherence (P2c FR-6/7/8/12)
+// ---------------------------------------------------------------------------
+
+describe("completeStep — tier adherence (P2c)", () => {
+  /** run_id: null throughout so checkAndCompleteRun never fires — keeps these
+   * tests focused on the tier-adherence write path only. */
+  function ctxFor(opts: {
+    stepData: Record<string, unknown>;
+    updatedStep: Record<string, unknown>;
+    userModelTierMap?: Record<string, unknown> | null;
+  }) {
+    let commentInserted: unknown = null;
+    let usersQueried = 0;
+    let lastStepChain: ReturnType<typeof createChain> | null = null;
+
+    const ctx = makeContext(((table: string) => {
+      if (table === "task_workflow_steps") {
+        const chain = createChain(null);
+        chain.chain.single = vi.fn(() => Promise.resolve({ data: opts.stepData, error: null }));
+        chain.chain.maybeSingle = vi.fn(() => Promise.resolve({ data: opts.updatedStep, error: null }));
+        lastStepChain = chain;
+        return chain.chain;
+      }
+      if (table === "users") {
+        usersQueried++;
+        return createChain({ model_tier_map: opts.userModelTierMap ?? null }).chain;
+      }
+      if (table === "workflow_step_comments") {
+        const chain = createChain(null);
+        chain.chain.insert = vi.fn((data: unknown) => {
+          commentInserted = data;
+          return chain.chain;
+        });
+        return chain.chain;
+      }
+      return createChain(null).chain;
+    }) as unknown as McpContext["supabase"]["from"]);
+
+    return {
+      ctx,
+      getUpdate: () => lastStepChain!.captured.updated as Record<string, unknown>,
+      getComment: () => commentInserted,
+      getUsersQueried: () => usersQueried,
+    };
+  }
+
+  const baseStep = {
+    claim_token_hash: TCT.hash,
+    id: STEP_ID,
+    run_id: null,
+    idea_id: IDEA_ID,
+    human_check_required: false,
+    status: "in_progress",
+    bot_id: null,
+  };
+  const baseUpdatedStep = {
+    id: STEP_ID,
+    task_id: TASK_ID,
+    run_id: null,
+    title: "Test Step",
+    agent_role: "developer",
+    status: "completed",
+    output: null,
+    completed_at: "2026-01-01T00:00:00Z",
+  };
+
+  it("model_used = resolved model -> executed_model set, tier_honored=true, no comment", async () => {
+    const { ctx, getUpdate, getComment } = ctxFor({
+      stepData: { ...baseStep, model_tier: "frontier" },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await completeStep(ctx, { claim_token: TCT.token, step_id: STEP_ID, model_used: "fable" });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBe("fable");
+    expect(update.tier_honored).toBe(true);
+    expect(getComment()).toBeNull();
+  });
+
+  it("model_used = the tier's allowed fallback -> tier_honored=true (fallback counts as honored)", async () => {
+    const { ctx, getUpdate, getComment } = ctxFor({
+      stepData: { ...baseStep, model_tier: "frontier" },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await completeStep(ctx, { claim_token: TCT.token, step_id: STEP_ID, model_used: "opus" });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBe("opus");
+    expect(update.tier_honored).toBe(true);
+    expect(getComment()).toBeNull();
+  });
+
+  it("model_used = an unrelated concrete model -> tier_honored=false and posts a 'comment' (not 'failure') mismatch comment", async () => {
+    const { ctx, getUpdate, getComment } = ctxFor({
+      stepData: { ...baseStep, model_tier: "frontier" },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await completeStep(ctx, { claim_token: TCT.token, step_id: STEP_ID, model_used: "sonnet" });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBe("sonnet");
+    expect(update.tier_honored).toBe(false);
+
+    const comment = getComment() as Record<string, unknown>;
+    expect(comment).not.toBeNull();
+    expect(comment.type).toBe("comment"); // NOT "failure" (Design-Review CONDITION 4)
+    expect(comment.step_id).toBe(STEP_ID);
+    expect(comment.idea_id).toBe(IDEA_ID);
+    expect(comment.author_id).toBe(USER_ID);
+    expect(comment.content as string).toContain("Tier not honored");
+    expect(comment.content as string).toContain(TIER_ADHERENCE_DISCLOSURE);
+    expect((comment.content as string).toLowerCase()).not.toContain("maps to");
+  });
+
+  it("model_used omitted -> executed_model=NULL, tier_honored=NULL (never false), no comment, no users query", async () => {
+    const { ctx, getUpdate, getComment, getUsersQueried } = ctxFor({
+      stepData: { ...baseStep, model_tier: "frontier" },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await completeStep(ctx, { claim_token: TCT.token, step_id: STEP_ID });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBeNull();
+    expect(update.tier_honored).toBeNull();
+    expect(getComment()).toBeNull();
+    expect(getUsersQueried()).toBe(0);
+  });
+
+  it("model_used='unknown' -> executed_model='unknown', tier_honored=NULL (never false), no comment, no users query", async () => {
+    const { ctx, getUpdate, getComment, getUsersQueried } = ctxFor({
+      stepData: { ...baseStep, model_tier: "frontier" },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await completeStep(ctx, { claim_token: TCT.token, step_id: STEP_ID, model_used: "unknown" });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBe("unknown");
+    expect(update.tier_honored).toBeNull();
+    expect(getComment()).toBeNull();
+    expect(getUsersQueried()).toBe(0);
+  });
+
+  it("Auto step (model_tier null) -> tier_honored stays NULL regardless of model_used, no users query", async () => {
+    const { ctx, getUpdate, getComment, getUsersQueried } = ctxFor({
+      stepData: { ...baseStep, model_tier: null },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await completeStep(ctx, { claim_token: TCT.token, step_id: STEP_ID, model_used: "sonnet" });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBe("sonnet");
+    expect(update.tier_honored).toBeNull();
+    expect(getComment()).toBeNull();
+    expect(getUsersQueried()).toBe(0);
+  });
+
+  it("resolves via the caller's model_tier_map override, not just the platform default", async () => {
+    const { ctx, getUpdate, getUsersQueried } = ctxFor({
+      stepData: { ...baseStep, model_tier: "frontier" },
+      updatedStep: baseUpdatedStep,
+      userModelTierMap: { frontier: "opus" },
+    });
+
+    // Override maps frontier -> opus, so opus is now the *resolved* model (not the fallback).
+    await completeStep(ctx, { claim_token: TCT.token, step_id: STEP_ID, model_used: "opus" });
+
+    const update = getUpdate();
+    expect(update.tier_honored).toBe(true);
+    expect(getUsersQueried()).toBe(1);
   });
 });
 
@@ -2008,6 +2225,169 @@ describe("failStep", () => {
       type: "changes_requested",
       content: "Validation logic is wrong",
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// failStep — tier adherence (P2c FR-6/7/8/12)
+// ---------------------------------------------------------------------------
+
+describe("failStep — tier adherence (P2c)", () => {
+  /** run_id: null throughout so the cascade/run-status paths never fire —
+   * keeps these tests focused on the tier-adherence write path only. */
+  function ctxFor(opts: {
+    stepData: Record<string, unknown>;
+    updatedStep: Record<string, unknown>;
+    userModelTierMap?: Record<string, unknown> | null;
+  }) {
+    const commentsInserted: Record<string, unknown>[] = [];
+    let usersQueried = 0;
+    let lastStepChain: ReturnType<typeof createChain> | null = null;
+
+    const ctx = makeContext(((table: string) => {
+      if (table === "task_workflow_steps") {
+        const chain = createChain(null);
+        chain.chain.single = vi.fn(() => Promise.resolve({ data: opts.stepData, error: null }));
+        chain.chain.maybeSingle = vi.fn(() => Promise.resolve({ data: opts.updatedStep, error: null }));
+        lastStepChain = chain;
+        return chain.chain;
+      }
+      if (table === "users") {
+        usersQueried++;
+        return createChain({ model_tier_map: opts.userModelTierMap ?? null }).chain;
+      }
+      if (table === "workflow_step_comments") {
+        const chain = createChain(null);
+        chain.chain.insert = vi.fn((data: unknown) => {
+          commentsInserted.push(data as Record<string, unknown>);
+          return chain.chain;
+        });
+        return chain.chain;
+      }
+      return createChain(null).chain;
+    }) as unknown as McpContext["supabase"]["from"]);
+
+    return {
+      ctx,
+      getUpdate: () => lastStepChain!.captured.updated as Record<string, unknown>,
+      getComments: () => commentsInserted,
+      getUsersQueried: () => usersQueried,
+    };
+  }
+
+  const baseStep = {
+    claim_token_hash: TCT.hash,
+    id: STEP_ID,
+    run_id: null,
+    step_order: 3,
+    idea_id: IDEA_ID,
+    bot_id: null,
+    agent_role: "developer",
+    status: "in_progress",
+  };
+  const baseUpdatedStep = {
+    id: STEP_ID,
+    task_id: TASK_ID,
+    run_id: null,
+    title: "Test Step",
+    agent_role: "developer",
+    status: "failed",
+    output: null,
+  };
+
+  it("model_used = an unrelated concrete model -> tier_honored=false and posts a 'comment' (not 'failure') mismatch comment", async () => {
+    const { ctx, getUpdate, getComments } = ctxFor({
+      stepData: { ...baseStep, model_tier: "standard" },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await failStep(ctx, { claim_token: TCT.token, step_id: STEP_ID, model_used: "haiku" });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBe("haiku");
+    expect(update.tier_honored).toBe(false);
+
+    const mismatchComment = getComments().find((c) => c.type === "comment");
+    expect(mismatchComment).toBeDefined();
+    expect(mismatchComment!.author_id).toBe(USER_ID);
+    expect(mismatchComment!.content as string).toContain("Tier not honored");
+    expect(mismatchComment!.content as string).toContain(TIER_ADHERENCE_DISCLOSURE);
+  });
+
+  it("does not confuse the mismatch comment with the separate failure-output comment", async () => {
+    const { ctx, getComments } = ctxFor({
+      stepData: { ...baseStep, model_tier: "standard" },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await failStep(ctx, {
+      claim_token: TCT.token,
+      step_id: STEP_ID,
+      output: "Build failed",
+      model_used: "haiku",
+    });
+
+    const comments = getComments();
+    expect(comments).toHaveLength(2);
+    expect(comments.find((c) => c.type === "failure")).toMatchObject({ content: "Build failed" });
+    expect(comments.find((c) => c.type === "comment")?.content).toContain("Tier not honored");
+  });
+
+  it("model_used omitted -> executed_model=NULL, tier_honored=NULL (never false), no mismatch comment, no users query", async () => {
+    const { ctx, getUpdate, getComments, getUsersQueried } = ctxFor({
+      stepData: { ...baseStep, model_tier: "standard" },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await failStep(ctx, { claim_token: TCT.token, step_id: STEP_ID });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBeNull();
+    expect(update.tier_honored).toBeNull();
+    expect(getComments()).toHaveLength(0);
+    expect(getUsersQueried()).toBe(0);
+  });
+
+  it("model_used='unknown' -> executed_model='unknown', tier_honored=NULL (never false), no mismatch comment", async () => {
+    const { ctx, getUpdate, getComments } = ctxFor({
+      stepData: { ...baseStep, model_tier: "standard" },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await failStep(ctx, { claim_token: TCT.token, step_id: STEP_ID, model_used: "unknown" });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBe("unknown");
+    expect(update.tier_honored).toBeNull();
+    expect(getComments()).toHaveLength(0);
+  });
+
+  it("Auto step (model_tier null) -> tier_honored stays NULL regardless of model_used", async () => {
+    const { ctx, getUpdate, getComments } = ctxFor({
+      stepData: { ...baseStep, model_tier: null },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await failStep(ctx, { claim_token: TCT.token, step_id: STEP_ID, model_used: "sonnet" });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBe("sonnet");
+    expect(update.tier_honored).toBeNull();
+    expect(getComments()).toHaveLength(0);
+  });
+
+  it("model_used = resolved model -> tier_honored=true, no mismatch comment", async () => {
+    const { ctx, getUpdate, getComments } = ctxFor({
+      stepData: { ...baseStep, model_tier: "standard" },
+      updatedStep: baseUpdatedStep,
+    });
+
+    await failStep(ctx, { claim_token: TCT.token, step_id: STEP_ID, model_used: "sonnet" });
+
+    const update = getUpdate();
+    expect(update.executed_model).toBe("sonnet");
+    expect(update.tier_honored).toBe(true);
+    expect(getComments()).toHaveLength(0);
   });
 });
 
@@ -2943,13 +3323,19 @@ describe("modelTierClause", () => {
   // Design-Review CONDITION 1 — exact directive string, verbatim.
   it("produces the exact MANDATORY MODEL directive string for the platform default (standard)", () => {
     expect(modelTierClause("standard")).toBe(
-      'MANDATORY MODEL: spawn this step\'s subagent with the Task tool parameter model: "sonnet". If "sonnet" is unavailable on this plan/session, use model: "opus" and state the substitution in your step output. Do not run this step inline and do not inherit your session model.'
+      'MANDATORY MODEL: spawn this step\'s subagent with the Task tool parameter model: "sonnet". If "sonnet" is unavailable on this plan/session, use model: "opus" and state the substitution in your step output. Do not run this step inline and do not inherit your session model. When calling complete_step/fail_step for this step, pass model_used = the model you actually ran the subagent on (the Task-tool model value, or the fallback if you substituted it).'
     );
   });
 
   it("produces the exact directive string for a user-overridden tier", () => {
     expect(modelTierClause("frontier", { frontier: "opus" })).toBe(
-      'MANDATORY MODEL: spawn this step\'s subagent with the Task tool parameter model: "opus". If "opus" is unavailable on this plan/session, use model: "fable" and state the substitution in your step output. Do not run this step inline and do not inherit your session model.'
+      'MANDATORY MODEL: spawn this step\'s subagent with the Task tool parameter model: "opus". If "opus" is unavailable on this plan/session, use model: "fable" and state the substitution in your step output. Do not run this step inline and do not inherit your session model. When calling complete_step/fail_step for this step, pass model_used = the model you actually ran the subagent on (the Task-tool model value, or the fallback if you substituted it).'
+    );
+  });
+
+  it("includes the model_used capture sentence (P2c FR-1/2/3)", () => {
+    expect(modelTierClause("cheap")).toContain(
+      "pass model_used = the model you actually ran the subagent on"
     );
   });
 
@@ -2962,6 +3348,78 @@ describe("modelTierClause", () => {
       expect(clause).toContain(`model: "${fallback}"`);
       expect(clause).not.toContain("Advisory");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTierAdherence — P2c FR-6/7/8 (exact cases, NULL ≠ false)
+// ---------------------------------------------------------------------------
+
+describe("resolveTierAdherence", () => {
+  it("model_used omitted -> executed=NULL, honored=NULL (never false)", () => {
+    expect(resolveTierAdherence("frontier", undefined)).toEqual({
+      executedModel: null,
+      tierHonored: null,
+    });
+  });
+
+  it("model_used='unknown' -> executed='unknown', honored=NULL (never false), regardless of tier", () => {
+    expect(resolveTierAdherence("frontier", "unknown")).toEqual({
+      executedModel: "unknown",
+      tierHonored: null,
+    });
+    expect(resolveTierAdherence(null, "unknown")).toEqual({
+      executedModel: "unknown",
+      tierHonored: null,
+    });
+  });
+
+  it("tier is null (Auto) -> executed=model_used, honored=NULL", () => {
+    expect(resolveTierAdherence(null, "sonnet")).toEqual({
+      executedModel: "sonnet",
+      tierHonored: null,
+    });
+    expect(resolveTierAdherence(undefined, "opus")).toEqual({
+      executedModel: "opus",
+      tierHonored: null,
+    });
+  });
+
+  it("tier set, model_used = platform-resolved model -> honored=true", () => {
+    expect(resolveTierAdherence("frontier", "fable")).toEqual({
+      executedModel: "fable",
+      tierHonored: true,
+    });
+  });
+
+  it("tier set, model_used = the tier's allowed fallback -> honored=true", () => {
+    // frontier resolves to fable, whose fallback is opus.
+    expect(resolveTierAdherence("frontier", "opus")).toEqual({
+      executedModel: "opus",
+      tierHonored: true,
+    });
+  });
+
+  it("tier set, model_used = a user's overridden resolved model -> honored=true", () => {
+    expect(resolveTierAdherence("frontier", "opus", { frontier: "opus" })).toEqual({
+      executedModel: "opus",
+      tierHonored: true,
+    });
+  });
+
+  it("tier set, model_used = an unrelated concrete alias -> honored=false (never NULL)", () => {
+    // frontier resolves to fable/opus — sonnet is neither.
+    expect(resolveTierAdherence("frontier", "sonnet")).toEqual({
+      executedModel: "sonnet",
+      tierHonored: false,
+    });
+  });
+
+  it("tier set, model_used='other' -> honored=false", () => {
+    expect(resolveTierAdherence("standard", "other")).toEqual({
+      executedModel: "other",
+      tierHonored: false,
+    });
   });
 });
 

--- a/mcp-server/src/tools/workflows.ts
+++ b/mcp-server/src/tools/workflows.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { logger } from "../../../src/lib/logger";
+import { tierMismatchSentence } from "../../../src/lib/constants";
 import type { McpContext } from "../context";
 import { mintClaimToken, verifyClaimToken } from "../claim-token";
 import { matchRolesWithAiOrFuzzy } from "../../../src/lib/ai-role-matching";
@@ -85,7 +86,44 @@ export function modelTierClause(tier: string | null | undefined, userModelTierMa
   const resolution = resolveModelTier(tier as "frontier" | "standard" | "cheap", userModelTierMap);
   if (!resolution) return "";
   const { resolved, fallback } = resolution;
-  return `MANDATORY MODEL: spawn this step's subagent with the Task tool parameter model: "${resolved}". If "${resolved}" is unavailable on this plan/session, use model: "${fallback}" and state the substitution in your step output. Do not run this step inline and do not inherit your session model.`;
+  return `MANDATORY MODEL: spawn this step's subagent with the Task tool parameter model: "${resolved}". If "${resolved}" is unavailable on this plan/session, use model: "${fallback}" and state the substitution in your step output. Do not run this step inline and do not inherit your session model. When calling complete_step/fail_step for this step, pass model_used = the model you actually ran the subagent on (the Task-tool model value, or the fallback if you substituted it).`;
+}
+
+// ============================================================
+// P2c — tier adherence (self-reported telemetry, never hard verification)
+// ============================================================
+
+/** Resolved adherence outcome for a step's completion/failure (FR-6/7/8). */
+export type TierAdherenceResult = { executedModel: string | null; tierHonored: boolean | null };
+
+/**
+ * Computes `executed_model`/`tier_honored` from the orchestrator's self-reported
+ * `model_used` for a step. Reuses `resolveModelTier` (same fallback rules as the
+ * MANDATORY MODEL directive) — never re-derives its own notion of "honored".
+ *
+ * Exact cases (P2c FR-7):
+ *  - model_used omitted            -> executed=NULL,      honored=NULL   (never false)
+ *  - model_used="unknown"          -> executed="unknown",  honored=NULL   (never false)
+ *  - tier is NULL (Auto)           -> executed=model_used, honored=NULL   (Auto made no promise)
+ *  - tier set, model_used=resolved -> executed=model_used, honored=true
+ *  - tier set, model_used=fallback -> executed=model_used, honored=true  (fallback counts as honored)
+ *  - tier set, model_used=other/"other" -> executed=model_used, honored=false
+ */
+export function resolveTierAdherence(
+  tier: string | null | undefined,
+  modelUsed: string | undefined,
+  userModelTierMap?: UserModelTierMap
+): TierAdherenceResult {
+  if (modelUsed === undefined) return { executedModel: null, tierHonored: null };
+  if (modelUsed === "unknown") return { executedModel: "unknown", tierHonored: null };
+  if (!tier) return { executedModel: modelUsed, tierHonored: null };
+
+  const resolution = resolveModelTier(tier as "frontier" | "standard" | "cheap", userModelTierMap);
+  if (!resolution) return { executedModel: modelUsed, tierHonored: null };
+
+  const { resolved, fallback } = resolution;
+  const tierHonored = modelUsed === resolved || modelUsed === fallback;
+  return { executedModel: modelUsed, tierHonored };
 }
 
 // ============================================================
@@ -920,16 +958,19 @@ export const completeStepSchema = z.object({
       "The one-time claim token returned by claim_next_step for this step. Proves you are the claimer. If lost, call claim_next_step to re-claim and receive a fresh token."
     ),
   output: z.string().max(50000).optional().describe("Step output or deliverable. This is stored on the step's `output` column and is how subsequent steps receive context — when the next step is claimed, all prior completed steps' outputs are passed in the `context` array. Also posted as a step comment for UI display."),
+  model_used: z.enum(["fable", "opus", "sonnet", "haiku", "other", "unknown"]).optional()
+    .describe("Self-reported: the Task-tool model alias this step's subagent actually ran on (or the fallback if you substituted it). Omit if you don't know. VibeCodes records this to report tier adherence — it is not verified."),
 });
 
 export async function completeStep(
   ctx: McpContext,
   params: z.infer<typeof completeStepSchema>
 ) {
-  // Fetch current step (include claim_token_hash + bot_id for the two-layer check)
+  // Fetch current step (include claim_token_hash + bot_id for the two-layer check;
+  // model_tier for P2c tier-adherence computation below)
   const { data: step, error: fetchError } = await ctx.supabase
     .from("task_workflow_steps")
-    .select("id, run_id, idea_id, human_check_required, status, bot_id, agent_role, claim_token_hash")
+    .select("id, run_id, idea_id, human_check_required, status, bot_id, agent_role, claim_token_hash, model_tier")
     .eq("id", params.step_id)
     .single();
 
@@ -971,8 +1012,29 @@ export async function completeStep(
   // Determine new status: awaiting_approval if human check required, else completed
   const newStatus = step.human_check_required ? "awaiting_approval" : "completed";
 
+  // P2c: resolve executed_model/tier_honored from the self-reported model_used.
+  // Only query the user's model_tier_map override when it's actually needed for
+  // resolution — a tier is set AND a concrete (non-"unknown") model_used was
+  // passed. No query on the Auto path or when model_used is omitted/"unknown".
+  let userModelTierMap: UserModelTierMap = null;
+  if (step.model_tier && params.model_used && params.model_used !== "unknown") {
+    const { data: userRow } = await ctx.supabase
+      .from("users")
+      .select("model_tier_map")
+      .eq("id", ctx.ownerUserId ?? ctx.userId)
+      .maybeSingle();
+    userModelTierMap = userRow?.model_tier_map ?? null;
+  }
+  const { executedModel, tierHonored } = resolveTierAdherence(step.model_tier, params.model_used, userModelTierMap);
+
   // Token is single-use: clear the hash as part of completion.
-  const updateFields: Record<string, unknown> = { status: newStatus, claimed_by: attributedTo, claim_token_hash: null };
+  const updateFields: Record<string, unknown> = {
+    status: newStatus,
+    claimed_by: attributedTo,
+    claim_token_hash: null,
+    executed_model: executedModel,
+    tier_honored: tierHonored,
+  };
   if (params.output !== undefined) updateFields.output = params.output;
   if (newStatus === "completed") updateFields.completed_at = new Date().toISOString();
 
@@ -981,7 +1043,7 @@ export async function completeStep(
     .update(updateFields)
     .eq("id", params.step_id)
     .eq("status", "in_progress")
-    .select("id, task_id, run_id, title, agent_role, status, output, completed_at")
+    .select("id, task_id, run_id, title, agent_role, status, output, completed_at, model_tier, executed_model, tier_honored")
     .maybeSingle();
 
   if (updateError) throw new Error(`Failed to complete step: ${updateError.message}`);
@@ -989,6 +1051,29 @@ export async function completeStep(
 
   // Touch board_tasks so Realtime fires before denormalized counts arrive
   await touchBoardTask(ctx, updated.task_id);
+
+  // P2c FR-12 (Design-Review CONDITION 4): dishonored tiers are signalled, never
+  // blocked — a logger.warn for ops-side aggregation, AND an auto step comment
+  // (plain 'comment' type, not 'failure') so the mismatch is visible in-product.
+  // Honored/unknown completions post nothing.
+  if (tierHonored === false) {
+    const resolution = resolveModelTier(step.model_tier as "frontier" | "standard" | "cheap", userModelTierMap);
+    logger.warn("workflow step tier dishonored", {
+      stepId: params.step_id,
+      tier: step.model_tier,
+      directed: resolution?.resolved,
+      fallback: resolution?.fallback,
+      executed: executedModel,
+      ownerUserId: ctx.ownerUserId,
+    });
+    await ctx.supabase.from("workflow_step_comments").insert({
+      step_id: params.step_id,
+      idea_id: step.idea_id,
+      author_id: attributedTo,
+      type: "comment",
+      content: tierMismatchSentence(step.model_tier as string, executedModel as string),
+    });
+  }
 
   // Check if all steps in the run are done
   let runComplete = false;
@@ -1019,6 +1104,8 @@ export const failStepSchema = z.object({
   output: z.string().max(10000).optional().describe(
     "Failure reason or error details (use `output`, not `reason`). Stored on the step's `output` column and auto-posted as a 'failure' comment. When cascade rejection is used and this step is re-claimed, this text is returned as `rework_instructions` to give the next agent context for retry."
   ),
+  model_used: z.enum(["fable", "opus", "sonnet", "haiku", "other", "unknown"]).optional()
+    .describe("Self-reported: the Task-tool model alias this step's subagent actually ran on (or the fallback if you substituted it). Omit if you don't know. VibeCodes records this to report tier adherence — it is not verified."),
   reset_to_step_id: z
     .string()
     .uuid()
@@ -1032,10 +1119,11 @@ export async function failStep(
   ctx: McpContext,
   params: z.infer<typeof failStepSchema>
 ) {
-  // Fetch current step (include claim_token_hash + bot_id for the two-layer check)
+  // Fetch current step (include claim_token_hash + bot_id for the two-layer check;
+  // model_tier for P2c tier-adherence computation below)
   const { data: step, error: fetchError } = await ctx.supabase
     .from("task_workflow_steps")
-    .select("id, run_id, step_order, idea_id, bot_id, agent_role, status, claim_token_hash")
+    .select("id, run_id, step_order, idea_id, bot_id, agent_role, status, claim_token_hash, model_tier")
     .eq("id", params.step_id)
     .single();
 
@@ -1073,10 +1161,27 @@ export async function failStep(
   // may still be set but the human gate owns the decision).
   const attributedTo = step.status !== "awaiting_approval" && step.bot_id ? step.bot_id : ctx.userId;
 
+  // P2c: resolve executed_model/tier_honored from the self-reported model_used
+  // (same rules as complete_step — see resolveTierAdherence). Only query the
+  // user's model_tier_map override when a tier is set AND a concrete
+  // (non-"unknown") model_used was passed.
+  let userModelTierMap: UserModelTierMap = null;
+  if (step.model_tier && params.model_used && params.model_used !== "unknown") {
+    const { data: userRow } = await ctx.supabase
+      .from("users")
+      .select("model_tier_map")
+      .eq("id", ctx.ownerUserId ?? ctx.userId)
+      .maybeSingle();
+    userModelTierMap = userRow?.model_tier_map ?? null;
+  }
+  const { executedModel, tierHonored } = resolveTierAdherence(step.model_tier, params.model_used, userModelTierMap);
+
   const updateFields: Record<string, unknown> = {
     status: "failed",
     completed_at: new Date().toISOString(),
     claim_token_hash: null,
+    executed_model: executedModel,
+    tier_honored: tierHonored,
   };
   if (params.output !== undefined) updateFields.output = params.output;
 
@@ -1085,7 +1190,7 @@ export async function failStep(
     .update(updateFields)
     .eq("id", params.step_id)
     .in("status", ["in_progress", "awaiting_approval"])
-    .select("id, task_id, run_id, title, agent_role, status, output")
+    .select("id, task_id, run_id, title, agent_role, status, output, model_tier, executed_model, tier_honored")
     .maybeSingle();
 
   if (updateError) throw new Error(`Failed to fail step: ${updateError.message}`);
@@ -1103,6 +1208,28 @@ export async function failStep(
       author_id: attributedTo,
       type: "failure",
       content: params.output,
+    });
+  }
+
+  // P2c FR-12 (Design-Review CONDITION 4): dishonored tiers are signalled, never
+  // blocked — mirrors complete_step. Plain 'comment' type (not 'failure') so it
+  // reads distinctly from the failure comment above. Honored/unknown post nothing.
+  if (tierHonored === false) {
+    const resolution = resolveModelTier(step.model_tier as "frontier" | "standard" | "cheap", userModelTierMap);
+    logger.warn("workflow step tier dishonored", {
+      stepId: params.step_id,
+      tier: step.model_tier,
+      directed: resolution?.resolved,
+      fallback: resolution?.fallback,
+      executed: executedModel,
+      ownerUserId: ctx.ownerUserId,
+    });
+    await ctx.supabase.from("workflow_step_comments").insert({
+      step_id: params.step_id,
+      idea_id: step.idea_id,
+      author_id: attributedTo,
+      type: "comment",
+      content: tierMismatchSentence(step.model_tier as string, executedModel as string),
     });
   }
 

--- a/src/actions/admin-tier-adherence.ts
+++ b/src/actions/admin-tier-adherence.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import type { Database } from "@/types/database";
+
+export type TierAdherenceSummaryRow = Database["public"]["Views"]["workflow_tier_adherence"]["Row"];
+export type TierAdherenceStepRow = Database["public"]["Views"]["workflow_tier_adherence_steps"]["Row"];
+
+async function requireAdmin() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const { data: profile } = await supabase
+    .from("users")
+    .select("is_admin")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile?.is_admin) throw new Error("Admin access required");
+  return { supabase };
+}
+
+/**
+ * P2c admin "Tier Adherence" card data (Design-Review CONDITION 3). Purely
+ * read-only reporting over the two self-reported adherence views (migration
+ * 00135) — no destructive ops, so gated the same as the rest of the admin
+ * dashboard's reporting cards (is_admin), not is_super_admin.
+ *
+ * Both reads are bounded (order + limit) so this never becomes an unbounded
+ * SELECT as adherence data accumulates over time.
+ */
+export async function getTierAdherenceReport(): Promise<{
+  summary: TierAdherenceSummaryRow[];
+  steps: TierAdherenceStepRow[];
+}> {
+  const { supabase } = await requireAdmin();
+
+  const [{ data: summary, error: summaryError }, { data: steps, error: stepsError }] = await Promise.all([
+    supabase
+      .from("workflow_tier_adherence")
+      .select("*")
+      .order("week", { ascending: false })
+      .limit(500),
+    supabase
+      .from("workflow_tier_adherence_steps")
+      .select("*")
+      .order("completed_at", { ascending: false })
+      .limit(500),
+  ]);
+
+  if (summaryError) throw new Error(summaryError.message);
+  if (stepsError) throw new Error(stepsError.message);
+
+  return { summary: summary ?? [], steps: steps ?? [] };
+}

--- a/src/actions/workflow.ts
+++ b/src/actions/workflow.ts
@@ -196,6 +196,10 @@ export async function completeWorkflowStep(stepId: string, output?: string) {
   const newStatus =
     existing?.human_check_required ? "awaiting_approval" : "completed";
 
+  // P2c: intentionally no model_used/executed_model/tier_honored here — this is
+  // the human UI completion path, not the MCP orchestrator path. UI completions
+  // have no self-reported model, so they land in the unknown bucket (NULL) by
+  // design, same as any pre-P2c row.
   const updateFields: Record<string, unknown> = {
     status: newStatus,
     completed_at: newStatus === "completed" ? new Date().toISOString() : null,
@@ -267,7 +271,11 @@ export async function failWorkflowStep(
   // Identity (bot_id) enforcement lives in the MCP `fail_step` tool, not here —
   // this server action is only called from the UI by humans manually failing
   // or rejecting a step. RLS restricts callers to idea team members.
-
+  //
+  // P2c: intentionally no model_used/executed_model/tier_honored here — this is
+  // the human UI failure path, not the MCP orchestrator path. UI failures have
+  // no self-reported model, so they land in the unknown bucket (NULL) by
+  // design, same as any pre-P2c row.
   const { data, error } = await supabase
     .from("task_workflow_steps")
     .update({

--- a/src/components/admin/admin-tabs.tsx
+++ b/src/components/admin/admin-tabs.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AiUsageDashboard } from "./ai-usage-dashboard";
+import { TierAdherenceDashboard } from "./tier-adherence-dashboard";
 import { FeedbackDashboard } from "./feedback-dashboard";
 import { AdminAgentsDashboard } from "./admin-agents-dashboard";
 import { AdminTeamsDashboard } from "./admin-teams-dashboard";
@@ -80,8 +81,12 @@ export function AdminTabs({
         <TabsTrigger value="templates">Workflows</TabsTrigger>
         <TabsTrigger value="mcp-tools">MCP Tools</TabsTrigger>
       </TabsList>
-      <TabsContent value="ai-usage" className="mt-6">
+      <TabsContent value="ai-usage" className="mt-6 space-y-10">
         <AiUsageDashboard usageLogs={usageLogs} filters={usageFilters} userCredits={userCredits} allPlatformLogs={allPlatformLogs} isSuperAdmin={isSuperAdmin} />
+        <div>
+          <h2 className="mb-3 text-lg font-semibold">Tier Adherence</h2>
+          <TierAdherenceDashboard />
+        </div>
       </TabsContent>
       <TabsContent value="feedback" className="mt-6">
         <FeedbackDashboard feedback={feedback} filters={feedbackFilters} />

--- a/src/components/admin/tier-adherence-dashboard.test.tsx
+++ b/src/components/admin/tier-adherence-dashboard.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import type { TierAdherenceStepRow, TierAdherenceSummaryRow } from "@/actions/admin-tier-adherence";
+
+// Mock the server action so we control loading/error/populated states directly
+// (this component fetches its own data specifically to get real loading/error
+// states, distinct from the rest of /admin's page-level SSR fetch — see the
+// component's doc comment).
+const getTierAdherenceReport = vi.fn();
+vi.mock("@/actions/admin-tier-adherence", () => ({
+  getTierAdherenceReport: (...args: unknown[]) => getTierAdherenceReport(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { TierAdherenceDashboard } from "./tier-adherence-dashboard";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function stepRow(overrides: Partial<TierAdherenceStepRow> = {}): TierAdherenceStepRow {
+  return {
+    step_id: "step-1",
+    task_id: "task-1",
+    task_title: "Ship the thing",
+    step_title: "Design review",
+    run_id: "run-1",
+    idea_id: "idea-1",
+    tier: "frontier",
+    executed_model: "fable",
+    tier_honored: true,
+    status: "completed",
+    claimed_by: "user-1",
+    bot_name: "Compass",
+    completed_at: "2026-07-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const emptySummary: TierAdherenceSummaryRow[] = [];
+
+describe("TierAdherenceDashboard", () => {
+  it("shows a loading skeleton while the report is in flight", () => {
+    getTierAdherenceReport.mockReturnValue(new Promise(() => {})); // never resolves
+    const { container } = render(<TierAdherenceDashboard />);
+    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+  });
+
+  it("shows the empty state — 'No tiered steps completed yet' — when there are no rows", async () => {
+    getTierAdherenceReport.mockResolvedValue({ summary: emptySummary, steps: [] });
+    render(<TierAdherenceDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText(/No tiered steps completed yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error state with a retry option when the fetch rejects", async () => {
+    getTierAdherenceReport.mockRejectedValue(new Error("boom"));
+    render(<TierAdherenceDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load tier adherence data/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("renders honored/not-honored/not-reported stat counts from the populated rows", async () => {
+    getTierAdherenceReport.mockResolvedValue({
+      summary: emptySummary,
+      steps: [
+        stepRow({ step_id: "s1", tier_honored: true }),
+        stepRow({ step_id: "s2", tier_honored: false, executed_model: "sonnet" }),
+        stepRow({ step_id: "s3", tier_honored: null, executed_model: null }),
+      ],
+    });
+    render(<TierAdherenceDashboard />);
+
+    // All three stat cards read "1 of 3" (Honored / Not honored / Not reported).
+    await waitFor(() => {
+      expect(screen.getAllByText("1 of 3")).toHaveLength(3);
+    });
+    expect(screen.getByText(/Self-reported by the orchestrator/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/admin/tier-adherence-dashboard.tsx
+++ b/src/components/admin/tier-adherence-dashboard.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { CheckCircle2, TriangleAlert, CircleHelp, RotateCcw } from "lucide-react";
+import { toast } from "sonner";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  getTierAdherenceReport,
+  type TierAdherenceStepRow,
+  type TierAdherenceSummaryRow,
+} from "@/actions/admin-tier-adherence";
+import {
+  TIER_ADHERENCE_DISCLOSURE,
+  MODEL_TIERS,
+  modelTierLabel,
+  capitalizeModelName,
+} from "@/lib/constants";
+import { formatRelativeTime } from "@/lib/utils";
+
+type LoadState = "loading" | "error" | "ready";
+
+/**
+ * P2c admin "Tier Adherence" card (Design-Review CONDITION 3, pulled into
+ * scope for this card). Self-reported telemetry over the two P2c views
+ * (migration 00135) — never framed as verification. Fetches its own data via
+ * a server action (rather than the page-level SSR prop pattern the rest of
+ * /admin uses) specifically so this card gets genuine loading/error states
+ * distinct from the page shell.
+ */
+export function TierAdherenceDashboard() {
+  const [state, setState] = useState<LoadState>("loading");
+  const [summary, setSummary] = useState<TierAdherenceSummaryRow[]>([]);
+  const [steps, setSteps] = useState<TierAdherenceStepRow[]>([]);
+  const [tierFilter, setTierFilter] = useState("all");
+  const [search, setSearch] = useState("");
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    getTierAdherenceReport()
+      .then(({ summary, steps }) => {
+        if (cancelled) return;
+        setSummary(summary);
+        setSteps(steps);
+        setState("ready");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        toast.error(err instanceof Error ? err.message : "Failed to load tier adherence data");
+        setState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  const stats = useMemo(() => {
+    const honored = steps.filter((s) => s.tier_honored === true).length;
+    const dishonored = steps.filter((s) => s.tier_honored === false).length;
+    const unknown = steps.filter((s) => s.tier_honored === null).length;
+    return { honored, dishonored, unknown, total: steps.length };
+  }, [steps]);
+
+  const filteredSteps = useMemo(() => {
+    let rows = steps;
+    if (tierFilter !== "all") rows = rows.filter((s) => s.tier === tierFilter);
+    const q = search.trim().toLowerCase();
+    if (q) {
+      rows = rows.filter(
+        (s) =>
+          s.task_title?.toLowerCase().includes(q) ||
+          s.step_title.toLowerCase().includes(q) ||
+          s.bot_name?.toLowerCase().includes(q)
+      );
+    }
+    return rows;
+  }, [steps, tierFilter, search]);
+
+  if (state === "loading") {
+    return (
+      <div className="space-y-6">
+        <div className="grid gap-4 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="rounded-lg border p-4">
+              <Skeleton className="mb-2 h-4 w-24" />
+              <Skeleton className="h-8 w-16" />
+            </div>
+          ))}
+        </div>
+        <div className="rounded-lg border p-4">
+          <Skeleton className="mb-4 h-5 w-40" />
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-6 w-full" />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-6 text-center">
+        <p className="text-sm text-red-400">Failed to load tier adherence data.</p>
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-3 gap-1.5 text-xs"
+          onClick={() => {
+            setState("loading");
+            setReloadToken((t) => t + 1);
+          }}
+        >
+          <RotateCcw className="h-3 w-3" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (steps.length === 0) {
+    return (
+      <div className="rounded-lg border p-8 text-center">
+        <p className="text-sm font-medium">No tiered steps completed yet.</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Rows appear after the first completion of a step that has a model tier.
+        </p>
+        <p className="mx-auto mt-3 max-w-md text-[11px] text-muted-foreground">
+          {TIER_ADHERENCE_DISCLOSURE}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatCard
+          icon={<CheckCircle2 className="h-4 w-4 text-emerald-500" />}
+          label="Honored"
+          value={`${stats.honored} of ${stats.total}`}
+        />
+        <StatCard
+          icon={<TriangleAlert className="h-4 w-4 text-amber-500" />}
+          label="Not honored"
+          value={`${stats.dishonored} of ${stats.total}`}
+        />
+        <StatCard
+          icon={<CircleHelp className="h-4 w-4 text-muted-foreground" />}
+          label="Not reported"
+          value={`${stats.unknown} of ${stats.total}`}
+        />
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-end gap-4 rounded-lg border p-4">
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Tier</Label>
+          <Select value={tierFilter} onValueChange={setTierFilter}>
+            <SelectTrigger className="h-8 w-40 text-xs">
+              <SelectValue placeholder="All tiers" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All tiers</SelectItem>
+              {MODEL_TIERS.map((t) => (
+                <SelectItem key={t.value} value={t.value}>
+                  {t.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Search</Label>
+          <Input
+            placeholder="Task, step, or reporter..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8 w-56 text-xs"
+          />
+        </div>
+      </div>
+
+      {/* Drill-down table (workflow_tier_adherence_steps) */}
+      <div>
+        <h3 className="mb-3 text-sm font-semibold">Tiered steps</h3>
+        <div className="max-h-[420px] overflow-y-auto rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Task / Step</TableHead>
+                <TableHead>Tier</TableHead>
+                <TableHead>Reported model</TableHead>
+                <TableHead>Adherence</TableHead>
+                <TableHead>Reported by</TableHead>
+                <TableHead>Completed</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredSteps.map((row) => (
+                <TableRow key={row.step_id}>
+                  <TableCell>
+                    <div className="max-w-64">
+                      <p className="truncate text-xs font-medium">{row.task_title ?? "Untitled task"}</p>
+                      <p className="truncate text-[11px] text-muted-foreground">{row.step_title}</p>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <span className="text-xs">{row.tier ? modelTierLabel(row.tier) : "—"}</span>
+                  </TableCell>
+                  <TableCell>
+                    <span className="text-xs">
+                      {row.executed_model ? capitalizeModelName(row.executed_model) : "—"}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <AdherenceBadge tierHonored={row.tier_honored} />
+                  </TableCell>
+                  <TableCell>
+                    <span className="text-xs text-muted-foreground">{row.bot_name ?? "Unknown"}</span>
+                  </TableCell>
+                  <TableCell>
+                    <span className="text-xs text-muted-foreground">
+                      {row.completed_at ? formatRelativeTime(row.completed_at) : "—"}
+                    </span>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {filteredSteps.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={6} className="p-8 text-center text-sm text-muted-foreground">
+                    No steps match this filter.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      {/* Weekly summary (workflow_tier_adherence) — the "what to run weekly" query, design §05 Q1 */}
+      {summary.length > 0 && (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold">Weekly summary by user &amp; tier</h3>
+          <div className="max-h-[280px] overflow-y-auto rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Week</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Tier</TableHead>
+                  <TableHead className="text-right">Honored</TableHead>
+                  <TableHead className="text-right">Not honored</TableHead>
+                  <TableHead className="text-right">Not reported</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {summary.map((row, i) => (
+                  <TableRow key={`${row.week}-${row.user_id}-${row.run_id}-${row.tier}-${i}`}>
+                    <TableCell>
+                      <span className="text-xs text-muted-foreground">
+                        {row.week ? new Date(row.week).toLocaleDateString() : "—"}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-xs">{row.user_email ?? "Unknown"}</span>
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-xs">{row.tier ? modelTierLabel(row.tier) : "—"}</span>
+                    </TableCell>
+                    <TableCell className="text-right text-xs">{row.honored}</TableCell>
+                    <TableCell className="text-right text-xs">
+                      <span className={row.dishonored > 0 ? "font-medium text-amber-500" : ""}>
+                        {row.dishonored}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right text-xs text-muted-foreground">{row.unknown}</TableCell>
+                    <TableCell className="text-right text-xs">{row.total}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      )}
+
+      <p className="max-w-2xl text-[11px] text-muted-foreground">{TIER_ADHERENCE_DISCLOSURE}</p>
+    </div>
+  );
+}
+
+function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <p className="mt-1 text-2xl font-bold">{value}</p>
+    </div>
+  );
+}
+
+function AdherenceBadge({ tierHonored }: { tierHonored: boolean | null }) {
+  if (tierHonored === true) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-emerald-500">
+        <CheckCircle2 className="h-3 w-3" /> Honored
+      </span>
+    );
+  }
+  if (tierHonored === false) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-amber-500">
+        <TriangleAlert className="h-3 w-3" /> Not honored
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+      <CircleHelp className="h-3 w-3" /> Not reported
+    </span>
+  );
+}

--- a/src/components/board/step-detail-dialog.tsx
+++ b/src/components/board/step-detail-dialog.tsx
@@ -19,6 +19,9 @@ import {
   X,
   SkipForward,
   Pencil,
+  TriangleAlert,
+  CircleHelp,
+  Info,
 } from "lucide-react";
 import {
   Dialog,
@@ -60,8 +63,92 @@ import {
   addStepComment,
 } from "@/actions/workflow";
 import { getInitials } from "@/lib/utils";
+import {
+  modelTierLabel,
+  capitalizeModelName,
+  tierDefaultsToCopy,
+  TIER_ADHERENCE_DISCLOSURE,
+} from "@/lib/constants";
 import type { TaskWorkflowStep, WorkflowStepComment } from "@/types";
 import { ApprovalLockIcon } from "./approval-lock-icon";
+
+/**
+ * P2c — the step-detail dialog's "Execution" line (design §02): the only
+ * place that shows all three tier-adherence states (honored / not honored /
+ * not reported). Only rendered for tiered, terminal (completed/failed) steps
+ * — Auto steps made no promise, and in-flight steps have nothing to report
+ * yet. Unknown is deliberately built to differ from dishonored on icon,
+ * border, tint, AND words (never colour alone) so it can never read as a
+ * failure — most legacy/non-reporting completions land here.
+ */
+function StepExecutionLine({ step }: { step: TaskWorkflowStep }) {
+  if (!step.model_tier) return null;
+  if (step.status !== "completed" && step.status !== "failed") return null;
+
+  const tierLabel = modelTierLabel(step.model_tier);
+
+  if (step.tier_honored === true) {
+    const modelLabel = capitalizeModelName(step.executed_model ?? "unknown");
+    return (
+      <div
+        className="flex items-start gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 text-xs"
+        aria-label={`Execution: ran on ${modelLabel}, tier honored`}
+      >
+        <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+        <span className="min-w-0">
+          <span className="font-medium">Ran on {modelLabel}</span>{" "}
+          <span className="text-muted-foreground">· tier honored</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="ml-1 inline h-3 w-3 cursor-help align-middle text-muted-foreground" />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-72 text-xs">
+              {`The orchestrator reported running this step on ${modelLabel} — the model ${tierLabel} defaults to, or that tier's allowed fallback. ${TIER_ADHERENCE_DISCLOSURE}`}
+            </TooltipContent>
+          </Tooltip>
+        </span>
+      </div>
+    );
+  }
+
+  if (step.tier_honored === false) {
+    const modelLabel = capitalizeModelName(step.executed_model ?? "unknown");
+    return (
+      <div
+        className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs"
+        aria-label={`Execution: ran on ${modelLabel}, tier not honored`}
+      >
+        <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+        <span className="min-w-0">
+          <span className="font-medium">
+            Ran on <em className="not-italic text-amber-500">{modelLabel}</em>
+          </span>{" "}
+          <span className="text-muted-foreground">· tier not honored</span>
+          <span className="block text-[11px] text-muted-foreground">
+            {tierDefaultsToCopy(step.model_tier)}. Self-reported — not verified.
+          </span>
+        </span>
+      </div>
+    );
+  }
+
+  // Unknown (tier_honored IS NULL): must never read as failure — different
+  // icon, border style, fill, AND wording from the dishonored state above.
+  return (
+    <div
+      className="flex items-start gap-2 rounded-md border border-dashed border-border px-3 py-2 text-xs"
+      aria-label="Execution: model not reported"
+    >
+      <CircleHelp className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0">
+        <span className="font-medium text-muted-foreground">Model not reported</span>
+        <span className="block text-[11px] text-muted-foreground">
+          Not a failure — the orchestrator completed this step without saying which model ran it. {TIER_ADHERENCE_DISCLOSURE}
+        </span>
+      </span>
+    </div>
+  );
+}
 
 const STATUS_CONFIG = {
   pending: {
@@ -563,6 +650,9 @@ export function StepDetailDialog({
                   </div>
                 </div>
               )}
+
+              {/* Execution — P2c self-reported tier adherence (design §02) */}
+              <StepExecutionLine step={step} />
 
               {/* Output */}
               {step.output && (

--- a/src/components/board/task-workflow-section.tsx
+++ b/src/components/board/task-workflow-section.tsx
@@ -573,7 +573,11 @@ export function TaskWorkflowSection({ taskId, ideaId, isReadOnly = false }: Task
                   </span>
                 )}
 
-                <ModelTierBadge tier={step.model_tier} />
+                <ModelTierBadge
+                  tier={step.model_tier}
+                  executedModel={step.executed_model}
+                  tierHonored={step.tier_honored}
+                />
                 {step.agent_role && (
                   <Badge
                     variant="outline"

--- a/src/components/shared/model-tier-select.test.tsx
+++ b/src/components/shared/model-tier-select.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ModelTierBadge } from "./model-tier-select";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+// Radix primitives use ResizeObserver, which jsdom lacks.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).ResizeObserver = ResizeObserverStub;
+
+// The dishonored state wraps the badge in a Radix Tooltip, which requires a
+// TooltipProvider ancestor (present app-wide via src/app/layout.tsx).
+function renderBadge(props: Parameters<typeof ModelTierBadge>[0]) {
+  return render(
+    <TooltipProvider>
+      <ModelTierBadge {...props} />
+    </TooltipProvider>
+  );
+}
+
+// P2c (design §03) — ModelTierBadge's exception-only row indicator: honored
+// and unknown must render identically to today (silence is the default);
+// only tier_honored === false changes anything on the row.
+describe("ModelTierBadge", () => {
+  it("renders nothing when there is no tier (Auto)", () => {
+    const { container } = renderBadge({ tier: null });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("honored (tier_honored=true) renders the plain tier badge — no suffix", () => {
+    renderBadge({ tier: "frontier", executedModel: "fable", tierHonored: true });
+    expect(screen.getByText("Frontier")).toBeInTheDocument();
+    expect(screen.queryByText(/ran on/i)).not.toBeInTheDocument();
+  });
+
+  it("unknown (tier_honored=null/undefined) renders identically to honored — no suffix", () => {
+    renderBadge({ tier: "frontier", executedModel: null, tierHonored: null });
+    expect(screen.getByText("Frontier")).toBeInTheDocument();
+    expect(screen.queryByText(/ran on/i)).not.toBeInTheDocument();
+
+    // Also true when the props are simply omitted (existing call sites pre-P2c).
+    renderBadge({ tier: "standard" });
+    expect(screen.getAllByText("Standard").length).toBeGreaterThan(0);
+  });
+
+  it("dishonored (tier_honored=false) adds the amber 'ran on <Model>' suffix and an aria-label stating the mismatch", () => {
+    renderBadge({ tier: "frontier", executedModel: "sonnet", tierHonored: false });
+    expect(screen.getByText("Frontier")).toBeInTheDocument();
+    expect(screen.getByText(/ran on sonnet/i)).toBeInTheDocument();
+
+    const badge = screen.getByLabelText(/Model tier Frontier — not honored: orchestrator reported Sonnet/i);
+    expect(badge).toBeInTheDocument();
+  });
+
+  it("dishonored with no reported executed model falls back to 'Unknown' rather than crashing", () => {
+    renderBadge({ tier: "frontier", executedModel: null, tierHonored: false });
+    expect(screen.getByText(/ran on unknown/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/model-tier-select.tsx
+++ b/src/components/shared/model-tier-select.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import * as React from "react";
-import { CheckIcon, ChevronDownIcon } from "lucide-react";
+import { CheckIcon, ChevronDownIcon, TriangleAlert } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { SelectContent } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useViewerModelTierMap } from "@/hooks/use-viewer-model-tier-map";
 import {
   MODEL_TIERS,
@@ -15,6 +16,8 @@ import {
   MODEL_TIER_RUNS_ON_HELPER,
   modelTierLabel,
   modelTierGloss,
+  capitalizeModelName,
+  tierMismatchSentence,
   type ModelTierMap,
 } from "@/lib/constants";
 
@@ -192,27 +195,64 @@ export function ModelTierSelect({
  * Read-only tier badge for step cards and dialog headers. Renders nothing for
  * Auto (null) — silence is the default. Monochrome outline so it never competes
  * with the colour-coded role/status badges.
+ *
+ * P2c (design §03, exception-only row indicator): pass `executedModel` +
+ * `tierHonored` to surface adherence — but ONLY `tierHonored === false`
+ * changes anything (an amber triangle + "ran on <model>" suffix, wrapped in a
+ * tooltip carrying the full self-reported disclosure). Honored and unknown
+ * (tierHonored true/null/undefined) render exactly as before — row-level
+ * silence is deliberate; the full three-state detail lives in the step-detail
+ * dialog's Execution line, not here.
  */
 export function ModelTierBadge({
   tier,
+  executedModel,
+  tierHonored,
   className,
 }: {
   tier: string | null | undefined;
+  executedModel?: string | null;
+  tierHonored?: boolean | null;
   className?: string;
 }) {
   if (!tier) return null;
   const label = modelTierLabel(tier);
-  return (
+  const dishonored = tierHonored === false;
+  const executedLabel = capitalizeModelName(executedModel ?? "unknown");
+
+  const badge = (
     <Badge
       variant="outline"
-      aria-label={`Model tier: ${label}`}
+      aria-label={
+        dishonored
+          ? `Model tier ${label} — not honored: orchestrator reported ${executedLabel}`
+          : `Model tier: ${label}`
+      }
       className={cn(
-        "shrink-0 gap-0.5 text-[10px] font-normal border-zinc-300 text-zinc-700 dark:border-zinc-700 dark:text-zinc-200",
+        "shrink-0 gap-1 text-[10px] font-normal border-zinc-300 text-zinc-700 dark:border-zinc-700 dark:text-zinc-200",
+        dishonored && "cursor-help border-amber-500/40 text-amber-700 dark:border-amber-500/40 dark:text-amber-400",
         className,
       )}
     >
       <span className="text-muted-foreground">tier:</span>
       {label}
+      {dishonored && (
+        <span className="inline-flex items-center gap-0.5">
+          <TriangleAlert className="size-2.5" />
+          {`ran on ${executedLabel}`}
+        </span>
+      )}
     </Badge>
+  );
+
+  if (!dishonored) return badge;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{badge}</TooltipTrigger>
+      <TooltipContent className="max-w-72 text-xs">
+        {tierMismatchSentence(tier, executedModel ?? "unknown")}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/lib/constants.test.ts
+++ b/src/lib/constants.test.ts
@@ -12,6 +12,10 @@ import {
   defaultTierForRole,
   modelTierGloss,
   MODEL_TIER_RUNS_ON_HELPER,
+  TIER_ADHERENCE_DISCLOSURE,
+  tierDefaultsToCopy,
+  tierMismatchSentence,
+  capitalizeModelName,
 } from "./constants";
 import type { IdeaStatus, CommentType } from "@/types";
 
@@ -290,5 +294,47 @@ describe("MODEL_TIER_RUNS_ON_HELPER", () => {
     // Fable -> Opus is a downgrade, so wording implying "up"/"next tier" would be false.
     expect(MODEL_TIER_RUNS_ON_HELPER.toLowerCase()).not.toContain("next tier");
     expect(MODEL_TIER_RUNS_ON_HELPER.toLowerCase()).not.toContain("tier up");
+  });
+});
+
+// ── P2c tier adherence copy (Design-Review CONDITION 1) ────────────────
+
+describe("TIER_ADHERENCE_DISCLOSURE", () => {
+  it("is the canonical self-reported disclosure and never claims verification", () => {
+    expect(TIER_ADHERENCE_DISCLOSURE).toContain("Self-reported");
+    expect(TIER_ADHERENCE_DISCLOSURE.toLowerCase()).toContain("does not verify");
+  });
+});
+
+describe("capitalizeModelName", () => {
+  it("capitalizes the first letter of a raw model alias", () => {
+    expect(capitalizeModelName("sonnet")).toBe("Sonnet");
+    expect(capitalizeModelName("unknown")).toBe("Unknown");
+  });
+});
+
+describe("tierDefaultsToCopy", () => {
+  it("says '<Tier> defaults to <Model>', never 'maps to'", () => {
+    expect(tierDefaultsToCopy("frontier")).toBe("Frontier defaults to Fable");
+    expect(tierDefaultsToCopy("standard")).toBe("Standard defaults to Sonnet");
+    expect(tierDefaultsToCopy("cheap")).toBe("Cheap defaults to Haiku");
+  });
+
+  it("never uses 'maps to' wording (CONDITION 1)", () => {
+    for (const tier of ["frontier", "standard", "cheap"]) {
+      expect(tierDefaultsToCopy(tier).toLowerCase()).not.toContain("maps to");
+    }
+  });
+});
+
+describe("tierMismatchSentence", () => {
+  it("states the mismatch, uses 'defaults to', and includes the disclosure verbatim", () => {
+    const sentence = tierMismatchSentence("frontier", "sonnet");
+    expect(sentence).toContain("Tier not honored");
+    expect(sentence).toContain("Frontier step defaults to Fable");
+    expect(sentence).toContain("reported running on Sonnet");
+    expect(sentence).toContain(TIER_ADHERENCE_DISCLOSURE);
+    expect(sentence.toLowerCase()).not.toContain("maps to");
+    expect(sentence.toLowerCase()).not.toContain("verified");
   });
 });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -61,7 +61,8 @@ export function modelTierLabel(tier: string): string {
   return MODEL_TIERS.find((t) => t.value === tier)?.label ?? tier;
 }
 
-function capitalizeModelName(model: string): string {
+/** Display-cased model alias, e.g. "sonnet" -> "Sonnet". Exported for P2c adherence copy (executed model names, which arrive as raw aliases). */
+export function capitalizeModelName(model: string): string {
   return model.charAt(0).toUpperCase() + model.slice(1);
 }
 
@@ -76,6 +77,48 @@ function capitalizeModelName(model: string): string {
 export function modelTierGloss(tier: ModelTierValue, resolvedModel?: string | null): string {
   const modelLabel = resolvedModel ? capitalizeModelName(resolvedModel) : MODEL_TIER_PLATFORM_DEFAULT_MODEL[tier];
   return `Runs on ${modelLabel} · ${MODEL_TIER_WHEN_TO_USE[tier]}`;
+}
+
+// ─── P2c — tier adherence (self-reported telemetry) ───
+// Records what model the orchestrator SAYS it ran a tiered step's subagent on
+// (executed_model) and whether that honoured the step's directed tier
+// (tier_honored) — never hard verification. Vocabulary is strictly
+// reported / honored / not honored / not reported; never "verify(ied)" or
+// "enforced" outside a negation. See docs/spikes/p2c-tier-adherence-design.html.
+
+/**
+ * The canonical disclosure sentence (design §01/§07) — reused verbatim on
+ * every surface that shows adherence data: the step-detail dialog, the row
+ * badge tooltip, the auto-posted mismatch comment, and the admin dashboard
+ * card's caption.
+ */
+export const TIER_ADHERENCE_DISCLOSURE =
+  "Self-reported by the orchestrator — VibeCodes records what the agent says it ran, and does not verify it.";
+
+/**
+ * "<Tier> defaults to <Model>" — the override-safe phrasing for tier→model
+ * correspondence (Design-Review CONDITION 1). Never "maps to": a user's
+ * model_tier_map override changes what a tier defaults to for them, and
+ * adherence data is never re-resolved against that map after the fact — this
+ * always names the stable platform default, which is what every surface
+ * displays.
+ */
+export function tierDefaultsToCopy(tier: string): string {
+  const label = modelTierLabel(tier);
+  const model = MODEL_TIER_PLATFORM_DEFAULT_MODEL[tier as ModelTierValue] ?? tier;
+  return `${label} defaults to ${model}`;
+}
+
+/**
+ * Full mismatch sentence (tier not honored) + disclosure — shared verbatim by
+ * the row badge's tooltip (model-tier-select.tsx) and the MCP auto-posted
+ * step comment (mcp-server/src/tools/workflows.ts), so the wording never
+ * drifts between the two surfaces (design §04/§07).
+ */
+export function tierMismatchSentence(tier: string, executedModel: string): string {
+  const label = modelTierLabel(tier);
+  const defaultModel = MODEL_TIER_PLATFORM_DEFAULT_MODEL[tier as ModelTierValue] ?? tier;
+  return `Tier not honored — this ${label} step defaults to ${defaultModel}, but the orchestrator reported running on ${capitalizeModelName(executedModel)}. ${TIER_ADHERENCE_DISCLOSURE}`;
 }
 
 /**

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -872,6 +872,8 @@ export type Database = {
           expected_deliverables: string[];
           match_tier: string | null;
           model_tier: string | null;
+          executed_model: string | null;
+          tier_honored: boolean | null;
           updated_at: string;
         };
         Insert: {
@@ -893,6 +895,8 @@ export type Database = {
           expected_deliverables?: string[];
           match_tier?: string | null;
           model_tier?: string | null;
+          executed_model?: string | null;
+          tier_honored?: boolean | null;
           comment_count?: number;
           started_at?: string | null;
           completed_at?: string | null;
@@ -918,6 +922,8 @@ export type Database = {
           expected_deliverables?: string[];
           match_tier?: string | null;
           model_tier?: string | null;
+          executed_model?: string | null;
+          tier_honored?: boolean | null;
           comment_count?: number;
           started_at?: string | null;
           completed_at?: string | null;
@@ -2693,7 +2699,42 @@ export type Database = {
     };
     };
     Views: {
-      [_ in never]: never;
+      // P2c — self-reported tier-adherence reporting views (migration 00135).
+      // Read-only aggregates/drill-down over task_workflow_steps; not
+      // updatable, so no Insert/Update (Relationships required as `[]` —
+      // GenericNonUpdatableView needs it even for plain views).
+      workflow_tier_adherence: {
+        Row: {
+          week: string | null;
+          user_id: string | null;
+          user_email: string | null;
+          run_id: string | null;
+          tier: string | null;
+          honored: number;
+          dishonored: number;
+          unknown: number;
+          total: number;
+        };
+        Relationships: [];
+      };
+      workflow_tier_adherence_steps: {
+        Row: {
+          step_id: string;
+          task_id: string;
+          task_title: string | null;
+          step_title: string;
+          run_id: string | null;
+          idea_id: string;
+          tier: string | null;
+          executed_model: string | null;
+          tier_honored: boolean | null;
+          status: "pending" | "in_progress" | "completed" | "failed" | "awaiting_approval" | "skipped";
+          claimed_by: string | null;
+          bot_name: string | null;
+          completed_at: string | null;
+        };
+        Relationships: [];
+      };
     };
     Functions: {
       admin_delete_user: {

--- a/supabase/migrations/00135_step_executed_model.sql
+++ b/supabase/migrations/00135_step_executed_model.sql
@@ -1,0 +1,111 @@
+-- P2c: Capture executed model + tier-adherence reporting.
+-- Records what model the orchestrator SELF-REPORTS running a tiered step's
+-- subagent on (executed_model) and whether that honoured the step's directed
+-- P2b tier (tier_honored). This is telemetry, not verification — VibeCodes
+-- never checks what actually ran, only records what the caller claims.
+-- Additive, nullable, no backfill (NULL on every pre-P2c row and on every
+-- step whose orchestrator doesn't pass model_used).
+--
+-- NULL != false, always. Storing `false` implies "we know this was dishonored";
+-- storing `NULL` means "we don't know" (omitted model_used, model_used =
+-- "unknown", or the step's model_tier is NULL/Auto, which makes no promise to
+-- honour). See mcp-server/src/tools/workflows.ts:resolveTierAdherence.
+
+ALTER TABLE task_workflow_steps
+  ADD COLUMN executed_model TEXT,
+  ADD COLUMN tier_honored BOOLEAN;
+
+ALTER TABLE task_workflow_steps
+  ADD CONSTRAINT task_workflow_steps_executed_model_check
+  CHECK (executed_model IS NULL OR executed_model IN ('fable', 'opus', 'sonnet', 'haiku', 'other', 'unknown'));
+
+COMMENT ON COLUMN task_workflow_steps.executed_model IS
+  'Self-reported by the orchestrator via complete_step/fail_step''s model_used param — the Task-tool model alias it says it ran this step''s subagent on (or "unknown"/"other"). NULL = not reported. Never verified against what actually ran.';
+
+COMMENT ON COLUMN task_workflow_steps.tier_honored IS
+  'Whether executed_model honoured this step''s model_tier (resolved model or its allowed fallback). NULL != false: NULL means unknown (model_tier is Auto/NULL, model_used was omitted, or model_used="unknown") — never conflate with false (a concrete, differing model was reported). Self-reported, not hard enforcement.';
+
+-- Admins can read all workflow steps (needed for the two adherence reporting
+-- views below, and the admin dashboard's "Tier Adherence" card — P2c
+-- Design-Review CONDITION 3) — mirrors the existing ai_usage_log admin policy.
+-- Non-admins keep the existing team-member/public-idea policy unchanged.
+CREATE POLICY "Admins can view all workflow steps"
+  ON task_workflow_steps FOR SELECT
+  USING (EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND is_admin = true));
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Reporting views (P2c Design-Review CONDITION 2). Both are self-reported
+-- telemetry, NOT hard verification — do not present counts here as proof of
+-- what actually ran. `security_invoker = true` so both views respect the
+-- querying role's RLS (the admin policy above, or the ordinary team-member
+-- policy for non-admin callers) rather than bypassing it as the view owner.
+--
+-- honored    = tier_honored = true
+-- dishonored = tier_honored = false
+-- unknown    = tier_honored IS NULL
+-- (never conflate — an adherence rate quoted without its `unknown`
+-- denominator is the numeric version of treating NULL as false.)
+--
+-- Only steps with a tier (model_tier IS NOT NULL — Auto made no promise) and
+-- a terminal status (completed/failed) are included; in-flight/pending/
+-- awaiting_approval/skipped steps have nothing to report yet.
+-- ─────────────────────────────────────────────────────────────────────────
+
+-- Query 1 — adherence summary (what you'd run weekly):
+--   select week, user_email, tier, honored, dishonored, unknown, total
+--   from workflow_tier_adherence
+--   where week >= now() - interval '30 days'
+--   order by week desc, dishonored desc;
+--
+-- 0 rows = no tiered steps completed yet. Rows appear after the first
+-- completion of a step that has a model tier. An all-`unknown` week means
+-- steps are completing but orchestrators aren't reporting model_used yet —
+-- that is not itself evidence of dishonoring.
+CREATE VIEW workflow_tier_adherence WITH (security_invoker = true) AS
+SELECT
+  date_trunc('week', s.completed_at) AS week,
+  s.claimed_by AS user_id,
+  u.email AS user_email,
+  s.run_id,
+  s.model_tier AS tier,
+  count(*) FILTER (WHERE s.tier_honored = true) AS honored,
+  count(*) FILTER (WHERE s.tier_honored = false) AS dishonored,
+  count(*) FILTER (WHERE s.tier_honored IS NULL) AS unknown,
+  count(*) AS total
+FROM task_workflow_steps s
+LEFT JOIN users u ON u.id = s.claimed_by
+WHERE s.model_tier IS NOT NULL
+  AND s.status IN ('completed', 'failed')
+GROUP BY week, s.claimed_by, u.email, s.run_id, s.model_tier;
+
+COMMENT ON VIEW workflow_tier_adherence IS
+  'P2c self-reported tier-adherence summary — grouped by completion week, claimed_by user, run, and tier. Self-reported by the orchestrator; VibeCodes records what the agent says it ran and does not verify it. honored/dishonored/unknown come from tier_honored=true/false/NULL respectively — never conflate NULL (unknown) with false (dishonored).';
+
+-- Query 2 — row-level drill-down, e.g. "which frontier steps didn't run on Fable?":
+--   select completed_at, task_title, step_title, executed_model, bot_name
+--   from workflow_tier_adherence_steps
+--   where tier = 'frontier' and tier_honored = false
+--   order by completed_at desc limit 20;
+CREATE VIEW workflow_tier_adherence_steps WITH (security_invoker = true) AS
+SELECT
+  s.id AS step_id,
+  s.task_id,
+  t.title AS task_title,
+  s.title AS step_title,
+  s.run_id,
+  s.idea_id,
+  s.model_tier AS tier,
+  s.executed_model,
+  s.tier_honored,
+  s.status,
+  s.claimed_by,
+  u.full_name AS bot_name,
+  s.completed_at
+FROM task_workflow_steps s
+LEFT JOIN board_tasks t ON t.id = s.task_id
+LEFT JOIN users u ON u.id = s.claimed_by
+WHERE s.model_tier IS NOT NULL
+  AND s.status IN ('completed', 'failed');
+
+COMMENT ON VIEW workflow_tier_adherence_steps IS
+  'P2c self-reported tier-adherence drill-down — one row per completed/failed tiered step. Self-reported by the orchestrator; VibeCodes records what the agent says it ran and does not verify it. Companion of workflow_tier_adherence (row-level detail behind that view''s aggregate counts).';


### PR DESCRIPTION
Makes P2b's tier directive **auditable**. `complete_step`/`fail_step` accept a self-reported `model_used`; each tiered completion computes and stores `executed_model` + `tier_honored`.

- **NULL ≠ false**: honored/fallback → true, wrong model → false, unknown/unreported/Auto → NULL (never a "failure").
- **Two SQL views** (migration `00135`): weekly summary + row-level drill-down ("frontier steps not on Fable").
- **Admin "Tier Adherence" dashboard** on the AI Usage tab (honored/dishonored/unknown + drill-down + disclosure).
- **Mismatch** → `logger.warn` + auto step-comment (type `comment`, not `failure`).
- **Self-reported** telemetry, framed as such everywhere — not hard verification. No backfill.

**Applied 00135 to prod** (dry-run rolled-back clean; recorded; drift clean). tsc clean; 1619 tests. Built via the Feature Development workflow, each step on its tier's model via the deployed P2b directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)