### PR TITLE
fix(ai): bound Generate Tasks output so large ideas don't stall on one giant task

### DIFF
--- a/src/app/api/ai/generate-tasks/route.ts
+++ b/src/app/api/ai/generate-tasks/route.ts
@@ -120,9 +120,20 @@ export async function POST(req: Request) {
 
     const hasAgent = !!(personaPrompt || agentRole || agentSkills?.length);
 
-    const systemPrompt = hasAgent
-      ? `${personaPrompt ?? "You are a specialist AI agent."}\n\nYou are generating a structured task board for a software project on a kanban-style project management platform. Focus your task generation on your area of expertise — prioritize tasks you would own or contribute to. Include any scaffolding or setup tasks relevant to your domain (e.g. a DevOps agent should include CI/CD and deployment setup). If a task has subtasks or implementation steps, include them as a markdown task list in the description (e.g. "- [ ] Step one\\n- [ ] Step two").`
-      : "You are an expert project manager generating a structured task board for a software project on a kanban-style project management platform. Include project scaffolding and setup tasks (e.g. repo setup, dev environment, CI/CD, deployment config) — not just feature work. Order tasks so foundational/setup tasks come first. If a task has subtasks or implementation steps, include them as a markdown task list in the description (e.g. \"- [ ] Step one\\n- [ ] Step two\").";
+    // Hard bound on the OUTPUT size. A large, detailed idea (long description with
+    // acceptance criteria, tables, epics) otherwise leads the model to mirror that
+    // density and generate one enormous task description — it can spend the whole
+    // generation on a single task and never advance, which manifests as the dock
+    // showing one task and then timing out. Keeping each task terse makes the model
+    // move through tasks quickly and keeps total output well within budget.
+    const OUTPUT_CONSTRAINTS =
+      " Produce a FOCUSED board of the most important, well-scoped tasks (aim for 12-24 tasks, not an exhaustive enumeration). Each task's description MUST be short — at most 3-5 markdown checklist items (\"- [ ] step\"). Summarize the idea into concrete, actionable steps; do NOT copy long acceptance criteria, RICE tables, user stories, or prose from the idea into descriptions.";
+
+    const systemPrompt =
+      (hasAgent
+        ? `${personaPrompt ?? "You are a specialist AI agent."}\n\nYou are generating a structured task board for a project on a kanban-style project management platform. Focus your task generation on your area of expertise — prioritize tasks you would own or contribute to. Include any scaffolding or setup tasks relevant to your domain (e.g. a DevOps agent should include CI/CD and deployment setup). If a task has subtasks or implementation steps, include them as a markdown task list in the description (e.g. "- [ ] Step one\\n- [ ] Step two").`
+        : "You are an expert project manager generating a structured task board for a project on a kanban-style project management platform. Include foundational/setup tasks where relevant (e.g. for software: repo setup, dev environment, CI/CD) — not just feature work. Order tasks so foundational/setup tasks come first. If a task has subtasks or implementation steps, include them as a markdown task list in the description (e.g. \"- [ ] Step one\\n- [ ] Step two\").") +
+      OUTPUT_CONSTRAINTS;
 
     const contextParts = buildPromptContextParts({
       prompt,
@@ -170,11 +181,18 @@ export async function POST(req: Request) {
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       async start(controller) {
+        // Progress telemetry — lets us tell a genuine stall ("stuck at 1 task")
+        // apart from a slow-but-advancing generation when a run is aborted.
+        const startedAt = Date.now();
+        let maxTasksSeen = 0;
+        let chunksEmitted = 0;
         try {
           for await (const partialObject of result.partialObjectStream) {
             const taskCount = partialObject.tasks?.length ?? 0;
+            maxTasksSeen = Math.max(maxTasksSeen, taskCount);
             // Only emit when we have at least one task with a title
             if (taskCount > 0 && partialObject.tasks![taskCount - 1]?.title) {
+              chunksEmitted += 1;
               controller.enqueue(
                 encoder.encode(JSON.stringify(partialObject) + "\n")
               );
@@ -190,6 +208,12 @@ export async function POST(req: Request) {
         // sentinel to show a retryable toast instead of treating a truncated
         // partial (e.g. a single task) as a complete result.
         if (streamError) {
+          logger.error("AI generate tasks stream ended in error", {
+            ideaId,
+            maxTasksSeen,
+            chunksEmitted,
+            elapsedMs: Date.now() - startedAt,
+          });
           controller.enqueue(
             encoder.encode(
               JSON.stringify({
@@ -200,6 +224,13 @@ export async function POST(req: Request) {
           controller.close();
           return;
         }
+
+        logger.info("AI generate tasks stream completed", {
+          ideaId,
+          maxTasksSeen,
+          chunksEmitted,
+          elapsedMs: Date.now() - startedAt,
+        });
 
         // Usage is best-effort billing/telemetry only (the credit was charged
         // upfront, free: true here) — NEVER let it block closing the response.


### PR DESCRIPTION
Follow-up to #112 (which stopped the infinite hang). With that safety net in place, Nick retried on a large idea and saw the real bug surface cleanly: **one task, ~2 min wait, then dropped back to the dialog** — the 120s abort catching a genuine generation stall.

## Root cause

The idea (`YCS Credibility Engine — 90-Day Programme`) has a ~5,000-token description — 9 epics with RICE tables, user stories, and acceptance criteria — on a board that already has 72 tasks. The model mirrors that density and generates **one enormous first-task description** (thousands of tokens of acceptance-criteria-style content), spending the whole generation on a single task without ever advancing to task 2.

It is **not** the token cap: hitting `maxOutputTokens` sends a `finish` chunk and yields 10-15 truncated tasks, not one. Getting stuck at exactly one means the first task alone didn't finish in 120s. So raising tokens or the timeout wouldn't help — it would just make task 1 bigger. **The fix is to bound the output.**

## Fix

- **Output constraints** appended to the system prompt (agent + non-agent variants): aim for 12-24 focused tasks, cap each description at 3-5 markdown checklist items, summarize rather than copy long acceptance criteria / tables / prose from the idea. Terse tasks make the model advance through the board quickly and keep total output small.
- **"software project" → "project"**: the failing idea is a business/consulting programme, so instructing the model to add "repo setup, CI/CD" scaffolding was actively wrong for it. Setup tasks are now software-*specific* rather than assumed.
- **Progress telemetry** (`maxTasksSeen`, `chunksEmitted`, `elapsedMs`) logged on both the completed and errored paths — so the next run's logs definitively show "stuck at 1 task" vs "advancing", confirming the mechanism.

## Verification

- `tsc --noEmit` and `eslint` clean. No test covers this inline prompt/route logic; verified against the live repro after deploy (Nick is reproducing on the actual idea).
- The #112 resilience fix stays as the backstop: if the model still over-generates, it aborts at 120s and shows a retry toast instead of hanging.

Preview deploy will fail on the known missing-Supabase-env issue (card `68df3983`) — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)