### PR TITLE
fix(ai): raise large-idea threshold to 12k chars; large-idea nudge targets description length only (no task-count hint)

### DIFF
--- a/src/app/api/ai/generate-tasks/route.ts
+++ b/src/app/api/ai/generate-tasks/route.ts
@@ -148,17 +148,18 @@ export async function POST(req: Request) {
       agentBio,
     });
 
-    // Large ideas ONLY: append decomposition guidance as the last thing the model
-    // reads (recency), with a positive few-shot example — the lever that actually
-    // gets this model to keep descriptions short so many tasks fit in the budget.
-    // NO upper cap on task count: the failure mode is UNDER-production (one giant
-    // task), and a detailed spec should yield MORE tasks than a small idea, not
-    // fewer. The count is driven by the content (one task per discrete unit of
-    // work); short descriptions are what let many tasks fit in the token budget.
+    // Large ideas ONLY: append a short nudge as the last thing the model reads
+    // (recency). The ONLY failure this addresses is the model writing one giant
+    // task description that eats the whole token budget before it makes a second
+    // task. So the nudge targets exactly that — short descriptions, don't reproduce
+    // the spec's detail verbatim, split long descriptions. It deliberately does NOT
+    // suggest a task count: the model decomposes to the right number on its own
+    // (30+ on normal ideas, which carry no count hint either), and a number would
+    // only anchor it. Short descriptions are what let many tasks fit in the budget.
     if (isLargeIdea) {
       contextParts.push(
         "---",
-        "This idea is large and detailed. Break it into MANY small, separate tasks — roughly one task per user story, deliverable, or discrete piece of work — rather than packing several areas into one big task; a detailed spec like this usually yields 25-40+ tasks. Keep each task's description short (about one sentence) and summarize rather than reproducing acceptance criteria, tables, RICE scores, user stories, or long prose verbatim; if a description is getting long, that means it should be several separate tasks. Match the size of these examples:\n" +
+        "This idea's description is long and detailed. Break it into separate tasks — one per discrete piece of work — rather than packing several areas into one large task, and keep each task's description short (about one sentence): summarize the work rather than reproducing acceptance criteria, tables, RICE scores, user stories, or long prose from the idea in a description. If a task's description is getting long, that means it should be split into several separate tasks. Match the size and shape of these examples:\n" +
           '- {"title": "Set up the project repository and CI", "description": "Create the repo and add a lint/test/build pipeline that runs on every PR.", "columnName": "To Do", "labels": ["infrastructure"]}\n' +
           '- {"title": "Design the sign-up flow", "description": "Wireframe the 3-step onboarding and get sign-off before build.", "columnName": "To Do", "labels": ["design"]}'
       );

--- a/src/app/api/ai/generate-tasks/route.ts
+++ b/src/app/api/ai/generate-tasks/route.ts
@@ -131,9 +131,9 @@ export async function POST(req: Request) {
     // and fills the token budget before making a second — confirmed by telemetry).
     // Normal ideas never hit this, so they keep the ORIGINAL prompt above untouched;
     // only large ideas get an added decomposition nudge. Threshold in characters:
-    // ~5000 chars ≈ 1200 tokens — well above a normal idea, well below YCS TEST's
-    // ~20000-char programme spec.
-    const LARGE_IDEA_CHARS = 5000;
+    // 12000 chars ≈ 2000 words — comfortably above a normal spec, well below YCS
+    // TEST's ~20000-char programme spec.
+    const LARGE_IDEA_CHARS = 12000;
     const isLargeIdea = (idea.description?.length ?? 0) > LARGE_IDEA_CHARS;
 
     const contextParts = buildPromptContextParts({
@@ -151,10 +151,14 @@ export async function POST(req: Request) {
     // Large ideas ONLY: append decomposition guidance as the last thing the model
     // reads (recency), with a positive few-shot example — the lever that actually
     // gets this model to keep descriptions short so many tasks fit in the budget.
+    // NO upper cap on task count: the failure mode is UNDER-production (one giant
+    // task), and a detailed spec should yield MORE tasks than a small idea, not
+    // fewer. The count is driven by the content (one task per discrete unit of
+    // work); short descriptions are what let many tasks fit in the token budget.
     if (isLargeIdea) {
       contextParts.push(
         "---",
-        "This idea is large and detailed. Decompose it into MANY small, separate tasks (aim for 15-25) — do not pack multiple areas of work into one task. Summarize the detail into short descriptions (roughly one sentence each) rather than reproducing acceptance criteria, tables, RICE scores, user stories, or long prose; a single task with a very long description should be split into several tasks. Match the size of these examples:\n" +
+        "This idea is large and detailed. Break it into MANY small, separate tasks — roughly one task per user story, deliverable, or discrete piece of work — rather than packing several areas into one big task; a detailed spec like this usually yields 25-40+ tasks. Keep each task's description short (about one sentence) and summarize rather than reproducing acceptance criteria, tables, RICE scores, user stories, or long prose verbatim; if a description is getting long, that means it should be several separate tasks. Match the size of these examples:\n" +
           '- {"title": "Set up the project repository and CI", "description": "Create the repo and add a lint/test/build pipeline that runs on every PR.", "columnName": "To Do", "labels": ["infrastructure"]}\n' +
           '- {"title": "Design the sign-up flow", "description": "Wireframe the 3-step onboarding and get sign-off before build.", "columnName": "To Do", "labels": ["design"]}'
       );


### PR DESCRIPTION
Corrections to the size-gated large-idea guidance, from Nick's review.

**1. Threshold 5,000 → 12,000 chars** (~800 → ~2,000 words). 5,000 was low enough that a normal ~1,000-word spec tripped the "large idea" path; 12,000 only catches genuinely huge specs (YCS TEST ≈ 20,000 chars). Normal ideas keep the untouched original prompt.

**2. No task-count hint anywhere.** The original normal-idea prompt carries no count suggestion and the model naturally makes 30+ tasks. Earlier iterations added a count to the large-idea path ("15-25", then "25-40+") — inconsistent, and a number can only anchor the model. Removed entirely.

The large-idea nudge now targets ONLY the actual failure: the model writing one giant task description that fills the 8k-token budget before it makes a second task. It says — break into separate tasks (one per discrete piece of work), keep each description ~one sentence, summarize rather than reproducing the spec verbatim, split long descriptions — with two examples showing the terse shape. No count; the model decomposes to the right number on its own once descriptions stay short, exactly as it does for normal ideas.

Net: normal ideas (<12k chars) unchanged; large ideas get only a "keep descriptions short / don't dump the spec into one task" nudge.

`tsc` + `eslint` clean. Preview deploy fails on the known Supabase-env issue (card `68df3983`), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)