### PR TITLE
fix(ai): stop AI Generate Tasks hanging forever when the model stream stalls

### DIFF
--- a/src/app/api/ai/generate-tasks/route.ts
+++ b/src/app/api/ai/generate-tasks/route.ts
@@ -12,6 +12,12 @@ import { buildPromptContextParts, buildAutoRuleMappings } from "@/lib/ai-prompt-
 
 export const maxDuration = 300;
 
+// Hard bound on the streaming generation. Without it, a provider-side stall (the
+// stream stops emitting tokens but never sends a `finish` chunk) leaves the dock
+// spinning until Vercel's 300s function kill. 120s is generous for 15-20 tasks
+// while still failing fast enough to show a retryable error.
+const GENERATE_TIMEOUT_MS = 120_000;
+
 const GeneratedTaskSchema = z.object({
   title: z.string(),
   description: z.string().optional(),
@@ -134,39 +140,93 @@ export async function POST(req: Request) {
     // post-stream step fails due to expired auth context. Usage logged after.
     await chargeAiUpfront(supabase, { userId: user.id, keyType });
 
+    // `streamError` captures a provider/stream failure. streamObject's default
+    // onError only console.error's, and its `partialObjectStream` iterator SWALLOWS
+    // error chunks (`case "error": break`), so without this hook a mid-stream
+    // failure is invisible to us. Critically, ai@6 resolves `result.usage` ONLY in
+    // its `case "finish"` branch — an errored/aborted stream never resolves it, so
+    // `await result.usage` below would hang forever, the ReadableStream would never
+    // close, and the dock would spin indefinitely (the reported bug).
+    let streamError: unknown = null;
     const result = streamObject({
       model: anthropic(AI_MODEL),
       system: systemPrompt,
       prompt: contextParts.join("\n\n"),
       schema: GeneratedBoardSchema,
       maxOutputTokens: 8000,
+      // A stall that emits no tokens (and no error) is bounded here rather than by
+      // the 300s function timeout — the abort surfaces through onError below.
+      abortSignal: AbortSignal.timeout(GENERATE_TIMEOUT_MS),
+      onError: ({ error }) => {
+        streamError = error;
+        logger.error("AI generate tasks stream error", {
+          ideaId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
     });
 
     // Stream partial objects as newline-delimited JSON
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       async start(controller) {
-        for await (const partialObject of result.partialObjectStream) {
-          const taskCount = partialObject.tasks?.length ?? 0;
-          // Only emit when we have at least one task with a title
-          if (taskCount > 0 && partialObject.tasks![taskCount - 1]?.title) {
-            controller.enqueue(
-              encoder.encode(JSON.stringify(partialObject) + "\n")
-            );
+        try {
+          for await (const partialObject of result.partialObjectStream) {
+            const taskCount = partialObject.tasks?.length ?? 0;
+            // Only emit when we have at least one task with a title
+            if (taskCount > 0 && partialObject.tasks![taskCount - 1]?.title) {
+              controller.enqueue(
+                encoder.encode(JSON.stringify(partialObject) + "\n")
+              );
+            }
           }
+        } catch (err) {
+          // partialObjectStream can also reject outright (not just emit an error
+          // chunk); treat both the same.
+          streamError = streamError ?? err;
         }
-        const usage = await result.usage;
-        // Log only — the credit was already charged upfront (free: true here).
-        await chargeAiUsage(supabase, {
-          userId: user.id,
-          actionType: "generate_board_tasks",
-          inputTokens: usage.inputTokens ?? 0,
-          outputTokens: usage.outputTokens ?? 0,
-          model: AI_MODEL,
-          ideaId,
-          keyType,
-          free: true,
-        });
+
+        // If the stream failed, tell the client explicitly. The dock keys off this
+        // sentinel to show a retryable toast instead of treating a truncated
+        // partial (e.g. a single task) as a complete result.
+        if (streamError) {
+          controller.enqueue(
+            encoder.encode(
+              JSON.stringify({
+                error: "Task generation was interrupted — please try again.",
+              }) + "\n"
+            )
+          );
+          controller.close();
+          return;
+        }
+
+        // Usage is best-effort billing/telemetry only (the credit was charged
+        // upfront, free: true here) — NEVER let it block closing the response.
+        // Guarded so a never-resolving `result.usage` can't hang the stream.
+        try {
+          const usage = await Promise.race([
+            result.usage.catch(() => null),
+            new Promise<null>((resolve) => setTimeout(() => resolve(null), 5_000)),
+          ]);
+          if (usage) {
+            await chargeAiUsage(supabase, {
+              userId: user.id,
+              actionType: "generate_board_tasks",
+              inputTokens: usage.inputTokens ?? 0,
+              outputTokens: usage.outputTokens ?? 0,
+              model: AI_MODEL,
+              ideaId,
+              keyType,
+              free: true,
+            });
+          }
+        } catch (err) {
+          logger.warn("AI generate tasks usage logging failed", {
+            ideaId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
         controller.close();
       },
     });

--- a/src/components/board/ai-generate-dialog.tsx
+++ b/src/components/board/ai-generate-dialog.tsx
@@ -229,13 +229,20 @@ export function AiGenerateDialog({
 
         for (const line of lines) {
           if (!line.trim()) continue;
+          let parsed: { tasks?: ImportTask[]; error?: string } | null = null;
           try {
-            lastParsed = JSON.parse(line);
-            const streamedTasks = (lastParsed!.tasks ?? []).slice(0, 50) as ImportTask[];
-            setGeneratedTasks(streamedTasks);
+            parsed = JSON.parse(line);
           } catch {
             // Incomplete JSON line — skip
+            continue;
           }
+          // Server-emitted failure sentinel — a stalled/aborted generation. Throw
+          // so a truncated partial isn't mistaken for a complete result; the outer
+          // catch turns it into a retryable toast.
+          if (parsed?.error) throw new Error(parsed.error);
+          lastParsed = parsed as { tasks: ImportTask[] };
+          const streamedTasks = (lastParsed.tasks ?? []).slice(0, 50) as ImportTask[];
+          setGeneratedTasks(streamedTasks);
         }
       }
 


### PR DESCRIPTION
## The bug (Nick, reproduced live)

The board's **AI Generate Tasks** dialog spins on "Generating tasks…" indefinitely — often after rendering a single task — with no error and no retry. Reproduced repeatedly against production: the request returns HTTP 200, then the body never ends. There is **no error line in the Vercel logs** (confirmed by tailing prod during a live run — `status=200`, zero log lines), which is what makes it a hang rather than a crash.

## Root cause — a code bug that turns an upstream stall into an infinite hang

Verified against the installed `ai@6` source:

1. `streamObject` resolves `result.usage` **only** inside its `case "finish"` branch. An errored or aborted stream (provider overload, connection reset, or a token stall) never sends a `finish` chunk, so `result.usage` stays a **forever-pending `DelayedPromise`** — it never resolves *and never rejects*.
2. The route did `await result.usage` before `controller.close()`, so a stalled stream left the `ReadableStream` — and the HTTP response body — open until Vercel's 300s function kill.
3. Compounding it: `partialObjectStream` **silently swallows error chunks** (`case "error": break`), and the route passed **no `abortSignal`**. So nothing bounded the stall or surfaced it, and the dock treated the truncated partial (one task) as an in-progress result and waited.

## Fix

**Route (`api/ai/generate-tasks/route.ts`):**
- `abortSignal: AbortSignal.timeout(120s)` so a token stall aborts instead of hanging to the function timeout — parity with the onboarding generate path, which already has a 90s timeout.
- `onError` to capture + log the failure (the SDK default only `console.error`s, which never surfaced).
- Wrap the `partialObjectStream` loop so an outright rejection is caught too.
- On failure, emit a JSON **error sentinel** line and close — the body never stays open.
- Make usage logging best-effort: `Promise.race` against a 5s timeout (with `.catch`) so a never-resolving `result.usage` can't block closing the stream. The credit was already charged upfront (`free: true`), so skipping the log is safe.

**Dock dialog (`components/board/ai-generate-dialog.tsx`):**
- Parse the error sentinel and throw → a stalled generation shows a retryable toast instead of applying a truncated 1-task result.

## Verification

- `npx tsc --noEmit` clean; `eslint` clean on both files (the 2 warnings shown are pre-existing and unrelated).
- No existing test covers this streaming route; the change is I/O orchestration with no clean pure seam, so it's verified statically + against the live repro. Nick is actively reproducing, so we confirm the fix in production after deploy.

## Note
Branches off current `master` (includes the just-merged `ac2be4b` attachment-context feature). Touches only the two files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)