### PR TITLE
feat(terminal): multiple concurrent terminals — tabbed dock, session registry + cap, pop-out window

### DIFF
--- a/docs/design-terminal-multi-session-popout.html
+++ b/docs/design-terminal-multi-session-popout.html
@@ -1,0 +1,772 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Multi-Session Terminal Dock + Pop-out — UX Design (Compass)</title>
+<style>
+  :root {
+    --bg: #0a0a0b;
+    --panel: #141417;
+    --panel-2: #1c1c21;
+    --panel-3: #232329;
+    --border: #2a2a31;
+    --border-2: #3a3a44;
+    --text: #e6e6ea;
+    --muted: #9a9aa6;
+    --muted-2: #6f6f7a;
+    --accent: #7dd3fc;
+    --emerald: #34d399;
+    --amber: #fbbf24;
+    --rose: #fb7185;
+    --violet: #a78bfa;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    line-height: 1.55; font-size: 15px;
+  }
+  .wrap { max-width: 1020px; margin: 0 auto; padding: 48px 28px 120px; }
+  header.doc { border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 32px; }
+  .kicker { color: var(--accent); font-size: 12px; letter-spacing: .14em; text-transform: uppercase; font-weight: 700; }
+  h1 { font-size: 30px; margin: 8px 0 6px; }
+  h2 { font-size: 21px; margin: 52px 0 14px; padding-top: 16px; border-top: 1px solid var(--border); }
+  h3 { font-size: 16px; margin: 28px 0 10px; color: var(--accent); }
+  p { color: var(--text); }
+  .sub { color: var(--muted); }
+  a { color: var(--accent); }
+  .persona { display: inline-block; background: var(--panel-2); border: 1px solid var(--border); border-radius: 999px; padding: 4px 12px; font-size: 12px; color: var(--violet); margin-right: 8px; }
+  code, .mono { font-family: var(--mono); font-size: 13px; }
+  code.inline { background: var(--panel-2); border: 1px solid var(--border); border-radius: 5px; padding: 1px 6px; color: var(--accent); }
+
+  .cite { background: linear-gradient(90deg, rgba(167,139,250,.08), transparent); border-left: 3px solid var(--violet); border-radius: 0 8px 8px 0; padding: 14px 18px; margin: 16px 0; font-size: 14px; }
+  .cite b { color: var(--violet); }
+  .rationale { background: linear-gradient(90deg, rgba(125,211,252,.07), transparent); border-left: 3px solid var(--accent); border-radius: 0 8px 8px 0; padding: 12px 16px; margin: 14px 0 22px; font-size: 13.5px; color: var(--muted); }
+  .rationale b { color: var(--text); }
+  .rationale .law { color: var(--accent); font-weight: 600; }
+  .reco { background: linear-gradient(90deg, rgba(52,211,153,.10), transparent); border: 1px solid rgba(52,211,153,.4); border-radius: 12px; padding: 18px 22px; margin: 18px 0; }
+  .reco h3 { margin-top: 0; color: var(--emerald); }
+  .reco .pick { display:inline-block; background: rgba(52,211,153,.16); border:1px solid rgba(52,211,153,.5); color: var(--emerald); border-radius: 6px; padding: 2px 9px; font-size: 12px; font-weight: 700; margin-left: 6px; }
+  .warnbox { background: linear-gradient(90deg, rgba(251,191,36,.10), transparent); border: 1px solid rgba(251,191,36,.4); border-radius: 12px; padding: 16px 20px; margin: 18px 0; font-size: 14px; }
+  .warnbox b { color: var(--amber); }
+  .req { display:inline-block; font-family: var(--mono); font-size: 11px; font-weight: 700; color: var(--violet); background: rgba(167,139,250,.12); border: 1px solid rgba(167,139,250,.45); border-radius: 5px; padding: 1px 6px; margin: 0 2px; vertical-align: 1px; white-space: nowrap; }
+
+  /* ── Mock chrome ── */
+  .browser { border: 1px solid var(--border); border-radius: 12px; overflow: hidden; margin: 14px 0; background: var(--panel); box-shadow: 0 8px 30px rgba(0,0,0,.4); }
+  .chrome-bar { display:flex; align-items:center; gap:8px; background: var(--panel-2); border-bottom: 1px solid var(--border); padding: 9px 14px; }
+  .dot { width:11px; height:11px; border-radius:50%; }
+  .dot.r{background:#fb7185}.dot.y{background:#fbbf24}.dot.g{background:#34d399}
+  .urlbar { flex:1; margin-left:8px; background: var(--bg); border:1px solid var(--border); border-radius:6px; padding:3px 10px; font-family:var(--mono); font-size:11.5px; color:var(--muted); }
+  .boardtop { display:flex; align-items:center; gap:12px; padding:11px 16px; background:var(--panel); border-bottom:1px solid var(--border); }
+  .boardtop .crumb { font-size:13px; color:var(--muted); }
+  .boardtop .crumb b { color:var(--text); }
+  .boardtop .spacer { flex:1; }
+  .kanban { display:flex; gap:12px; padding:10px 16px; background:#0d0d10; overflow:hidden; }
+  .col { flex:1; min-width:0; }
+  .col h4 { margin:0 0 9px; font-size:12px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--muted); display:flex; align-items:center; gap:7px; }
+  .col h4 .count { background:var(--panel-3); border:1px solid var(--border); color:var(--muted); border-radius:999px; padding:0 7px; font-size:11px; }
+  .tcard { background:var(--panel-2); border:1px solid var(--border); border-radius:9px; padding:8px 10px; margin-bottom:9px; }
+  .tcard .ttl { font-size:12px; color:var(--text); line-height:1.4; }
+  .splitbtn { display:inline-flex; }
+  .splitbtn .main { background: var(--accent); border:1px solid var(--accent); border-right:0; border-radius:8px 0 0 8px; color:#06222e; height:34px; display:flex; align-items:center; gap:7px; padding:0 14px; font-size:13.5px; font-weight:700; }
+  .splitbtn .caret { background: var(--accent); border:1px solid var(--accent); border-radius:0 8px 8px 0; color:#06222e; height:34px; display:flex; align-items:center; padding:0 9px; }
+
+  /* ── State pills (P1 language, reused verbatim) ── */
+  .statepill { display:inline-flex; align-items:center; gap:6px; border-radius:7px; padding:4px 10px; font-size:12.5px; font-weight:600; border:1px solid var(--border-2); background: var(--panel-3); }
+  .statepill .ic { font-size:12px; line-height:1; }
+  .statepill.connected { color: var(--emerald); border-color: rgba(52,211,153,.5); background: rgba(52,211,153,.10); }
+  .statepill.connecting { color: var(--amber); border-color: rgba(251,191,36,.5); background: rgba(251,191,36,.10); }
+  .statepill.waiting { color: var(--accent); border-color: rgba(125,211,252,.5); background: rgba(125,211,252,.10); }
+  .statepill.disconnected { color: var(--amber); border-color: rgba(251,191,36,.5); background: rgba(251,191,36,.08); }
+  .statepill.ended { color: var(--muted); border-color: var(--border-2); background: var(--panel-3); }
+  .statepill.error { color: var(--rose); border-color: rgba(251,113,133,.55); background: rgba(251,113,133,.10); }
+  .hostinfo { font-family: var(--mono); font-size: 12px; color: var(--muted); display:flex; align-items:center; gap:6px; }
+  .hostinfo .sep { color: var(--muted-2); }
+  .ro-badge { display:inline-flex; align-items:center; gap:5px; font-size:11.5px; font-weight:700; color: var(--violet); background: rgba(167,139,250,.12); border:1px solid rgba(167,139,250,.55); border-radius:6px; padding:3px 9px; letter-spacing:.02em; }
+  .spacer { flex:1; }
+  .tctrls { display:flex; align-items:center; gap:6px; }
+  .ibtn { display:inline-flex; align-items:center; gap:5px; height:30px; min-width:30px; justify-content:center; padding:0 9px; border-radius:7px; border:1px solid var(--border-2); background: var(--panel-3); color: var(--text); font-size:12.5px; cursor:pointer; }
+  .ibtn:hover { background: #2c2c34; }
+  .ibtn.danger { color: var(--rose); border-color: rgba(251,113,133,.45); }
+  .ibtn.danger:hover { background: rgba(251,113,133,.12); }
+  .ibtn:focus-visible, .btn:focus-visible, .ttab:focus-visible, .plus:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  /* ── NEW: tab strip ── */
+  .tabstrip { display:flex; align-items:stretch; background: var(--panel); border-bottom: 1px solid var(--border); overflow:hidden; position:relative; }
+  .tabscroll { display:flex; align-items:stretch; overflow-x:auto; scrollbar-width:none; flex:1; min-width:0; }
+  .tabscroll::-webkit-scrollbar { display:none; }
+  .ttab { display:flex; align-items:center; gap:7px; padding: 0 10px 0 12px; height: 38px; min-width: 110px; max-width: 190px; border-right: 1px solid var(--border); background: var(--panel); color: var(--muted); font-size: 12.5px; cursor:pointer; border-top: 2px solid transparent; position:relative; flex: 0 1 auto; }
+  .ttab .st { font-size: 11px; line-height: 1; flex: 0 0 auto; }
+  .ttab .st.ok { color: var(--emerald); }
+  .ttab .st.warn { color: var(--amber); }
+  .ttab .st.err { color: var(--rose); }
+  .ttab .st.mut { color: var(--muted-2); }
+  .ttab .st.cy { color: var(--accent); }
+  .ttab .lbl { overflow:hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+  .ttab .x { flex: 0 0 auto; width: 18px; height: 18px; border-radius: 5px; display:flex; align-items:center; justify-content:center; color: var(--muted-2); font-size: 12px; line-height:1; }
+  .ttab .x:hover { background: var(--panel-3); color: var(--text); }
+  .ttab.active { background: #0c0c0e; color: var(--text); border-top-color: var(--accent); font-weight: 600; }
+  .ttab:hover:not(.active) { background: var(--panel-2); color: var(--text); }
+  .plus { flex: 0 0 auto; width: 38px; height: 38px; display:flex; align-items:center; justify-content:center; color: var(--muted); background: var(--panel); border:0; border-right:1px solid var(--border); font-size: 16px; cursor:pointer; }
+  .plus:hover { background: var(--panel-2); color: var(--text); }
+  .strip-end { display:flex; align-items:center; gap:6px; padding: 0 10px; border-left: 1px solid var(--border); background: var(--panel); flex: 0 0 auto; }
+  .sessbtn { display:inline-flex; align-items:center; gap:6px; height: 26px; padding: 0 10px; border-radius: 7px; border: 1px solid var(--border-2); background: var(--panel-3); color: var(--muted); font-size: 11.5px; font-weight: 600; cursor:pointer; }
+  .sessbtn:hover { color: var(--text); background:#2c2c34; }
+  .sessbtn .n { background: var(--panel); border:1px solid var(--border-2); border-radius: 999px; padding: 0 6px; font-size: 10.5px; color: var(--accent); }
+  .fadeR { position:absolute; right:0; top:0; bottom:0; width:26px; background: linear-gradient(90deg, transparent, var(--panel)); pointer-events:none; }
+  .anno { font-size: 12px; color: var(--muted-2); text-align: center; margin: 6px 0 0; }
+  .callout-pin { display:inline-block; font-size:10px; font-weight:800; color:#06222e; background: var(--accent); border-radius: 999px; width: 16px; height:16px; line-height:16px; text-align:center; margin-right:6px; }
+  ol.annos { margin: 10px 0 0; padding-left: 0; list-style: none; }
+  ol.annos li { font-size: 13px; color: var(--muted); margin: 6px 0; }
+  ol.annos li b { color: var(--text); }
+
+  /* term body */
+  .term { background:#0c0c0e; }
+  .term-header { display:flex; align-items:center; gap:10px; background: var(--panel-2); border-bottom:1px solid var(--border); padding: 8px 12px; flex-wrap: wrap; }
+  .xterm { font-family: var(--mono); font-size: 12.5px; line-height: 1.5; padding: 14px 18px; color: #cfd8df; min-height: 150px; white-space: pre-wrap; }
+  .xterm .c-cyan { color: #7dd3fc; } .xterm .c-green { color: #34d399; } .xterm .c-dim { color: #6f6f7a; }
+  .xterm .c-amber { color: #fbbf24; } .xterm .c-violet { color: #a78bfa; } .xterm .c-white { color: #e6e6ea; }
+  .xterm .bullet { color:#34d399; }
+  .cursor { display:inline-block; width:8px; height:15px; background:#cfd8df; vertical-align:-2px; animation: blink 1.1s steps(1) infinite; }
+  @keyframes blink { 50% { opacity: 0; } }
+  .term-input { display:flex; align-items:center; gap:8px; border-top:1px solid var(--border); background: var(--panel); padding:8px 12px; }
+  .term-input .prompt { color: var(--emerald); font-family:var(--mono); font-size:12.5px; }
+  .tin { flex:1; background: var(--bg); border:1px solid var(--border-2); border-radius:7px; padding:6px 10px; color: var(--text); font-family:var(--mono); font-size:12.5px; }
+  .tin::placeholder { color: var(--muted-2); }
+
+  /* collapsed dockbar */
+  .dockbar { display:flex; align-items:center; gap:10px; background:var(--panel-2); border-top:1px solid var(--border-2); padding:7px 14px; }
+  .dockbar .lbl { display:inline-flex; align-items:center; gap:8px; font-size:12.5px; font-weight:600; color:var(--text); }
+  .dockbar .spacer { flex:1; }
+  .sumchip { display:inline-flex; align-items:center; gap:5px; font-size:11px; font-weight:700; border-radius:6px; padding:2px 8px; border:1px solid var(--border-2); }
+  .sumchip.ok { color: var(--emerald); border-color: rgba(52,211,153,.5); background: rgba(52,211,153,.10); }
+  .sumchip.warn { color: var(--amber); border-color: rgba(251,191,36,.5); background: rgba(251,191,36,.10); }
+  .sumchip.err { color: var(--rose); border-color: rgba(251,113,133,.5); background: rgba(251,113,133,.10); }
+  .sumchip.mut { color: var(--muted); background: var(--panel-3); }
+
+  /* overlays */
+  .overlay { min-height: 170px; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; padding: 24px; gap:10px; background:#0c0c0e; }
+  .overlay .big { font-size: 28px; line-height:1; }
+  .overlay .ttl { font-size: 15.5px; font-weight: 700; }
+  .overlay .ttl.cyan{color:var(--accent);} .overlay .ttl.muted{color:var(--muted);} .overlay .ttl.rose{color:var(--rose);} .overlay .ttl.amber{color:var(--amber);}
+  .overlay .msg { color: var(--muted); font-size:13px; max-width: 440px; }
+  .btn { display:inline-flex; align-items:center; gap:7px; height:36px; padding:0 18px; border-radius:8px; font-size:13.5px; font-weight:600; cursor:pointer; border:1px solid transparent; }
+  .btn.primary { background: var(--accent); color:#06222e; }
+  .btn.ghost { background: var(--panel-3); color: var(--text); border-color: var(--border-2); }
+  .btn.danger { background: rgba(251,113,133,.12); color: var(--rose); border:1px solid rgba(251,113,133,.5); }
+  .btnrow { display:flex; gap:10px; flex-wrap:wrap; justify-content:center; }
+
+  /* my-sessions panel */
+  .sesspanel { width: 460px; max-width:100%; background: var(--panel); border:1px solid var(--border-2); border-radius:12px; box-shadow:0 18px 50px rgba(0,0,0,.6); overflow:hidden; margin: 14px 0; }
+  .sesspanel .sp-head { display:flex; align-items:center; gap:8px; padding: 12px 14px 8px; font-size: 13px; font-weight: 700; }
+  .sesspanel .sp-head .sub2 { font-weight: 400; color: var(--muted-2); font-size: 11.5px; margin-left:auto; }
+  .sessrow { display:flex; align-items:center; gap:10px; padding: 10px 14px; border-top: 1px solid var(--border); }
+  .sessrow .info { min-width:0; flex:1; }
+  .sessrow .l1 { font-size: 13px; color: var(--text); font-weight: 600; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; display:flex; align-items:center; gap:7px; }
+  .sessrow .l1 .where { font-weight:400; color: var(--muted-2); font-size: 11.5px; flex:0 0 auto; }
+  .sessrow .l2 { font-family: var(--mono); font-size: 11px; color: var(--muted-2); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; margin-top:2px; }
+  .sessrow .age { flex: 0 0 auto; font-size: 11.5px; color: var(--muted); }
+  .sesspanel .sp-foot { display:flex; align-items:center; gap:10px; padding: 10px 14px; border-top:1px solid var(--border); background: var(--panel-2); }
+  .sesspanel .sp-foot .hint { font-size: 11.5px; color: var(--muted-2); }
+
+  /* toast */
+  .toast { display:flex; gap:10px; align-items:flex-start; width: 400px; max-width:100%; background:#232327; border:1px solid var(--border-2); border-left: 3px solid var(--rose); border-radius:10px; padding: 12px 14px; box-shadow:0 12px 40px rgba(0,0,0,.55); margin: 12px 0; }
+  .toast.warn { border-left-color: var(--amber); }
+  .toast .t { font-size: 13px; font-weight: 700; }
+  .toast .d { font-size: 12.5px; color: var(--muted); margin-top: 2px; }
+  .toast .d a { font-weight: 600; }
+
+  /* notice bar */
+  .noticebar { display:flex; align-items:center; gap:8px; font-size: 11.5px; color: var(--accent); background: rgba(125,211,252,.07); border-bottom: 1px solid rgba(125,211,252,.25); padding: 6px 12px; }
+  .noticebar .dismiss { margin-left:auto; color: var(--muted-2); cursor:pointer; }
+  .reconbar { display:flex; align-items:center; gap:8px; border-top:1px solid rgba(251,191,36,.3); background: rgba(251,191,36,.05); padding: 7px 12px; font-size: 11px; color: var(--amber); }
+  .reconbar u { cursor:pointer; }
+
+  /* state grid */
+  .grid { display:grid; grid-template-columns: 1fr 1fr; gap:14px; margin:16px 0; }
+  @media (max-width:760px){ .grid { grid-template-columns: 1fr; } }
+  .state { border:1px solid var(--border); border-radius:12px; padding:14px 16px; background: var(--panel); }
+  .state .tag { font-size:11px; font-weight:700; letter-spacing:.06em; text-transform:uppercase; display:flex; align-items:center; gap:6px; }
+  .state.ok{border-color:rgba(52,211,153,.4)} .state.ok .tag{color:var(--emerald)}
+  .state.wait{border-color:rgba(125,211,252,.4)} .state.wait .tag{color:var(--accent)}
+  .state.warn{border-color:rgba(251,191,36,.4)} .state.warn .tag{color:var(--amber)}
+  .state.err{border-color:rgba(251,113,133,.45)} .state.err .tag{color:var(--rose)}
+  .state.kill{border-color:rgba(167,139,250,.45)} .state.kill .tag{color:var(--violet)}
+  .state.neutral .tag{color:var(--muted)}
+  .state p { font-size:13px; color:var(--muted); margin:8px 0 0; }
+
+  table { width:100%; border-collapse:collapse; margin:14px 0; font-size:13.5px; }
+  th,td { text-align:left; padding:9px 12px; border-bottom:1px solid var(--border); vertical-align:top; }
+  th { color:var(--muted); font-weight:600; font-size:12px; text-transform:uppercase; letter-spacing:.05em; }
+  td code { color: var(--accent); }
+
+  /* flows */
+  .flow { display:flex; flex-direction:column; margin:18px 0; }
+  .step { display:flex; gap:14px; }
+  .step .num { flex:0 0 34px; height:34px; border-radius:50%; background:var(--panel-2); border:1px solid var(--border); display:flex; align-items:center; justify-content:center; font-weight:700; font-size:13px; color:var(--accent); }
+  .step .body { flex:1; background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:11px 16px; margin-bottom:10px; }
+  .step .body .t { font-weight:600; }
+  .step .body .d { color:var(--muted); font-size:13px; margin-top:2px; }
+  .step .body .branch { margin-top:8px; padding: 8px 12px; border-left: 2px solid var(--border-2); font-size: 12.5px; color: var(--muted); border-radius: 0 6px 6px 0; background: var(--panel-2); }
+  .step .body .branch b { color: var(--amber); }
+  .connector { margin:-6px 0 4px 16px; color:var(--border-2); font-size:18px; line-height:1; }
+
+  .label { display:inline-block; font-size:11px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; color:var(--muted); background:var(--panel-2); border:1px solid var(--border); border-radius:6px; padding:3px 10px; margin-bottom:10px; }
+  .toc { columns:2; gap:24px; font-size:13.5px; color:var(--muted); }
+  @media (max-width:680px){ .toc{columns:1;} }
+  .toc a { display:block; padding:3px 0; }
+  ul.tight { margin:8px 0 0; padding-left:18px; }
+  ul.tight li { margin:5px 0; font-size:13.5px; color:var(--muted); }
+  ul.tight li b { color: var(--text); }
+
+  /* copy sweep before/after */
+  .copyswap { display:grid; grid-template-columns: 1fr 1fr; gap: 12px; margin: 12px 0; }
+  @media (max-width:720px){ .copyswap { grid-template-columns: 1fr; } }
+  .copyswap .before, .copyswap .after { border-radius: 10px; padding: 12px 14px; font-size: 13px; }
+  .copyswap .before { border: 1px solid rgba(251,113,133,.35); background: rgba(251,113,133,.05); color: var(--muted); }
+  .copyswap .after { border: 1px solid rgba(52,211,153,.35); background: rgba(52,211,153,.05); }
+  .copyswap .cap { font-size: 10.5px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase; margin-bottom: 6px; }
+  .copyswap .before .cap { color: var(--rose); }
+  .copyswap .after .cap { color: var(--emerald); }
+
+  /* popped-out window mock */
+  .popwin { border: 1px solid var(--border-2); border-radius: 12px; overflow:hidden; margin: 14px auto; max-width: 660px; background: var(--panel); box-shadow: 0 20px 60px rgba(0,0,0,.6); }
+  kbd { font-family: var(--mono); font-size: 11.5px; background: var(--panel-3); border: 1px solid var(--border-2); border-bottom-width: 2px; border-radius: 5px; padding: 1px 6px; color: var(--text); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="doc">
+  <div class="kicker">UX Design · Step 2 of 6 · In-App Terminal — Later Phase: Multi-Session + Pop-out</div>
+  <h1>Many terminals, one honest dock — tabs, a sessions list, and pop-out</h1>
+  <p class="sub">
+    <span class="persona">Compass · UX Designer</span>
+    This phase turns the P1 single-session terminal dock into a <b>VS Code-style tabbed multi-session surface</b>,
+    adds a <b>"My sessions"</b> list with a one-click panic button, and lets any session be <b>popped out into its own
+    browser window</b>. Everything here is UI on top of plumbing that already isolates sessions (one relay DO per
+    session, worktree isolation on disk). <b>Desktop-only (≥768px)</b> per requirement <span class="req">NG2</span> — the dock
+    remains absent on mobile, exactly as in P1. Feature-flag OFF = none of this exists <span class="req">B9</span> <span class="req">F6</span>.
+  </p>
+</header>
+
+<div class="warnbox">
+  <b>⚠ Gate reminder (EC1–EC5).</b> This is a design-only deliverable. The Requirements step's blocking entry gate is
+  <b>not met</b> (parent P1 task e31f4594 at 3/6 steps). Nothing in this document licenses implementation before the gate opens.
+</div>
+
+<!-- ============================================================= -->
+<h2 id="reqs">1 · Building on Requirements (step 1)</h2>
+
+<div class="cite">
+  <b>Binding input: the Requirements step (Product Owner).</b> That document fixed the shape of this phase and this design
+  implements it rather than re-deciding it: <b>tabs, not panes</b> (<span class="req">NG4</span>); <b>pop-out as a same-origin browser
+  window re-attaching the same relay session via owner-verified preemption</b>, not native handoff (<span class="req">D1</span>, <span class="req">NG3</span>);
+  a <b>server-enforced cap of 3</b> with a user-explainable refusal (<span class="req">C2</span> <span class="req">E1</span>); a <b>registry-backed "My sessions"
+  list with End-all</b> (<span class="req">C3</span>); and <b>every P1 security invariant unchanged</b> (<span class="req">F1–F6</span>).
+  Where the Requirements doc left Q2 (board-scoped vs global tabs) to design, §3 answers it with a recommendation.
+</div>
+
+<p class="sub">Requirement-to-design map — where each UI-facing requirement lands in this document:</p>
+<table>
+  <tr><th>Requirement</th><th>What it demands</th><th>Designed in</th></tr>
+  <tr><td><span class="req">B1</span> <span class="req">B3</span> <span class="req">B6</span></td><td>Tab strip, per-tab anatomy, labels, P1 controls carried over</td><td>§2 (anatomy), §4 (full mockup)</td></tr>
+  <tr><td><span class="req">B4</span> <span class="req">B5</span></td><td>Background tabs stay attached; attention indicators; collapsed-bar summary</td><td>§5, §6</td></tr>
+  <tr><td><span class="req">B7</span> <span class="req">C2</span> <span class="req">E1</span></td><td>Launch routing to a new tab; cap refusal copy + path to session list</td><td>§7, Flow 1, Flow 4</td></tr>
+  <tr><td><span class="req">B8</span> <span class="req">B9</span></td><td>Collapse never ends sessions; empty/idle state; flag-off honest absence</td><td>§6, §8</td></tr>
+  <tr><td><span class="req">C3</span> <span class="req">C4</span> <span class="req">F5</span></td><td>"My sessions" across ideas, identity line, per-session End, End-all panic</td><td>§9, Flow 5</td></tr>
+  <tr><td><span class="req">D1–D7</span></td><td>Pop-out window, placeholder tab, bring-back, blocked-popup, truncation notice</td><td>§10, Flow 3</td></tr>
+  <tr><td><span class="req">A3</span> <span class="req">R5</span></td><td>"One place at a time" copy sweep</td><td>§11</td></tr>
+  <tr><td><span class="req">R4</span></td><td>Machine-load honesty on the "+" affordance</td><td>§2 (callout 4), §7</td></tr>
+  <tr><td>ACs 3–10, 13–18</td><td>State-level acceptance criteria</td><td>§5, §12 (state index), flows</td></tr>
+</table>
+
+<p class="sub"><b>Conflicts found: none material.</b> One tension worth flagging for the Design Review: <span class="req">B1</span> says the tab close affordance is "⏻" (End). VS Code's convention — which <span class="req">B1</span> itself invokes — is an <b>×</b> close glyph. Using ⏻ on every tab would read as seven tiny danger buttons. This design uses <b>× on the tab</b> but keeps its behaviour exactly what B1 intends: closing a tab <b>ends that session</b> (with a confirm), because a session without a tab would be invisible-but-running — the opposite of G4's observability goal. See §2, callout 3, and OQ3.</p>
+
+<!-- ============================================================= -->
+<h2 id="anatomy">2 · Tab anatomy — one tab, every part named</h2>
+<p class="sub">The tab strip replaces P1's single "Terminal" label row in the expanded dock header. Each tab is one session. Anatomy, magnified:</p>
+
+<div style="display:flex; justify-content:center; margin:18px 0 6px;">
+  <div class="tabstrip" style="border:1px solid var(--border-2); border-radius:10px; transform:scale(1.35); transform-origin:center; margin: 24px 0;">
+    <div class="ttab active" role="tab" aria-selected="true" style="max-width:250px;">
+      <span class="st ok" aria-hidden="true">●</span>
+      <span class="lbl">Add pagination to the recipe list</span>
+      <span class="x" role="button" aria-label="End session and close tab">×</span>
+    </div>
+    <button class="plus" aria-label="New terminal session">+</button>
+  </div>
+</div>
+
+<ol class="annos" style="max-width:640px; margin:14px auto;">
+  <li><span class="callout-pin">1</span><b>Status glyph</b> — icon + colour, <i>never colour alone</i> <span class="req">B5</span>: <span style="color:var(--emerald)">●</span> connected, <span style="color:var(--amber)">↻</span> reconnecting (spins), <span style="color:var(--accent)">◌</span> connecting/waiting, <span style="color:var(--muted-2)">■</span> ended, <span style="color:var(--rose)">▲</span> error, <span style="color:var(--violet)">⧉</span> popped out. Shapes are distinct, so a colour-blind user reads state from form.</li>
+  <li><span class="callout-pin">2</span><b>Label</b> <span class="req">B3</span> — task title when the session was launched from a task-card menu; otherwise <span class="mono">idea-slug · sid</span> (e.g. <span class="mono">recipe-saver · a3f9</span>). Truncates with ellipsis at max-width 190px; the <b>tooltip carries the full identity line</b> <span class="req">C4</span>: <span class="mono">Nick's MacBook Pro · ~/projects/recipe-saver · session a3f9</span>.</li>
+  <li><span class="callout-pin">3</span><b>Close (×)</b> — ends this session (both relay legs) after an inline confirm; only that tab's session is touched <span class="req">B6</span> <span class="req">F5</span>. 18×18px visual, but the hit target is padded to ≥24×24 and the whole tab row is 38px tall — comfortably above pointer-target minimums (Fitts's Law; this is a desktop-only, cursor-driven surface per NG2).</li>
+  <li><span class="callout-pin">4</span><b>"+" launch</b> — mints a new session for this board <span class="req">B7</span>. Tooltip carries the honesty copy from <span class="req">R4</span>: <i>"New terminal — runs on your computer. Each session uses real resources."</i> At the cap it stays enabled and clicking explains (no dead disabled button — see §7).</li>
+</ol>
+
+<div class="rationale">
+  <b>Why VS Code's grammar, exactly.</b> <span class="law">Jakob's Law</span> — every user who has seen VS Code's panel
+  tabs (P1's stated model) already knows: active tab shares the panel background and gets a top accent line; background
+  tabs are dimmer; × on hover-and-active; "+" at the end. We innovate on <i>value</i> (per-tab live status glyphs, which
+  VS Code terminals also do) and nowhere on interaction pattern. Active-tab signalling is <b>threefold</b> — background
+  colour, top accent bar, and bolder text — never colour alone.
+</div>
+
+<!-- ============================================================= -->
+<h2 id="q2">3 · Q2 answered — board-scoped tabs, global "My sessions"</h2>
+
+<div class="reco">
+  <h3>Recommendation: board-scoped tab strip + global sessions list <span class="pick">RECOMMENDED</span></h3>
+  <p style="font-size:13.5px; margin:8px 0 0;">
+    The dock's tabs show <b>only this idea's sessions</b>. The <b>"My sessions" panel (§9) is global</b> — every live
+    session across all ideas, with idea/task labels. This matches the Requirements doc's own inclination in Q2 and is
+    the honest choice for four reasons:
+  </p>
+  <ul class="tight">
+    <li><b>The dock's identity line stays truthful.</b> The dock lives on <i>a board</i>; its sessions run in <i>that idea's folder</i> (or its worktrees). A tab for another idea's session would show a cwd that has nothing to do with the board behind it.</li>
+    <li><b>The launch bus is already board-scoped.</b> <code class="inline">vibecodes:terminal-browser-launch</code> events come from this board's toolbar and task cards <span class="req">B7</span>; routing them into a mixed global strip invites delivering a prompt to the wrong idea's session.</li>
+    <li><b><span class="law">Hick's Law</span>.</b> A user with 3 sessions across 2 ideas sees at most the 2 relevant tabs here, not all 3 — fewer choices at the point of action.</li>
+    <li><b>Nothing is hidden.</b> US5's "lost track" fear is answered globally by "My sessions", which is one click away from the strip and is <i>the</i> named path in the cap-refusal message. The collapsed bar's session button shows the <b>global</b> count, so off-board sessions are never invisible (§6).</li>
+  </ul>
+  <p style="font-size:12.5px; color:var(--muted); margin:10px 0 0;">Trade-off accepted: switching between two ideas' terminals means switching boards (or popping one out — §10 is the designed answer to exactly that need). A global strip was rejected because it couples every board's dock to every session's lifecycle and breaks the label scheme in B3.</p>
+</div>
+
+<!-- ============================================================= -->
+<h2 id="hero">4 · The multi-session dock — hero mockup</h2>
+<p class="sub">Three sessions on the Recipe Saver board: a task-scoped tab (active, connected), a long-titled task tab (background, reconnecting — note the attention treatment), and a board-level session (ended). Realistic worst-case data: long titles truncate, the strip scrolls when tabs overflow, with a fade hint at the clipped edge.</p>
+
+<div class="browser">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/ideas/recipe-saver/board</span></div>
+  <div class="boardtop">
+    <span class="crumb">Recipe Saver <span style="color:var(--muted-2)">/</span> <b>Board</b></span>
+    <span class="spacer"></span>
+    <span class="splitbtn"><span class="main">▸ Launch Claude Code</span><span class="caret" aria-label="Choose where Claude runs">▾</span></span>
+  </div>
+  <div class="kanban">
+    <div class="col"><h4>To Do <span class="count">3</span></h4><div class="tcard"><div class="ttl">Email when a saved recipe goes on sale</div></div></div>
+    <div class="col"><h4>In Progress <span class="count">2</span></h4><div class="tcard" style="border-color:rgba(251,191,36,.4);"><div class="ttl">Add pagination to the recipe list</div></div></div>
+    <div class="col"><h4>Verify <span class="count">2</span></h4></div>
+    <div class="col"><h4>Done <span class="count">8</span></h4></div>
+  </div>
+
+  <div class="term">
+    <!-- TAB STRIP -->
+    <div class="tabstrip" role="tablist" aria-label="Terminal sessions">
+      <div class="tabscroll">
+        <div class="ttab active" role="tab" aria-selected="true" tabindex="0" title="Nick's MacBook Pro · ~/projects/recipe-saver · session a3f9">
+          <span class="st ok" aria-hidden="true">●</span>
+          <span class="lbl">Add pagination to the recipe list</span>
+          <span class="x" role="button" aria-label="End session and close tab: Add pagination">×</span>
+        </div>
+        <div class="ttab" role="tab" aria-selected="false" tabindex="-1" title="Reconnecting — Nick's MacBook Pro · ~/projects/recipe-saver.vibe/wt-1 · session c2d8">
+          <span class="st warn" aria-hidden="true">↻</span>
+          <span class="lbl">Migrate ingredient quantities to metric units everywhere…</span>
+          <span class="x" role="button" aria-label="End session and close tab: Migrate ingredient quantities">×</span>
+        </div>
+        <div class="ttab" role="tab" aria-selected="false" tabindex="-1" title="Ended — Nick's MacBook Pro · ~/projects/recipe-saver.vibe/wt-2 · session 9be1">
+          <span class="st mut" aria-hidden="true">■</span>
+          <span class="lbl">recipe-saver · 9be1</span>
+          <span class="x" role="button" aria-label="Close tab: recipe-saver 9be1 (session ended)">×</span>
+        </div>
+        <button class="plus" aria-label="New terminal session — runs on your computer; each session uses real resources" title="New terminal — runs on your computer. Each session uses real resources.">+</button>
+      </div>
+      <span class="fadeR" aria-hidden="true"></span>
+      <div class="strip-end">
+        <button class="sessbtn" aria-haspopup="dialog">☰ My sessions <span class="n">4</span></button>
+      </div>
+    </div>
+
+    <!-- ACTIVE TAB'S SESSION: unchanged P1 header, scoped to this tab (B6) -->
+    <div class="term-header">
+      <span class="statepill connected"><span class="ic">●</span> Connected</span>
+      <span class="hostinfo">Nick's MacBook Pro <span class="sep">·</span> ~/projects/recipe-saver <span class="sep">·</span> session a3f9</span>
+      <span class="spacer"></span>
+      <div class="tctrls">
+        <button class="ibtn" aria-label="Pop this session out into its own window">⧉ Pop out</button>
+        <button class="ibtn" aria-label="Switch to read-only">🔒 Read-only</button>
+        <button class="ibtn" aria-label="Fullscreen the terminal">⛶</button>
+        <button class="ibtn" aria-label="Collapse terminal panel">⌄</button>
+        <button class="ibtn danger" aria-label="End session">⏻ End</button>
+      </div>
+    </div>
+    <div class="xterm"><span class="bullet">●</span> Claiming <span class="c-white">"Add pagination to the recipe list"</span> → <span class="c-amber">In Progress</span>
+
+<span class="bullet">●</span> <span class="c-cyan">Edit</span> src/components/recipe-list.tsx
+  <span class="c-dim">⎿ added cursor-based page fetch + IntersectionObserver sentinel</span>
+
+<span class="bullet">●</span> Running <span class="c-cyan">npm test</span> — 14 passing<span class="cursor"></span></div>
+    <div class="term-input">
+      <span class="prompt">›</span>
+      <input class="tin" placeholder="Type here to steer this session — Enter sends to your machine" aria-label="Terminal input for session a3f9">
+    </div>
+  </div>
+</div>
+<div class="anno">The tab strip sits above the P1 session header. Everything below the strip — status pill, identity, Pop out / Read-only / Fullscreen / End — belongs to the <b>active tab only</b> (<span class="req">B6</span>). Tab 2 shows the attention treatment for a background reconnect; tab 3 an ended board-level session with the <span class="mono">slug · sid</span> label (<span class="req">B3</span>). "My sessions <b>4</b>" counts globally — one session lives on another idea (§9).</div>
+
+<div class="rationale">
+  <b>One new header control, in the old header.</b> "Pop out" joins the P1 control cluster rather than living on each tab —
+  it acts on the session you're looking at, keeps tabs lean, and stays a <i>visible</i> button (never hover-revealed).
+  <span class="law">Proximity</span>: pop-out sits with the other session-scoped controls, left of the destructive End,
+  which remains rightmost and visually distinct (harder to hit by accident — <span class="law">Fitts's Law</span> for
+  destructive actions). The strip is the only new chrome; with a single session it still renders (one tab + "+"), so the
+  surface never reshapes itself surprisingly between one and two sessions.
+</div>
+
+<h3>4a · Overflow — many tabs, long titles</h3>
+<ul class="tight">
+  <li><b>Shrink then scroll:</b> tabs flex between 190px and 110px min-width; past that the strip scrolls horizontally (mouse wheel / trackpad / arrow-key focus walking scrolls the focused tab into view). A gradient fade at the clipped edge signals more tabs (<span class="law">Continuity</span> — the eye follows the row off-edge).</li>
+  <li><b>Never wrap, never hide the "+":</b> "+" and "My sessions" are pinned outside the scroll region — launch and oversight stay one click away at any tab count.</li>
+  <li><b>Truncation is safe</b> because the tooltip and the session header both carry the full title + identity; with cap 3 per user, pathological tab counts are bounded anyway <span class="req">E1</span>.</li>
+</ul>
+
+<!-- ============================================================= -->
+<h2 id="tabstates">5 · Per-tab states — the connection machine, per session</h2>
+<p class="sub">Each tab owns an independent instance of P1's <code class="inline">terminalReducer</code>, buffer, heartbeat watchdog and grace-window loop <span class="req">B2</span>. The tab glyph is a faithful, compressed projection of that tab's <code class="inline">TerminalStatus</code> — the same states P1 defined, nothing new invented:</p>
+
+<table>
+  <tr><th>Session state (connection.ts)</th><th>Tab glyph</th><th>Background-tab attention</th><th>Active-tab body (unchanged from P1)</th></tr>
+  <tr><td><code>connecting</code> / <code>waiting-to-pair</code></td><td><span style="color:var(--accent)">◌</span> hollow ring (pulses)</td><td>None — starting up is expected</td><td>P1 connecting / waiting-for-machine overlays</td></tr>
+  <tr><td><code>connected</code></td><td><span style="color:var(--emerald)">●</span> solid dot</td><td>None — healthy is quiet</td><td>Live stream + input row</td></tr>
+  <tr><td><code>disconnected</code> (drop or watchdog <code>link-silent</code>)</td><td><span style="color:var(--amber)">↻</span> spinner</td><td><b>Yes</b> — spinner + amber label tint</td><td>Dimmed stream + amber "Reconnecting — your work is safe" bar</td></tr>
+  <tr><td><code>session-ended</code> (user / idle / max / reconnect-failed)</td><td><span style="color:var(--muted-2)">■</span> solid square</td><td><b>Yes</b> — square (calm, not alarming)</td><td>P1 ended overlay with reason copy + "Launch again"</td></tr>
+  <tr><td><code>error</code> (mint-failed, owner-mismatch, timeout…)</td><td><span style="color:var(--rose)">▲</span> triangle</td><td><b>Yes</b> — triangle + rose label tint</td><td>P1 error overlays, per <code>errorKind</code></td></tr>
+  <tr><td><i>popped out</i> (this phase, §10)</td><td><span style="color:var(--violet)">⧉</span> pop-out glyph</td><td>None — deliberate user state</td><td>"Popped out" placeholder (§10b)</td></tr>
+</table>
+
+<div class="rationale">
+  <b>Attention without alarm.</b> A background tab leaving <code class="inline">connected</code> changes its <i>glyph
+  shape</i> and tints its label — icon + colour together, satisfying <span class="req">B5</span>'s "never colour alone".
+  We deliberately do <b>not</b> flash, bounce, or badge-count tabs: with up to 3 sessions the strip is always fully
+  visible, and a persistent shape change is findable at a glance without training users to ignore motion.
+  Watchdogs keep running on background tabs on wall-clock time <span class="req">B4</span>, so a hidden tab's
+  reconnect shows up at most a poll-cadence late, never faked-fresh (AC 19).
+</div>
+
+<!-- ============================================================= -->
+<h2 id="collapsed">6 · Collapsed bar — the worst-status summary</h2>
+<p class="sub">Collapsing the dock never ends anything <span class="req">B8</span>. The collapsed bar must answer "are my agents okay?" without expanding <span class="req">B5</span>: it shows a count-by-state summary, ordered worst-first, plus the global sessions button.</p>
+
+<div class="browser" style="max-width:860px;">
+  <div class="dockbar">
+    <span class="lbl"><span aria-hidden="true" style="color:var(--muted)">▣</span> Terminals</span>
+    <span class="sumchip ok">● 2 connected</span>
+    <span class="sumchip warn">↻ 1 reconnecting</span>
+    <span class="spacer"></span>
+    <button class="sessbtn">☰ My sessions <span class="n">4</span></button>
+    <button class="ibtn" style="height:26px;" aria-label="Expand terminal panel" aria-expanded="false">⌃ Expand</button>
+  </div>
+</div>
+<div class="anno">Mixed state: "● 2 connected · ↻ 1 reconnecting" (AC 5). Chips appear only for states that exist — all healthy collapses to a single "● 3 connected". An error state adds a rose "▲ 1 needs attention" chip, which is also the bar's leftmost (worst-first ordering = <span class="law">information scent</span>: the first thing you read is the thing to act on). Clicking any chip expands the dock and activates the worst-affected tab.</div>
+
+<!-- ============================================================= -->
+<h2 id="launch">7 · Launch routing &amp; the cap</h2>
+
+<h3>7a · A launch arrives while tabs exist <span class="req">B7</span></h3>
+<p class="sub">Toolbar "In the browser", a task-card "Launch in browser terminal", or the strip's "+" all do the same thing: <b>open a new tab</b> — never replace a running session. The new tab becomes active immediately in <code class="inline">connecting</code>; the launch payload (prompt + cwd) is delivered to that tab only. Existing sessions' streams are untouched (AC 4). If the dock was collapsed, it expands with the new tab active.</p>
+
+<h3>7b · Cap reached <span class="req">C2</span> <span class="req">E1</span></h3>
+<p class="sub">The mint route refuses before creating anything. The "+" (and launch menu items) are <b>not disabled</b> — a dead control with no explanation is a dead end. Instead the refusal explains and routes (constraint: no disabled buttons without adjacent explanation):</p>
+
+<div class="toast" role="alert">
+  <span style="font-size:16px;" aria-hidden="true">⚠️</span>
+  <div>
+    <div class="t">You already have 3 terminals running</div>
+    <div class="d">That's the limit for now. End one to start another — <a href="#sessions">view my sessions</a>.</div>
+  </div>
+</div>
+<div class="anno">Cap refusal, shown as a toast anchored to whatever triggered the launch. The link opens the "My sessions" panel (§9) — the fix is one click from the failure (<span class="law">recognition over recall</span>: we show the sessions rather than asking the user to remember where they are). Same copy and behaviour from the toolbar menu, the task-card menu, and "+". No session is minted; no tab appears (AC 9).</div>
+
+<!-- ============================================================= -->
+<h2 id="empty">8 · First-run, empty, and flag-off</h2>
+<div class="grid">
+  <div class="state neutral">
+    <div class="tag">◻ No sessions yet (dock idle)</div>
+    <p>Identical to P1's resting state: the dock only exists after the user launches "In the browser". No tab strip renders with zero sessions — the strip appears with the first session and persists (even as a single tab + "+") so the surface is stable. First launch runs the unchanged P1 install/pair path, then lands as tab 1.</p>
+  </div>
+  <div class="state neutral">
+    <div class="tag">◻ Last session ended</div>
+    <p>Ending the final session returns the dock to the P1 idle/resting state <span class="req">B8</span> — the strip does not linger empty. Ended tabs before that stay visible (■) until closed, preserving their scrollback for reading.</p>
+  </div>
+  <div class="state kill">
+    <div class="tag">⚑ Flag OFF <span class="req">B9</span> <span class="req">F6</span></div>
+    <p><b>Honest absence.</b> No dock, no strip, no "My sessions", no pop-out routes, no new menu items. Users who never opted in see zero new UI anywhere in this phase.</p>
+  </div>
+  <div class="state warn">
+    <div class="tag">◔ Loading (sessions list)</div>
+    <p>The "My sessions" panel loads from the registry: skeleton rows (label + identity-line bars), never a spinner-only void. Registry unreachable → inline error with Retry, and the panel still offers End for locally-known sessions.</p>
+  </div>
+</div>
+
+<!-- ============================================================= -->
+<h2 id="sessions">9 · "My sessions" — the global list + panic button</h2>
+<p class="sub">Opened from the strip or collapsed bar button, or from the cap-refusal link. A popover panel (not a modal — it must not block the board; constraint: no modals for content that could be inline). Lists <b>every live session across all ideas</b> from the registry <span class="req">C3</span>, each with the full identity line <span class="req">C4</span>. Popped-out sessions appear once, marked ⧉ (AC 18).</p>
+
+<div class="sesspanel" role="dialog" aria-label="My terminal sessions">
+  <div class="sp-head">My sessions <span class="sub2">runs on your machines — updated just now</span></div>
+
+  <div class="sessrow">
+    <span style="color:var(--emerald); flex:0 0 auto;" aria-hidden="true">●</span>
+    <div class="info">
+      <div class="l1">Add pagination to the recipe list <span class="where">Recipe Saver</span></div>
+      <div class="l2">Nick's MacBook Pro · ~/projects/recipe-saver · a3f9</div>
+    </div>
+    <span class="age">12m</span>
+    <button class="ibtn danger" style="height:26px; font-size:11.5px;" aria-label="End session: Add pagination">⏻ End</button>
+  </div>
+
+  <div class="sessrow">
+    <span style="color:var(--amber); flex:0 0 auto;" aria-hidden="true">↻</span>
+    <div class="info">
+      <div class="l1">Migrate ingredient quantities to metric… <span class="where">Recipe Saver</span></div>
+      <div class="l2">Nick's MacBook Pro · ~/projects/recipe-saver.vibe/wt-1 · c2d8</div>
+    </div>
+    <span class="age">41m</span>
+    <button class="ibtn danger" style="height:26px; font-size:11.5px;" aria-label="End session: Migrate ingredient quantities">⏻ End</button>
+  </div>
+
+  <div class="sessrow">
+    <span style="color:var(--violet); flex:0 0 auto;" aria-hidden="true">⧉</span>
+    <div class="info">
+      <div class="l1">Fix onboarding e-mail bounce handling <span class="where">Mail Robot · popped out</span></div>
+      <div class="l2">Nick's MacBook Pro · ~/projects/mail-robot · 77f2</div>
+    </div>
+    <span class="age">2h</span>
+    <button class="ibtn danger" style="height:26px; font-size:11.5px;" aria-label="End session: Fix onboarding e-mail bounce handling">⏻ End</button>
+  </div>
+
+  <div class="sessrow">
+    <span style="color:var(--emerald); flex:0 0 auto;" aria-hidden="true">●</span>
+    <div class="info">
+      <div class="l1">mail-robot · 3e01 <span class="where">Mail Robot</span></div>
+      <div class="l2">Nick's MacBook Pro · ~/projects/mail-robot.vibe/wt-1 · 3e01</div>
+    </div>
+    <span class="age">3h 50m</span>
+    <button class="ibtn danger" style="height:26px; font-size:11.5px;" aria-label="End session: mail-robot 3e01">⏻ End</button>
+  </div>
+
+  <div class="sp-foot">
+    <span class="hint">4 sessions · in-browser cap 3 per user</span>
+    <span class="spacer"></span>
+    <button class="btn danger" style="height:30px; font-size:12.5px;">⏻ End all sessions</button>
+  </div>
+</div>
+
+<h3>9a · End-all confirmation <span class="req">C3</span> <span class="req">F5</span></h3>
+<p class="sub">End-all is the panic button — it must be reachable in two clicks but never a misclick. The confirm replaces the panel footer inline (destructive action moved away from the trigger position — <span class="law">Fitts's Law</span>: you must travel to Confirm):</p>
+<div class="sesspanel" style="width:460px;">
+  <div class="sp-foot" style="border-top:0; background: rgba(251,113,133,.06); border-left:3px solid var(--rose);">
+    <div>
+      <div style="font-size:13px; font-weight:700; color:var(--rose);">End all 4 sessions?</div>
+      <div style="font-size:12px; color:var(--muted); margin-top:2px;">Claude stops on your machine in every one. Unpushed worktree changes stay on disk.</div>
+    </div>
+    <span class="spacer"></span>
+    <button class="btn ghost" style="height:30px; font-size:12.5px;">Cancel</button>
+    <button class="btn danger" style="height:30px; font-size:12.5px;">End all</button>
+  </div>
+</div>
+<div class="anno">While ending, each row shows "Ending…" with its End button replaced; rows flip to a muted "Ended" and clear on close. Both relay legs are closed per session — never merely detached (<span class="req">C3</span>, AC 10). Per-session End uses no confirm (single, visible, reversible-by-relaunching) — only the bulk action confirms.</div>
+
+<div class="grid">
+  <div class="state neutral">
+    <div class="tag">◻ Empty state</div>
+    <p><b>"No terminals running."</b> One line below: "Launch one from an idea board — Launch Claude Code → In the browser." Specific, actionable, and teaches the entry point (<span class="law">information scent</span>).</p>
+  </div>
+  <div class="state warn">
+    <div class="tag">◔ Registry drift <span class="req">R2</span></div>
+    <p>A row the relay reports gone renders as "Already ended" and clears on next open. Cap errors always name the blocking sessions via this list — the user can always see and kill what counts against them.</p>
+  </div>
+</div>
+
+<!-- ============================================================= -->
+<h2 id="popout">10 · Pop-out — same session, different glass</h2>
+<p class="sub">Pop-out re-attaches the browser leg of the <b>same relay session</b> in a new same-origin window <span class="req">D1</span>. Owner-verified preemption does the safety work: the moment the popped window attaches, the relay closes the dock's leg — one browser leg at all times <span class="req">F2</span> (AC 13). No tokens ever ride the URL <span class="req">D4</span> (AC 16).</p>
+
+<h3>10a · The popped-out window <span class="req">D2</span></h3>
+<div class="popwin">
+  <div class="chrome-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="urlbar">vibecodes.co.uk/terminal/a3f9 — Terminal · Add pagination</span></div>
+  <div class="term">
+    <div class="term-header">
+      <span class="statepill connected"><span class="ic">●</span> Connected</span>
+      <span class="hostinfo">Nick's MacBook Pro <span class="sep">·</span> ~/projects/recipe-saver <span class="sep">·</span> a3f9</span>
+      <span class="spacer"></span>
+      <div class="tctrls">
+        <button class="ibtn" aria-label="Switch to read-only">🔒 Read-only</button>
+        <button class="ibtn danger" aria-label="End session">⏻ End</button>
+      </div>
+    </div>
+    <div class="noticebar" role="status">ℹ Showing output from pop-out onward. <span class="dismiss" role="button" aria-label="Dismiss notice">✕</span></div>
+    <div class="xterm"><span class="bullet">●</span> Running <span class="c-cyan">npm test</span> — 14 passing
+
+<span class="bullet">●</span> Moving <span class="c-white">"Add pagination to the recipe list"</span> → <span class="c-amber">Verify</span><span class="cursor"></span></div>
+    <div class="term-input">
+      <span class="prompt">›</span>
+      <input class="tin" placeholder="Type here to steer this session" aria-label="Terminal input">
+    </div>
+  </div>
+</div>
+<div class="anno">The popped window is deliberately minimal: exactly the P1 header quartet — <b>status · identity · read-only · End</b> — plus the stream and input. No tab strip, no collapse, no pop-out-of-a-pop-out. The window title mirrors the tab label so it's findable in the OS window switcher. The one-time notice bar is the MVP scrollback honesty from <span class="req">D5</span> (AC 17); if the serialize-addon transfer ships later, the bar simply never appears. It still counts toward the cap and appears in "My sessions" <span class="req">D6</span>.</div>
+
+<h3>10b · The originating tab — "Popped out" placeholder <span class="req">D2</span> <span class="req">D3</span></h3>
+<div class="browser" style="max-width:860px;">
+  <div class="term">
+    <div class="tabstrip" role="tablist" aria-label="Terminal sessions">
+      <div class="tabscroll">
+        <div class="ttab active" role="tab" aria-selected="true" tabindex="0">
+          <span class="st" style="color:var(--violet)" aria-hidden="true">⧉</span>
+          <span class="lbl">Add pagination to the recipe list</span>
+          <span class="x" role="button" aria-label="End session and close tab: Add pagination">×</span>
+        </div>
+        <button class="plus" aria-label="New terminal session">+</button>
+      </div>
+      <div class="strip-end"><button class="sessbtn">☰ My sessions <span class="n">4</span></button></div>
+    </div>
+    <div class="overlay">
+      <div class="big" aria-hidden="true" style="color:var(--violet)">⧉</div>
+      <div class="ttl" style="color:var(--violet)">Popped out</div>
+      <div class="msg">This session is open in another window. It keeps running there — close that window and it returns here automatically.</div>
+      <div class="btnrow">
+        <button class="btn primary">⇤ Bring back to dock</button>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="anno">The placeholder never auto-reattaches while the popped window lives — that would preempt-loop <span class="req">D3</span> <span class="req">R3</span>. Reattach happens two ways only: (1) the user clicks <b>Bring back to dock</b> (dock preempts the window; the window shows its own honest "This session went back to the dock" end-card with a "Close window" button), or (2) the popped window closes and signals via BroadcastChannel, after which the dock reattaches automatically. If the close-signal is missed (crashed window), the placeholder's Bring-back still works — it's the manual override for every failure of the automatic path.</div>
+
+<h3>10c · Pop-out failure — blocked popup <span class="req">D7</span></h3>
+<div class="toast warn" role="alert">
+  <span style="font-size:16px;" aria-hidden="true">⧉</span>
+  <div>
+    <div class="t">Couldn't open the terminal window</div>
+    <div class="d">Your browser blocked the pop-up. Allow pop-ups for vibecodes.co.uk and try again.</div>
+  </div>
+</div>
+<div class="anno">Pop out is always a direct click (never automatic), satisfying popup policies. On failure: this toast, and <b>no state change</b> — the tab stays attached and streaming. Nothing to undo.</div>
+
+<!-- ============================================================= -->
+<h2 id="copy">11 · Copy sweep — retiring "one place at a time" <span class="req">A3</span> <span class="req">R5</span></h2>
+<p class="sub">P1's load-bearing promise — "you run Claude in one place at a time" — becomes false the day this ships. Every location, with replacement copy:</p>
+
+<div class="copyswap">
+  <div class="before"><div class="cap">Before — launch menu footer</div>"You run Claude in one place at a time — terminal window <b>or</b> browser, never both."</div>
+  <div class="after"><div class="cap">After</div>"Run several sessions at once — terminal windows and browser tabs. Each runs on your computer; in-browser sessions are capped at 3."</div>
+</div>
+<div class="copyswap">
+  <div class="before"><div class="cap">Before — opt-in panel (P1 §5)</div>"…one session, one machine, one place at a time."</div>
+  <div class="after"><div class="cap">After</div>"…every session is yours alone: owner-bound, individually endable, and listed under My sessions."</div>
+</div>
+<div class="copyswap">
+  <div class="before"><div class="cap">Before — guide pages (/guide/launching-claude-code)</div>Single-session framing throughout; worktrees manual: "several in-app terminals at once is a later feature."</div>
+  <div class="after"><div class="cap">After <span class="req">A4</span></div>Concurrency documented as supported: native + in-browser mix, worktree isolation summarised ("session 2+ gets its own private worktree"), cap and My sessions explained.</div>
+</div>
+
+<!-- ============================================================= -->
+<h2 id="stateindex">12 · Full state index</h2>
+<div class="grid">
+  <div class="state ok"><div class="tag">● Tab connected</div><p>Quiet glyph; active tab shows P1 connected panel. Next: user works, pops out, or ends.</p></div>
+  <div class="state wait"><div class="tag">◌ Tab connecting / waiting-to-pair</div><p>Pulsing ring; P1 connecting/waiting overlays in body. New-tab default state after any launch route.</p></div>
+  <div class="state warn"><div class="tag">↻ Tab reconnecting (background)</div><p>Spinner glyph + amber label; collapsed bar adds "↻ n reconnecting". Grace window runs per-tab; recovery is silent, exhaustion → ■ ended with honest copy.</p></div>
+  <div class="state err"><div class="tag">▲ Tab error</div><p>Triangle + rose tint; body shows the P1 error overlay for that <code>errorKind</code>. Only this tab is affected — siblings stream on (AC 5, 19).</p></div>
+  <div class="state neutral"><div class="tag">■ Tab ended</div><p>Calm square; body shows P1 ended overlay (user/idle/max/reconnect-failed copy) + "Launch again". Tab stays until closed so output can be read.</p></div>
+  <div class="state kill"><div class="tag">⧉ Tab popped out</div><p>Violet glyph; placeholder body with Bring back. Window closing auto-returns the session to the dock.</p></div>
+  <div class="state err"><div class="tag">⚠ Cap reached</div><p>Toast: "You already have 3 terminals running — end one to start another" + link to My sessions. No mint, no tab (AC 9).</p></div>
+  <div class="state warn"><div class="tag">⧉ Pop-up blocked</div><p>Toast explains; tab unchanged and still attached (<span class="req">D7</span>).</p></div>
+  <div class="state neutral"><div class="tag">◻ Empty / idle</div><p>P1 resting dock; sessions list empty state teaches the launch path.</p></div>
+  <div class="state kill"><div class="tag">⚑ Flag off</div><p>Nothing renders. Anywhere. <span class="req">B9</span> <span class="req">F6</span> (AC 8).</p></div>
+</div>
+
+<!-- ============================================================= -->
+<h2 id="flows">13 · Interaction flows</h2>
+
+<h3>Flow 1 — Open a second tab (AC 4, 6)</h3>
+<div class="flow">
+  <div class="step"><div class="num">1</div><div class="body"><div class="t">Trigger</div><div class="d">Session 1 is Connected. User clicks a task card's "Launch in browser terminal" (or toolbar "In the browser", or "+").</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">2</div><div class="body"><div class="t">Cap check → mint</div><div class="d">Registry says 1 of 3 — mint proceeds, new sid.<div class="branch"><b>Cap hit?</b> → Flow 4. No tab is created.</div></div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">3</div><div class="body"><div class="t">New tab appears, active, ◌ connecting</div><div class="d">Label = task title (task-scoped) or slug · sid. Launch payload (prompt + cwd) delivered to this tab only <span class="req">B7</span>. Tab 1 slides to background — its stream, socket, and watchdog untouched <span class="req">B2</span>.</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">4</div><div class="body"><div class="t">End states</div><div class="d"><b>Success:</b> bridge attaches → ● Connected, worktree banner in stream (session 2 gets wt-1). <b>Failure:</b> this tab shows the P1 error overlay (▲); tab 1 unaffected. <b>Recovery:</b> Retry inside the failed tab, or × to close it.</div></div></div>
+</div>
+
+<h3>Flow 2 — Background tab loses its link (AC 5, 19)</h3>
+<div class="flow">
+  <div class="step"><div class="num">1</div><div class="body"><div class="t">Trigger</div><div class="d">Two tabs Connected; user is watching tab A. Tab B's bridge network drops silently.</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">2</div><div class="body"><div class="t">Tab B's own watchdog fires</div><div class="d">≤45s of silence (wall-clock; hidden-tab clamping only delays) → tab B: disconnected. Its glyph flips to ↻ amber; label tints. Tab A: nothing happens.</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">3</div><div class="body"><div class="t">Ambient signal</div><div class="d">If the dock is collapsed, the bar now reads "● 1 connected · ↻ 1 reconnecting". Clicking the amber chip expands with tab B active, showing the P1 reconnect bar ("your work is safe").</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">4</div><div class="body"><div class="t">End states</div><div class="d"><b>Recovered inside 90s grace:</b> glyph returns to ● silently. <b>Exhausted:</b> tab B → ■ ended, honest reconnect-failed copy, "Launch again". Tab A streams on throughout.</div></div></div>
+</div>
+
+<h3>Flow 3 — Pop out, then bring back (AC 13–17)</h3>
+<div class="flow">
+  <div class="step"><div class="num">1</div><div class="body"><div class="t">Trigger</div><div class="d">User clicks ⧉ Pop out in the active tab's header (direct gesture — popup-policy safe <span class="req">D7</span>).</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">2</div><div class="body"><div class="t">Window opens; credentials cross via BroadcastChannel</div><div class="d">Same-origin minimal page; sid + token via postMessage/BroadcastChannel — never the URL <span class="req">D4</span>.<div class="branch"><b>Blocked?</b> Toast (§10c); tab stays attached; flow ends.</div></div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">3</div><div class="body"><div class="t">Relay preempts the dock leg</div><div class="d">Window attaches with same <code>sub</code> → dock leg closed (existing 4001/PREEMPTED path). Dock tab → ⧉ "Popped out" placeholder; window shows ● Connected + one-time "output from pop-out onward" notice <span class="req">D5</span>. One browser leg at every instant <span class="req">F2</span>.</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">4</div><div class="body"><div class="t">Working popped out</div><div class="d">Typing, read-only, End all act on the same session <span class="req">D6</span>. Focus lands in the window's terminal on open.</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">5</div><div class="body"><div class="t">Return — two paths, never a race <span class="req">D3</span></div><div class="d"><b>(a) Window closed:</b> close-signal on BroadcastChannel → dock reattaches automatically, glyph → ●. <b>(b) "Bring back to dock":</b> dock preempts; window shows "This session went back to the dock" + Close window. The placeholder never auto-reattaches while the window lives <span class="req">R3</span>.<div class="branch"><b>Crashed window / missed signal?</b> Placeholder persists; "Bring back" is the manual recovery. <b>Session ended while popped out?</b> Both surfaces show the honest P1 ended overlay.</div></div></div></div>
+</div>
+
+<h3>Flow 4 — Cap hit (AC 9)</h3>
+<div class="flow">
+  <div class="step"><div class="num">1</div><div class="body"><div class="t">Trigger</div><div class="d">3 in-browser sessions live (any mix of docked/popped, any ideas). User attempts a fourth launch from any route.</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">2</div><div class="body"><div class="t">Mint refused server-side</div><div class="d">Registry check fails pre-mint; distinct error code; nothing created <span class="req">C2</span>.</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">3</div><div class="body"><div class="t">Explain + route</div><div class="d">Toast: "You already have 3 terminals running — end one to start another · View my sessions". Link opens §9 listing all three with End buttons.</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">4</div><div class="body"><div class="t">Recovery</div><div class="d">User ends one (or End-all) → relaunches → Flow 1 succeeds. Stale-registry phantom rows are reaped on mint <span class="req">R2</span> so a ghost can't wedge the cap permanently.</div></div></div>
+</div>
+
+<h3>Flow 5 — End all sessions (AC 10)</h3>
+<div class="flow">
+  <div class="step"><div class="num">1</div><div class="body"><div class="t">Trigger</div><div class="d">User opens "My sessions" (strip, collapsed bar, or cap toast) and clicks "End all sessions".</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">2</div><div class="body"><div class="t">Inline confirm</div><div class="d">"End all 4 sessions? Claude stops on your machine in every one. Unpushed worktree changes stay on disk." Cancel / End all.</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">3</div><div class="body"><div class="t">Ending</div><div class="d">Rows show "Ending…"; each session's relay legs are closed (killed, not detached) and registry rows marked ended.</div></div></div>
+  <div class="connector">↓</div>
+  <div class="step"><div class="num">4</div><div class="body"><div class="t">End states</div><div class="d"><b>Success:</b> all rows "Ended"; open tabs and popped windows everywhere flip to their honest ■ ended overlays within seconds <span class="req">F5</span>. <b>Partial failure (relay unreachable for one):</b> that row shows "Couldn't end — retry", others succeed; the panel never claims a clean sweep it didn't make.</div></div></div>
+</div>
+
+<!-- ============================================================= -->
+<h2 id="a11y">14 · Accessibility</h2>
+<ul class="tight">
+  <li><b>WAI-ARIA tabs pattern:</b> the strip is <code class="inline">role="tablist"</code> (aria-label "Terminal sessions"); tabs are <code class="inline">role="tab"</code> with <code class="inline">aria-selected</code>, roving tabindex. <kbd>←</kbd>/<kbd>→</kbd> move focus, <kbd>Home</kbd>/<kbd>End</kbd> jump, <kbd>Enter</kbd>/<kbd>Space</kbd> activate. <b>Manual activation</b> (focus ≠ select), because activating swaps a live xterm surface — arrow-browsing must not thrash sessions' rendering.</li>
+  <li><b>Close from keyboard:</b> <kbd>Delete</kbd> on a focused tab triggers the same end-session confirm as ×. We deliberately do <b>not</b> bind Ctrl/Cmd+W (it closes the browser tab — catastrophic mis-affordance).</li>
+  <li><b>Status is announced, not just drawn:</b> each tab carries visually-hidden state text ("reconnecting", "ended"…) appended to its accessible name; background-tab state changes post to a single polite <code class="inline">aria-live</code> region ("Migrate ingredient quantities: reconnecting") — one announcer, so three tabs can't shout over each other. Cap and popup-blocked toasts are <code class="inline">role="alert"</code>.</li>
+  <li><b>Pop-out focus management:</b> on pop-out, focus lands in the new window's terminal input; the dock placeholder's "Bring back to dock" is its first focusable. On bring-back/auto-return, focus goes to the reattached tab. The popped window's <code class="inline">&lt;title&gt;</code> is "Terminal · {label}" for window-switchers and screen readers.</li>
+  <li><b>Contrast (WCAG 2.1 AA):</b> all state colours on the dark panels are the P1-audited pairs (emerald/amber/rose/violet 300-range on zinc-900 ≥ 4.5:1 for the 11–12.5px bold labels; glyphs are supplementary to text, and state is always also words in tooltip, header pill, and accessible name — never colour alone). Muted label text stays at or above zinc-400 on the strip; zinc-500 is reserved for the non-essential identity line, which is duplicated in tooltips.</li>
+  <li><b>Targets & visibility:</b> tab rows 38px tall; × hit area ≥24×24 inside a ≥110px tab; all controls visible at rest (no hover-only affordances — × is always rendered, not hover-revealed). Focus rings: 2px accent, offset 2, on tabs, ×, +, and all panel buttons.</li>
+  <li><b>Desktop-only:</b> per <span class="req">NG2</span> the dock (and therefore the strip, panel, pop-out) does not render under 768px; no mobile layouts are specified, matching P1.</li>
+</ul>
+
+<!-- ============================================================= -->
+<h2 id="oq">15 · Open questions for Design Review</h2>
+<table>
+  <tr><th>#</th><th>Question</th><th>Design's default if unchallenged</th></tr>
+  <tr><td>OQ1</td><td>Tab × ends the session (with confirm) rather than a P1-style ⏻ per tab — accepted deviation from <span class="req">B1</span>'s glyph note? (§1, §2)</td><td>× glyph, end-session semantics, inline confirm on live sessions only (ended tabs close instantly).</td></tr>
+  <tr><td>OQ2</td><td>Q2 resolution: board-scoped tabs + global My sessions (§3) — Product Owner sign-off?</td><td>Board-scoped, per the recommendation.</td></tr>
+  <tr><td>OQ3</td><td>Should "My sessions" also live outside the dock (e.g. user menu) so a session on idea B is findable without visiting any board? MVP keeps it dock-only.</td><td>Dock-only for MVP; global count on the button makes cross-idea sessions visible.</td></tr>
+  <tr><td>OQ4</td><td>Cap value display: the panel footer states "cap 3 per user" — should the cap number be hidden until hit instead? (Q3's env-tunable value must not be hardcoded in copy.)</td><td>Show it, template from config.</td></tr>
+  <tr><td>OQ5</td><td>Popped window: is Fullscreen wanted there, or is the OS window's own maximise sufficient? Currently omitted for minimalism.</td><td>Omitted; OS chrome suffices.</td></tr>
+  <tr><td>OQ6</td><td>When a launch arrives for a task that already has a live tab, do we focus the existing tab or open a duplicate session? Requirements are silent.</td><td>Focus the existing tab and deliver nothing (toast: "This task already has a terminal — switched to it"), avoiding accidental double agents on one task.</td></tr>
+</table>
+
+<p class="sub" style="margin-top:40px; border-top:1px solid var(--border); padding-top:16px;">
+  Compass · UX Design step 2 of 6 · builds on the Requirements step (Product Owner) · for the Design Review step (Product Owner, human check).
+  Companion docs: <span class="mono">in-app-terminal-design.html</span> (P1 dock), <span class="mono">install-first-terminal-ux.html</span> (first run),
+  <span class="mono">design-task-menu-browser-launch.html</span> (task-scoped launch), <span class="mono">concurrent-terminal-worktrees-manual.html</span> (disk isolation).
+</p>
+
+</div>
+</body>
+</html>

--- a/src/app/api/terminal/session/[sid]/route.ts
+++ b/src/app/api/terminal/session/[sid]/route.ts
@@ -1,0 +1,59 @@
+// Terminal session PATCH — multi-session stage 3 (C4: the My-sessions identity
+// line — "machine · cwd · short sid").
+//
+// Best-effort, client-known identity fields ONLY. The browser has no real
+// signal for a machine's display name (no JS API exposes it), so
+// `machine_label` is never set here — only `cwd`, which the dock already
+// resolves client-side to build the launch prompt/deep link (see
+// use-terminal-session.ts → resolveLaunchPromptParts). Called fire-and-forget
+// right after a session mints; a failure here never surfaces to the user (the
+// registry row still exists with cwd left null — an honest omission, not a
+// broken feature).
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  cwd: z.string().trim().min(1).max(1024),
+});
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ sid: string }> }) {
+  try {
+    const { sid } = await params;
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const parsed = BodySchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const { error } = await supabase
+      .from("terminal_sessions")
+      .update({ cwd: parsed.data.cwd })
+      .eq("sid", sid)
+      .eq("user_id", user.id)
+      .eq("status", "active");
+    if (error) {
+      logger.error("Terminal session identity PATCH failed", { sid, error: error.message });
+      return NextResponse.json({ error: "Couldn't update session identity" }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    logger.error("Terminal session identity PATCH error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
+  }
+}

--- a/src/app/api/terminal/session/end/route.ts
+++ b/src/app/api/terminal/session/end/route.ts
@@ -1,0 +1,131 @@
+// Terminal session END — multi-session stage 3 (C3/F5: per-tab End, My-sessions
+// "End" and the "End all sessions" panic button).
+//
+// `POST { sid }` ends ONE of the caller's own sessions; `POST { all: true }`
+// ends every one of them. Ownership is resolved via the `terminal_sessions`
+// registry (RLS-scoped to the caller — never a raw sid trusted blind), then
+// each target is closed at the relay via a short-lived, sid-bound CONTROL
+// token (terminal/shared/session-token.mjs → mintControlToken/authorizeControl)
+// before the registry row is marked ended.
+//
+// SKEW-SAFETY: if the relay can't confirm (old relay with no /end route,
+// transient network failure), the registry row is marked ended ANYWAY — it is
+// a best-effort record (design doc §9, R2), and a user who clicked "End" must
+// see it reflected in "My sessions" even when the relay call itself failed.
+// `relayConfirmed` on each result reports that partial-success case honestly
+// instead of silently masking it.
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { mintControlToken } from "../../../../../../terminal/shared/session-token.mjs";
+import { relayHttpBaseUrl } from "@/lib/terminal/relay-http";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.union([
+  z.object({ sid: z.string().min(1).max(128) }),
+  z.object({ all: z.literal(true) }),
+]);
+
+interface EndResult {
+  sid: string;
+  ended: boolean;
+  /** Did the relay itself confirm the close, vs. a best-effort registry-only end? */
+  relayConfirmed: boolean;
+}
+
+export async function POST(req: Request) {
+  try {
+    const secret = process.env.TERMINAL_SESSION_SECRET;
+    if (!secret) {
+      logger.error("Terminal session end failed: TERMINAL_SESSION_SECRET not configured");
+      return NextResponse.json({ error: "Terminal sessions are not configured" }, { status: 503 });
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const parsed = BodySchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    // Resolve targets — ALWAYS the caller's own active rows. RLS also enforces
+    // this (owner-only policies), but the explicit filter keeps the query
+    // honest even if this route ever runs under a different client.
+    let query = supabase
+      .from("terminal_sessions")
+      .select("id, sid")
+      .eq("user_id", user.id)
+      .eq("status", "active");
+    if ("sid" in parsed.data) query = query.eq("sid", parsed.data.sid);
+    const { data: targets, error: targetsErr } = await query;
+    if (targetsErr) {
+      logger.error("Terminal session end: target lookup failed", { error: targetsErr.message });
+      return NextResponse.json({ error: "Couldn't look up your sessions" }, { status: 500 });
+    }
+
+    if (!targets || targets.length === 0) {
+      // Not an error — an already-ended/foreign sid, or "end all" with none
+      // active. The caller (My sessions) treats an empty result list as a no-op.
+      return NextResponse.json({ results: [] satisfies EndResult[] });
+    }
+
+    const httpBase = relayHttpBaseUrl();
+    const results: EndResult[] = [];
+    for (const target of targets) {
+      let relayConfirmed = false;
+      try {
+        const control = await mintControlToken({ sub: user.id, sid: target.sid, secret });
+        const res = await fetch(`${httpBase}/end?session=${encodeURIComponent(target.sid)}`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${control}` },
+        });
+        // Any response the relay actually sent (ended:true, or the honest
+        // ended:false/"no-session") counts as CONFIRMED — the relay understood
+        // the call. A thrown fetch (connection refused / DNS / old relay with
+        // no route at all) is the "couldn't confirm" case handled below.
+        relayConfirmed = res.ok;
+        if (!res.ok) {
+          logger.warn("Terminal session end: relay rejected the control call", {
+            sid: target.sid,
+            status: res.status,
+          });
+        }
+      } catch (err) {
+        logger.warn("Terminal session end: relay unreachable — ending registry-only (skew-safe)", {
+          sid: target.sid,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      const { error: updateErr } = await supabase
+        .from("terminal_sessions")
+        .update({ status: "ended", ended_at: new Date().toISOString() })
+        .eq("id", target.id);
+      if (updateErr) {
+        logger.error("Terminal session end: registry update failed", {
+          sid: target.sid,
+          error: updateErr.message,
+        });
+      }
+      results.push({ sid: target.sid, ended: true, relayConfirmed });
+    }
+
+    logger.info("Ended terminal session(s)", { userId: user.id, count: results.length });
+    return NextResponse.json({ results });
+  } catch (err) {
+    logger.error("Terminal session end error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
+  }
+}

--- a/src/app/api/terminal/session/list/route.ts
+++ b/src/app/api/terminal/session/list/route.ts
@@ -1,0 +1,61 @@
+// Terminal session LIST — multi-session stage 3 (C3/C4: the "My sessions" panel).
+//
+// GET returns every one of the caller's ACTIVE sessions, across all ideas,
+// newest first — the registry row plus the idea title (a second query; small
+// N per user, not worth a join). RLS scopes this to the caller's own rows
+// regardless; the explicit `.eq("user_id", ...)` keeps the query itself honest.
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { data: rows, error } = await supabase
+      .from("terminal_sessions")
+      .select("sid, idea_id, task_id, task_title, machine_label, cwd, created_at")
+      .eq("user_id", user.id)
+      .eq("status", "active")
+      .order("created_at", { ascending: false });
+    if (error) {
+      logger.error("Terminal session list failed", { error: error.message });
+      return NextResponse.json({ error: "Couldn't load your sessions" }, { status: 500 });
+    }
+
+    const ideaIds = Array.from(new Set((rows ?? []).map((r) => r.idea_id)));
+    let ideaTitles: Record<string, string> = {};
+    if (ideaIds.length > 0) {
+      const { data: ideas } = await supabase.from("ideas").select("id, title").in("id", ideaIds);
+      ideaTitles = Object.fromEntries((ideas ?? []).map((i) => [i.id, i.title]));
+    }
+
+    const sessions = (rows ?? []).map((row) => ({
+      sid: row.sid,
+      ideaId: row.idea_id,
+      ideaTitle: ideaTitles[row.idea_id] ?? null,
+      taskId: row.task_id,
+      taskTitle: row.task_title,
+      machineLabel: row.machine_label,
+      cwd: row.cwd,
+      createdAt: row.created_at,
+    }));
+
+    return NextResponse.json({ sessions });
+  } catch (err) {
+    logger.error("Terminal session list error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
+  }
+}

--- a/src/app/api/terminal/session/route.ts
+++ b/src/app/api/terminal/session/route.ts
@@ -15,6 +15,21 @@ import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 // One shared implementation of the token scheme — also imported by the relay.
 import { mintSessionTokens } from "../../../../../terminal/shared/session-token.mjs";
+import {
+  getServerTerminalSessionCap,
+  getTerminalMintRateLimit,
+  capRefusalMessage,
+  RATE_LIMIT_MESSAGE,
+  CAP_REFUSAL_CODE,
+  RATE_LIMIT_CODE,
+} from "@/lib/terminal/session-cap";
+import {
+  computeSessionExpiresAt,
+  decideCap,
+  decideRateLimit,
+  isSessionExpired,
+  rateLimitWindowStart,
+} from "@/lib/terminal/session-registry";
 
 // Pin the runtime: this handler mints per-request, auth-bound tokens and must never
 // be statically optimized or flipped to the Edge runtime. The pin stays as hygiene,
@@ -29,6 +44,11 @@ export const dynamic = "force-dynamic";
 
 const BodySchema = z.object({
   ideaId: z.string().uuid(),
+  // Multi-session stage 3 (C1/C4): carried through to the terminal_sessions
+  // registry row so "My sessions" can show a task-scoped label. Both optional
+  // — a board-level launch (toolbar "In the browser") carries neither.
+  taskId: z.string().uuid().optional(),
+  taskTitle: z.string().trim().min(1).max(500).optional(),
 });
 
 export async function POST(req: Request) {
@@ -51,7 +71,7 @@ export async function POST(req: Request) {
     if (!parsed.success) {
       return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
     }
-    const { ideaId } = parsed.data;
+    const { ideaId, taskId, taskTitle } = parsed.data;
 
     // Only a member of the idea (author or collaborator) may open a terminal on it.
     const { data: idea } = await supabase
@@ -77,7 +97,100 @@ export async function POST(req: Request) {
       }
     }
 
+    // ── (a) REAP: mark this user's own expired-but-still-"active" rows ended
+    // BEFORE trusting any count below (R2 mitigation) — the registry is
+    // best-effort and can drift from the relay (e.g. a max-duration close the
+    // registry was never told about), so an unreaped stale row would wrongly
+    // count against the cap/rate-limit forever.
+    const nowMs = Date.now();
+    const { data: activeRows, error: activeErr } = await supabase
+      .from("terminal_sessions")
+      .select("id, expires_at")
+      .eq("user_id", user.id)
+      .eq("status", "active");
+    if (activeErr) {
+      logger.error("Terminal session registry read failed", { error: activeErr.message });
+    }
+    const staleIds = (activeRows ?? [])
+      .filter((row) => isSessionExpired(row.expires_at, nowMs))
+      .map((row) => row.id);
+    if (staleIds.length > 0) {
+      const { error: reapErr } = await supabase
+        .from("terminal_sessions")
+        .update({ status: "ended", ended_at: new Date(nowMs).toISOString() })
+        .in("id", staleIds);
+      if (reapErr) {
+        logger.error("Terminal session reap failed", { error: reapErr.message, count: staleIds.length });
+      } else {
+        logger.info("Reaped expired terminal session rows", { userId: user.id, count: staleIds.length });
+      }
+    }
+    const activeCount = (activeRows?.length ?? 0) - staleIds.length;
+
+    // ── (b) CAP (E1) — refuse before minting anything. ──────────────────────
+    const cap = getServerTerminalSessionCap();
+    const capDecision = decideCap(activeCount, cap);
+    if (!capDecision.ok) {
+      const { data: activeSummaries } = await supabase
+        .from("terminal_sessions")
+        .select("sid, idea_id, task_title, created_at")
+        .eq("user_id", user.id)
+        .eq("status", "active")
+        .order("created_at", { ascending: false });
+      return NextResponse.json(
+        {
+          error: capRefusalMessage(cap),
+          code: CAP_REFUSAL_CODE,
+          cap,
+          active: (activeSummaries ?? []).map((row) => ({
+            sid: row.sid,
+            idea_id: row.idea_id,
+            task_title: row.task_title,
+            created_at: row.created_at,
+          })),
+        },
+        { status: 409 },
+      );
+    }
+
+    // ── (c) RATE LIMIT (E2) — distinct state, distinct copy (binding note: NO
+    // mention of ending a session — this refusal isn't about the cap). ──────
+    const rateLimit = getTerminalMintRateLimit();
+    const { count: recentCount, error: recentErr } = await supabase
+      .from("terminal_sessions")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", user.id)
+      .gte("created_at", rateLimitWindowStart(nowMs));
+    if (recentErr) {
+      logger.error("Terminal session rate-limit read failed", { error: recentErr.message });
+    }
+    const rateDecision = decideRateLimit(recentCount ?? 0, rateLimit);
+    if (!rateDecision.ok) {
+      return NextResponse.json({ error: RATE_LIMIT_MESSAGE, code: RATE_LIMIT_CODE }, { status: 429 });
+    }
+
+    // ── (d) MINT + register. ────────────────────────────────────────────────
     const tokens = await mintSessionTokens({ sub: user.id, idea: ideaId, secret });
+
+    const { error: insertErr } = await supabase.from("terminal_sessions").insert({
+      sid: tokens.sid,
+      user_id: user.id,
+      idea_id: ideaId,
+      task_id: taskId ?? null,
+      task_title: taskTitle ?? null,
+      status: "active",
+      expires_at: computeSessionExpiresAt(nowMs),
+    });
+    if (insertErr) {
+      // The registry is best-effort (R2) — never fail an otherwise-successful
+      // mint just because its bookkeeping row didn't write; the relay session
+      // is real either way. My-sessions / the cap count simply undercount this
+      // one session until the next reap or mint self-corrects.
+      logger.error("Terminal session registry insert failed", {
+        error: insertErr.message,
+        sid: tokens.sid,
+      });
+    }
 
     logger.info("Minted terminal session tokens", {
       userId: user.id,

--- a/src/app/guide/launching-claude-code/page.tsx
+++ b/src/app/guide/launching-claude-code/page.tsx
@@ -124,6 +124,86 @@ export default function LaunchingClaudeCodePage() {
         </section>
 
         <section>
+          <h2 className="mb-4 text-2xl font-semibold">
+            Running It In The Browser — Multiple Sessions at Once
+          </h2>
+          <p className="mb-4 text-muted-foreground">
+            Picking{" "}
+            <strong className="text-foreground">
+              &quot;In the browser&quot;
+            </strong>{" "}
+            (Beta) from the Launch options dropdown opens a live terminal
+            docked to the bottom of the board, mirroring Claude Code running
+            on your own machine through the VibeCodes helper — your code
+            never leaves your computer.
+          </p>
+          <p className="mb-4 text-muted-foreground">
+            You&apos;re not limited to one session at a time. You can run
+            several sessions concurrently — any mix of terminal windows and
+            in-browser tabs — each working on its own task:
+          </p>
+          <ul className="mb-4 list-inside list-disc space-y-2 text-muted-foreground">
+            <li>
+              <strong className="text-foreground">Tabs in the dock</strong> —
+              every launch (toolbar, task card, or the dock&apos;s{" "}
+              <strong className="text-foreground">&quot;+&quot;</strong>)
+              opens a new tab rather than replacing what&apos;s already
+              running. The dock shows how many in-browser sessions you can
+              have running at once, and explains what to do if you&apos;re at
+              that limit.
+            </li>
+            <li>
+              <strong className="text-foreground">
+                Automatic worktree isolation
+              </strong>{" "}
+              — your second and later concurrent sessions on the same repo
+              each get their own private git worktree (a sibling{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                &lt;repo&gt;.vibe/wt-1
+              </code>
+              ,{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                wt-2
+              </code>
+              , and so on, each on its own branch) so two sessions never
+              collide editing the same files. Your first/primary session keeps
+              working in the repo folder itself, unchanged.
+            </li>
+            <li>
+              <strong className="text-foreground">My sessions</strong> — the
+              dock&apos;s{" "}
+              <strong className="text-foreground">&quot;My sessions&quot;</strong>{" "}
+              button lists every session running across all your ideas, with
+              a one-click <strong className="text-foreground">End</strong> per
+              session and an{" "}
+              <strong className="text-foreground">&quot;End all sessions&quot;</strong>{" "}
+              panic button for when you just want everything stopped.
+            </li>
+            <li>
+              <strong className="text-foreground">Pop-out</strong> — any
+              in-browser session can be popped into its own browser window
+              (the tab&apos;s{" "}
+              <strong className="text-foreground">&quot;Pop out&quot;</strong>{" "}
+              button). It&apos;s the exact same session, just in different
+              glass: closing the popped-out window brings it back to the dock
+              automatically, or use{" "}
+              <strong className="text-foreground">
+                &quot;Bring back to dock&quot;
+              </strong>{" "}
+              from the dock&apos;s tab at any time.
+            </li>
+          </ul>
+          <div className="rounded-xl border border-border bg-muted/30 p-6">
+            <p className="text-sm text-muted-foreground">
+              Each session runs a real Claude Code process on your computer —
+              running several at once uses more of your machine&apos;s
+              resources. Close sessions you&apos;re done with rather than
+              leaving them running indefinitely.
+            </p>
+          </div>
+        </section>
+
+        <section>
           <h2 className="mb-4 text-2xl font-semibold">What the Launch Actually Does</h2>
           <p className="mb-4 text-muted-foreground">
             The launch generates a prompt that tells Claude Code to do four

--- a/src/app/terminal/popout/layout.tsx
+++ b/src/app/terminal/popout/layout.tsx
@@ -1,0 +1,8 @@
+// The popped-out terminal window's OWN minimal layout — no navbar, no footer,
+// no board chrome (unlike `(main)/layout.tsx`, this route sits outside that
+// group entirely). Root layout (src/app/layout.tsx) still provides
+// html/body/fonts/theme, which is all this window needs on top.
+
+export default function TerminalPopoutLayout({ children }: { children: React.ReactNode }) {
+  return <div className="h-screen w-screen overflow-hidden bg-[#0a0a0b] text-zinc-200">{children}</div>;
+}

--- a/src/app/terminal/popout/page.tsx
+++ b/src/app/terminal/popout/page.tsx
@@ -1,0 +1,31 @@
+// The popped-out terminal window's route (multi-session stage 4, D2).
+//
+// Deliberately an OPAQUE route per the Design-Review binding note: the sid is
+// NEVER in this URL (or the query string, or a static param) — the popped
+// window's rendezvous NONCE rides the URL HASH instead (hashes never leave
+// the browser, never hit this server component) and the actual session
+// credentials cross exclusively over a same-origin BroadcastChannel, after
+// the page has mounted client-side. See src/lib/terminal/popout-channel.ts
+// and terminal-popout-client.tsx for the hand-off protocol.
+//
+// Server-side: an ordinary authenticated-page gate (requireAuth — the same
+// helper every other protected page in the app uses) plus the feature flag,
+// so a popped-out window with the flag off (or before login) renders nothing
+// rather than a broken terminal.
+
+import { requireAuth } from "@/lib/auth";
+import { isTerminalEnabled } from "@/lib/terminal/connection";
+import { TerminalPopoutClient } from "./terminal-popout-client";
+
+export const metadata = {
+  title: "Terminal",
+  robots: { index: false, follow: false },
+};
+
+export default async function TerminalPopoutPage() {
+  await requireAuth();
+
+  if (!isTerminalEnabled()) return null;
+
+  return <TerminalPopoutClient />;
+}

--- a/src/app/terminal/popout/terminal-popout-client.tsx
+++ b/src/app/terminal/popout/terminal-popout-client.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+// The popped-out terminal window's client entry point (multi-session stage 4,
+// D2/D4/D7). Owns the hand-off HANDSHAKE only — everything about actually
+// running a session lives in TerminalPopoutView, mounted once the payload
+// arrives.
+//
+// Nonce resolution: the URL HASH first (what the dock's window.open() sets —
+// see terminal-dock.tsx's handlePopOut), falling back to `window.name` per
+// the stage brief ("NONCE comes from the URL hash or window.name") — a
+// fallback that matters if some intermediate navigation ever drops the hash
+// (e.g. a browser "restore session" round-trip); `window.name` persists
+// across navigations within the same tab/window in a way the hash doesn't
+// survive every code path. Either way the nonce carries NO session meaning by
+// itself (see popout-channel.ts's module doc) — it only names the rendezvous
+// channel.
+
+import { useEffect, useState } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import {
+  hasPopoutHandoffTimedOut,
+  parsePopoutChannelMessage,
+  popoutChannelName,
+  type PopoutPayload,
+} from "@/lib/terminal/popout-channel";
+import { TerminalPopoutView } from "@/components/board/terminal-popout-view";
+
+// The dock's window.open() target name is `vibecodes-terminal-<nonce>` (see
+// terminal-dock.tsx's handlePopOut) — that string becomes this window's OWN
+// `window.name` automatically, so the fallback strips the same prefix back
+// off rather than treating the whole target string as the nonce.
+const WINDOW_NAME_PREFIX = "vibecodes-terminal-";
+
+function resolveNonce(): string | null {
+  const hash = window.location.hash.replace(/^#/, "").trim();
+  if (hash) return hash;
+  const name = window.name.trim();
+  if (name.startsWith(WINDOW_NAME_PREFIX)) return name.slice(WINDOW_NAME_PREFIX.length) || null;
+  return name || null;
+}
+
+export function TerminalPopoutClient() {
+  // Read once, at initial render — a derived, render-time fact about this
+  // window (its hash/name), not something that needs its own effect+setState
+  // round trip. `null` on the server render (no `window`); corrected the
+  // instant this lazy initializer runs client-side, before paint.
+  const [nonce] = useState<string | null>(() => (typeof window === "undefined" ? null : resolveNonce()));
+  const [payload, setPayload] = useState<PopoutPayload | null>(null);
+  const [timedOut, setTimedOut] = useState(false);
+
+  useEffect(() => {
+    if (!nonce) return;
+    // Keep the nonce in window.name too, so it survives a same-window
+    // reload/back-forward that might drop the hash — a cheap, harmless extra
+    // (window.name is per-tab, never sent anywhere).
+    window.name = nonce;
+
+    const channel = new BroadcastChannel(popoutChannelName(nonce));
+    const startedAt = Date.now();
+
+    channel.onmessage = (ev) => {
+      const message = parsePopoutChannelMessage(ev.data);
+      if (message?.type === "payload") setPayload(message.payload);
+    };
+    channel.postMessage({ type: "ready" });
+
+    const pollTimer = window.setInterval(() => {
+      if (hasPopoutHandoffTimedOut(startedAt, Date.now())) {
+        setTimedOut(true);
+        window.clearInterval(pollTimer);
+      }
+    }, 250);
+
+    const sendClosed = () => {
+      try {
+        channel.postMessage({ type: "closed" });
+      } catch {
+        /* channel already gone — nothing to signal */
+      }
+    };
+    window.addEventListener("beforeunload", sendClosed);
+    window.addEventListener("pagehide", sendClosed);
+
+    return () => {
+      window.clearInterval(pollTimer);
+      window.removeEventListener("beforeunload", sendClosed);
+      window.removeEventListener("pagehide", sendClosed);
+      // Deliberately NOT closing the channel or sending "closed" here — this
+      // cleanup also runs on React StrictMode's dev double-invoke, which must
+      // never look like the user closing the window. Only the real browser
+      // lifecycle events above count as "closed".
+    };
+  }, [nonce]);
+
+  // Once `payload` is set, the render below returns the live view BEFORE it
+  // ever looks at `timedOut` — so a late interval tick racing a just-arrived
+  // payload is harmless; there's no need to also clear `timedOut` here.
+  if (payload) return <TerminalPopoutView payload={payload} />;
+
+  if (!nonce || timedOut) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+        <AlertTriangle className="h-7 w-7 text-amber-400" />
+        <div className="text-base font-semibold text-zinc-200">Lost the session hand-off</div>
+        <p className="max-w-sm text-[13px] text-zinc-400">
+          This window lost its session hand-off — close it and pop out again.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+      <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
+      <div className="text-base font-semibold text-sky-400">Connecting your terminal…</div>
+    </div>
+  );
+}

--- a/src/components/board/launch-claude-code-button.tsx
+++ b/src/components/board/launch-claude-code-button.tsx
@@ -356,8 +356,13 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
     requestBrowserLaunch({
       essentials,
       cwd: resolveLaunchCwd(state, effectiveTarget.cwd),
+      // Multi-session stage 2 (B10 dedupe, B3 tab labels): only task-scoped
+      // variants carry a task identity — a board-level launch never does, so
+      // B10's dedupe never mistakes two board launches for the same task.
+      taskId: props.variant === "board" ? undefined : props.taskId,
+      taskTitle: props.variant === "board" ? undefined : props.taskTitle,
     });
-  }, [posthog, buildCompactEssentials, resolveState, effectiveTarget.cwd]);
+  }, [posthog, buildCompactEssentials, resolveState, effectiveTarget.cwd, props]);
 
   const openDialog = useCallback((mode: LaunchMode, launch: boolean) => {
     setPendingLaunch(launch);

--- a/src/components/board/launch-claude-code-button.tsx
+++ b/src/components/board/launch-claude-code-button.tsx
@@ -337,8 +337,11 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
   // is OFF this is false, so the menu collapses to exactly today's single
   // terminal-window action — the existing behaviour is completely untouched.
   // Picking "In the browser" asks the board's terminal dock (a page-level sibling)
-  // to open + auto-launch via the vibecodes:// deep link; it does NOT also run the
-  // terminal-window flow — Claude runs in one place at a time.
+  // to open a NEW tab + auto-launch via the vibecodes:// deep link; it does NOT also
+  // run the terminal-window flow for THIS click — each click still starts exactly
+  // one session in exactly one destination. That's no longer a claim about the app
+  // as a whole, though: multiple sessions (terminal windows and/or browser tabs) can
+  // run concurrently — see the terminal dock's "My sessions" / pop-out support.
   const browserLaunchAvailable = isBrowserLaunchAvailable(isTerminalEnabled());
   const handleLaunchInBrowser = useCallback(() => {
     posthog?.capture("launch_claude_code_clicked", { method: "in_browser" });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -8,64 +8,77 @@
 //   POST /api/terminal/session  →  { sessionId, browserToken, bridgeToken }
 //   WebSocket  <relay>/?session&role=browser&token  →  xterm.js
 //
-// INSTALL-FIRST FIRST RUN (docs/install-first-terminal-ux.html, Compass UX; built on
-// the ProdOwner Requirements): an unpaired browser lands on a calm numbered SETUP
-// panel and NO `vibecodes://` deep link fires until the user explicitly presses
-// Connect — so a first-timer with nothing installed never sees macOS's scary
-// "no application set / Search App Store" dialog. On the first successful connection
-// we set a localStorage paired flag; a paired browser then auto-connects on open and
-// skips the setup wall. Non-Mac machines get a "coming soon" and never fire the link.
+// MULTI-SESSION (stage 2, docs/design-terminal-multi-session-popout.html): the
+// dock now manages an ORDERED LIST of session tabs, board-scoped (this idea
+// only — the approved OQ2 recommendation; a global "My sessions" list is stage
+// 3). One always-mounted `useTerminalSession` instance backs each tab, via the
+// per-tab `TerminalSessionView` (terminal-session-view.tsx) — this file owns
+// only the DOCK CHROME shared across tabs: the collapsed bar (single-session
+// pill, or a worst-first status summary across tabs — B5), the tab strip
+// (VS Code convention — status glyph, label, × close, "+" — B1/B3), launch-bus
+// routing into either a NEW tab or a focus-existing dedupe (B7/B10), and the
+// dock-wide `expanded` open/close state.
 //
-// ARCHITECTURE (multi-session stage 1, docs/design-terminal-multi-session-popout.html):
-// everything ONE session needs — the connection state machine, the WebSocket browser
-// leg, xterm + resize/focus, the heartbeat watchdog, the grace-window reattach loop,
-// and the vibecodes:// deep-link fire — lives behind `useTerminalSession` (see
-// use-terminal-session.ts). This component owns the DOCK CHROME shared across
-// sessions (collapsed bar, expanded panel, `expanded` open/close) and the launch-bus
-// wiring, and renders the states that hook exposes. The connection STATE MACHINE +
-// close-code mapping + framing are pure and live in src/lib/terminal/connection.ts;
-// the OS/arch detection, the paired-flag gate, and the first-run copy are pure and
-// live in src/lib/terminal/{platform,paired-flag,first-run-copy}.ts (all
-// unit-tested).
+// SESSIONS MODEL (B2/B4): `sessions: SessionEntry[]` (terminal-tabs.ts) is the
+// list of tabs. EVERY entry renders its own `TerminalSessionView`, ALWAYS —
+// never conditionally mounted/unmounted while live — so a background tab's
+// socket, xterm buffer, heartbeat watchdog and grace-window reconnect loop
+// keep running exactly as if it were the only tab; only the ACTIVE entry's
+// panel is visually shown (CSS `hidden`, not an unmount — see that file's doc).
+// The dock keeps exactly ONE entry mounted from page load (the "pristine"
+// slot, `launchSeq: 0`) so a first-time/returning user sees the unchanged P1
+// idle/setup/auto-connect experience with NO tab strip (the strip only
+// renders once a 2nd tab exists — "single session keeps P1's existing copy").
+// The very first launch on a board REUSES that pristine slot in place
+// (`findPristineSlot`); every launch after that opens a genuinely new tab.
+// Ending the dock's only remaining tab resets `sessions` back to a fresh
+// pristine entry (B8: last-session-ended returns to the P1 idle state, no
+// lingering empty strip); ending one of several tabs just removes that entry
+// (its underlying session has already been torn down via `actions.end()`).
+//
+// ARCHITECTURE (multi-session stage 1, same design doc): everything ONE
+// session needs — the connection state machine, the WebSocket browser leg,
+// xterm + resize/focus, the heartbeat watchdog, the grace-window reattach
+// loop, and the vibecodes:// deep-link fire — lives behind `useTerminalSession`
+// (use-terminal-session.ts). The connection STATE MACHINE + close-code mapping
+// + framing are pure and live in src/lib/terminal/connection.ts (UNTOUCHED);
+// the OS/arch detection, the paired-flag gate, and the first-run copy are pure
+// and live in src/lib/terminal/{platform,paired-flag,first-run-copy}.ts; the
+// tab-strip decisions (labels, dedupe, status→glyph, collapsed summary, a11y
+// announce gating) are pure and live in terminal-tabs.ts — all unit-tested.
 //
 // GATING: off by default. Renders nothing unless NEXT_PUBLIC_TERMINAL_ENABLED is
-// exactly "true" (checked here AND at the board page mount).
+// exactly "true" (checked here AND at the board page mount) — B9: flag off means
+// zero new UI anywhere, including the tab strip and "+".
 
-import { useCallback, useEffect, useState, type ReactNode } from "react";
-import {
-  ChevronUp,
-  ChevronDown,
-  Circle,
-  CircleDot,
-  CircleDashed,
-  Loader2,
-  WifiOff,
-  Square,
-  CircleAlert,
-  Power,
-  Lock,
-  LockOpen,
-  Copy,
-  Clock,
-  Info,
-  Laptop,
-  Terminal as TerminalIcon,
-  RotateCw,
-  Download,
-  ChevronRight,
-} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { ChevronUp, ChevronDown, Circle, Plus, Terminal as TerminalIcon, X } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { isTerminalEnabled, type TerminalStatus } from "@/lib/terminal/connection";
+import { subscribeBrowserLaunch, type BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
+import { resolveDockView } from "@/lib/terminal/first-run-flow";
+import { slugifyIdeaTitle } from "@/lib/launch-claude-code";
+import { newSessionTooltip } from "@/lib/terminal/session-cap";
 import {
-  isTerminalEnabled,
-  type TerminalConnectionState,
-  type TerminalStatus,
-} from "@/lib/terminal/connection";
-import { subscribeBrowserLaunch } from "@/lib/terminal/launch-mode";
-import { type TerminalPlatform, TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
-import { FIRST_RUN_COPY } from "@/lib/terminal/first-run-copy";
-import { type DockView, resolveDockView } from "@/lib/terminal/first-run-flow";
-import { useTerminalSession, type PairInfo } from "./use-terminal-session";
+  type SessionEntry,
+  type TabTone,
+  tabStatusMeta,
+  isLiveTabStatus,
+  deriveTabLabel,
+  findPristineSlot,
+  decideTaskLaunch,
+  summarizeSessionStatuses,
+  type DedupeCandidate,
+} from "./terminal-tabs";
+import {
+  TerminalSessionView,
+  dockStatusMeta,
+  type SessionSummary,
+} from "./terminal-session-view";
+import type { TerminalSessionActions, TerminalSessionDescriptor } from "./use-terminal-session";
 
 interface TerminalDockProps {
   ideaId: string;
@@ -78,42 +91,26 @@ interface TerminalDockProps {
   ideaGithubUrl: string | null;
 }
 
-interface StatusMeta {
-  label: string;
-  Icon: typeof Circle;
-  spin?: boolean;
-  className: string;
+let sessionKeySeq = 0;
+/** Locally-unique tab key — never sent anywhere, just a React/registry key. */
+function freshSessionKey(): string {
+  sessionKeySeq += 1;
+  return `tab-${Date.now().toString(36)}-${sessionKeySeq}`;
 }
 
-// Header pill — icon + text + colour (never colour alone), one per view.
-function dockStatusMeta(view: DockView, state: TerminalConnectionState): StatusMeta {
-  switch (view) {
-    case "connected":
-      return { label: "Connected", Icon: CircleDot, className: "border-emerald-500/50 bg-emerald-500/10 text-emerald-400" };
-    case "connecting":
-    case "connecting-returning":
-      return { label: "Connecting…", Icon: Loader2, spin: true, className: "border-amber-500/50 bg-amber-500/10 text-amber-400" };
-    case "legacy-waiting":
-      return { label: "Waiting to pair", Icon: Loader2, spin: true, className: "border-sky-500/50 bg-sky-500/10 text-sky-400" };
-    case "timeout-new":
-    case "timeout-returning":
-      return { label: FIRST_RUN_COPY.pill.notConnected, Icon: CircleDashed, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
-    case "setup":
-      return { label: FIRST_RUN_COPY.pill.setup, Icon: Circle, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
-    case "coming-soon":
-      return { label: FIRST_RUN_COPY.pill.comingSoon, Icon: Clock, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
-    case "disconnected":
-      return { label: "Reconnecting…", Icon: WifiOff, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
-    case "session-ended":
-      return { label: "Session ended", Icon: Square, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
-    case "error":
-      return { label: state.errorKind === "owner-mismatch" ? "Owner mismatch" : "Error", Icon: CircleAlert, className: "border-rose-500/55 bg-rose-500/10 text-rose-400" };
-    default:
-      return { label: "Terminal · off", Icon: Circle, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
-  }
+function createPristineEntry(): SessionEntry {
+  return {
+    key: freshSessionKey(),
+    origin: "toolbar",
+    taskId: undefined,
+    taskTitle: undefined,
+    createdAt: Date.now(),
+    launchSeq: 0,
+    launchPayload: null,
+  };
 }
 
-// A small dot for the collapsed bar that echoes the live state at a glance.
+// A small dot for the collapsed bar's single-session pill.
 function dotClass(status: TerminalStatus): string {
   switch (status) {
     case "connected":
@@ -130,68 +127,281 @@ function dotClass(status: TerminalStatus): string {
 
 export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockProps) {
   // Defence-in-depth: also gated at the page mount. When off, render nothing —
-  // no dock, no entry point, board unchanged.
+  // no dock, no entry point, board unchanged (B9).
   const enabled = isTerminalEnabled();
   const [expanded, setExpanded] = useState(false);
+  const [sessions, setSessions] = useState<SessionEntry[]>(() => [createPristineEntry()]);
+  const [activeKey, setActiveKey] = useState<string>(() => sessions[0].key);
+  const [summaries, setSummaries] = useState<Record<string, SessionSummary>>({});
+  // Tab close arms an inline confirm on a LIVE session (OQ1) — the second click
+  // on the SAME tab's × (or a second Delete keypress) actually ends it. Ended
+  // tabs close instantly, no confirm.
+  const [confirmingKey, setConfirmingKey] = useState<string | null>(null);
+  // Single shared aria-live announcer for background-tab attention (a11y §14) —
+  // one region so simultaneous background transitions never talk over each other.
+  const [announcement, setAnnouncement] = useState("");
+  const actionsMapRef = useRef<Map<string, TerminalSessionActions>>(new Map());
+  // Mirrors so `deliverLaunch` (used by both the launch-bus subscription and
+  // "+") can read the CURRENT list/summaries without depending on them — that
+  // keeps its identity stable across renders instead of forcing the launch-bus
+  // effect to unsubscribe/resubscribe on every tab status change.
+  const sessionsRef = useRef(sessions);
+  const summariesRef = useRef(summaries);
+  const posthog = usePostHog();
+  const posthogRef = useRef(posthog);
+  // Refs must only be WRITTEN outside render (react-hooks/refs) — sync them in
+  // an effect, which always commits before any later event handler can read
+  // them, so `deliverLaunch` (called only from event handlers / the launch-bus
+  // subscription) never sees a stale value.
+  useEffect(() => {
+    sessionsRef.current = sessions;
+    summariesRef.current = summaries;
+    posthogRef.current = posthog;
+  }, [sessions, summaries, posthog]);
 
-  // Dock CHROME: shared by every session (only one today; stage 2 adds a tab strip
-  // over the same expanded/collapsed panel). The hook calls this at the same points
-  // the old single-session component called `setExpanded(true)` directly.
+  const descriptor: TerminalSessionDescriptor = useMemo(
+    () => ({ ideaId, ideaTitle, ideaGithubUrl }),
+    [ideaId, ideaTitle, ideaGithubUrl],
+  );
+  const ideaSlug = useMemo(() => slugifyIdeaTitle(ideaTitle), [ideaTitle]);
+
+  // Dock CHROME: shared by every session. Each tab calls this at the same points
+  // P1's single hook called `setExpanded(true)` directly.
   const requestExpand = useCallback(() => setExpanded(true), []);
 
-  const session = useTerminalSession(
-    { ideaId, ideaTitle, ideaGithubUrl },
-    { enabled, expanded, requestExpand },
-  );
-  const { state, launchPhase, peerDegraded, pair, readOnly, inputEnabled, platform, paired, containerRef, actions } = session;
+  const registerActions = useCallback((key: string, actions: TerminalSessionActions | null) => {
+    if (actions) actionsMapRef.current.set(key, actions);
+    else actionsMapRef.current.delete(key);
+  }, []);
 
-  // The "In the browser" menu item (board toolbar) fires the launch bus; pick it up
-  // here and forward it to the session. Board-level wiring — in stage 2 this is
-  // where a NEW tab (and its own hook instance) would be created instead.
-  const { launchFromBus } = actions;
+  const reportSummary = useCallback((key: string, summary: SessionSummary) => {
+    setSummaries((prev) => {
+      const cur = prev[key];
+      if (
+        cur &&
+        cur.status === summary.status &&
+        cur.sessionId === summary.sessionId &&
+        cur.errorKind === summary.errorKind &&
+        cur.launchPhase === summary.launchPhase &&
+        cur.platformSupported === summary.platformSupported &&
+        cur.paired === summary.paired
+      ) {
+        return prev;
+      }
+      return { ...prev, [key]: summary };
+    });
+  }, []);
+
+  const announce = useCallback((text: string) => setAnnouncement(text), []);
+
+  // ── close / remove a tab ────────────────────────────────────────────────────
+  const removeEntry = useCallback(
+    (key: string) => {
+      setSessions((prev) => {
+        const idx = prev.findIndex((s) => s.key === key);
+        if (idx === -1) return prev;
+        const next = prev.filter((s) => s.key !== key);
+        if (next.length === 0) {
+          // Last tab closed → back to the true P1 idle/resting state (B8), not a
+          // lingering empty strip.
+          const fresh = createPristineEntry();
+          setActiveKey(fresh.key);
+          return [fresh];
+        }
+        setActiveKey((cur) => {
+          if (cur !== key) return cur;
+          const neighbor = prev[idx - 1] ?? prev[idx + 1] ?? next[0];
+          return neighbor.key;
+        });
+        return next;
+      });
+      setSummaries((prev) => {
+        if (!(key in prev)) return prev;
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    },
+    [],
+  );
+
+  const requestClose = useCallback(
+    (key: string) => {
+      const status = summaries[key]?.status ?? "idle";
+      if (!isLiveTabStatus(status)) {
+        // Already ended/errored — nothing to end, just close the tab (OQ1).
+        setConfirmingKey((c) => (c === key ? null : c));
+        removeEntry(key);
+        return;
+      }
+      if (confirmingKey !== key) {
+        setConfirmingKey(key);
+        return;
+      }
+      // Second click/keypress on an armed LIVE tab — confirmed.
+      actionsMapRef.current.get(key)?.end();
+      setConfirmingKey(null);
+      removeEntry(key);
+    },
+    [summaries, confirmingKey, removeEntry],
+  );
+
+  const cancelClose = useCallback(() => setConfirmingKey(null), []);
+
+  // ── launch routing (B7/B10) + the pristine-slot reuse for the FIRST launch ──
+  const deliverLaunch = useCallback((payload: BrowserLaunchPayload | null) => {
+    const currentSessions = sessionsRef.current;
+    const currentSummaries = summariesRef.current;
+    const candidates: DedupeCandidate[] = currentSessions.map((s) => ({
+      key: s.key,
+      taskId: s.taskId,
+      status: currentSummaries[s.key]?.status ?? "idle",
+    }));
+    const dedupe = decideTaskLaunch(candidates, payload?.taskId);
+    if (dedupe.action === "focus") {
+      setActiveKey(dedupe.key);
+      setExpanded(true);
+      toast.info("This task already has a terminal — switched to it.");
+      return;
+    }
+
+    setExpanded(true);
+    const pristineKey = findPristineSlot(currentSessions.map((s) => ({ key: s.key, launchSeq: s.launchSeq })));
+    if (pristineKey) {
+      setSessions((prev) =>
+        prev.map((s) =>
+          s.key === pristineKey
+            ? {
+                ...s,
+                origin: payload?.taskId ? "task" : "toolbar",
+                taskId: payload?.taskId,
+                taskTitle: payload?.taskTitle,
+                launchSeq: s.launchSeq + 1,
+                launchPayload: payload ?? null,
+              }
+            : s,
+        ),
+      );
+      setActiveKey(pristineKey);
+      return;
+    }
+
+    const entry: SessionEntry = {
+      key: freshSessionKey(),
+      origin: payload?.taskId ? "task" : "toolbar",
+      taskId: payload?.taskId,
+      taskTitle: payload?.taskTitle,
+      createdAt: Date.now(),
+      launchSeq: 1,
+      launchPayload: payload ?? null,
+    };
+    setSessions((prev) => [...prev, entry]);
+    setActiveKey(entry.key);
+    // Mirrors launch_claude_code_clicked's pattern — fired only for a GENUINE
+    // 2nd+ tab (the pristine-slot reuse above is still the board's first tab,
+    // same as P1, and isn't a "multi-session" event).
+    posthogRef.current?.capture("terminal_tab_opened", { origin: entry.origin });
+  }, []);
+
+  // The "In the browser" menu item (board toolbar) and task-card menus fire the
+  // launch bus; forward every event to the routing decision above. Called
+  // unconditionally (Rules of Hooks) — `enabled` is checked inside, same as
+  // every effect in use-terminal-session.ts.
   useEffect(() => {
     if (!enabled) return;
-    return subscribeBrowserLaunch((payload) => {
-      launchFromBus(payload ?? null);
-    });
-  }, [enabled, launchFromBus]);
+    return subscribeBrowserLaunch((payload) => deliverLaunch(payload ?? null));
+  }, [enabled, deliverLaunch]);
+
+  const handlePlus = useCallback(() => {
+    // "+" only appears once a 2nd tab already exists (see the tab-strip render
+    // guard below), so the pristine slot is always already consumed by then —
+    // this always mints a genuinely new, board-level tab (B7).
+    deliverLaunch(null);
+  }, [deliverLaunch]);
+
+  const handleTabKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>, index: number, key: string) => {
+      if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+        e.preventDefault();
+        const dir = e.key === "ArrowRight" ? 1 : -1;
+        const next = sessions[(index + dir + sessions.length) % sessions.length];
+        document.getElementById(`terminal-tab-${next.key}`)?.focus();
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        document.getElementById(`terminal-tab-${sessions[0].key}`)?.focus();
+      } else if (e.key === "End") {
+        e.preventDefault();
+        document.getElementById(`terminal-tab-${sessions[sessions.length - 1].key}`)?.focus();
+      } else if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        setActiveKey(key);
+        setExpanded(true);
+      } else if (e.key === "Delete") {
+        e.preventDefault();
+        requestClose(key);
+      } else if (e.key === "Escape" && confirmingKey === key) {
+        e.preventDefault();
+        cancelClose();
+      }
+    },
+    [sessions, requestClose, confirmingKey, cancelClose],
+  );
 
   if (!enabled) return null;
 
-  const view = resolveDockView(state.status, launchPhase, platform.supported, paired);
-  const meta = dockStatusMeta(view, state);
-  const showStream = state.status === "connected" || state.status === "disconnected";
-  const canLaunch =
-    state.status === "idle" ||
-    state.status === "error" ||
-    state.status === "session-ended" ||
-    state.status === "disconnected";
-  // The End control is only meaningful once a session exists and is still live/opening.
-  const showEnd =
-    view === "connected" ||
-    view === "disconnected" ||
-    view === "connecting" ||
-    view === "connecting-returning" ||
-    view === "legacy-waiting";
+  const activeSummary = summaries[activeKey];
+  const activeStatus: TerminalStatus = activeSummary?.status ?? "idle";
+  const multi = sessions.length > 1;
+
+  const statusChips = multi ? summarizeSessionStatuses(sessions.map((s) => summaries[s.key]?.status ?? "idle")) : [];
+  const singleView = activeSummary
+    ? resolveDockView(activeSummary.status, activeSummary.launchPhase, activeSummary.platformSupported, activeSummary.paired)
+    : "setup";
+  const singleMeta = dockStatusMeta(singleView, activeSummary?.errorKind ?? null);
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-40 border-t border-zinc-700 bg-[#141417] text-zinc-200 shadow-[0_-8px_30px_rgba(0,0,0,0.4)]">
+      {/* Shared aria-live region — background-tab attention only (a11y §14). */}
+      <div aria-live="polite" role="status" className="sr-only">
+        {announcement}
+      </div>
+
       {/* Collapsed dock bar — always visible */}
       <div className="flex items-center gap-2.5 px-3 py-1.5">
         <span className="inline-flex items-center gap-2 text-xs font-semibold">
-          <Circle className={cn("h-2.5 w-2.5 fill-current", dotClass(state.status))} />
+          {!multi && <Circle className={cn("h-2.5 w-2.5 fill-current", dotClass(activeStatus))} />}
           <TerminalIcon className="h-3.5 w-3.5 text-zinc-400" />
-          <span className="hidden sm:inline">Terminal</span>
-          {pair && (
+          <span className="hidden sm:inline">{multi ? "Terminals" : "Terminal"}</span>
+          {!multi && activeSummary?.sessionId && (
             <span className="hidden font-mono text-[11px] font-normal text-zinc-500 md:inline">
-              · session {pair.sessionId.slice(0, 8)}
+              · session {activeSummary.sessionId.slice(0, 8)}
             </span>
           )}
         </span>
-        <span className="ml-auto inline-flex items-center" />
-        <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-semibold", meta.className)}>
-          <meta.Icon className={cn("h-3 w-3", meta.spin && "animate-spin")} />
-          {meta.label}
+        <span className="ml-auto inline-flex items-center gap-1.5">
+          {multi &&
+            statusChips.map((chip) => (
+              <span
+                key={chip.label}
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10.5px] font-bold",
+                  chip.tone === "ok" && "border-emerald-500/50 bg-emerald-500/10 text-emerald-400",
+                  chip.tone === "info" && "border-sky-500/50 bg-sky-500/10 text-sky-400",
+                  chip.tone === "warn" && "border-amber-500/50 bg-amber-500/10 text-amber-400",
+                  chip.tone === "err" && "border-rose-500/50 bg-rose-500/10 text-rose-400",
+                  chip.tone === "mut" && "border-zinc-600 bg-zinc-800/60 text-zinc-400",
+                )}
+              >
+                <span aria-hidden="true">{chip.glyph}</span>
+                {chip.label}
+              </span>
+            ))}
+          {!multi && (
+            <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-semibold", singleMeta.className)}>
+              <singleMeta.Icon className={cn("h-3 w-3", singleMeta.spin && "animate-spin")} />
+              {singleMeta.label}
+            </span>
+          )}
         </span>
         <Button
           variant="ghost"
@@ -206,426 +416,147 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
         </Button>
       </div>
 
-      {/* Expanded body — kept mounted (hidden when collapsed) so the xterm instance
-          and its scrollback survive collapse/expand and live bytes are never lost. */}
+      {/* Expanded body — kept mounted (hidden when collapsed) so every tab's xterm
+          instance and its scrollback survive collapse/expand and live bytes are
+          never lost. */}
       <div className={cn("border-t border-zinc-800 bg-[#0c0c0e]", !expanded && "hidden")}>
-        {/* Header: state · identity · controls (safest → most destructive) */}
-        <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 bg-[#141417] px-3 py-2">
-          <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold", meta.className)}>
-            <meta.Icon className={cn("h-3 w-3", meta.spin && "animate-spin")} />
-            {meta.label}
-          </span>
-          {readOnly && state.status === "connected" && (
-            <span className="inline-flex items-center gap-1.5 rounded-md border border-violet-500/55 bg-violet-500/10 px-2 py-1 text-[11px] font-bold text-violet-300">
-              <Lock className="h-3 w-3" /> Read-only
-            </span>
-          )}
-          <span className="hidden font-mono text-xs text-zinc-500 sm:inline">
-            {ideaTitle}
-            {pair && <span className="text-zinc-600"> · session {pair.sessionId.slice(0, 8)}</span>}
-          </span>
-          <span className="ml-auto inline-flex items-center gap-1.5">
-            {showStream && (
-              <Button
-                variant="outline"
-                size="xs"
-                className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
-                onClick={() => actions.setReadOnly((r) => !r)}
-                aria-pressed={readOnly}
-                aria-label={readOnly ? "Read-only is on — click to allow input" : "Switch to read-only"}
-              >
-                {readOnly ? <Lock className="h-3 w-3" /> : <LockOpen className="h-3 w-3" />}
-                {readOnly ? "Read-only · on" : "Read-only"}
-              </Button>
-            )}
-            {showEnd && (
-              <Button
-                variant="outline"
-                size="xs"
-                className="border-rose-500/45 bg-transparent text-rose-400 hover:bg-rose-500/10"
-                onClick={actions.end}
-                aria-label="End session"
-              >
-                <Power className="h-3 w-3" /> End
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              className="text-zinc-300 hover:text-zinc-100"
-              onClick={() => setExpanded(false)}
-              aria-label="Collapse terminal panel"
+        {multi && (
+          <div role="tablist" aria-label="Terminal sessions" className="flex items-stretch border-b border-zinc-800 bg-[#141417]">
+            {/* Tabs shrink then scroll; "+" (below) stays pinned OUTSIDE this
+                scroll region so launch + oversight are never scrolled away
+                (design §4a: "never wrap, never hide the '+'"). */}
+            <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto">
+              {sessions.map((entry, index) => {
+                const summary = summaries[entry.key];
+                const status = summary?.status ?? "idle";
+                const meta = tabStatusMeta(status);
+                const label = deriveTabLabel({
+                  taskTitle: entry.taskTitle,
+                  ideaSlug,
+                  sessionId: summary?.sessionId ?? null,
+                });
+                const isActive = entry.key === activeKey;
+                const confirming = confirmingKey === entry.key;
+                return (
+                  <div
+                    key={entry.key}
+                    id={`terminal-tab-${entry.key}`}
+                    role="tab"
+                    aria-selected={isActive}
+                    tabIndex={isActive ? 0 : -1}
+                    title={label}
+                    onKeyDown={(e) => handleTabKeyDown(e, index, entry.key)}
+                    onClick={() => {
+                      setActiveKey(entry.key);
+                      setExpanded(true);
+                    }}
+                    className={cn(
+                      "flex min-w-[110px] max-w-[190px] flex-none cursor-pointer items-center gap-1.5 border-r border-t-2 border-zinc-800 border-t-transparent px-2.5 py-0 text-[12.5px] text-zinc-400",
+                      isActive && "border-t-sky-400 bg-[#0c0c0e] font-semibold text-zinc-100",
+                      !isActive && "hover:bg-zinc-800/60 hover:text-zinc-100",
+                    )}
+                  >
+                    {confirming ? (
+                      <>
+                        <span className="min-w-0 flex-1 truncate text-[11.5px] text-rose-300">End session?</span>
+                        <button
+                          type="button"
+                          aria-label={`Confirm end session: ${label}`}
+                          className="flex h-[18px] w-[18px] flex-none items-center justify-center rounded text-rose-400 hover:bg-rose-500/15"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            requestClose(entry.key);
+                          }}
+                        >
+                          ✓
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Cancel"
+                          className="flex h-[18px] w-[18px] flex-none items-center justify-center rounded text-zinc-400 hover:bg-zinc-700"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            cancelClose();
+                          }}
+                        >
+                          ✕
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <span aria-hidden="true" className="flex-none text-[11px]" style={toneStyle(meta.tone)}>
+                          {meta.glyph}
+                        </span>
+                        <span className="sr-only">{meta.ariaText}</span>
+                        <span className="min-w-0 flex-1 truncate">{label}</span>
+                        <button
+                          type="button"
+                          aria-label={`${isLiveTabStatus(status) ? "End session and close tab" : "Close tab"}: ${label}`}
+                          className="flex h-[18px] w-[18px] flex-none items-center justify-center rounded text-zinc-500 hover:bg-zinc-700 hover:text-zinc-200"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            requestClose(entry.key);
+                          }}
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+            <button
+              type="button"
+              aria-label="New terminal session"
+              title={newSessionTooltip()}
+              onClick={handlePlus}
+              className="flex h-[38px] w-[38px] flex-none items-center justify-center border-l border-zinc-800 text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-100"
             >
-              <ChevronDown className="h-3.5 w-3.5" />
-            </Button>
-          </span>
-        </div>
-
-        {/* Terminal body — the xterm host plus a state overlay. The host stays
-            mounted under every state so scrollback is frozen + readable on end. */}
-        <div className="relative h-[38vh] min-h-[220px]">
-          <div
-            ref={containerRef}
-            className={cn("h-full w-full px-3 py-2", state.status === "disconnected" && "opacity-45")}
-          />
-          {!showStream && (
-            <StateOverlay
-              view={view}
-              state={state}
-              pair={pair}
-              platform={platform}
-              canLaunch={canLaunch}
-              onConnect={() => void actions.connect({ autoLaunch: true })}
-              onRetry={() => void actions.connect({ autoLaunch: true })}
-              onLaunchAgain={actions.beginBrowserLaunch}
-              onCopyBridge={actions.copyBridgeCommand}
-            />
-          )}
-          {/* Our OWN link dropped — we're actively REATTACHING to the same session
-              within the grace window (retained token, no re-mint). Copy only claims
-              what's true DURING the window: the agent is held/running locally and we
-              reconnect automatically; if the window lapses the overlay switches to the
-              honest "session ended" end state. */}
-          {state.status === "disconnected" && (
-            <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
-              <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
-              <b>Reconnecting to your session…</b> Your machine may have slept or dropped Wi-Fi. Your agent keeps running locally while we reattach.
-              <button className="ml-2 underline hover:text-amber-200" onClick={actions.reconnectNow}>
-                Reconnect now
-              </button>
-            </div>
-          )}
-          {/* Peer (the bridge) dropped but our link is fine — the relay is HOLDING the
-              session. Keep the live terminal visible; just show a subtle hint. */}
-          {state.status === "connected" && peerDegraded && (
-            <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
-              <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
-              <b>Connection interrupted — reconnecting…</b> Your machine may have slept; we&apos;re holding your session and will resume automatically.
-            </div>
-          )}
-        </div>
-
-        {/* Input affordance — read-write bar, or the read-only explanatory note. */}
-        {state.status === "connected" && (
-          inputEnabled ? (
-            <div className="flex items-center gap-2 border-t border-zinc-800 bg-[#141417] px-3 py-2 text-xs text-zinc-500">
-              <span className="font-mono text-emerald-400">›</span>
-              <span>Click the terminal and type to steer the agent. Enter sends.</span>
-            </div>
-          ) : (
-            <div className="border-t border-zinc-800 bg-violet-500/5 px-3 py-2 text-[11px] text-zinc-400">
-              <Lock className="mr-1 inline h-3 w-3 text-violet-300" />
-              <b className="text-violet-300">Read-only is on.</b> You&apos;re watching live; keystrokes are frozen.
-              <button className="ml-2 underline hover:text-zinc-200" onClick={() => actions.setReadOnly(false)}>
-                Allow input
-              </button>
-            </div>
-          )
+              <Plus className="h-4 w-4" />
+            </button>
+          </div>
         )}
+
+        {sessions.map((entry) => (
+          <TerminalSessionView
+            key={entry.key}
+            entry={entry}
+            descriptor={descriptor}
+            label={deriveTabLabel({
+              taskTitle: entry.taskTitle,
+              ideaSlug,
+              sessionId: summaries[entry.key]?.sessionId ?? null,
+            })}
+            isActive={entry.key === activeKey}
+            expanded={expanded && entry.key === activeKey}
+            onRequestExpand={requestExpand}
+            autoConnectWhenExpanded={entry.launchSeq === 0}
+            onReportSummary={reportSummary}
+            onRegisterActions={registerActions}
+            onAnnounce={announce}
+          />
+        ))}
       </div>
     </div>
   );
 }
 
-// ── per-view centred overlays (icon + text + next step) ───────────────────────
-function StateOverlay({
-  view,
-  state,
-  pair,
-  platform,
-  canLaunch,
-  onConnect,
-  onRetry,
-  onLaunchAgain,
-  onCopyBridge,
-}: {
-  view: DockView;
-  state: TerminalConnectionState;
-  pair: PairInfo | null;
-  platform: TerminalPlatform;
-  canLaunch: boolean;
-  onConnect: () => void;
-  onRetry: () => void;
-  onLaunchAgain: () => void;
-  onCopyBridge: () => void;
-}) {
-  return (
-    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 overflow-y-auto bg-[#0c0c0e]/95 px-6 py-6 text-center">
-      {view === "coming-soon" && <ComingSoonPanel />}
-
-      {view === "setup" && <SetupPanel platform={platform} onConnect={onConnect} />}
-
-      {(view === "connecting" || view === "connecting-returning") && (
-        <ConnectingPanel returning={view === "connecting-returning"} />
-      )}
-
-      {view === "timeout-new" && (
-        <TimeoutPanel variant="new" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
-      )}
-      {view === "timeout-returning" && (
-        <TimeoutPanel variant="returning" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
-      )}
-
-      {view === "legacy-waiting" && (
-        <>
-          <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
-          <div className="text-base font-semibold text-sky-400">Waiting for your machine to attach</div>
-          <p className="max-w-md text-[13px] text-zinc-400">
-            The link is up. Start a bridge on your computer for this session to go live.
-          </p>
-          {/* Advanced ▾ — cross-machine fallback: copy the manual bridge command.
-              Untouched by the install-first redesign (per the approved UX scope guard). */}
-          {pair && (
-            <details className="mt-1 w-full max-w-md text-left">
-              <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-[12px] text-zinc-500 hover:text-zinc-300 [&::-webkit-details-marker]:hidden">
-                <ChevronRight className="h-3 w-3" /> Advanced — pair a remote machine by hand
-              </summary>
-              <div className="mt-2 flex flex-col items-start gap-1.5 rounded-md border border-zinc-800 bg-[#0a0a0b] px-3 py-2.5">
-                <code className="font-mono text-xs tracking-wide text-sky-300">
-                  session {pair.sessionId.slice(0, 8)}
-                </code>
-                <Button
-                  variant="outline"
-                  size="xs"
-                  className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
-                  onClick={onCopyBridge}
-                >
-                  <Copy className="h-3 w-3" /> Copy bridge command
-                </Button>
-                <span className="text-[11px] text-zinc-600">Single-use · expires ~5 min · bound to your account</span>
-              </div>
-            </details>
-          )}
-        </>
-      )}
-
-      {view === "session-ended" && (
-        <>
-          <Square className="h-7 w-7 text-zinc-400" />
-          <div className="text-base font-semibold text-zinc-300">{endedTitle(state)}</div>
-          <p className="max-w-md text-[13px] text-zinc-400">{endedMessage(state)}</p>
-          <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onLaunchAgain}>
-            <TerminalIcon className="h-4 w-4" /> Launch again
-          </Button>
-        </>
-      )}
-
-      {view === "error" && (
-        <>
-          <CircleAlert className="h-7 w-7 text-rose-400" />
-          <div className="text-base font-semibold text-rose-400">{errorTitle(state)}</div>
-          <p className="max-w-md text-[13px] text-zinc-400">{errorMessage(state)}</p>
-          {canLaunch && state.errorKind !== "owner-mismatch" && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
-              onClick={onLaunchAgain}
-            >
-              <RotateCw className="h-3.5 w-3.5" /> Try again
-            </Button>
-          )}
-        </>
-      )}
-    </div>
-  );
-}
-
-// ── install-first panels ──────────────────────────────────────────────────────
-
-// Screen ① — the numbered one-time setup (unpaired). No deep link has fired here.
-function SetupPanel({ platform, onConnect }: { platform: TerminalPlatform; onConnect: () => void }) {
-  const copy = FIRST_RUN_COPY.setup;
-  return (
-    <div className="flex w-full max-w-lg flex-col text-left">
-      <div className="mb-3 text-center">
-        <TerminalIcon className="mx-auto h-6 w-6 text-emerald-400" />
-        <h4 className="mt-2 text-[17px] font-bold text-zinc-100">{copy.heading}</h4>
-        <p className="mt-1 text-[13px] text-zinc-400">{copy.subheading}</p>
-      </div>
-
-      <SetupStep n={1} title={copy.step1Title}>
-        <p className="mb-2.5 text-[12.5px] text-zinc-400">{copy.step1Desc}</p>
-        <a
-          href={platform.downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-md bg-emerald-500 px-4 text-sm font-semibold text-emerald-950 hover:bg-emerald-400"
-        >
-          <Download className="h-4 w-4" /> {platform.downloadLabel}
-        </a>
-      </SetupStep>
-
-      <SetupStep n={2} title={copy.step2Title}>
-        <p className="text-[12.5px] text-zinc-400">{copy.step2Desc}</p>
-      </SetupStep>
-
-      <SetupStep n={3} title={copy.step3Title}>
-        <div className="mb-3 flex items-start gap-2 rounded-md border border-amber-500/35 bg-amber-500/[0.06] px-3 py-2.5 text-[12.5px] text-amber-200/90">
-          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-300" aria-hidden="true" />
-          <span>{copy.openPrompt}</span>
-        </div>
-        <Button
-          className="min-h-[44px] w-full bg-emerald-500 text-sm font-semibold text-emerald-950 hover:bg-emerald-400"
-          onClick={onConnect}
-        >
-          {copy.connect}
-        </Button>
-        <p className="mt-2 text-center text-[11.5px] text-zinc-500">{copy.alreadyInstalled}</p>
-      </SetupStep>
-    </div>
-  );
-}
-
-function SetupStep({ n, title, children }: { n: number; title: string; children: ReactNode }) {
-  return (
-    <div className="flex gap-3.5 border-t border-zinc-800 py-3.5 first-of-type:border-t-0">
-      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-emerald-500/40 bg-emerald-500/[0.12] text-[13px] font-bold text-emerald-400">
-        {n}
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="mb-1.5 text-sm font-semibold text-zinc-200">{title}</div>
-        {children}
-      </div>
-    </div>
-  );
-}
-
-// Screen ② — connecting (after Connect, or auto-connect for a returning user).
-function ConnectingPanel({ returning }: { returning: boolean }) {
-  const copy = FIRST_RUN_COPY.connecting;
-  return (
-    <>
-      <Loader2 className="h-7 w-7 animate-spin text-amber-400" />
-      <div className="text-base font-semibold text-amber-400">{copy.heading}</div>
-      <p className="max-w-md text-[13px] text-zinc-400">{returning ? copy.returningBody : copy.body}</p>
-      <p className="max-w-md text-[12.5px] text-zinc-500">{copy.openNudge}</p>
-    </>
-  );
-}
-
-// Screen ④ — the calm ~8s fallback. `variant` picks the first-timer vs returning copy.
-function TimeoutPanel({
-  variant,
-  downloadUrl,
-  onRetry,
-}: {
-  variant: "new" | "returning";
-  downloadUrl: string | null;
-  onRetry: () => void;
-}) {
-  const copy = variant === "new" ? FIRST_RUN_COPY.timeoutNew : FIRST_RUN_COPY.timeoutReturning;
-  const href = downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL;
-  const secondaryLabel = variant === "new" ? FIRST_RUN_COPY.timeoutNew.download : FIRST_RUN_COPY.timeoutReturning.reinstall;
-  const footer = variant === "new" ? FIRST_RUN_COPY.timeoutNew.hint : FIRST_RUN_COPY.timeoutReturning.reassure;
-  return (
-    <>
-      <CircleDashed className="h-7 w-7 text-sky-400" />
-      <div className="text-base font-semibold text-zinc-200">{copy.heading}</div>
-      <p className="max-w-md text-[13px] text-zinc-400">{copy.body}</p>
-      <div className="flex w-full flex-wrap justify-center gap-2.5">
-        <Button
-          className="min-h-[44px] bg-sky-500 px-4 text-sm font-semibold text-sky-950 hover:bg-sky-400"
-          onClick={onRetry}
-        >
-          <RotateCw className="h-4 w-4" /> {copy.retry}
-        </Button>
-        <a
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-md border border-zinc-700 bg-zinc-800/60 px-4 text-sm font-semibold text-zinc-200 hover:bg-zinc-700"
-        >
-          <Download className="h-4 w-4" /> {secondaryLabel}
-        </a>
-      </div>
-      <p className="text-[11.5px] text-zinc-500">{footer}</p>
-    </>
-  );
-}
-
-// Screen ⑥ — non-Mac / unsupported machine. No deep link, gated download.
-function ComingSoonPanel() {
-  const copy = FIRST_RUN_COPY.comingSoon;
-  return (
-    <>
-      <Laptop className="h-7 w-7 text-zinc-300" />
-      <div className="text-base font-semibold text-zinc-100">{copy.heading}</div>
-      <p className="max-w-md text-[13px] text-zinc-400">{copy.body}</p>
-      <Button
-        disabled
-        aria-disabled="true"
-        className="min-h-[44px] cursor-not-allowed border border-zinc-800 bg-zinc-900 text-sm font-semibold text-zinc-500"
-      >
-        {copy.download}
-      </Button>
-      <p className="text-[11.5px] text-zinc-500">{copy.hint}</p>
-    </>
-  );
-}
-
-function endedTitle(state: TerminalConnectionState): string {
-  switch (state.endedReason) {
-    case "user":
-      return "You ended the session";
-    case "idle":
-      return "Ended after being idle";
-    case "max-duration":
-      return "Reached the session time limit";
-    case "reconnect-failed":
-      return "This session ended";
+// Tone → text colour, matching terminal-tabs.ts's shared vocabulary (TabTone) —
+// the SAME tone that also picks the collapsed-bar chip's border/background.
+function toneStyle(tone: TabTone): { color: string } {
+  switch (tone) {
+    case "ok":
+      return { color: "#34d399" };
+    case "warn":
+      return { color: "#fbbf24" };
+    case "err":
+      return { color: "#fb7185" };
+    case "info":
+      return { color: "#7dd3fc" };
+    case "mut":
     default:
-      return "Session ended";
+      return { color: "#6f6f7a" };
   }
 }
 
-function endedMessage(state: TerminalConnectionState): string {
-  switch (state.endedReason) {
-    case "idle":
-    case "max-duration":
-      return "We closed the session to keep things tidy and safe. Nothing went wrong — your work on your machine is untouched.";
-    case "reconnect-failed":
-      // The grace window / token validity lapsed before the link came back. Honest,
-      // reassuring, and the "Launch again" button below starts a clean fresh session.
-      return "We couldn't reattach in time after the connection dropped. Your saved work is safe — start a new session to pick things back up.";
-    default:
-      return "Claude Code on your machine stopped. The scrollback above is kept.";
-  }
-}
-
-function errorTitle(state: TerminalConnectionState): string {
-  switch (state.errorKind) {
-    case "owner-mismatch":
-      return "This bridge belongs to another account";
-    case "bad-token":
-      return "Couldn't verify this session";
-    case "duplicate":
-      return "This session is already open elsewhere";
-    case "connect-timeout":
-    case "relay-unreachable":
-      return "Couldn't reach your machine";
-    case "session-mint-failed":
-      return "Couldn't start a session";
-    default:
-      return "Something went wrong";
-  }
-}
-
-function errorMessage(state: TerminalConnectionState): string {
-  switch (state.errorKind) {
-    case "owner-mismatch":
-      return "For safety, a bridge only attaches to the person who launched it. Start your own bridge, or sign in as the owning account.";
-    case "bad-token":
-      return "The session couldn't be verified. Launch again to start a fresh one.";
-    case "duplicate":
-      return "Another browser tab is already attached to this session. Close it, then launch again.";
-    case "connect-timeout":
-      return "We waited a while but nothing connected. Is the helper running and allowed to open?";
-    case "relay-unreachable":
-      return "We couldn't set up the secure link. Check your connection, then try again.";
-    case "session-mint-failed":
-      return "The session request didn't go through. Check your connection and try again.";
-    default:
-      return "The terminal session didn't start. Try launching again.";
-  }
-}

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -57,13 +57,23 @@ import { usePostHog } from "posthog-js/react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { isTerminalEnabled, type TerminalStatus } from "@/lib/terminal/connection";
+import { isTerminalEnabled, relayBaseUrl, type TerminalStatus } from "@/lib/terminal/connection";
 import { subscribeBrowserLaunch, type BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
 import { resolveDockView } from "@/lib/terminal/first-run-flow";
 import { slugifyIdeaTitle } from "@/lib/launch-claude-code";
 import { newSessionTooltip } from "@/lib/terminal/session-cap";
 import {
+  generatePopoutNonce,
+  parsePopoutChannelMessage,
+  popoutChannelName,
+  reduceDockHandshake,
+  INITIAL_DOCK_HANDSHAKE_STATE,
+  type DockHandshakeState,
+  type PopoutPayload,
+} from "@/lib/terminal/popout-channel";
+import {
   type SessionEntry,
+  type TabDisplayStatus,
   type TabTone,
   tabStatusMeta,
   isLiveTabStatus,
@@ -150,6 +160,19 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   const [mySessionsCount, setMySessionsCount] = useState<number | null>(null);
   const openMySessions = useCallback(() => setMySessionsOpen(true), []);
   const actionsMapRef = useRef<Map<string, TerminalSessionActions>>(new Map());
+  // Multi-session stage 4 (D1-D3, popout-channel.ts): which tabs are CURRENTLY
+  // popped out. Purely a dock-tracked fact — the underlying session's real
+  // TerminalStatus is usually "error"/duplicate (the 4001 preemption) the
+  // instant this is true, but that's not what the UI should show (design §5:
+  // "popped out ... deliberate user state", never an attention/error
+  // treatment). `popoutChannelsRef` holds the live BroadcastChannel + its
+  // handshake phase per popped-out key, for the lifetime of the pop-out (open
+  // from the moment "Pop out" is clicked until either "Bring back" or the
+  // popped window's own close-signal).
+  const [poppedOutKeys, setPoppedOutKeys] = useState<Set<string>>(() => new Set());
+  const popoutChannelsRef = useRef<Map<string, { channel: BroadcastChannel; handshake: DockHandshakeState }>>(
+    new Map(),
+  );
   // Mirrors so `deliverLaunch` (used by both the launch-bus subscription and
   // "+") can read the CURRENT list/summaries without depending on them — that
   // keeps its identity stable across renders instead of forcing the launch-bus
@@ -167,6 +190,26 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     summariesRef.current = summaries;
     posthogRef.current = posthog;
   }, [sessions, summaries, posthog]);
+
+  // Close every open pop-out hand-off channel if the dock itself unmounts
+  // (board navigation away) — the popped windows keep running independently
+  // either way; this just stops the dock's side from listening. The Map
+  // instance itself never changes identity across renders (created once by
+  // useRef), so capturing it here is just satisfying the lint rule, not
+  // guarding against a real staleness bug.
+  useEffect(() => {
+    const channels = popoutChannelsRef.current;
+    return () => {
+      for (const { channel } of channels.values()) {
+        try {
+          channel.close();
+        } catch {
+          /* already closed */
+        }
+      }
+      channels.clear();
+    };
+  }, []);
 
   const descriptor: TerminalSessionDescriptor = useMemo(
     () => ({ ideaId, ideaTitle, ideaGithubUrl }),
@@ -193,7 +236,9 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
         cur.errorKind === summary.errorKind &&
         cur.launchPhase === summary.launchPhase &&
         cur.platformSupported === summary.platformSupported &&
-        cur.paired === summary.paired
+        cur.paired === summary.paired &&
+        cur.browserToken === summary.browserToken &&
+        cur.readOnly === summary.readOnly
       ) {
         return prev;
       }
@@ -203,9 +248,104 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
 
   const announce = useCallback((text: string) => setAnnouncement(text), []);
 
+  // ── pop-out (D1-D7, design §10 + §13 Flow 3) ────────────────────────────────
+  // Tears down THIS tab's pop-out bookkeeping — the BroadcastChannel and the
+  // `poppedOutKeys` membership — without touching the underlying session
+  // itself. Shared by both return paths: the user's own "Bring back to dock"
+  // click and the popped window's own close-signal (D3).
+  const endPopOut = useCallback((key: string) => {
+    const entry = popoutChannelsRef.current.get(key);
+    if (entry) {
+      try {
+        entry.channel.close();
+      } catch {
+        /* already closed */
+      }
+      popoutChannelsRef.current.delete(key);
+    }
+    setPoppedOutKeys((prev) => {
+      if (!prev.has(key)) return prev;
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+  }, []);
+
+  // Reattach the dock's OWN leg for this session (no re-mint — reconnectNow()
+  // reuses the retained sid/browserToken, see use-terminal-session.ts) and
+  // drop the pop-out bookkeeping. This is what BOTH "Bring back to dock" and
+  // the popped window's close-signal do — the only difference is who
+  // triggered it (design §10b: "two paths, never a race").
+  const bringBackToDock = useCallback(
+    (key: string) => {
+      actionsMapRef.current.get(key)?.reconnectNow();
+      endPopOut(key);
+    },
+    [endPopOut],
+  );
+
+  const handlePopOut = useCallback(
+    (key: string) => {
+      const summary = summariesRef.current[key];
+      if (!summary?.sessionId || !summary.browserToken) return; // nothing minted yet — button shouldn't even be visible
+      const entry = sessionsRef.current.find((s) => s.key === key);
+      const label = deriveTabLabel({
+        taskTitle: entry?.taskTitle,
+        ideaSlug,
+        sessionId: summary.sessionId,
+      });
+      const identity = `${ideaTitle} · session ${summary.sessionId.slice(0, 8)}`;
+      const nonce = generatePopoutNonce();
+      // MUST be the direct, synchronous result of the click — no await before
+      // this line — or popup blockers treat it as an unsolicited pop-up (D7).
+      const win = window.open(
+        `/terminal/popout#${nonce}`,
+        `vibecodes-terminal-${nonce}`,
+        "width=760,height=560,noopener",
+      );
+      if (!win) {
+        toast.error("Couldn't open the terminal window", {
+          description: "Your browser blocked the pop-up. Allow pop-ups for vibecodes.co.uk and try again.",
+        });
+        return; // D7: no state change on failure — the tab stays attached and streaming.
+      }
+      posthogRef.current?.capture("terminal_popout_used", { origin: entry?.origin ?? "toolbar" });
+      setPoppedOutKeys((prev) => new Set(prev).add(key));
+
+      const payload: PopoutPayload = {
+        sid: summary.sessionId,
+        browserToken: summary.browserToken,
+        relayUrl: relayBaseUrl(),
+        ideaId,
+        ideaTitle,
+        label,
+        identity,
+        readOnly: summary.readOnly,
+      };
+      const channel = new BroadcastChannel(popoutChannelName(nonce));
+      popoutChannelsRef.current.set(key, { channel, handshake: INITIAL_DOCK_HANDSHAKE_STATE });
+      channel.onmessage = (ev) => {
+        const message = parsePopoutChannelMessage(ev.data);
+        if (!message) return;
+        const current = popoutChannelsRef.current.get(key);
+        if (!current) return; // already torn down (e.g. a racing bring-back)
+        const result = reduceDockHandshake(current.handshake, message);
+        popoutChannelsRef.current.set(key, { channel, handshake: result.state });
+        if (result.action === "send-payload") {
+          channel.postMessage({ type: "payload", payload });
+        } else if (result.action === "reattach") {
+          // The popped window told us it's closing (D3) — reattach automatically.
+          bringBackToDock(key);
+        }
+      };
+    },
+    [ideaId, ideaTitle, ideaSlug, bringBackToDock],
+  );
+
   // ── close / remove a tab ────────────────────────────────────────────────────
   const removeEntry = useCallback(
     (key: string) => {
+      endPopOut(key);
       setSessions((prev) => {
         const idx = prev.findIndex((s) => s.key === key);
         if (idx === -1) return prev;
@@ -231,13 +371,19 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
         return next;
       });
     },
-    [],
+    [endPopOut],
   );
 
   const requestClose = useCallback(
     (key: string) => {
       const status = summaries[key]?.status ?? "idle";
-      if (!isLiveTabStatus(status)) {
+      // A popped-out tab's OWN reported status is usually "error"/duplicate
+      // (the 4001 preemption) at this point, which `isLiveTabStatus` would
+      // read as "already over" — but the session is very much alive, just
+      // running in the popped window. × on this tab must still end the WHOLE
+      // session (both legs, wherever they are), never silently orphan it.
+      const live = poppedOutKeys.has(key) || isLiveTabStatus(status);
+      if (!live) {
         // Already ended/errored — nothing to end, just close the tab (OQ1).
         setConfirmingKey((c) => (c === key ? null : c));
         removeEntry(key);
@@ -252,7 +398,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       setConfirmingKey(null);
       removeEntry(key);
     },
-    [summaries, confirmingKey, removeEntry],
+    [summaries, confirmingKey, removeEntry, poppedOutKeys],
   );
 
   const cancelClose = useCallback(() => setConfirmingKey(null), []);
@@ -361,8 +507,16 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   const activeSummary = summaries[activeKey];
   const activeStatus: TerminalStatus = activeSummary?.status ?? "idle";
   const multi = sessions.length > 1;
+  const activeIsPoppedOut = poppedOutKeys.has(activeKey);
+  const soleIsPoppedOut = !multi && !!sessions[0] && poppedOutKeys.has(sessions[0].key);
 
-  const statusChips = multi ? summarizeSessionStatuses(sessions.map((s) => summaries[s.key]?.status ?? "idle")) : [];
+  // Substitute "popped-out" for any tab the dock knows it popped — its real
+  // status is usually mid-preemption at this exact moment and would
+  // otherwise misread as an error in the collapsed-bar summary (design §5).
+  const displayStatusFor = (key: string): TabDisplayStatus =>
+    poppedOutKeys.has(key) ? "popped-out" : (summaries[key]?.status ?? "idle");
+
+  const statusChips = multi ? summarizeSessionStatuses(sessions.map((s) => displayStatusFor(s.key))) : [];
   const singleView = activeSummary
     ? resolveDockView(activeSummary.status, activeSummary.launchPhase, activeSummary.platformSupported, activeSummary.paired)
     : "setup";
@@ -378,7 +532,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       {/* Collapsed dock bar — always visible */}
       <div className="flex items-center gap-2.5 px-3 py-1.5">
         <span className="inline-flex items-center gap-2 text-xs font-semibold">
-          {!multi && <Circle className={cn("h-2.5 w-2.5 fill-current", dotClass(activeStatus))} />}
+          {!multi && (
+            <Circle
+              className={cn("h-2.5 w-2.5 fill-current", activeIsPoppedOut ? "text-violet-400" : dotClass(activeStatus))}
+            />
+          )}
           <TerminalIcon className="h-3.5 w-3.5 text-zinc-400" />
           <span className="hidden sm:inline">{multi ? "Terminals" : "Terminal"}</span>
           {!multi && activeSummary?.sessionId && (
@@ -398,6 +556,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
                   chip.tone === "info" && "border-sky-500/50 bg-sky-500/10 text-sky-400",
                   chip.tone === "warn" && "border-amber-500/50 bg-amber-500/10 text-amber-400",
                   chip.tone === "err" && "border-rose-500/50 bg-rose-500/10 text-rose-400",
+                  chip.tone === "popped" && "border-violet-500/50 bg-violet-500/10 text-violet-300",
                   chip.tone === "mut" && "border-zinc-600 bg-zinc-800/60 text-zinc-400",
                 )}
               >
@@ -405,7 +564,12 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
                 {chip.label}
               </span>
             ))}
-          {!multi && (
+          {!multi && soleIsPoppedOut && (
+            <span className="inline-flex items-center gap-1.5 rounded-md border border-violet-500/50 bg-violet-500/10 px-2 py-0.5 text-[11px] font-semibold text-violet-300">
+              <span aria-hidden="true">⧉</span> Popped out
+            </span>
+          )}
+          {!multi && !soleIsPoppedOut && (
             <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-semibold", singleMeta.className)}>
               <singleMeta.Icon className={cn("h-3 w-3", singleMeta.spin && "animate-spin")} />
               {singleMeta.label}
@@ -459,7 +623,9 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
               {sessions.map((entry, index) => {
                 const summary = summaries[entry.key];
                 const status = summary?.status ?? "idle";
-                const meta = tabStatusMeta(status);
+                const poppedOut = poppedOutKeys.has(entry.key);
+                const meta = tabStatusMeta(displayStatusFor(entry.key));
+                const tabIsLive = poppedOut || isLiveTabStatus(status);
                 const label = deriveTabLabel({
                   taskTitle: entry.taskTitle,
                   ideaSlug,
@@ -521,7 +687,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
                         <span className="min-w-0 flex-1 truncate">{label}</span>
                         <button
                           type="button"
-                          aria-label={`${isLiveTabStatus(status) ? "End session and close tab" : "Close tab"}: ${label}`}
+                          aria-label={`${tabIsLive ? "End session and close tab" : "Close tab"}: ${label}`}
                           className="flex h-[18px] w-[18px] flex-none items-center justify-center rounded text-zinc-500 hover:bg-zinc-700 hover:text-zinc-200"
                           onClick={(e) => {
                             e.stopPropagation();
@@ -566,6 +732,9 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
             onRegisterActions={registerActions}
             onAnnounce={announce}
             onCapExceeded={openMySessions}
+            poppedOut={poppedOutKeys.has(entry.key)}
+            onPopOut={() => handlePopOut(entry.key)}
+            onBringBack={() => bringBackToDock(entry.key)}
           />
         ))}
       </div>
@@ -585,6 +754,8 @@ function toneStyle(tone: TabTone): { color: string } {
       return { color: "#fb7185" };
     case "info":
       return { color: "#7dd3fc" };
+    case "popped":
+      return { color: "#a78bfa" };
     case "mut":
     default:
       return { color: "#6f6f7a" };

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -52,7 +52,7 @@
 // zero new UI anywhere, including the tab strip and "+".
 
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
-import { ChevronUp, ChevronDown, Circle, Plus, Terminal as TerminalIcon, X } from "lucide-react";
+import { ChevronUp, ChevronDown, Circle, ListTree, Plus, Terminal as TerminalIcon, X } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -78,6 +78,7 @@ import {
   dockStatusMeta,
   type SessionSummary,
 } from "./terminal-session-view";
+import { TerminalMySessionsPanel } from "./terminal-my-sessions-panel";
 import type { TerminalSessionActions, TerminalSessionDescriptor } from "./use-terminal-session";
 
 interface TerminalDockProps {
@@ -140,6 +141,14 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // Single shared aria-live announcer for background-tab attention (a11y §14) —
   // one region so simultaneous background transitions never talk over each other.
   const [announcement, setAnnouncement] = useState("");
+  // Multi-session stage 3 (C3/C4): the global "My sessions" panel — one
+  // instance, opened from the collapsed bar's button (always visible,
+  // collapsed or expanded) OR by a cap refusal on ANY tab's mint (E1, design
+  // §7b). `mySessionsCount` mirrors the panel's own fetch so the trigger's
+  // badge stays in sync without a second independent poll.
+  const [mySessionsOpen, setMySessionsOpen] = useState(false);
+  const [mySessionsCount, setMySessionsCount] = useState<number | null>(null);
+  const openMySessions = useCallback(() => setMySessionsOpen(true), []);
   const actionsMapRef = useRef<Map<string, TerminalSessionActions>>(new Map());
   // Mirrors so `deliverLaunch` (used by both the launch-bus subscription and
   // "+") can read the CURRENT list/summaries without depending on them — that
@@ -403,6 +412,27 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
             </span>
           )}
         </span>
+        <TerminalMySessionsPanel
+          open={mySessionsOpen}
+          onOpenChange={setMySessionsOpen}
+          onCountChange={setMySessionsCount}
+        >
+          <Button
+            variant="ghost"
+            size="xs"
+            className="text-zinc-300 hover:text-zinc-100"
+            aria-label="My terminal sessions — every terminal running across your ideas"
+            aria-haspopup="dialog"
+          >
+            <ListTree className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">My sessions</span>
+            {!!mySessionsCount && (
+              <span className="rounded-full border border-zinc-600 bg-zinc-800 px-1.5 text-[10px] font-bold text-sky-300">
+                {mySessionsCount}
+              </span>
+            )}
+          </Button>
+        </TerminalMySessionsPanel>
         <Button
           variant="ghost"
           size="xs"
@@ -535,6 +565,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
             onReportSummary={reportSummary}
             onRegisterActions={registerActions}
             onAnnounce={announce}
+            onCapExceeded={openMySessions}
           />
         ))}
       </div>

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -16,17 +16,22 @@
 // we set a localStorage paired flag; a paired browser then auto-connects on open and
 // skips the setup wall. Non-Mac machines get a "coming soon" and never fire the link.
 //
-// The connection STATE MACHINE + close-code mapping + framing are pure and live in
-// src/lib/terminal/connection.ts; the OS/arch detection, the paired-flag gate, and
-// the first-run copy are pure and live in src/lib/terminal/{platform,paired-flag,
-// first-run-copy}.ts (all unit-tested). This component owns only the side effects
-// (fetch, socket, xterm, timers, the deep-link fire) and renders the visible states.
+// ARCHITECTURE (multi-session stage 1, docs/design-terminal-multi-session-popout.html):
+// everything ONE session needs — the connection state machine, the WebSocket browser
+// leg, xterm + resize/focus, the heartbeat watchdog, the grace-window reattach loop,
+// and the vibecodes:// deep-link fire — lives behind `useTerminalSession` (see
+// use-terminal-session.ts). This component owns the DOCK CHROME shared across
+// sessions (collapsed bar, expanded panel, `expanded` open/close) and the launch-bus
+// wiring, and renders the states that hook exposes. The connection STATE MACHINE +
+// close-code mapping + framing are pure and live in src/lib/terminal/connection.ts;
+// the OS/arch detection, the paired-flag gate, and the first-run copy are pure and
+// live in src/lib/terminal/{platform,paired-flag,first-run-copy}.ts (all
+// unit-tested).
 //
 // GATING: off by default. Renders nothing unless NEXT_PUBLIC_TERMINAL_ENABLED is
 // exactly "true" (checked here AND at the board page mount).
 
-import "@xterm/xterm/css/xterm.css";
-import { useCallback, useEffect, useReducer, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import {
   ChevronUp,
   ChevronDown,
@@ -49,95 +54,28 @@ import {
   Download,
   ChevronRight,
 } from "lucide-react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { logger } from "@/lib/logger";
-import type { Terminal as XTerm } from "@xterm/xterm";
-import type { FitAddon as XFitAddon } from "@xterm/addon-fit";
 import {
-  CONNECT_TIMEOUT_MS,
-  HEARTBEAT_INTERVAL_MS,
-  LINK_SILENT_CHECK_MS,
-  RECONNECT_GRACE_MS,
-  buildRelayUrl,
-  claimConnectGeneration,
-  decideResize,
-  isConnectSuperseded,
-  encodeHeartbeatFrame,
-  encodeResizeMessage,
-  initialConnectionState,
-  isHeartbeatAckFrame,
-  isInputEnabled,
-  isPeerDegradedFrame,
-  isPeerReattachedFrame,
   isTerminalEnabled,
-  mapCloseCode,
-  relayBaseUrl,
-  shouldDeclareLinkSilent,
-  terminalReducer,
   type TerminalConnectionState,
   type TerminalStatus,
 } from "@/lib/terminal/connection";
-import {
-  MAX_LAUNCH_URL_LENGTH,
-  buildLaunchDeepLink,
-  redactDeepLinkToken,
-} from "@/lib/terminal/deep-link";
-import { type BrowserLaunchPayload, subscribeBrowserLaunch } from "@/lib/terminal/launch-mode";
-import {
-  buildBoundedDeepLink,
-  buildCompactPromptEssentials,
-  resolveAppUrl,
-  resolveDefaultLaunchState,
-  resolveLaunchCwd,
-} from "@/lib/launch-claude-code";
-import {
-  type TerminalPlatform,
-  TERMINAL_HELPER_DOWNLOAD_URL,
-  readPlatformSignals,
-  resolveTerminalPlatform,
-} from "@/lib/terminal/platform";
-import {
-  isBrowserPaired,
-  markBrowserPaired,
-  resolveFirstRunEntry,
-} from "@/lib/terminal/paired-flag";
+import { subscribeBrowserLaunch } from "@/lib/terminal/launch-mode";
+import { type TerminalPlatform, TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
 import { FIRST_RUN_COPY } from "@/lib/terminal/first-run-copy";
-import {
-  type DockView,
-  type LaunchPhase,
-  nextLaunchPhaseOnTimeout,
-  resolveDockView,
-} from "@/lib/terminal/first-run-flow";
-
-// How long we wait for the helper to attach after firing the deep link before
-// dropping to the calm fallback (~8s, per the approved UX). This is the safety net
-// for criterion #8: a custom-scheme link with no handler can't be reliably detected,
-// so we always fall through here rather than spin forever.
-const HELPER_OPEN_TIMEOUT_MS = 8000;
+import { type DockView, resolveDockView } from "@/lib/terminal/first-run-flow";
+import { useTerminalSession, type PairInfo } from "./use-terminal-session";
 
 interface TerminalDockProps {
   ideaId: string;
   ideaTitle: string;
   /**
-   * The idea's GitHub URL (or null). Needed so dock-initiated launches — paired
+   * The idea's GitHub URL (or null). Needed so hook-initiated launches — paired
    * auto-connect and Retry, which never pass through the launch button — can
-   * build the SAME board-level compact bootstrap prompt the button would
-   * (shared resolveDefaultLaunchState + buildCompactPromptEssentials).
+   * build the SAME board-level compact bootstrap prompt the button would.
    */
   ideaGithubUrl: string | null;
-}
-
-interface PairInfo {
-  sessionId: string;
-  bridgeToken: string;
-  // Retained so a TRANSIENT drop can REATTACH to the SAME sid with no re-mint
-  // (grace-window reconnect). `browserToken` re-opens the browser leg. Reattach is
-  // bounded purely by RECONNECT_GRACE_MS — the relay waives token expiry for a
-  // same-owner reattach to a live session (fix/terminal-expired-reattach), so no
-  // client-side expiry gate exists here.
-  browserToken: string;
 }
 
 interface StatusMeta {
@@ -194,849 +132,34 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // Defence-in-depth: also gated at the page mount. When off, render nothing —
   // no dock, no entry point, board unchanged.
   const enabled = isTerminalEnabled();
-
-  const [state, dispatch] = useReducer(terminalReducer, initialConnectionState);
   const [expanded, setExpanded] = useState(false);
-  const [readOnly, setReadOnly] = useState(false);
-  const [pair, setPair] = useState<PairInfo | null>(null);
-  const [xtermReady, setXtermReady] = useState(false);
-  // Same-machine auto-launch UI (the vibecodes:// deep-link path). "idle" = the
-  // manual cross-machine flow (copy a command); "opening" = we fired a deep link and
-  // are waiting on the local helper; "helper-timeout" = the calm ~8s fallback.
-  const [launchPhase, setLaunchPhase] = useState<LaunchPhase>("idle");
-  // Install-first gate inputs. Initialised SSR-safe (server → unsupported/unpaired)
-  // then corrected on mount; the dock body is only visible after an explicit open,
-  // which always re-reads these first.
-  const [platform, setPlatform] = useState<TerminalPlatform>(() =>
-    resolveTerminalPlatform(readPlatformSignals()),
+
+  // Dock CHROME: shared by every session (only one today; stage 2 adds a tab strip
+  // over the same expanded/collapsed panel). The hook calls this at the same points
+  // the old single-session component called `setExpanded(true)` directly.
+  const requestExpand = useCallback(() => setExpanded(true), []);
+
+  const session = useTerminalSession(
+    { ideaId, ideaTitle, ideaGithubUrl },
+    { enabled, expanded, requestExpand },
   );
-  const [paired, setPaired] = useState<boolean>(() => isBrowserPaired());
-  // Grace-window degrade hint: the relay told us our peer (the bridge) dropped and
-  // it's HOLDING the session. The terminal stays visible; we show a subtle
-  // "reconnecting" hint until peer-reattached (or the window expires).
-  const [peerDegraded, setPeerDegraded] = useState(false);
-
-  const wsRef = useRef<WebSocket | null>(null);
-  const termRef = useRef<XTerm | null>(null);
-  const fitRef = useRef<XFitAddon | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const connectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const helperTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const launchIframeRef = useRef<HTMLIFrameElement | null>(null);
-  const lastDimsRef = useRef<string>("");
-  // Single-flight guard: every connect() bumps this and captures its value. If a
-  // newer connect() starts while an older one is still awaiting its session mint,
-  // the older one aborts before minting a 2nd session / firing a 2nd deep link —
-  // otherwise two sessions + two bridges race and the relay tears both down
-  // (single-attach / peer-gone). This is the fix for the "connect fires twice" bug.
-  const connectGenRef = useRef(0);
-  // Grace-window reconnect bookkeeping. `reconnectDeadlineRef.current === 0` means
-  // "healthy, not reconnecting"; it's set on the first transient drop and cleared
-  // once a byte proves the link healthy again. The pair (sid + retained tokens) is
-  // mirrored into a ref so the timer-driven reconnect loop reads current creds
-  // without re-binding. `scheduleReconnectRef` breaks the openBrowserLeg ⇄
-  // scheduleReconnect cycle. `degradeTimerRef` bounds the peer-degraded wait.
-  const reconnectDeadlineRef = useRef(0);
-  const reconnectAttemptRef = useRef(0);
-  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const degradeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pairRef = useRef<PairInfo | null>(null);
-  const scheduleReconnectRef = useRef<() => void>(() => {});
-  // Silent-link watchdog bookkeeping (fix/terminal-dock-heartbeat).
-  // `lastInboundAtRef` is stamped on EVERY inbound frame (PTY bytes, control
-  // frames, hb-acks); `hbArmedRef` is a PER-SOCKET latch set on the socket's first
-  // hb-ack — an old relay never acks, so the watchdog stays disarmed there and the
-  // pre-watchdog behaviour is unchanged (version-skew gate). Both are reset in
-  // openBrowserLeg when a fresh socket is opened.
-  const lastInboundAtRef = useRef(0);
-  const hbArmedRef = useRef(false);
-  // The compact bootstrap prompt ESSENTIALS (BUG5 follow-through, 4th rework
-  // cycle) the LAST launch-bus event carried — i.e. what the launch button
-  // resolved. Dock-initiated launches with no bus payload (paired auto-connect
-  // on open, Retry) fall back to building the board-level essentials themselves
-  // via the same shared builder (see resolveLaunchPromptParts), so every launch
-  // is primed.
-  const promptPartsRef = useRef<BrowserLaunchPayload | null>(null);
-
-  // Mirror live state into refs so the stable xterm onData handler + socket handlers
-  // read current values without re-binding on every render.
-  const statusRef = useRef(state.status);
-  const readOnlyRef = useRef(readOnly);
-  const pairedRef = useRef(paired);
-  statusRef.current = state.status;
-  readOnlyRef.current = readOnly;
-  pairedRef.current = paired;
-  pairRef.current = pair;
-
-  // Previous connection status, updated ONLY by the first-connect focus effect
-  // below (fix/terminal-dock-launch-defects) — so it reflects status "as of the
-  // last time that effect ran" rather than every render, letting it tell a
-  // genuine first connect (prev connecting/waiting-to-pair) apart from a
-  // grace-window reattach (prev disconnected), which must NOT steal focus.
-  const prevStatusRef = useRef<TerminalStatus>(state.status);
-
-  // ── lazy, client-only xterm init ────────────────────────────────────────────
-  useEffect(() => {
-    if (!enabled) return;
-    let disposed = false;
-    let term: XTerm | null = null;
-
-    (async () => {
-      const [{ Terminal }, { FitAddon }] = await Promise.all([
-        import("@xterm/xterm"),
-        import("@xterm/addon-fit"),
-      ]);
-      if (disposed || !containerRef.current) return;
-
-      term = new Terminal({
-        convertEol: false,
-        cursorBlink: true,
-        fontFamily: 'ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace',
-        fontSize: 12.5,
-        theme: { background: "#0c0c0e", foreground: "#cfd8df", cursor: "#cfd8df" },
-        scrollback: 5000,
-      });
-      const fit = new FitAddon();
-      term.loadAddon(fit);
-      term.open(containerRef.current);
-      try {
-        fit.fit();
-      } catch {
-        /* container may be 0-size while collapsed — refit on expand */
-      }
-
-      // Keystrokes → relay (binary). Guarded by the pure input-enabled predicate so
-      // read-only / non-connected states never reach the PTY.
-      term.onData((data) => {
-        if (statusRef.current !== "connected" || readOnlyRef.current) return;
-        const ws = wsRef.current;
-        if (ws && ws.readyState === WebSocket.OPEN) {
-          ws.send(new TextEncoder().encode(data));
-        }
-      });
-
-      termRef.current = term;
-      fitRef.current = fit;
-      setXtermReady(true);
-    })().catch((err) => {
-      logger.error("Terminal xterm init failed", { error: err instanceof Error ? err.message : String(err) });
-    });
-
-    return () => {
-      disposed = true;
-      term?.dispose();
-      termRef.current = null;
-      fitRef.current = null;
-    };
-  }, [enabled]);
-
-  // Correct the install-first gate inputs on mount (navigator is only reliable
-  // client-side; the SSR defaults above assume unsupported/unpaired).
-  useEffect(() => {
-    if (!enabled) return;
-    setPlatform(resolveTerminalPlatform(readPlatformSignals()));
-    setPaired(isBrowserPaired());
-  }, [enabled]);
-
-  // Fit + emit a resize control frame (TEXT) matching the bridge's framing.
-  //
-  // Deferred via decideResize (fix/terminal-dock-launch-defects,
-  // fix/terminal-dock-cold-launch-resize): a resize can only REACH the PTY once the
-  // socket is OPEN *and* the bridge/peer is attached (status "connected") — the
-  // relay drops browser→bridge frames with no buffering while unpaired, so socket
-  // OPEN alone is not sufficient (see the `ResizeDecision` doc comment in
-  // connection.ts). On a cold autolaunch the browser's wss handshake beats the
-  // helper→bridge attach by hundreds of ms to seconds, so the ResizeObserver /
-  // expand-rAF below fire while the socket is OPEN but still unpaired — sending
-  // then would be silently dropped by the relay. A "defer" leaves lastDimsRef
-  // untouched, so the SAME key resolves to a "send" once the connected-transition
-  // effect re-fires this (below).
-  const sendResize = useCallback(() => {
-    const term = termRef.current;
-    const fit = fitRef.current;
-    if (!term || !fit) return;
-    try {
-      fit.fit();
-    } catch {
-      return;
-    }
-    const msg = encodeResizeMessage(term.cols, term.rows);
-    if (!msg) return;
-    const key = `${term.cols}x${term.rows}`;
-    const ws = wsRef.current;
-    const isReachable = ws?.readyState === WebSocket.OPEN && statusRef.current === "connected";
-    const decision = decideResize(key, lastDimsRef.current, isReachable);
-    if (decision.action !== "send") return;
-    lastDimsRef.current = decision.nextLastKey;
-    ws?.send(msg);
-  }, []);
-
-  // Refit on container resize and whenever the dock expands.
-  useEffect(() => {
-    if (!xtermReady || !containerRef.current) return;
-    const ro = new ResizeObserver(() => sendResize());
-    ro.observe(containerRef.current);
-    return () => ro.disconnect();
-  }, [xtermReady, sendResize]);
-
-  useEffect(() => {
-    if (expanded) {
-      // Next paint, once the body has non-zero size.
-      const id = window.requestAnimationFrame(() => sendResize());
-      return () => window.cancelAnimationFrame(id);
-    }
-  }, [expanded, sendResize]);
-
-  // Resend on the transition to "connected" (fix/terminal-dock-cold-launch-resize).
-  // The bridge/peer only becomes reachable the moment status flips to "connected"
-  // (first inbound PTY byte), so any resize computed BEFORE that point — the
-  // ResizeObserver / expand-rAF above fire well before this on a cold autolaunch —
-  // was deferred with its key un-advanced. Re-running sendResize() here is exactly
-  // the retry that resolves that deferred key to a real "send" now that it can
-  // reach the PTY. Fires on every transition INTO "connected", so it also covers a
-  // grace-window reattach; when dims are unchanged that's just a "skip" (harmless).
-  useEffect(() => {
-    if (state.status === "connected") sendResize();
-  }, [state.status, sendResize]);
-
-  // ── launch focus (fix/terminal-dock-launch-defects, Defect 2) ──────────────
-  // Nothing previously called termRef.current.focus() — a freshly connected
-  // terminal never had keyboard focus, so the first keystroke was silently lost
-  // (isInputEnabled gates on state.status === "connected", but the DOM node never
-  // had focus for the browser to route the keystroke to).
-  //
-  // First-connect focus: fires only on a genuine "we just reached the bridge for
-  // the first time" transition (prior status connecting/waiting-to-pair), never on
-  // a grace-window reattach (prior status disconnected) — a user typing mid-drop
-  // must not have their cursor/scroll position hijacked by an automatic reattach.
-  useEffect(() => {
-    const prev = prevStatusRef.current;
-    if (
-      state.status === "connected" &&
-      (prev === "connecting" || prev === "waiting-to-pair") &&
-      expanded
-    ) {
-      termRef.current?.focus();
-    }
-    prevStatusRef.current = state.status;
-  }, [state.status, expanded]);
-
-  // Expand focus: a user-initiated expand of an already-live session (e.g.
-  // collapse then re-expand while connected) should also land focus in the
-  // terminal. Keyed ONLY on `expanded` (not state.status) so a background status
-  // change — e.g. a reattach completing while the dock is already expanded —
-  // never re-triggers this and steals focus; it reads the current status from
-  // closure at the moment `expanded` itself transitions.
-  useEffect(() => {
-    if (!expanded || state.status !== "connected") return;
-    // Next paint, mirroring the expand-rAF resize above — the container must be
-    // un-hidden before focus() can land.
-    const id = window.requestAnimationFrame(() => termRef.current?.focus());
-    return () => window.cancelAnimationFrame(id);
-    // Deliberately excludes state.status: see comment above (must only re-run on
-    // `expanded` transitions, not on every status change, or a background
-    // reattach while already expanded would steal focus).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [expanded]);
-
-  const clearConnectTimer = useCallback(() => {
-    if (connectTimerRef.current) {
-      clearTimeout(connectTimerRef.current);
-      connectTimerRef.current = null;
-    }
-  }, []);
-
-  const clearHelperTimer = useCallback(() => {
-    if (helperTimerRef.current) {
-      clearTimeout(helperTimerRef.current);
-      helperTimerRef.current = null;
-    }
-  }, []);
-
-  const clearReconnectTimer = useCallback(() => {
-    if (reconnectTimerRef.current) {
-      clearTimeout(reconnectTimerRef.current);
-      reconnectTimerRef.current = null;
-    }
-  }, []);
-
-  const clearDegradeTimer = useCallback(() => {
-    if (degradeTimerRef.current) {
-      clearTimeout(degradeTimerRef.current);
-      degradeTimerRef.current = null;
-    }
-  }, []);
-
-  // Remove the hidden probe iframe used to fire the deep link (see fireLaunchDeepLink).
-  const removeLaunchIframe = useCallback(() => {
-    const frame = launchIframeRef.current;
-    launchIframeRef.current = null;
-    if (frame && frame.parentNode) frame.parentNode.removeChild(frame);
-  }, []);
-
-  // The compact bootstrap prompt ESSENTIALS + cwd for THIS launch: the payload
-  // the launch button put on the bus (its exact resolved state — task- or
-  // board-level) or, for dock-initiated launches (paired auto-connect / Retry),
-  // the board-level essentials built here from the SAME shared state resolver +
-  // builder the button uses — so the in-browser prompt is byte-identical to the
-  // terminal-window deep link's for the same state, and never duplicated. BUG5
-  // follow-through (4th rework cycle): built as ESSENTIALS (buildCompactPromptEssentials),
-  // not the unconditional buildCompactBootstrapPromptParts this used to call —
-  // that builder bakes the worktree-isolation protocol into a never-trimmed
-  // head, so fireLaunchDeepLink's own budget clamp had no clean way to drop it
-  // on overflow. The fallback's cwd uses the same shared rule (resolveLaunchCwd);
-  // the dock has no recordedProjectPaths, so it passes no effective cwd — a
-  // pinned existing-mode folder still resolves (rule 1), while the
-  // recorded-path injection only flows through the button payload, exactly as
-  // the terminal-window default path would behave.
-  const resolveLaunchPromptParts = useCallback((): BrowserLaunchPayload => {
-    const carried = promptPartsRef.current;
-    if (carried) return carried;
-    const state = resolveDefaultLaunchState(ideaId, ideaTitle, ideaGithubUrl);
-    const essentials = buildCompactPromptEssentials({
-      appUrl: resolveAppUrl(),
-      ideaId,
-      ideaTitle,
-      mode: state.mode,
-      repoUrl: ideaGithubUrl,
-      newProject: state.mode === "new" ? { newProjectPath: state.path } : undefined,
-      // Parity with the launch button: a pinned existing folder emits the same
-      // verify-folder step. The dock has no recorded DB paths, so this only fires
-      // for a user-pinned localStorage path (resolveDefaultLaunchState → existing).
-      existingPath:
-        state.mode === "existing" && state.path.trim() ? state.path.trim() : undefined,
-    });
-    return { essentials, cwd: resolveLaunchCwd(state, undefined) };
-  }, [ideaId, ideaTitle, ideaGithubUrl]);
-
-  // Fire the signed vibecodes:// deep link so a same-machine helper attaches as the
-  // bridge leg with no copied command. The bridge token is a secret — it travels in
-  // the link but is NEVER logged (only the redacted form is). The link also carries
-  // the compact bootstrap prompt as an INERT string: the helper/bridge hold it and
-  // only pass it to a spawned claude AFTER the relay accepts the owner-bound token
-  // (R1); an old helper simply ignores the unknown param (graceful cold launch).
-  //
-  // BEST-EFFORT dialog mitigation (criterion #8): we fire via a hidden, detached
-  // iframe rather than a top-level window.location.assign. A top-level navigation to
-  // an unhandled custom scheme is the surest way to trigger macOS's "no application
-  // set / Search App Store" dialog; routing it through a probe iframe suppresses that
-  // dialog in most Chromium builds. It is NOT a cross-browser guarantee (Safari /
-  // Firefox may still surface a milder prompt) — the ~8s timeout below is the real
-  // safety net, and the authoritative success signal is the first byte from the
-  // bridge (ws.onmessage), which proves the helper actually opened AND attached.
-  const fireLaunchDeepLink = useCallback(
-    (sessionId: string, bridgeToken: string) => {
-      let link: string;
-      let urlChars = 0;
-      let hasCwd = false;
-      let droppedCwd = false;
-      try {
-        const { essentials, cwd } = resolveLaunchPromptParts();
-        hasCwd = !!cwd;
-        // Budget the prompt against the vibecodes:// URL ceiling via
-        // buildBoundedDeepLink (FIX A, QA BUG A) — the SAME shared helper the
-        // claude-cli:// deep link uses. BUG5 follow-through (4th rework
-        // cycle): it routes through fitCompactWorktreeProtocol so the
-        // worktree-isolation protocol rides the head only when it fits whole
-        // (never a half-truncated fragment, essentials always prioritised
-        // over the best-effort protocol). New this cycle: it ALSO guarantees
-        // the fired URL is never over-cap when `cwd` ITSELF (not just the
-        // prompt) is long enough to blow the cap alone — the vibecodes://
-        // `prompt=` param key is only present once the prompt is non-empty,
-        // so `promptKeyOverhead` reserves room for it up front (mirrors the
-        // manual `- "&prompt=".length` this replaces).
-        const result = buildBoundedDeepLink({
-          essentials,
-          cwd,
-          cap: MAX_LAUNCH_URL_LENGTH,
-          promptKeyOverhead: "&prompt=".length,
-          buildLink: ({ prompt, cwd: linkCwd }) =>
-            buildLaunchDeepLink({
-              relay: relayBaseUrl(),
-              session: sessionId,
-              token: bridgeToken,
-              cwd: linkCwd,
-              prompt,
-            }),
-        });
-        if (!result.ok) {
-          logger.error("Terminal deep-link build failed", {
-            reason: "path_too_long",
-          });
-          toast.error("Project path too long to launch — open the folder manually and run Claude Code there");
-          setLaunchPhase("helper-timeout");
-          return;
-        }
-        link = result.url;
-        droppedCwd = result.droppedCwd;
-        urlChars = link.length;
-      } catch (err) {
-        logger.error("Terminal deep-link build failed", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-        setLaunchPhase("helper-timeout");
-        return;
-      }
-      // redactDeepLinkToken elides BOTH the token (secret) and the prompt (user
-      // content); the cwd (a local filesystem path) is stripped here too — only
-      // its PRESENCE and the prompt's length are logged.
-      logger.info("Terminal firing launch deep link", {
-        sessionId,
-        url: redactDeepLinkToken(link).replace(/([?&]cwd=)[^&]*/g, "$1***"),
-        urlChars,
-        hasCwd,
-        droppedCwd,
-      });
-      setLaunchPhase("opening");
-
-      removeLaunchIframe();
-      try {
-        const frame = document.createElement("iframe");
-        frame.setAttribute("aria-hidden", "true");
-        frame.style.display = "none";
-        frame.src = link;
-        document.body.appendChild(frame);
-        launchIframeRef.current = frame;
-      } catch {
-        // Iframe path unavailable — fall back to a direct assign.
-        try {
-          window.location.assign(link);
-        } catch {
-          setLaunchPhase("helper-timeout");
-          return;
-        }
-      }
-
-      // If the helper doesn't stream within ~8s, drop to the calm fallback (never an
-      // infinite spinner — criterion #8).
-      clearHelperTimer();
-      helperTimerRef.current = setTimeout(() => {
-        removeLaunchIframe();
-        setLaunchPhase(nextLaunchPhaseOnTimeout);
-      }, HELPER_OPEN_TIMEOUT_MS);
-    },
-    [clearHelperTimer, removeLaunchIframe, resolveLaunchPromptParts],
-  );
-
-  const teardownSocket = useCallback(() => {
-    clearConnectTimer();
-    // Cancel any in-flight grace-window reconnect loop / degrade wait, and reset the
-    // reconnect budget. Nulling the socket's handlers below means a teardown-initiated
-    // close never re-triggers the reconnect loop (only genuine drops do).
-    clearReconnectTimer();
-    clearDegradeTimer();
-    reconnectDeadlineRef.current = 0;
-    reconnectAttemptRef.current = 0;
-    setPeerDegraded(false);
-    const ws = wsRef.current;
-    wsRef.current = null;
-    if (ws) {
-      ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
-      try {
-        ws.close();
-      } catch {
-        /* already closing */
-      }
-    }
-  }, [clearConnectTimer, clearReconnectTimer, clearDegradeTimer]);
-
-  // Open (or RE-open) the BROWSER leg to the relay and wire its handlers. Shared by
-  // connect() (fresh session) and the grace-window reconnect loop (same sid, retained
-  // token — NO re-mint). `reconnect` skips the hard 30s connect-timeout→error: while
-  // reconnecting the grace-window scheduler bounds the retries instead.
-  const openBrowserLeg = useCallback(
-    (sessionId: string, browserToken: string, opts?: { reconnect?: boolean }) => {
-      const reconnect = opts?.reconnect ?? false;
-      const url = buildRelayUrl(relayBaseUrl(), sessionId, browserToken);
-      let ws: WebSocket;
-      try {
-        ws = new WebSocket(url);
-      } catch (err) {
-        logger.error("Terminal relay socket open failed", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-        dispatch({ type: "closed", code: 1006 });
-        return;
-      }
-      ws.binaryType = "arraybuffer";
-      wsRef.current = ws;
-      // Fresh socket → fresh watchdog: disarm until ITS first hb-ack and restart
-      // the silence clock (an inherited stale stamp must never condemn a new leg).
-      hbArmedRef.current = false;
-      lastInboundAtRef.current = Date.now();
-
-      if (!reconnect) {
-        connectTimerRef.current = setTimeout(() => {
-          dispatch({ type: "connect-timeout" });
-          teardownSocket();
-        }, CONNECT_TIMEOUT_MS);
-      }
-
-      ws.onopen = () => {
-        clearConnectTimer();
-        dispatch({ type: "relay-open" });
-        // No sendResize() retry here (fix/terminal-dock-cold-launch-resize): OPEN
-        // means the socket reached the relay, but the bridge/peer may not be
-        // attached yet, so decideResize would just "defer" again — a wasted call.
-        // The connected-transition effect (see sendResize's call sites) is the one
-        // retry that matters: it fires once reachability is actually true.
-      };
-      ws.onmessage = (ev) => {
-        // ANY inbound frame proves the link carried something just now — feed the
-        // silent-link watchdog before any classification.
-        lastInboundAtRef.current = Date.now();
-        // TEXT = relay control frame on the BROWSER leg. The grace-window notices
-        // arrive here (the R1 `attached` frame goes to the bridge leg only).
-        if (typeof ev.data === "string") {
-          if (isHeartbeatAckFrame(ev.data)) {
-            // The relay's liveness echo — arm the watchdog for THIS socket. Never
-            // written to the xterm and never logged as content.
-            hbArmedRef.current = true;
-            return;
-          }
-          if (isPeerDegradedFrame(ev.data)) {
-            // Our peer (the bridge) dropped; the relay is HOLDING the session. Keep
-            // the terminal, show a subtle hint, and bound the wait to the grace window.
-            setPeerDegraded(true);
-            if (!degradeTimerRef.current) {
-              degradeTimerRef.current = setTimeout(() => {
-                degradeTimerRef.current = null;
-                setPeerDegraded(false);
-                dispatch({ type: "reconnect-exhausted" });
-                try {
-                  wsRef.current?.close(1000, "reconnect-grace-expired");
-                } catch {
-                  /* already closing */
-                }
-              }, RECONNECT_GRACE_MS);
-            }
-          } else if (isPeerReattachedFrame(ev.data)) {
-            // The pair is whole again inside the window — resume. Proves the pipe is
-            // restored even before the next byte, so drop back to connected + reset
-            // the reconnect budget (a scenario-1 already-connected leg no-ops).
-            clearDegradeTimer();
-            setPeerDegraded(false);
-            reconnectDeadlineRef.current = 0;
-            reconnectAttemptRef.current = 0;
-            dispatch({ type: "data" });
-          }
-          return;
-        }
-        // BINARY = opaque PTY bytes → the bridge is streaming; the link is HEALTHY.
-        // Clear the launch nudges, mark paired on first success, and reset every
-        // reconnect/degrade timer + budget so a later drop starts a fresh window.
-        clearHelperTimer();
-        removeLaunchIframe();
-        setLaunchPhase("idle");
-        clearDegradeTimer();
-        setPeerDegraded(false);
-        reconnectDeadlineRef.current = 0;
-        reconnectAttemptRef.current = 0;
-        if (!pairedRef.current) {
-          markBrowserPaired();
-          setPaired(true);
-        }
-        dispatch({ type: "data" });
-        termRef.current?.write(new Uint8Array(ev.data as ArrayBuffer));
-      };
-      ws.onerror = () => {
-        logger.warn("Terminal relay socket error", { sessionId });
-      };
-      ws.onclose = (ev) => {
-        clearConnectTimer();
-        wsRef.current = null;
-        dispatch({ type: "closed", code: ev.code, reason: ev.reason });
-        // Grace-window reconnect: a transient drop AFTER a live stream (PEER_GONE /
-        // abnormal 1006) is recoverable → keep reattaching within the window. Any
-        // terminal / clean-end code maps to a non-disconnected state and stops here.
-        // A teardown-initiated close nulled these handlers, so it never reaches this.
-        const mapped = mapCloseCode(ev.code, ev.reason, statusRef.current);
-        if (mapped.status === "disconnected") scheduleReconnectRef.current();
-      };
-    },
-    [teardownSocket, clearConnectTimer, clearHelperTimer, removeLaunchIframe, clearDegradeTimer],
-  );
-
-  // Drive the grace-window reconnect loop: reattach to the SAME sid with the retained
-  // browser token, with jittered exponential backoff, bounded purely by the grace
-  // window (the relay waives token expiry for a same-owner reattach to a live
-  // session, so an AGED session reconnects too — fix/terminal-expired-reattach).
-  // When the window is spent with no reattach, end honestly (reconnect-exhausted →
-  // the calm "session ended, start a new one" overlay). No re-mint, no deep link —
-  // a bounded, silent reattach.
-  const scheduleReconnect = useCallback(() => {
-    clearDegradeTimer();
-    const p = pairRef.current;
-    const now = Date.now();
-    if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
-    if (!p || now >= reconnectDeadlineRef.current) {
-      reconnectDeadlineRef.current = 0;
-      reconnectAttemptRef.current = 0;
-      dispatch({ type: "reconnect-exhausted" });
-      return;
-    }
-    const attempt = reconnectAttemptRef.current++;
-    const delay = Math.min(1000 * 2 ** attempt, 8000) + Math.floor(Math.random() * 250);
-    clearReconnectTimer();
-    reconnectTimerRef.current = setTimeout(() => {
-      const pp = pairRef.current;
-      if (!pp || Date.now() >= reconnectDeadlineRef.current) {
-        reconnectDeadlineRef.current = 0;
-        reconnectAttemptRef.current = 0;
-        dispatch({ type: "reconnect-exhausted" });
-        return;
-      }
-      openBrowserLeg(pp.sessionId, pp.browserToken, { reconnect: true });
-    }, delay);
-  }, [openBrowserLeg, clearReconnectTimer, clearDegradeTimer]);
-  scheduleReconnectRef.current = scheduleReconnect;
-
-  // ── silent-link watchdog (fix/terminal-dock-heartbeat) ─────────────────────
-  // The watchdog verdict landed: the socket still LOOKS open but nothing inbound
-  // (PTY bytes or hb-acks) arrived for the whole silence threshold — a silent link
-  // death (wifi off / network switch; macOS never RSTs, so no close event ever
-  // fires). Tear down the ZOMBIE socket exactly like teardownSocket's socket step
-  // — null the handlers FIRST so its eventual close can't double-drive the state —
-  // then route into the EXISTING reattach machinery: disconnected + the
-  // grace-window reconnect loop (same sid, retained token, no re-mint).
-  const declareLinkSilent = useCallback(() => {
-    const ws = wsRef.current;
-    wsRef.current = null;
-    if (ws) {
-      ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
-      try {
-        ws.close();
-      } catch {
-        /* already closing */
-      }
-    }
-    clearDegradeTimer();
-    setPeerDegraded(false);
-    dispatch({ type: "link-silent" });
-    scheduleReconnectRef.current();
-  }, [clearDegradeTimer]);
-
-  // While CONNECTED: probe the relay with the app-level heartbeat every
-  // HEARTBEAT_INTERVAL_MS and run the silence check every LINK_SILENT_CHECK_MS.
-  // The check computes WALL-CLOCK elapsed (a hidden tab's clamped timers can only
-  // delay a tick, never fake recency) and re-runs immediately when the tab becomes
-  // visible or the browser flips online/offline — the moments a silent death is
-  // most likely to be discovered.
-  useEffect(() => {
-    if (!enabled || state.status !== "connected") return;
-
-    const sendHeartbeat = () => {
-      const ws = wsRef.current;
-      if (ws && ws.readyState === WebSocket.OPEN) ws.send(encodeHeartbeatFrame());
-    };
-    const check = () => {
-      if (statusRef.current !== "connected") return;
-      if (shouldDeclareLinkSilent(lastInboundAtRef.current, Date.now(), hbArmedRef.current)) {
-        logger.warn("Terminal link silent — declaring dead, reattaching", {
-          silentMs: Date.now() - lastInboundAtRef.current,
-        });
-        declareLinkSilent();
-      }
-    };
-    const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") check();
-    };
-
-    // Probe immediately so the watchdog ARMS on the first ack instead of waiting a
-    // whole interval (matters when a drop happens right after connecting).
-    sendHeartbeat();
-    const sendTimer = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS);
-    const checkTimer = setInterval(check, LINK_SILENT_CHECK_MS);
-    document.addEventListener("visibilitychange", onVisibilityChange);
-    window.addEventListener("online", check);
-    window.addEventListener("offline", check);
-    return () => {
-      clearInterval(sendTimer);
-      clearInterval(checkTimer);
-      document.removeEventListener("visibilitychange", onVisibilityChange);
-      window.removeEventListener("online", check);
-      window.removeEventListener("offline", check);
-    };
-  }, [enabled, state.status, declareLinkSilent]);
-
-  // ── connect (browser leg) ───────────────────────────────────────────────────
-  // `autoLaunch` = the same-machine path: after minting, fire the vibecodes:// deep
-  // link so the local helper attaches automatically (no copied command). Without it
-  // (manual reconnect), we stay in the cross-machine "copy a command" flow. Callers
-  // must gate autoLaunch behind the install-first flow (setup Connect / paired
-  // auto-connect / Retry) — never on a bare dock open for an unpaired browser.
-  const connect = useCallback(async (options?: { autoLaunch?: boolean }) => {
-    // Claim this attempt's generation. A later connect() bumps it, which makes this
-    // one abort at the post-mint checkpoint below instead of racing a 2nd session.
-    const gen = (connectGenRef.current = claimConnectGeneration(connectGenRef.current));
-    const autoLaunch = options?.autoLaunch ?? false;
-    teardownSocket();
-    clearHelperTimer();
-    removeLaunchIframe();
-    setLaunchPhase(autoLaunch ? "opening" : "idle");
-    setExpanded(true);
-    lastDimsRef.current = "";
-    dispatch({ type: "connect" });
-
-    let data: { sessionId: string; browserToken: string; bridgeToken: string; expiresAt: number };
-    try {
-      const res = await fetch("/api/terminal/session", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ideaId }),
-      });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(body?.error || `Session request failed (${res.status})`);
-      }
-      data = await res.json();
-    } catch (err) {
-      // Superseded while minting → let the newer attempt own the outcome.
-      if (isConnectSuperseded(gen, connectGenRef.current)) return;
-      logger.error("Terminal session mint failed (client)", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      dispatch({ type: "session-mint-failed" });
-      toast.error("Couldn't start a terminal session", {
-        description: err instanceof Error ? err.message : undefined,
-      });
-      return;
-    }
-
-    // A newer connect() started while we awaited the mint → abort BEFORE firing a
-    // second deep link or opening a second socket. The newer attempt already ran
-    // teardownSocket() + dispatch(connect); doing anything here would orphan a
-    // bridge and trip the relay's single-attach. This is the double-connect fix.
-    if (isConnectSuperseded(gen, connectGenRef.current)) return;
-
-    dispatch({ type: "session-created", sessionId: data.sessionId });
-    // Retain the browser token too, so a transient drop can REATTACH to this same
-    // sid with no re-mint (grace-window reconnect).
-    setPair({
-      sessionId: data.sessionId,
-      bridgeToken: data.bridgeToken,
-      browserToken: data.browserToken,
-    });
-    // A fresh mint starts a fresh reconnect budget.
-    reconnectDeadlineRef.current = 0;
-    reconnectAttemptRef.current = 0;
-    termRef.current?.clear();
-
-    // Same-machine: hand the bridge token to the local helper via the deep link.
-    if (autoLaunch) fireLaunchDeepLink(data.sessionId, data.bridgeToken);
-
-    openBrowserLeg(data.sessionId, data.browserToken);
-  }, [ideaId, teardownSocket, clearHelperTimer, removeLaunchIframe, fireLaunchDeepLink, openBrowserLeg]);
-
-  // Manual "Reconnect now" — force an immediate reattach attempt (skip the backoff
-  // wait) using the retained token, or fall back to a clean fresh launch if the
-  // grace window is spent. Fixes the old button, which minted an EMPTY session with
-  // no autoLaunch and timed out after 30s.
-  const reconnectNow = useCallback(() => {
-    const p = pairRef.current;
-    const now = Date.now();
-    const withinWindow =
-      reconnectDeadlineRef.current === 0 || now < reconnectDeadlineRef.current;
-    if (p && withinWindow) {
-      clearReconnectTimer();
-      if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
-      openBrowserLeg(p.sessionId, p.browserToken, { reconnect: true });
-    } else {
-      void connect({ autoLaunch: true });
-    }
-  }, [openBrowserLeg, clearReconnectTimer, connect]);
-
-  // Install-first entry gate. This is the ONE place a browser "open" is turned into
-  // either a setup panel, a coming-soon panel, or an auto-connect — the deep link is
-  // never fired for an unpaired browser here (criterion #2).
-  const beginBrowserLaunch = useCallback(() => {
-    setExpanded(true);
-    const fresh = resolveTerminalPlatform(readPlatformSignals());
-    setPlatform(fresh);
-    const nowPaired = isBrowserPaired();
-    setPaired(nowPaired);
-    const entry = resolveFirstRunEntry({ supported: fresh.supported, paired: nowPaired });
-    if (entry === "connecting") {
-      // Paired browser deliberately reopening its session → auto-connect (fires the
-      // deep link). "setup" / "coming-soon" just show the overlay; no link fires.
-      void connect({ autoLaunch: true });
-    }
-  }, [connect]);
-
-  const endSession = useCallback(() => {
-    dispatch({ type: "user-end" });
-    clearHelperTimer();
-    removeLaunchIframe();
-    setLaunchPhase("idle");
-    const ws = wsRef.current;
-    if (ws) {
-      try {
-        ws.close(1000, "user-end");
-      } catch {
-        /* already closing */
-      }
-    }
-    teardownSocket();
-  }, [teardownSocket, clearHelperTimer, removeLaunchIframe]);
-
-  // Clean up the socket + helper timer + probe iframe if the dock unmounts mid-flow.
-  useEffect(() => () => teardownSocket(), [teardownSocket]);
-  useEffect(() => () => clearHelperTimer(), [clearHelperTimer]);
-  useEffect(() => () => removeLaunchIframe(), [removeLaunchIframe]);
+  const { state, launchPhase, peerDegraded, pair, readOnly, inputEnabled, platform, paired, containerRef, actions } = session;
 
   // The "In the browser" menu item (board toolbar) fires the launch bus; pick it up
-  // here and run the install-first gate. Keeping the mint in ONE place (the dock)
-  // means the session — and its bridge token — is never created twice. The payload
-  // (the button's resolved compact prompt, as head/tail parts) is remembered so
-  // this launch AND a later Retry carry the exact prompt the user launched with;
-  // a payload-less event falls back to the dock-built board-level prompt.
+  // here and forward it to the session. Board-level wiring — in stage 2 this is
+  // where a NEW tab (and its own hook instance) would be created instead.
+  const { launchFromBus } = actions;
   useEffect(() => {
     if (!enabled) return;
     return subscribeBrowserLaunch((payload) => {
-      promptPartsRef.current = payload ?? null;
-      beginBrowserLaunch();
+      launchFromBus(payload ?? null);
     });
-  }, [enabled, beginBrowserLaunch]);
-
-  // The carried payload is scoped to ONE launch intent: it survives Retry (same
-  // intent, fresh session/token) but is dropped once the session ENDS (user End
-  // or a relay idle/max close), so a stale task prompt can never ride a later
-  // paired auto-connect — that launch rebuilds the board-level default instead.
-  useEffect(() => {
-    if (state.status === "session-ended") promptPartsRef.current = null;
-  }, [state.status]);
-
-  // Auto-connect a paired browser whenever the body becomes visible while idle — so
-  // a returning user who simply expands the dock also skips the setup wall
-  // (criterion #6). Unpaired / unsupported browsers never satisfy this guard, so no
-  // deep link fires for them.
-  useEffect(() => {
-    if (!enabled) return;
-    if (
-      expanded &&
-      state.status === "idle" &&
-      platform.supported &&
-      paired &&
-      launchPhase === "idle"
-    ) {
-      void connect({ autoLaunch: true });
-    }
-  }, [enabled, expanded, state.status, platform.supported, paired, launchPhase, connect]);
-
-  const copyBridgeCommand = useCallback(() => {
-    if (!pair) return;
-    const cmd = `RELAY_URL=${relayBaseUrl()} SESSION_ID=${pair.sessionId} BRIDGE_TOKEN=${pair.bridgeToken} node terminal/bridge/src/index.js --cmd bash`;
-    navigator.clipboard
-      .writeText(cmd)
-      .then(() => toast.success("Bridge command copied"))
-      .catch(() => toast.error("Couldn't copy the command"));
-  }, [pair]);
+  }, [enabled, launchFromBus]);
 
   if (!enabled) return null;
 
   const view = resolveDockView(state.status, launchPhase, platform.supported, paired);
   const meta = dockStatusMeta(view, state);
-  const inputEnabled = isInputEnabled(state, readOnly);
   const showStream = state.status === "connected" || state.status === "disconnected";
   const canLaunch =
     state.status === "idle" ||
@@ -1107,7 +230,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
                 variant="outline"
                 size="xs"
                 className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
-                onClick={() => setReadOnly((r) => !r)}
+                onClick={() => actions.setReadOnly((r) => !r)}
                 aria-pressed={readOnly}
                 aria-label={readOnly ? "Read-only is on — click to allow input" : "Switch to read-only"}
               >
@@ -1120,7 +243,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
                 variant="outline"
                 size="xs"
                 className="border-rose-500/45 bg-transparent text-rose-400 hover:bg-rose-500/10"
-                onClick={endSession}
+                onClick={actions.end}
                 aria-label="End session"
               >
                 <Power className="h-3 w-3" /> End
@@ -1152,10 +275,10 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
               pair={pair}
               platform={platform}
               canLaunch={canLaunch}
-              onConnect={() => void connect({ autoLaunch: true })}
-              onRetry={() => void connect({ autoLaunch: true })}
-              onLaunchAgain={beginBrowserLaunch}
-              onCopyBridge={copyBridgeCommand}
+              onConnect={() => void actions.connect({ autoLaunch: true })}
+              onRetry={() => void actions.connect({ autoLaunch: true })}
+              onLaunchAgain={actions.beginBrowserLaunch}
+              onCopyBridge={actions.copyBridgeCommand}
             />
           )}
           {/* Our OWN link dropped — we're actively REATTACHING to the same session
@@ -1167,7 +290,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
             <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
               <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
               <b>Reconnecting to your session…</b> Your machine may have slept or dropped Wi-Fi. Your agent keeps running locally while we reattach.
-              <button className="ml-2 underline hover:text-amber-200" onClick={reconnectNow}>
+              <button className="ml-2 underline hover:text-amber-200" onClick={actions.reconnectNow}>
                 Reconnect now
               </button>
             </div>
@@ -1193,7 +316,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
             <div className="border-t border-zinc-800 bg-violet-500/5 px-3 py-2 text-[11px] text-zinc-400">
               <Lock className="mr-1 inline h-3 w-3 text-violet-300" />
               <b className="text-violet-300">Read-only is on.</b> You&apos;re watching live; keystrokes are frozen.
-              <button className="ml-2 underline hover:text-zinc-200" onClick={() => setReadOnly(false)}>
+              <button className="ml-2 underline hover:text-zinc-200" onClick={() => actions.setReadOnly(false)}>
                 Allow input
               </button>
             </div>

--- a/src/components/board/terminal-my-sessions-panel.tsx
+++ b/src/components/board/terminal-my-sessions-panel.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+// In-app terminal — the global "My sessions" panel (multi-session stage 3,
+// design §9). A popover (not a modal — it must never block the board) opened
+// from the dock's "My sessions" button. Lists EVERY active session across ALL
+// of the user's ideas, newest first, each with an End button (no confirm —
+// design §9a: "per-session End uses no confirm, single/visible/reversible").
+// The footer's "End all sessions" is the panic button and DOES confirm
+// inline (binding note) before calling the same end route with `{ all: true }`.
+//
+// Fetch-on-open + refresh-after-action (no realtime, per the stage brief).
+
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { usePostHog } from "posthog-js/react";
+import { Loader2, Power, Terminal as TerminalIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { slugifyIdeaTitle } from "@/lib/launch-claude-code";
+import { formatSessionAge, formatSessionIdentity } from "@/lib/terminal/session-registry";
+import { deriveTabLabel } from "./terminal-tabs";
+
+interface ListedSession {
+  sid: string;
+  ideaId: string;
+  ideaTitle: string | null;
+  taskId: string | null;
+  taskTitle: string | null;
+  machineLabel: string | null;
+  cwd: string | null;
+  createdAt: string;
+}
+
+type LoadState = "idle" | "loading" | "ready" | "error";
+
+interface TerminalMySessionsPanelProps {
+  /** Fires whenever the panel's session count is known/changes, so the dock's badge stays in sync. */
+  onCountChange?: (count: number) => void;
+  /** Imperative open control — the cap-refusal toast's action opens this panel (design §7b). */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}
+
+export function TerminalMySessionsPanel({
+  onCountChange,
+  open,
+  onOpenChange,
+  children,
+}: TerminalMySessionsPanelProps) {
+  const [loadState, setLoadState] = useState<LoadState>("idle");
+  const [sessions, setSessions] = useState<ListedSession[]>([]);
+  const [endingSid, setEndingSid] = useState<string | null>(null);
+  const [confirmingEndAll, setConfirmingEndAll] = useState(false);
+  const [endingAll, setEndingAll] = useState(false);
+  const posthog = usePostHog();
+
+  const load = useCallback(async () => {
+    setLoadState((s) => (s === "idle" ? "loading" : s));
+    try {
+      const res = await fetch("/api/terminal/session/list");
+      if (!res.ok) throw new Error(`Failed to load sessions (${res.status})`);
+      const body = (await res.json()) as { sessions: ListedSession[] };
+      setSessions(body.sessions);
+      onCountChange?.(body.sessions.length);
+      setLoadState("ready");
+    } catch {
+      setLoadState("error");
+    }
+  }, [onCountChange]);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [open, load]);
+
+  const endOne = useCallback(
+    async (sid: string) => {
+      setEndingSid(sid);
+      try {
+        await fetch("/api/terminal/session/end", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sid }),
+        });
+      } catch {
+        toast.error("Couldn't end that session — try again.");
+      } finally {
+        setEndingSid(null);
+        void load();
+      }
+    },
+    [load],
+  );
+
+  const endAll = useCallback(async () => {
+    setEndingAll(true);
+    posthog?.capture("terminal_end_all_used", { count: sessions.length });
+    try {
+      await fetch("/api/terminal/session/end", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ all: true }),
+      });
+    } catch {
+      toast.error("Couldn't end all sessions — try again.");
+    } finally {
+      setEndingAll(false);
+      setConfirmingEndAll(false);
+      void load();
+    }
+  }, [load, posthog, sessions.length]);
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent align="end" className="w-96 p-0" aria-label="My terminal sessions">
+        <div className="flex items-center gap-2 border-b border-zinc-800 px-3.5 py-2.5 text-[13px] font-bold text-zinc-200">
+          My sessions
+          <span className="ml-auto text-[11.5px] font-normal text-zinc-500">runs on your machines</span>
+        </div>
+
+        {loadState === "loading" && (
+          <div className="flex items-center justify-center gap-2 px-4 py-8 text-[12.5px] text-zinc-500">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading…
+          </div>
+        )}
+
+        {loadState === "error" && (
+          <div className="flex flex-col items-center gap-2 px-4 py-6 text-center text-[12.5px] text-zinc-400">
+            Couldn&apos;t load your sessions.
+            <Button variant="outline" size="xs" onClick={() => void load()}>
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {loadState === "ready" && sessions.length === 0 && (
+          <div className="flex flex-col items-center gap-1 px-4 py-8 text-center">
+            <TerminalIcon className="h-5 w-5 text-zinc-600" />
+            <p className="text-[13px] font-semibold text-zinc-300">No terminals running.</p>
+            <p className="max-w-[240px] text-[12px] text-zinc-500">
+              Launch one from an idea board — Launch Claude Code → In the browser.
+            </p>
+          </div>
+        )}
+
+        {loadState === "ready" && sessions.length > 0 && (
+          <ul className="max-h-80 overflow-y-auto">
+            {sessions.map((s) => {
+              const ideaSlug = slugifyIdeaTitle(s.ideaTitle ?? "");
+              const label = deriveTabLabel({
+                taskTitle: s.taskTitle,
+                ideaSlug,
+                sessionId: s.sid,
+              });
+              const identity = formatSessionIdentity({
+                machineLabel: s.machineLabel,
+                cwd: s.cwd,
+                sid: s.sid,
+              });
+              const ending = endingSid === s.sid;
+              return (
+                <li key={s.sid} className="flex items-center gap-2.5 border-t border-zinc-800 px-3.5 py-2.5 first:border-t-0">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5 truncate text-[13px] font-semibold text-zinc-100">
+                      <span className="truncate">{label}</span>
+                      {s.ideaTitle && (
+                        <span className="flex-none truncate text-[11.5px] font-normal text-zinc-500">
+                          {s.ideaTitle}
+                        </span>
+                      )}
+                    </div>
+                    <div className="truncate font-mono text-[11px] text-zinc-500">{identity}</div>
+                  </div>
+                  <span className="flex-none text-[11.5px] text-zinc-500">{formatSessionAge(s.createdAt)}</span>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    className="flex-none border-rose-500/45 bg-transparent text-rose-400 hover:bg-rose-500/10"
+                    disabled={ending}
+                    onClick={() => void endOne(s.sid)}
+                    aria-label={`End session: ${label}`}
+                  >
+                    {ending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Power className="h-3 w-3" />} End
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {loadState === "ready" && sessions.length > 0 && (
+          <div
+            className={cn(
+              "flex items-center gap-2.5 border-t border-zinc-800 px-3.5 py-2.5",
+              confirmingEndAll && "border-l-2 border-l-rose-500 bg-rose-500/5",
+            )}
+          >
+            {confirmingEndAll ? (
+              <>
+                <div className="min-w-0 flex-1">
+                  <div className="text-[12.5px] font-bold text-rose-400">End all {sessions.length} sessions?</div>
+                  <div className="text-[11px] text-zinc-500">
+                    Claude stops on your machine in every one. Unpushed worktree changes stay on disk.
+                  </div>
+                </div>
+                <Button variant="ghost" size="xs" onClick={() => setConfirmingEndAll(false)} disabled={endingAll}>
+                  Cancel
+                </Button>
+                <Button
+                  size="xs"
+                  className="flex-none bg-rose-500 text-rose-950 hover:bg-rose-400"
+                  onClick={() => void endAll()}
+                  disabled={endingAll}
+                >
+                  {endingAll ? <Loader2 className="h-3 w-3 animate-spin" /> : <Power className="h-3 w-3" />} End all
+                </Button>
+              </>
+            ) : (
+              <>
+                <span className="text-[11.5px] text-zinc-500">{sessions.length} sessions</span>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  className="ml-auto flex-none border-rose-500/45 bg-transparent text-rose-400 hover:bg-rose-500/10"
+                  onClick={() => setConfirmingEndAll(true)}
+                >
+                  <Power className="h-3 w-3" /> End all sessions
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/board/terminal-popout-view.tsx
+++ b/src/components/board/terminal-popout-view.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+// In-app terminal — the POPPED-OUT window's own session chrome (multi-session
+// stage 4, docs/design-terminal-multi-session-popout.html §10a, D1-D7).
+//
+// Deliberately its OWN small component rather than a reuse of
+// terminal-session-view.tsx: that component's contract is tab-strip-shaped
+// (a `SessionEntry`, an `onReportSummary`/`onRegisterActions` pair the dock
+// consumes, a `poppedOut` placeholder branch it renders INSTEAD of a body) —
+// none of that applies inside the popped window itself, which has no tabs, no
+// dock, and exactly one thing to show: "status · identity · read-only · End"
+// (the binding note's P1 header quartet) plus the stream. Reusing the dock's
+// component here would mean threading a pile of no-op callbacks through it for
+// a context it was never shaped for; a small dedicated view is the more honest
+// fit. `dockStatusMeta` / `resolveDockView` (pure, already exported) ARE
+// reused, so the pill language matches the dock everywhere.
+//
+// This view ATTACHES to an already-minted session (via `useTerminalSession`'s
+// `attachExisting` option) — it never mints, never fires a deep link, never
+// runs the install-first gate. See use-terminal-session.ts's `attachExisting`
+// doc for why that's safe (same-owner reattach, relay's existing 4001 path).
+
+import { useEffect, useState } from "react";
+import { CircleAlert, Info, Loader2, Lock, LockOpen, Power, Square, Undo2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { resolveDockView, type DockView } from "@/lib/terminal/first-run-flow";
+import type { TerminalConnectionState } from "@/lib/terminal/connection";
+import { isPreemptedClose, type PopoutPayload } from "@/lib/terminal/popout-channel";
+import { dockStatusMeta } from "./terminal-session-view";
+import {
+  useTerminalSession,
+  type AttachExistingPair,
+  type TerminalSessionDescriptor,
+} from "./use-terminal-session";
+
+interface TerminalPopoutViewProps {
+  payload: PopoutPayload;
+}
+
+export function TerminalPopoutView({ payload }: TerminalPopoutViewProps) {
+  const descriptor: TerminalSessionDescriptor = {
+    ideaId: payload.ideaId,
+    ideaTitle: payload.ideaTitle,
+    // No launch prompt is ever built in this window (attachExisting skips
+    // the whole launch path), so the GitHub URL that path would need is
+    // simply never read here.
+    ideaGithubUrl: null,
+  };
+  const attach: AttachExistingPair = { sessionId: payload.sid, browserToken: payload.browserToken };
+
+  const session = useTerminalSession(descriptor, {
+    enabled: true,
+    // The popped window has no collapse/expand concept — it's always "open".
+    expanded: true,
+    requestExpand: () => {},
+    // Critical: without this, the pristine/paired auto-connect effect would
+    // see "expanded, idle, paired" on THIS window too and mint a SECOND,
+    // orphaned session the instant it mounts. attachExisting is this
+    // window's only entry point.
+    autoConnectWhenExpanded: false,
+    attachExisting: attach,
+  });
+  const { state, readOnly, inputEnabled, launchPhase, platform, paired, containerRef, actions } = session;
+
+  // Apply the read-only toggle state the dock tab was in at the moment of
+  // pop-out (D1's payload) — once, on mount. `actions.setReadOnly` is the
+  // hook's own `useState` setter, so it's referentially stable; this is safe
+  // to run exactly once despite the empty dependency array.
+  useEffect(() => {
+    actions.setReadOnly(payload.readOnly);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    document.title = `Terminal · ${payload.label}`;
+  }, [payload.label]);
+
+  const [noticeDismissed, setNoticeDismissed] = useState(false);
+  const view = resolveDockView(state.status, launchPhase, platform.supported, paired);
+  const meta = dockStatusMeta(view, state.errorKind);
+  const showStream = state.status === "connected" || state.status === "disconnected";
+  const showEnd =
+    view === "connected" || view === "disconnected" || view === "connecting" || view === "connecting-returning";
+
+  // The binding note's special case: THIS window's own leg was preempted
+  // (4001) — within this feature that has exactly one cause, "Bring back to
+  // dock" (explicit or via this window's own close-signal racing it). Show a
+  // calm hand-off message, never the generic "duplicate session" error copy.
+  const broughtBack = state.status === "error" && isPreemptedClose(state.closeCode);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 bg-[#141417] px-3 py-2">
+        <span
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold",
+            meta.className,
+          )}
+        >
+          <meta.Icon className={cn("h-3 w-3", meta.spin && "animate-spin")} />
+          {meta.label}
+        </span>
+        {readOnly && state.status === "connected" && (
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-violet-500/55 bg-violet-500/10 px-2 py-1 text-[11px] font-bold text-violet-300">
+            <Lock className="h-3 w-3" /> Read-only
+          </span>
+        )}
+        <span className="font-mono text-xs text-zinc-500">{payload.identity}</span>
+        <span className="ml-auto inline-flex items-center gap-1.5">
+          {showStream && (
+            <Button
+              variant="outline"
+              size="xs"
+              className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+              onClick={() => actions.setReadOnly((r) => !r)}
+              aria-pressed={readOnly}
+              aria-label={readOnly ? "Read-only is on — click to allow input" : "Switch to read-only"}
+            >
+              {readOnly ? <Lock className="h-3 w-3" /> : <LockOpen className="h-3 w-3" />}
+              {readOnly ? "Read-only · on" : "Read-only"}
+            </Button>
+          )}
+          {showEnd && (
+            <Button
+              variant="outline"
+              size="xs"
+              className="border-rose-500/45 bg-transparent text-rose-400 hover:bg-rose-500/10"
+              onClick={actions.end}
+              aria-label="End session"
+            >
+              <Power className="h-3 w-3" /> End
+            </Button>
+          )}
+        </span>
+      </div>
+
+      {/* One-time MVP scrollback honesty (D5, AC 17): dismissible, never
+          reappears once closed. Disappears entirely once a future
+          serialize-addon transfer ships real scrollback (design §10a). */}
+      {showStream && !noticeDismissed && (
+        <div
+          role="status"
+          className="flex items-center gap-2 border-b border-sky-500/25 bg-sky-500/[0.07] px-3 py-1.5 text-[11.5px] text-sky-300"
+        >
+          <Info className="h-3.5 w-3.5 flex-none" />
+          Showing output from pop-out onward.
+          <button
+            type="button"
+            className="ml-auto flex-none text-sky-400/70 hover:text-sky-200"
+            aria-label="Dismiss notice"
+            onClick={() => setNoticeDismissed(true)}
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      <div className="relative min-h-0 flex-1">
+        <div
+          ref={containerRef}
+          className={cn("h-full w-full px-3 py-2", state.status === "disconnected" && "opacity-45")}
+        />
+        {broughtBack ? (
+          <BroughtBackOverlay />
+        ) : (
+          !showStream && <PopoutOverlay view={view} state={state} onRetry={actions.reconnectNow} />
+        )}
+        {state.status === "disconnected" && !broughtBack && (
+          <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
+            <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
+            <b>Reconnecting to your session…</b> Your machine may have slept or dropped Wi-Fi. Your agent keeps
+            running locally while we reattach.
+            <button className="ml-2 underline hover:text-amber-200" onClick={actions.reconnectNow}>
+              Reconnect now
+            </button>
+          </div>
+        )}
+      </div>
+
+      {state.status === "connected" &&
+        (inputEnabled ? (
+          <div className="flex items-center gap-2 border-t border-zinc-800 bg-[#141417] px-3 py-2 text-xs text-zinc-500">
+            <span className="font-mono text-emerald-400">›</span>
+            <span>Click the terminal and type to steer the agent. Enter sends.</span>
+          </div>
+        ) : (
+          <div className="border-t border-zinc-800 bg-violet-500/5 px-3 py-2 text-[11px] text-zinc-400">
+            <Lock className="mr-1 inline h-3 w-3 text-violet-300" />
+            <b className="text-violet-300">Read-only is on.</b> You&apos;re watching live; keystrokes are frozen.
+            <button className="ml-2 underline hover:text-zinc-200" onClick={() => actions.setReadOnly(false)}>
+              Allow input
+            </button>
+          </div>
+        ))}
+    </div>
+  );
+}
+
+// The calm "the dock took this back" state (binding note) — replaces the
+// generic P1 "duplicate session" error copy for exactly this one cause.
+function BroughtBackOverlay() {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-[#0c0c0e]/95 px-6 py-6 text-center">
+      <Undo2 className="h-7 w-7 text-sky-400" />
+      <div className="text-base font-semibold text-sky-400">Brought back to the dock</div>
+      <p className="max-w-md text-[13px] text-zinc-400">
+        This session moved back to its board tab — you can close this window.
+      </p>
+      <Button
+        variant="outline"
+        className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+        onClick={() => window.close()}
+      >
+        Close window
+      </Button>
+    </div>
+  );
+}
+
+// Every OTHER overlay this window can realistically hit — attach-in-progress,
+// an honest error, or the session having ended entirely. Deliberately not a
+// reuse of terminal-session-view.tsx's install-first StateOverlay: none of
+// its setup/coming-soon/timeout branches are reachable from attachExisting
+// (no mint, no deep link ever fires here), so a small tailored overlay is
+// clearer than importing states that can't occur.
+function PopoutOverlay({
+  view,
+  state,
+  onRetry,
+}: {
+  view: DockView;
+  state: TerminalConnectionState;
+  onRetry: () => void;
+}) {
+  if (view === "session-ended") {
+    return (
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-[#0c0c0e]/95 px-6 py-6 text-center">
+        <Square className="h-7 w-7 text-zinc-400" />
+        <div className="text-base font-semibold text-zinc-300">Session ended</div>
+        <p className="max-w-md text-[13px] text-zinc-400">
+          Claude Code on your machine stopped. The scrollback above is kept — you can close this window, or check
+          the board for what happened.
+        </p>
+      </div>
+    );
+  }
+
+  if (view === "error") {
+    return (
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-[#0c0c0e]/95 px-6 py-6 text-center">
+        <CircleAlert className="h-7 w-7 text-rose-400" />
+        <div className="text-base font-semibold text-rose-400">Couldn&apos;t reattach</div>
+        <p className="max-w-md text-[13px] text-zinc-400">
+          {state.errorKind === "owner-mismatch"
+            ? "For safety, a session only attaches for the account that owns it."
+            : "We couldn't reconnect this window to your session. Your work on your machine is safe."}
+        </p>
+        {state.errorKind !== "owner-mismatch" && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+            onClick={onRetry}
+          >
+            Try again
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  // connecting / connecting-returning / legacy-waiting / timeout-* / idle —
+  // all read as "still attaching" from this window's point of view (it's
+  // reattaching to a session that was already live a moment ago in another
+  // window, so this is normally near-instant).
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-[#0c0c0e]/95 px-6 py-6 text-center">
+      <Loader2 className="h-7 w-7 animate-spin text-amber-400" />
+      <div className="text-base font-semibold text-amber-400">Reattaching…</div>
+      <p className="max-w-md text-[13px] text-zinc-400">Connecting this window to your session.</p>
+    </div>
+  );
+}

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -105,6 +105,8 @@ interface TerminalSessionViewProps {
   onReportSummary: (key: string, summary: SessionSummary) => void;
   onRegisterActions: (key: string, actions: TerminalSessionActions | null) => void;
   onAnnounce: (text: string) => void;
+  /** Opens the dock's "My sessions" panel on a cap refusal (E1, design §7b). */
+  onCapExceeded?: () => void;
 }
 
 export function TerminalSessionView({
@@ -118,12 +120,16 @@ export function TerminalSessionView({
   onReportSummary,
   onRegisterActions,
   onAnnounce,
+  onCapExceeded,
 }: TerminalSessionViewProps) {
   const session = useTerminalSession(descriptor, {
     enabled: true,
     expanded,
     requestExpand: onRequestExpand,
     autoConnectWhenExpanded,
+    taskId: entry.taskId,
+    taskTitle: entry.taskTitle,
+    onCapExceeded,
   });
   const { state, launchPhase, peerDegraded, pair, readOnly, inputEnabled, platform, paired, containerRef, actions } =
     session;

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -1,0 +1,646 @@
+"use client";
+
+// In-app terminal — ONE TAB's session chrome (multi-session stage 2).
+//
+// Mounts exactly one `useTerminalSession` instance and renders the P1 session
+// panel (status pill, identity line, read-only/End controls, terminal viewport,
+// reconnect/peer-degraded banners, input row) UNCHANGED from the single-session
+// dock — this file is that markup, relocated so `terminal-dock.tsx` can mount
+// ONE of these PER TAB (`SessionEntry`, see terminal-tabs.ts) instead of one for
+// the whole board.
+//
+// Mount/visibility strategy (B2/B4): the dock renders EVERY entry's
+// `TerminalSessionView` on EVERY render, always — never conditionally, never
+// keyed out — so every tab's socket, xterm buffer, heartbeat watchdog and
+// grace-window reconnect loop keep running while it's in the background. Only
+// the ACTIVE tab's panel is visually shown; a background tab's panel gets
+// Tailwind's `hidden` (display:none) via the `isActive` prop — CSS, never an
+// unmount. `useTerminalSession`'s own effects don't care whether their
+// container is visible (the pre-existing "container may be 0-size while
+// collapsed" degradation already covers this — see that hook's xterm-init
+// effect) — becoming active again just re-triggers its resize-on-expand /
+// focus-on-expand effects (see the `expanded` prop below), exactly like
+// re-opening the P1 dock did.
+//
+// This view does NOT own the tab strip, the collapsed bar, or launch-bus
+// routing — those are board-wide (one dock, many tabs) and live in
+// terminal-dock.tsx. It reports enough about its own session upward
+// (`onReportSummary`) for the dock to build the tab glyph, the collapsed-bar
+// worst-first summary, and the B10 dedupe check without lifting this session's
+// full state out of the component that actually owns it.
+
+import { useEffect, useRef, type ReactNode } from "react";
+import {
+  CircleDot,
+  Loader2,
+  WifiOff,
+  Square,
+  CircleAlert,
+  Power,
+  Lock,
+  LockOpen,
+  Copy,
+  Clock,
+  Info,
+  Laptop,
+  Terminal as TerminalIcon,
+  RotateCw,
+  Download,
+  ChevronRight,
+  Circle,
+  CircleDashed,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { TerminalConnectionState, TerminalStatus } from "@/lib/terminal/connection";
+import { type TerminalPlatform, TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
+import { FIRST_RUN_COPY } from "@/lib/terminal/first-run-copy";
+import { type DockView, type LaunchPhase, resolveDockView } from "@/lib/terminal/first-run-flow";
+import {
+  formatAttentionAnnouncement,
+  shouldAnnounceAttention,
+  type SessionEntry,
+} from "./terminal-tabs";
+import {
+  useTerminalSession,
+  type PairInfo,
+  type TerminalSessionActions,
+  type TerminalSessionDescriptor,
+} from "./use-terminal-session";
+
+/**
+ * Everything the dock needs about ONE tab's session without lifting the whole
+ * hook result out of the component that owns it. `launchPhase` /
+ * `platformSupported` / `paired` exist ONLY so the collapsed bar can rebuild
+ * the exact single-session pill `resolveDockView` + `dockStatusMeta` produced
+ * pre-multi-session (B5: "single session keeps P1's existing copy") — with 2+
+ * tabs the dock uses `summarizeSessionStatuses` over `status` instead and never
+ * touches these three.
+ */
+export interface SessionSummary {
+  status: TerminalStatus;
+  sessionId: string | null;
+  errorKind: TerminalConnectionState["errorKind"];
+  launchPhase: LaunchPhase;
+  platformSupported: boolean;
+  paired: boolean;
+}
+
+interface TerminalSessionViewProps {
+  entry: SessionEntry;
+  descriptor: TerminalSessionDescriptor;
+  /** This tab's label, for the a11y announcer ("Terminal "<label>": reconnecting"). */
+  label: string;
+  isActive: boolean;
+  /** Is the dock panel open AND is this the active tab? See use-terminal-session's doc. */
+  expanded: boolean;
+  onRequestExpand: () => void;
+  /**
+   * Only the pristine (never-launched) entry auto-connects when a paired
+   * browser opens the panel — every explicitly-launched tab delivers its own
+   * launch below instead (see the module doc on `UseTerminalSessionOptions`
+   * in use-terminal-session.ts for why both firing together would double-mint).
+   */
+  autoConnectWhenExpanded: boolean;
+  onReportSummary: (key: string, summary: SessionSummary) => void;
+  onRegisterActions: (key: string, actions: TerminalSessionActions | null) => void;
+  onAnnounce: (text: string) => void;
+}
+
+export function TerminalSessionView({
+  entry,
+  descriptor,
+  label,
+  isActive,
+  expanded,
+  onRequestExpand,
+  autoConnectWhenExpanded,
+  onReportSummary,
+  onRegisterActions,
+  onAnnounce,
+}: TerminalSessionViewProps) {
+  const session = useTerminalSession(descriptor, {
+    enabled: true,
+    expanded,
+    requestExpand: onRequestExpand,
+    autoConnectWhenExpanded,
+  });
+  const { state, launchPhase, peerDegraded, pair, readOnly, inputEnabled, platform, paired, containerRef, actions } =
+    session;
+
+  // Deliver this entry's launch exactly once per `launchSeq` bump (B7/B10): a
+  // real bus payload goes through `launchFromBus` (carries the resolved
+  // task/board prompt); a payload-less launch (the "+" affordance, or the
+  // pristine slot's very first bus delivery with nothing carried) runs the same
+  // install-first gate the hook's own Connect button and paired auto-connect
+  // use, via `beginBrowserLaunch`.
+  const deliveredSeqRef = useRef(0);
+  useEffect(() => {
+    if (entry.launchSeq === 0) return;
+    if (deliveredSeqRef.current === entry.launchSeq) return;
+    deliveredSeqRef.current = entry.launchSeq;
+    if (entry.launchPayload) actions.launchFromBus(entry.launchPayload);
+    else actions.beginBrowserLaunch();
+    // launchFromBus/beginBrowserLaunch are useCallback-stable across renders
+    // (their own deps are just the descriptor + internal refs), so depending on
+    // them directly — not on `actions` itself, which is a fresh object every
+    // render — keeps this effect from re-running on unrelated renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entry.launchSeq, entry.launchPayload, actions.launchFromBus, actions.beginBrowserLaunch]);
+
+  // Report this tab's status/sessionId upward on every change (tab glyph,
+  // collapsed-bar summary, B10 dedupe candidates) and — only for a BACKGROUND
+  // tab entering a needs-attention state — fire the single shared aria-live
+  // announcement (a11y, design §14).
+  const prevStatusRef = useRef<TerminalStatus | undefined>(undefined);
+  useEffect(() => {
+    onReportSummary(entry.key, {
+      status: state.status,
+      sessionId: pair?.sessionId ?? null,
+      errorKind: state.errorKind,
+      launchPhase,
+      platformSupported: platform.supported,
+      paired,
+    });
+    if (shouldAnnounceAttention(prevStatusRef.current, state.status, isActive)) {
+      onAnnounce(formatAttentionAnnouncement(label, state.status));
+    }
+    prevStatusRef.current = state.status;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    entry.key,
+    state.status,
+    state.errorKind,
+    pair?.sessionId,
+    launchPhase,
+    platform.supported,
+    paired,
+    isActive,
+    label,
+  ]);
+
+  // Keep the dock's action registry current so a tab strip close (×) — which
+  // lives in the PARENT, not here — can call this session's own `end()`
+  // without lifting the whole hook result out of this component.
+  useEffect(() => {
+    onRegisterActions(entry.key, actions);
+  });
+  useEffect(() => () => onRegisterActions(entry.key, null), [entry.key, onRegisterActions]);
+
+  const view = resolveDockView(state.status, launchPhase, platform.supported, paired);
+  const meta = dockStatusMeta(view, state.errorKind);
+  const showStream = state.status === "connected" || state.status === "disconnected";
+  const canLaunch =
+    state.status === "idle" ||
+    state.status === "error" ||
+    state.status === "session-ended" ||
+    state.status === "disconnected";
+  const showEnd =
+    view === "connected" ||
+    view === "disconnected" ||
+    view === "connecting" ||
+    view === "connecting-returning" ||
+    view === "legacy-waiting";
+
+  return (
+    <div className={cn(!isActive && "hidden")} aria-hidden={!isActive}>
+      {/* Header: state · identity · controls (safest → most destructive) */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 bg-[#141417] px-3 py-2">
+        <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold", meta.className)}>
+          <meta.Icon className={cn("h-3 w-3", meta.spin && "animate-spin")} />
+          {meta.label}
+        </span>
+        {readOnly && state.status === "connected" && (
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-violet-500/55 bg-violet-500/10 px-2 py-1 text-[11px] font-bold text-violet-300">
+            <Lock className="h-3 w-3" /> Read-only
+          </span>
+        )}
+        <span className="hidden font-mono text-xs text-zinc-500 sm:inline">
+          {descriptor.ideaTitle}
+          {pair && <span className="text-zinc-600"> · session {pair.sessionId.slice(0, 8)}</span>}
+        </span>
+        <span className="ml-auto inline-flex items-center gap-1.5">
+          {showStream && (
+            <Button
+              variant="outline"
+              size="xs"
+              className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+              onClick={() => actions.setReadOnly((r) => !r)}
+              aria-pressed={readOnly}
+              aria-label={readOnly ? "Read-only is on — click to allow input" : "Switch to read-only"}
+            >
+              {readOnly ? <Lock className="h-3 w-3" /> : <LockOpen className="h-3 w-3" />}
+              {readOnly ? "Read-only · on" : "Read-only"}
+            </Button>
+          )}
+          {showEnd && (
+            <Button
+              variant="outline"
+              size="xs"
+              className="border-rose-500/45 bg-transparent text-rose-400 hover:bg-rose-500/10"
+              onClick={actions.end}
+              aria-label="End session"
+            >
+              <Power className="h-3 w-3" /> End
+            </Button>
+          )}
+        </span>
+      </div>
+
+      {/* Terminal body — the xterm host plus a state overlay. The host stays
+          mounted under every state so scrollback is frozen + readable on end. */}
+      <div className="relative h-[38vh] min-h-[220px]">
+        <div
+          ref={containerRef}
+          className={cn("h-full w-full px-3 py-2", state.status === "disconnected" && "opacity-45")}
+        />
+        {!showStream && (
+          <StateOverlay
+            view={view}
+            state={state}
+            pair={pair}
+            platform={platform}
+            canLaunch={canLaunch}
+            onConnect={() => void actions.connect({ autoLaunch: true })}
+            onRetry={() => void actions.connect({ autoLaunch: true })}
+            onLaunchAgain={actions.beginBrowserLaunch}
+            onCopyBridge={actions.copyBridgeCommand}
+          />
+        )}
+        {state.status === "disconnected" && (
+          <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
+            <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
+            <b>Reconnecting to your session…</b> Your machine may have slept or dropped Wi-Fi. Your agent keeps running locally while we reattach.
+            <button className="ml-2 underline hover:text-amber-200" onClick={actions.reconnectNow}>
+              Reconnect now
+            </button>
+          </div>
+        )}
+        {state.status === "connected" && peerDegraded && (
+          <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
+            <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
+            <b>Connection interrupted — reconnecting…</b> Your machine may have slept; we&apos;re holding your session and will resume automatically.
+          </div>
+        )}
+      </div>
+
+      {/* Input affordance — read-write bar, or the read-only explanatory note. */}
+      {state.status === "connected" && (
+        inputEnabled ? (
+          <div className="flex items-center gap-2 border-t border-zinc-800 bg-[#141417] px-3 py-2 text-xs text-zinc-500">
+            <span className="font-mono text-emerald-400">›</span>
+            <span>Click the terminal and type to steer the agent. Enter sends.</span>
+          </div>
+        ) : (
+          <div className="border-t border-zinc-800 bg-violet-500/5 px-3 py-2 text-[11px] text-zinc-400">
+            <Lock className="mr-1 inline h-3 w-3 text-violet-300" />
+            <b className="text-violet-300">Read-only is on.</b> You&apos;re watching live; keystrokes are frozen.
+            <button className="ml-2 underline hover:text-zinc-200" onClick={() => actions.setReadOnly(false)}>
+              Allow input
+            </button>
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+
+export interface StatusMeta {
+  label: string;
+  Icon: typeof Circle;
+  spin?: boolean;
+  className: string;
+}
+
+// Header pill — icon + text + colour (never colour alone), one per view. Exported
+// so the dock can rebuild the IDENTICAL single-session collapsed-bar pill (B5:
+// "single session keeps P1's existing copy") from a reported SessionSummary
+// without duplicating this table.
+export function dockStatusMeta(
+  view: DockView,
+  errorKind: TerminalConnectionState["errorKind"],
+): StatusMeta {
+  switch (view) {
+    case "connected":
+      return { label: "Connected", Icon: CircleDot, className: "border-emerald-500/50 bg-emerald-500/10 text-emerald-400" };
+    case "connecting":
+    case "connecting-returning":
+      return { label: "Connecting…", Icon: Loader2, spin: true, className: "border-amber-500/50 bg-amber-500/10 text-amber-400" };
+    case "legacy-waiting":
+      return { label: "Waiting to pair", Icon: Loader2, spin: true, className: "border-sky-500/50 bg-sky-500/10 text-sky-400" };
+    case "timeout-new":
+    case "timeout-returning":
+      return { label: FIRST_RUN_COPY.pill.notConnected, Icon: CircleDashed, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
+    case "setup":
+      return { label: FIRST_RUN_COPY.pill.setup, Icon: Circle, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
+    case "coming-soon":
+      return { label: FIRST_RUN_COPY.pill.comingSoon, Icon: Clock, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
+    case "disconnected":
+      return { label: "Reconnecting…", Icon: WifiOff, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
+    case "session-ended":
+      return { label: "Session ended", Icon: Square, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
+    case "error":
+      return { label: errorKind === "owner-mismatch" ? "Owner mismatch" : "Error", Icon: CircleAlert, className: "border-rose-500/55 bg-rose-500/10 text-rose-400" };
+    default:
+      return { label: "Terminal · off", Icon: Circle, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
+  }
+}
+
+// ── per-view centred overlays (icon + text + next step) ───────────────────────
+function StateOverlay({
+  view,
+  state,
+  pair,
+  platform,
+  canLaunch,
+  onConnect,
+  onRetry,
+  onLaunchAgain,
+  onCopyBridge,
+}: {
+  view: DockView;
+  state: TerminalConnectionState;
+  pair: PairInfo | null;
+  platform: TerminalPlatform;
+  canLaunch: boolean;
+  onConnect: () => void;
+  onRetry: () => void;
+  onLaunchAgain: () => void;
+  onCopyBridge: () => void;
+}) {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 overflow-y-auto bg-[#0c0c0e]/95 px-6 py-6 text-center">
+      {view === "coming-soon" && <ComingSoonPanel />}
+
+      {view === "setup" && <SetupPanel platform={platform} onConnect={onConnect} />}
+
+      {(view === "connecting" || view === "connecting-returning") && (
+        <ConnectingPanel returning={view === "connecting-returning"} />
+      )}
+
+      {view === "timeout-new" && (
+        <TimeoutPanel variant="new" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
+      )}
+      {view === "timeout-returning" && (
+        <TimeoutPanel variant="returning" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
+      )}
+
+      {view === "legacy-waiting" && (
+        <>
+          <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
+          <div className="text-base font-semibold text-sky-400">Waiting for your machine to attach</div>
+          <p className="max-w-md text-[13px] text-zinc-400">
+            The link is up. Start a bridge on your computer for this session to go live.
+          </p>
+          {pair && (
+            <details className="mt-1 w-full max-w-md text-left">
+              <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-[12px] text-zinc-500 hover:text-zinc-300 [&::-webkit-details-marker]:hidden">
+                <ChevronRight className="h-3 w-3" /> Advanced — pair a remote machine by hand
+              </summary>
+              <div className="mt-2 flex flex-col items-start gap-1.5 rounded-md border border-zinc-800 bg-[#0a0a0b] px-3 py-2.5">
+                <code className="font-mono text-xs tracking-wide text-sky-300">
+                  session {pair.sessionId.slice(0, 8)}
+                </code>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+                  onClick={onCopyBridge}
+                >
+                  <Copy className="h-3 w-3" /> Copy bridge command
+                </Button>
+                <span className="text-[11px] text-zinc-600">Single-use · expires ~5 min · bound to your account</span>
+              </div>
+            </details>
+          )}
+        </>
+      )}
+
+      {view === "session-ended" && (
+        <>
+          <Square className="h-7 w-7 text-zinc-400" />
+          <div className="text-base font-semibold text-zinc-300">{endedTitle(state)}</div>
+          <p className="max-w-md text-[13px] text-zinc-400">{endedMessage(state)}</p>
+          <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onLaunchAgain}>
+            <TerminalIcon className="h-4 w-4" /> Launch again
+          </Button>
+        </>
+      )}
+
+      {view === "error" && (
+        <>
+          <CircleAlert className="h-7 w-7 text-rose-400" />
+          <div className="text-base font-semibold text-rose-400">{errorTitle(state)}</div>
+          <p className="max-w-md text-[13px] text-zinc-400">{errorMessage(state)}</p>
+          {canLaunch && state.errorKind !== "owner-mismatch" && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+              onClick={onLaunchAgain}
+            >
+              <RotateCw className="h-3.5 w-3.5" /> Try again
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── install-first panels ──────────────────────────────────────────────────────
+
+// Screen ① — the numbered one-time setup (unpaired). No deep link has fired here.
+function SetupPanel({ platform, onConnect }: { platform: TerminalPlatform; onConnect: () => void }) {
+  const copy = FIRST_RUN_COPY.setup;
+  return (
+    <div className="flex w-full max-w-lg flex-col text-left">
+      <div className="mb-3 text-center">
+        <TerminalIcon className="mx-auto h-6 w-6 text-emerald-400" />
+        <h4 className="mt-2 text-[17px] font-bold text-zinc-100">{copy.heading}</h4>
+        <p className="mt-1 text-[13px] text-zinc-400">{copy.subheading}</p>
+      </div>
+
+      <SetupStep n={1} title={copy.step1Title}>
+        <p className="mb-2.5 text-[12.5px] text-zinc-400">{copy.step1Desc}</p>
+        <a
+          href={platform.downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-md bg-emerald-500 px-4 text-sm font-semibold text-emerald-950 hover:bg-emerald-400"
+        >
+          <Download className="h-4 w-4" /> {platform.downloadLabel}
+        </a>
+      </SetupStep>
+
+      <SetupStep n={2} title={copy.step2Title}>
+        <p className="text-[12.5px] text-zinc-400">{copy.step2Desc}</p>
+      </SetupStep>
+
+      <SetupStep n={3} title={copy.step3Title}>
+        <div className="mb-3 flex items-start gap-2 rounded-md border border-amber-500/35 bg-amber-500/[0.06] px-3 py-2.5 text-[12.5px] text-amber-200/90">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-300" aria-hidden="true" />
+          <span>{copy.openPrompt}</span>
+        </div>
+        <Button
+          className="min-h-[44px] w-full bg-emerald-500 text-sm font-semibold text-emerald-950 hover:bg-emerald-400"
+          onClick={onConnect}
+        >
+          {copy.connect}
+        </Button>
+        <p className="mt-2 text-center text-[11.5px] text-zinc-500">{copy.alreadyInstalled}</p>
+      </SetupStep>
+    </div>
+  );
+}
+
+function SetupStep({ n, title, children }: { n: number; title: string; children: ReactNode }) {
+  return (
+    <div className="flex gap-3.5 border-t border-zinc-800 py-3.5 first-of-type:border-t-0">
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-emerald-500/40 bg-emerald-500/[0.12] text-[13px] font-bold text-emerald-400">
+        {n}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="mb-1.5 text-sm font-semibold text-zinc-200">{title}</div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// Screen ② — connecting (after Connect, or auto-connect for a returning user).
+function ConnectingPanel({ returning }: { returning: boolean }) {
+  const copy = FIRST_RUN_COPY.connecting;
+  return (
+    <>
+      <Loader2 className="h-7 w-7 animate-spin text-amber-400" />
+      <div className="text-base font-semibold text-amber-400">{copy.heading}</div>
+      <p className="max-w-md text-[13px] text-zinc-400">{returning ? copy.returningBody : copy.body}</p>
+      <p className="max-w-md text-[12.5px] text-zinc-500">{copy.openNudge}</p>
+    </>
+  );
+}
+
+// Screen ④ — the calm ~8s fallback. `variant` picks the first-timer vs returning copy.
+function TimeoutPanel({
+  variant,
+  downloadUrl,
+  onRetry,
+}: {
+  variant: "new" | "returning";
+  downloadUrl: string | null;
+  onRetry: () => void;
+}) {
+  const copy = variant === "new" ? FIRST_RUN_COPY.timeoutNew : FIRST_RUN_COPY.timeoutReturning;
+  const href = downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL;
+  const secondaryLabel = variant === "new" ? FIRST_RUN_COPY.timeoutNew.download : FIRST_RUN_COPY.timeoutReturning.reinstall;
+  const footer = variant === "new" ? FIRST_RUN_COPY.timeoutNew.hint : FIRST_RUN_COPY.timeoutReturning.reassure;
+  return (
+    <>
+      <CircleDashed className="h-7 w-7 text-sky-400" />
+      <div className="text-base font-semibold text-zinc-200">{copy.heading}</div>
+      <p className="max-w-md text-[13px] text-zinc-400">{copy.body}</p>
+      <div className="flex w-full flex-wrap justify-center gap-2.5">
+        <Button
+          className="min-h-[44px] bg-sky-500 px-4 text-sm font-semibold text-sky-950 hover:bg-sky-400"
+          onClick={onRetry}
+        >
+          <RotateCw className="h-4 w-4" /> {copy.retry}
+        </Button>
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-md border border-zinc-700 bg-zinc-800/60 px-4 text-sm font-semibold text-zinc-200 hover:bg-zinc-700"
+        >
+          <Download className="h-4 w-4" /> {secondaryLabel}
+        </a>
+      </div>
+      <p className="text-[11.5px] text-zinc-500">{footer}</p>
+    </>
+  );
+}
+
+// Screen ⑥ — non-Mac / unsupported machine. No deep link, gated download.
+function ComingSoonPanel() {
+  const copy = FIRST_RUN_COPY.comingSoon;
+  return (
+    <>
+      <Laptop className="h-7 w-7 text-zinc-300" />
+      <div className="text-base font-semibold text-zinc-100">{copy.heading}</div>
+      <p className="max-w-md text-[13px] text-zinc-400">{copy.body}</p>
+      <Button
+        disabled
+        aria-disabled="true"
+        className="min-h-[44px] cursor-not-allowed border border-zinc-800 bg-zinc-900 text-sm font-semibold text-zinc-500"
+      >
+        {copy.download}
+      </Button>
+      <p className="text-[11.5px] text-zinc-500">{copy.hint}</p>
+    </>
+  );
+}
+
+function endedTitle(state: TerminalConnectionState): string {
+  switch (state.endedReason) {
+    case "user":
+      return "You ended the session";
+    case "idle":
+      return "Ended after being idle";
+    case "max-duration":
+      return "Reached the session time limit";
+    case "reconnect-failed":
+      return "This session ended";
+    default:
+      return "Session ended";
+  }
+}
+
+function endedMessage(state: TerminalConnectionState): string {
+  switch (state.endedReason) {
+    case "idle":
+    case "max-duration":
+      return "We closed the session to keep things tidy and safe. Nothing went wrong — your work on your machine is untouched.";
+    case "reconnect-failed":
+      return "We couldn't reattach in time after the connection dropped. Your saved work is safe — start a new session to pick things back up.";
+    default:
+      return "Claude Code on your machine stopped. The scrollback above is kept.";
+  }
+}
+
+function errorTitle(state: TerminalConnectionState): string {
+  switch (state.errorKind) {
+    case "owner-mismatch":
+      return "This bridge belongs to another account";
+    case "bad-token":
+      return "Couldn't verify this session";
+    case "duplicate":
+      return "This session is already open elsewhere";
+    case "connect-timeout":
+    case "relay-unreachable":
+      return "Couldn't reach your machine";
+    case "session-mint-failed":
+      return "Couldn't start a session";
+    default:
+      return "Something went wrong";
+  }
+}
+
+function errorMessage(state: TerminalConnectionState): string {
+  switch (state.errorKind) {
+    case "owner-mismatch":
+      return "For safety, a bridge only attaches to the person who launched it. Start your own bridge, or sign in as the owning account.";
+    case "bad-token":
+      return "The session couldn't be verified. Launch again to start a fresh one.";
+    case "duplicate":
+      return "Another browser tab is already attached to this session. Close it, then launch again.";
+    case "connect-timeout":
+      return "We waited a while but nothing connected. Is the helper running and allowed to open?";
+    case "relay-unreachable":
+      return "We couldn't set up the secure link. Check your connection, then try again.";
+    case "session-mint-failed":
+      return "The session request didn't go through. Check your connection and try again.";
+    default:
+      return "The terminal session didn't start. Try launching again.";
+  }
+}

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -49,6 +49,8 @@ import {
   ChevronRight,
   Circle,
   CircleDashed,
+  ExternalLink,
+  Undo2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -84,6 +86,17 @@ export interface SessionSummary {
   launchPhase: LaunchPhase;
   platformSupported: boolean;
   paired: boolean;
+  /**
+   * Multi-session stage 4 (D1): the browser-leg token, mirrored up so the
+   * dock can build a pop-out hand-off payload WITHOUT threading a second
+   * imperative accessor through the actions registry — it changes in
+   * lock-step with `sessionId` (both are set together by connect()/
+   * attachToExisting), so it's always current whenever sessionId is. `null`
+   * before a session exists (nothing to pop out).
+   */
+  browserToken: string | null;
+  /** Mirrored so a pop-out payload can carry the CURRENT read-only toggle across into the popped window (D1). */
+  readOnly: boolean;
 }
 
 interface TerminalSessionViewProps {
@@ -107,6 +120,20 @@ interface TerminalSessionViewProps {
   onAnnounce: (text: string) => void;
   /** Opens the dock's "My sessions" panel on a cap refusal (E1, design §7b). */
   onCapExceeded?: () => void;
+  /**
+   * Multi-session stage 4 (D1-D7): true once the dock has popped this tab's
+   * session out into its own window. Renders the "Popped out" placeholder
+   * (design §10b) INSTEAD OF the normal header/body/input — the underlying
+   * `useTerminalSession` instance keeps running unaffected (its socket gets
+   * preempted by the relay moments after the popped window attaches, exactly
+   * like any other 4001 close), it's purely this component's PRESENTATION
+   * that changes. Omitted/false renders exactly as before (P1 unchanged).
+   */
+  poppedOut?: boolean;
+  /** "Pop out" header control (D1/D2) — omitted hides the button entirely. */
+  onPopOut?: () => void;
+  /** "Bring back to dock" (D3) — only rendered while `poppedOut`. */
+  onBringBack?: () => void;
 }
 
 export function TerminalSessionView({
@@ -121,6 +148,9 @@ export function TerminalSessionView({
   onRegisterActions,
   onAnnounce,
   onCapExceeded,
+  poppedOut = false,
+  onPopOut,
+  onBringBack,
 }: TerminalSessionViewProps) {
   const session = useTerminalSession(descriptor, {
     enabled: true,
@@ -167,6 +197,8 @@ export function TerminalSessionView({
       launchPhase,
       platformSupported: platform.supported,
       paired,
+      browserToken: pair?.browserToken ?? null,
+      readOnly,
     });
     if (shouldAnnounceAttention(prevStatusRef.current, state.status, isActive)) {
       onAnnounce(formatAttentionAnnouncement(label, state.status));
@@ -183,6 +215,7 @@ export function TerminalSessionView({
     paired,
     isActive,
     label,
+    readOnly,
   ]);
 
   // Keep the dock's action registry current so a tab strip close (×) — which
@@ -208,6 +241,36 @@ export function TerminalSessionView({
     view === "connecting-returning" ||
     view === "legacy-waiting";
 
+  // Multi-session stage 4 (D2/D3, design §10b): once this tab has been popped
+  // out, its whole body becomes the placeholder — no header/pill/stream/input.
+  // The underlying `useTerminalSession` instance above keeps running (its
+  // socket will shortly be preempted by the relay, or already has been); we
+  // just don't SHOW any of that here. The tab strip above this component is
+  // unaffected (owned by terminal-dock.tsx).
+  if (poppedOut) {
+    return (
+      <div className={cn(!isActive && "hidden")} aria-hidden={!isActive}>
+        <div className="flex h-[38vh] min-h-[220px] flex-col items-center justify-center gap-3 bg-[#0c0c0e] px-6 py-6 text-center">
+          <span className="text-2xl text-violet-400" aria-hidden="true">
+            ⧉
+          </span>
+          <div className="text-base font-semibold text-violet-400">Popped out</div>
+          <p className="max-w-md text-[13px] text-zinc-400">
+            This session is open in another window. It keeps running there — close that window and it
+            returns here automatically.
+          </p>
+          <Button
+            className="bg-sky-500 text-sky-950 hover:bg-sky-400"
+            onClick={onBringBack}
+            aria-label={`Bring back to dock: ${label}`}
+          >
+            <Undo2 className="h-4 w-4" /> Bring back to dock
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={cn(!isActive && "hidden")} aria-hidden={!isActive}>
       {/* Header: state · identity · controls (safest → most destructive) */}
@@ -226,6 +289,24 @@ export function TerminalSessionView({
           {pair && <span className="text-zinc-600"> · session {pair.sessionId.slice(0, 8)}</span>}
         </span>
         <span className="ml-auto inline-flex items-center gap-1.5">
+          {/* Pop out (D1/D2, design §4 "one new header control, in the old
+              header") — left of Read-only/End, per the design's control
+              cluster ordering (safest → most destructive). Gated on
+              `showStream` like Read-only: popping out only makes sense once
+              there's a live/reconnecting stream to move into another window;
+              `onPopOut` itself is dock-only (the popped window's own view
+              never renders this component with a handler wired). */}
+          {showStream && onPopOut && (
+            <Button
+              variant="outline"
+              size="xs"
+              className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+              onClick={onPopOut}
+              aria-label="Pop this session out into its own window"
+            >
+              <ExternalLink className="h-3 w-3" /> Pop out
+            </Button>
+          )}
           {showStream && (
             <Button
               variant="outline"

--- a/src/components/board/terminal-tabs.test.ts
+++ b/src/components/board/terminal-tabs.test.ts
@@ -30,6 +30,21 @@ describe("tabStatusMeta", () => {
     expect(tabStatusMeta(status).needsAttention).toBe(expected);
   });
 
+  it("gives 'popped-out' its own violet glyph, tone, and aria text, distinct from every real status", () => {
+    const popped = tabStatusMeta("popped-out");
+    expect(popped).toEqual({ glyph: "⧉", tone: "popped", ariaText: "popped out", needsAttention: false });
+    const realGlyphs = new Set(
+      (["idle", "connecting", "waiting-to-pair", "connected", "disconnected", "session-ended", "error"] as const).map(
+        (s) => tabStatusMeta(s).glyph,
+      ),
+    );
+    expect(realGlyphs.has(popped.glyph)).toBe(false);
+  });
+
+  it("'popped-out' is never an attention state — it's a deliberate user choice, not a problem", () => {
+    expect(tabStatusMeta("popped-out").needsAttention).toBe(false);
+  });
+
   it("gives every status a distinct glyph shape (never colour alone)", () => {
     const statuses: TerminalStatus[] = [
       "idle",
@@ -181,6 +196,18 @@ describe("summarizeSessionStatuses (B5)", () => {
 
   it("returns an empty array for no sessions", () => {
     expect(summarizeSessionStatuses([])).toEqual([]);
+  });
+
+  it("gives a popped-out session its own calm chip, never lumped into 'needs attention'", () => {
+    // A popped-out session's UNDERLYING socket is usually sitting in an
+    // "error"/duplicate state at this exact moment (the 4001 preemption) —
+    // the caller substitutes "popped-out" for it precisely so this summary
+    // never misreads a deliberate pop-out as something wrong.
+    const chips = summarizeSessionStatuses(["connected", "popped-out"]);
+    expect(chips).toEqual([
+      { tone: "popped", glyph: "⧉", count: 1, label: "1 popped out" },
+      { tone: "ok", glyph: "●", count: 1, label: "1 connected" },
+    ]);
   });
 });
 

--- a/src/components/board/terminal-tabs.test.ts
+++ b/src/components/board/terminal-tabs.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+import {
+  tabStatusMeta,
+  isLiveTabStatus,
+  deriveTabLabel,
+  findPristineSlot,
+  decideTaskLaunch,
+  summarizeSessionStatuses,
+  shouldAnnounceAttention,
+  formatAttentionAnnouncement,
+  type DedupeCandidate,
+  type PristineCandidate,
+} from "./terminal-tabs";
+import type { TerminalStatus } from "@/lib/terminal/connection";
+
+describe("tabStatusMeta", () => {
+  it("gives connected a quiet ok glyph with no attention flag", () => {
+    const meta = tabStatusMeta("connected");
+    expect(meta).toEqual({ glyph: "●", tone: "ok", ariaText: "connected", needsAttention: false });
+  });
+
+  it.each<[TerminalStatus, boolean]>([
+    ["connecting", false],
+    ["waiting-to-pair", false],
+    ["connected", false],
+    ["disconnected", true],
+    ["session-ended", true],
+    ["error", true],
+  ])("needsAttention(%s) === %s", (status, expected) => {
+    expect(tabStatusMeta(status).needsAttention).toBe(expected);
+  });
+
+  it("gives every status a distinct glyph shape (never colour alone)", () => {
+    const statuses: TerminalStatus[] = [
+      "idle",
+      "connecting",
+      "waiting-to-pair",
+      "connected",
+      "disconnected",
+      "session-ended",
+      "error",
+    ];
+    const glyphs = new Set(statuses.map((s) => tabStatusMeta(s).glyph));
+    // connecting / waiting-to-pair intentionally share a glyph (both are
+    // "still handshaking"); every other status gets its own shape.
+    expect(glyphs.size).toBe(statuses.length - 1);
+  });
+});
+
+describe("isLiveTabStatus", () => {
+  it("treats session-ended and error as not-live", () => {
+    expect(isLiveTabStatus("session-ended")).toBe(false);
+    expect(isLiveTabStatus("error")).toBe(false);
+  });
+
+  it("treats every other status as live", () => {
+    const live: TerminalStatus[] = ["idle", "connecting", "waiting-to-pair", "connected", "disconnected"];
+    for (const s of live) expect(isLiveTabStatus(s)).toBe(true);
+  });
+});
+
+describe("deriveTabLabel (B3)", () => {
+  it("uses the task title when the launch was task-scoped", () => {
+    expect(
+      deriveTabLabel({ taskTitle: "Add pagination to the recipe list", ideaSlug: "recipe-saver", sessionId: "a3f9c2e1" })
+    ).toBe("Add pagination to the recipe list");
+  });
+
+  it("trims a task title that has stray whitespace", () => {
+    expect(deriveTabLabel({ taskTitle: "  Fix login  ", ideaSlug: "recipe-saver", sessionId: null })).toBe(
+      "Fix login"
+    );
+  });
+
+  it("falls back to `<idea slug> · <sid-short>` when board-scoped", () => {
+    expect(deriveTabLabel({ taskTitle: undefined, ideaSlug: "recipe-saver", sessionId: "a3f9c2e1" })).toBe(
+      "recipe-saver · a3f9"
+    );
+  });
+
+  it("treats an empty/whitespace-only task title as board-scoped", () => {
+    expect(deriveTabLabel({ taskTitle: "   ", ideaSlug: "recipe-saver", sessionId: "c2d8" })).toBe(
+      "recipe-saver · c2d8"
+    );
+  });
+
+  it("uses an ellipsis placeholder before the session id is known", () => {
+    expect(deriveTabLabel({ taskTitle: undefined, ideaSlug: "recipe-saver", sessionId: null })).toBe(
+      "recipe-saver · …"
+    );
+  });
+});
+
+describe("findPristineSlot (first-launch reuse)", () => {
+  it("reuses the sole entry when it has never been launched", () => {
+    const sessions: PristineCandidate[] = [{ key: "s1", launchSeq: 0 }];
+    expect(findPristineSlot(sessions)).toBe("s1");
+  });
+
+  it("returns null once the sole entry has been launched at least once", () => {
+    const sessions: PristineCandidate[] = [{ key: "s1", launchSeq: 1 }];
+    expect(findPristineSlot(sessions)).toBeNull();
+  });
+
+  it("returns null with zero entries", () => {
+    expect(findPristineSlot([])).toBeNull();
+  });
+
+  it("returns null once a second tab exists, even if one is still pristine", () => {
+    const sessions: PristineCandidate[] = [
+      { key: "s1", launchSeq: 0 },
+      { key: "s2", launchSeq: 1 },
+    ];
+    expect(findPristineSlot(sessions)).toBeNull();
+  });
+});
+
+describe("decideTaskLaunch (B10)", () => {
+  it("always opens a new tab for a board-level launch (no task identity)", () => {
+    const sessions: DedupeCandidate[] = [{ key: "s1", taskId: "task-1", status: "connected" }];
+    expect(decideTaskLaunch(sessions, undefined)).toEqual({ action: "open" });
+  });
+
+  it("focuses the existing tab when the same task already has a LIVE tab", () => {
+    const sessions: DedupeCandidate[] = [
+      { key: "s1", taskId: "task-1", status: "connected" },
+      { key: "s2", taskId: "task-2", status: "connected" },
+    ];
+    expect(decideTaskLaunch(sessions, "task-1")).toEqual({ action: "focus", key: "s1" });
+  });
+
+  it("opens a new tab when no existing tab matches the task id", () => {
+    const sessions: DedupeCandidate[] = [{ key: "s1", taskId: "task-2", status: "connected" }];
+    expect(decideTaskLaunch(sessions, "task-1")).toEqual({ action: "open" });
+  });
+
+  it("does NOT dedupe against an ended or errored tab for the same task", () => {
+    const sessions: DedupeCandidate[] = [
+      { key: "s1", taskId: "task-1", status: "session-ended" },
+      { key: "s2", taskId: "task-1", status: "error" },
+    ];
+    expect(decideTaskLaunch(sessions, "task-1")).toEqual({ action: "open" });
+  });
+
+  it("matches on a mid-handshake tab too (connecting/waiting still count as live)", () => {
+    const sessions: DedupeCandidate[] = [{ key: "s1", taskId: "task-1", status: "connecting" }];
+    expect(decideTaskLaunch(sessions, "task-1")).toEqual({ action: "focus", key: "s1" });
+  });
+
+  it("never matches on cwd/prompt equivalence — only a real taskId is keyed on", () => {
+    // Two board-level (taskId undefined) sessions must never collide with each
+    // other or with a later task-scoped launch just because they'd resolve the
+    // same cwd/prompt.
+    const sessions: DedupeCandidate[] = [{ key: "s1", taskId: undefined, status: "connected" }];
+    expect(decideTaskLaunch(sessions, "task-1")).toEqual({ action: "open" });
+  });
+});
+
+describe("summarizeSessionStatuses (B5)", () => {
+  it("collapses an all-healthy set to a single connected chip", () => {
+    expect(summarizeSessionStatuses(["connected", "connected", "connected"])).toEqual([
+      { tone: "ok", glyph: "●", count: 3, label: "3 connected" },
+    ]);
+  });
+
+  it("orders chips worst-first: error, then reconnecting, then connected", () => {
+    const chips = summarizeSessionStatuses(["connected", "connected", "disconnected", "error"]);
+    expect(chips.map((c) => c.label)).toEqual(["1 needs attention", "1 reconnecting", "2 connected"]);
+  });
+
+  it("omits categories with zero members", () => {
+    const chips = summarizeSessionStatuses(["connected", "disconnected"]);
+    expect(chips).toHaveLength(2);
+    expect(chips.some((c) => c.label.includes("needs attention"))).toBe(false);
+  });
+
+  it("merges connecting and waiting-to-pair into one 'connecting' chip", () => {
+    const chips = summarizeSessionStatuses(["connecting", "waiting-to-pair"]);
+    expect(chips).toEqual([{ tone: "info", glyph: "◌", count: 2, label: "2 connecting" }]);
+  });
+
+  it("returns an empty array for no sessions", () => {
+    expect(summarizeSessionStatuses([])).toEqual([]);
+  });
+});
+
+describe("shouldAnnounceAttention (a11y)", () => {
+  it("does not announce the active tab's own state changes", () => {
+    expect(shouldAnnounceAttention("connected", "disconnected", true)).toBe(false);
+  });
+
+  it("does not announce a first report from a just-mounted tab", () => {
+    expect(shouldAnnounceAttention(undefined, "connecting", false)).toBe(false);
+  });
+
+  it("does not announce a no-op re-render (status unchanged)", () => {
+    expect(shouldAnnounceAttention("connected", "connected", false)).toBe(false);
+  });
+
+  it("announces a background tab entering a needs-attention state", () => {
+    expect(shouldAnnounceAttention("connected", "disconnected", false)).toBe(true);
+    expect(shouldAnnounceAttention("connected", "error", false)).toBe(true);
+    expect(shouldAnnounceAttention("connected", "session-ended", false)).toBe(true);
+  });
+
+  it("does not announce a background tab entering a quiet state", () => {
+    expect(shouldAnnounceAttention("connecting", "connected", false)).toBe(false);
+  });
+});
+
+describe("formatAttentionAnnouncement", () => {
+  it("formats a quoted label + status word", () => {
+    expect(formatAttentionAnnouncement("Fix login", "disconnected")).toBe(
+      'Terminal "Fix login": reconnecting'
+    );
+  });
+});

--- a/src/components/board/terminal-tabs.ts
+++ b/src/components/board/terminal-tabs.ts
@@ -1,0 +1,261 @@
+// In-app terminal — multi-session tab-strip PURE logic (multi-session stage 2,
+// docs/design-terminal-multi-session-popout.html).
+//
+// terminal-dock.tsx owns a small `sessions: SessionEntry[]` list (one entry per
+// tab, board-scoped per the approved design's §3 recommendation) and mounts one
+// `TerminalSessionView` (→ one `useTerminalSession` instance) per entry. This
+// module holds every DECISION that list-management needs that can be expressed
+// as a pure function over plain data, so it's unit-testable without React, a
+// DOM, or a socket — mirroring how connection.ts / first-run-flow.ts keep the
+// state-machine and presentation-branching logic pure and separate from the
+// component that wires it to the DOM.
+//
+// Covers:
+//   - B3  tab label derivation (task title, else `<idea slug> · <sid-short>`)
+//   - B5  per-tab attention glyph/tone + the collapsed-bar worst-first summary
+//   - B10 dedupe: a launch for a task that already has a LIVE tab focuses it
+//         instead of minting a second session
+//   - a11y: when a BACKGROUND tab's state change is worth a polite aria-live
+//         announcement (never the active tab, never a no-op re-render)
+
+import type { TerminalStatus } from "@/lib/terminal/connection";
+import type { BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
+
+/**
+ * One tab = one `useTerminalSession` instance, mounted by a dedicated
+ * `TerminalSessionView` child (B2 — hooks can't be called in a loop, so each
+ * entry gets its own component instance). `launchSeq` is a monotonic
+ * per-entry command counter: the dock bumps it (and sets `launchPayload`)
+ * every time a launch should be DELIVERED to this entry — a fresh entry is
+ * created with `launchSeq: 1` so its first mount fires immediately; the
+ * child's effect re-fires `actions.launchFromBus` whenever `launchSeq`
+ * changes. `launchSeq === 0` marks a PRISTINE entry (mounted but never
+ * launched) — the sole slot the dock reuses for the very first launch on a
+ * board, exactly matching P1's single always-mounted hook.
+ */
+export interface SessionEntry {
+  key: string;
+  origin: "toolbar" | "task";
+  taskId?: string;
+  taskTitle?: string;
+  createdAt: number;
+  launchSeq: number;
+  launchPayload: BrowserLaunchPayload | null;
+}
+
+// ── shared tone vocabulary (drives both the per-tab glyph and the collapsed
+// bar's summary chips — same colours, same meaning, everywhere) ──────────────
+
+export type TabTone = "ok" | "info" | "warn" | "err" | "mut";
+
+export interface TabStatusMeta {
+  /** Shape-distinct glyph — never colour alone (B5 / design §2 callout 1). */
+  glyph: string;
+  tone: TabTone;
+  /** Lowercase word for the accessible name / aria-live announcement. */
+  ariaText: string;
+  /** True for states a BACKGROUND tab should visually call attention to. */
+  needsAttention: boolean;
+}
+
+const STATUS_META: Record<TerminalStatus, TabStatusMeta> = {
+  idle: { glyph: "○", tone: "mut", ariaText: "idle", needsAttention: false },
+  connecting: { glyph: "◌", tone: "info", ariaText: "connecting", needsAttention: false },
+  "waiting-to-pair": { glyph: "◌", tone: "info", ariaText: "waiting to pair", needsAttention: false },
+  connected: { glyph: "●", tone: "ok", ariaText: "connected", needsAttention: false },
+  disconnected: { glyph: "↻", tone: "warn", ariaText: "reconnecting", needsAttention: true },
+  "session-ended": { glyph: "■", tone: "mut", ariaText: "ended", needsAttention: true },
+  error: { glyph: "▲", tone: "err", ariaText: "needs attention", needsAttention: true },
+};
+
+/** Per-tab glyph/tone/aria projection of a session's TerminalStatus (B5, design §5). */
+export function tabStatusMeta(status: TerminalStatus): TabStatusMeta {
+  return STATUS_META[status] ?? STATUS_META.idle;
+}
+
+/**
+ * Statuses that mean "nothing is actually running for this tab any more" — a
+ * B10 dedupe match must NOT block a fresh launch against a tab in one of
+ * these (retrying/relaunching a dead task session is exactly the point of
+ * relaunching; only a genuinely LIVE tab should be protected from a duplicate).
+ */
+const SESSION_OVER: ReadonlySet<TerminalStatus> = new Set(["session-ended", "error"]);
+
+export function isLiveTabStatus(status: TerminalStatus): boolean {
+  return !SESSION_OVER.has(status);
+}
+
+// ── B3: tab label ────────────────────────────────────────────────────────────
+
+export interface TabLabelInput {
+  /** Set only for a task-scoped launch (LaunchClaudeCodeButton task variants). */
+  taskTitle?: string | null;
+  /** Slugified idea title (see slugifyIdeaTitle) — used when NOT task-scoped. */
+  ideaSlug: string;
+  /** The minted session id, once known (null before mint completes). */
+  sessionId: string | null;
+}
+
+const SID_SHORT_LEN = 4;
+
+/**
+ * Task title when the launch was task-scoped, else `<idea slug> · <sid-short>`
+ * (B3, design §2 callout 2 / §4). Callers truncate the rendered label with CSS
+ * ellipsis and use the full title (or this same string, for board-level tabs)
+ * as the tooltip/title attribute.
+ */
+export function deriveTabLabel(input: TabLabelInput): string {
+  const title = input.taskTitle?.trim();
+  if (title) return title;
+  const sid = input.sessionId ? input.sessionId.slice(0, SID_SHORT_LEN) : "…";
+  return `${input.ideaSlug} · ${sid}`;
+}
+
+// ── first-launch reuse: the pristine slot ───────────────────────────────────
+
+export interface PristineCandidate {
+  key: string;
+  launchSeq: number;
+}
+
+/**
+ * The dock always keeps at least one `useTerminalSession` instance mounted from
+ * page load (matching P1's single always-mounted hook — see the `SessionEntry`
+ * doc above). That entry is "pristine" — never yet handed a launch — for exactly
+ * as long as it's the ONLY entry and its `launchSeq` is still 0. The very FIRST
+ * launch on a board reuses it in place (bump its `launchSeq`, attach the
+ * payload) instead of minting a second, redundant idle instance; every launch
+ * after that opens a genuinely new tab (B7). Returns the reusable entry's key,
+ * or null when there's nothing to reuse (a second+ launch, or the single entry
+ * has already been used).
+ */
+export function findPristineSlot(sessions: PristineCandidate[]): string | null {
+  if (sessions.length !== 1) return null;
+  const [only] = sessions;
+  return only.launchSeq === 0 ? only.key : null;
+}
+
+// ── B10: dedupe a task-scoped launch against existing tabs ─────────────────
+
+export interface DedupeCandidate {
+  key: string;
+  taskId?: string;
+  status: TerminalStatus;
+}
+
+export type LaunchDedupeDecision = { action: "focus"; key: string } | { action: "open" };
+
+/**
+ * A launch (toolbar or task-menu) for a task that already has a LIVE tab must
+ * focus that tab instead of minting a second session or delivering the
+ * payload (B10). Only a REAL task identity is keyed on — board-level launches
+ * (no taskId) always open, and cwd/prompt equivalence is deliberately never
+ * treated as a match (two board-level launches for the same idea are allowed
+ * to be two independent sessions).
+ */
+export function decideTaskLaunch(
+  sessions: DedupeCandidate[],
+  taskId: string | undefined,
+): LaunchDedupeDecision {
+  if (!taskId) return { action: "open" };
+  const existing = sessions.find((s) => s.taskId === taskId && isLiveTabStatus(s.status));
+  return existing ? { action: "focus", key: existing.key } : { action: "open" };
+}
+
+// ── B5: collapsed-bar worst-first status summary ────────────────────────────
+
+export interface StatusSummaryChip {
+  tone: TabTone;
+  glyph: string;
+  count: number;
+  /** e.g. "2 connected" */
+  label: string;
+}
+
+type SummaryCategory = "error" | "disconnected" | "connecting" | "idle" | "ended" | "connected";
+
+// Worst-first (design §6: "the first thing you read is the thing to act on").
+const CATEGORY_ORDER: SummaryCategory[] = [
+  "error",
+  "disconnected",
+  "connecting",
+  "idle",
+  "ended",
+  "connected",
+];
+
+const CATEGORY_META: Record<SummaryCategory, { tone: TabTone; glyph: string; word: string }> = {
+  error: { tone: "err", glyph: "▲", word: "needs attention" },
+  disconnected: { tone: "warn", glyph: "↻", word: "reconnecting" },
+  connecting: { tone: "info", glyph: "◌", word: "connecting" },
+  idle: { tone: "mut", glyph: "○", word: "idle" },
+  ended: { tone: "mut", glyph: "■", word: "ended" },
+  connected: { tone: "ok", glyph: "●", word: "connected" },
+};
+
+function categoryOf(status: TerminalStatus): SummaryCategory {
+  switch (status) {
+    case "error":
+      return "error";
+    case "disconnected":
+      return "disconnected";
+    case "connecting":
+    case "waiting-to-pair":
+      return "connecting";
+    case "session-ended":
+      return "ended";
+    case "connected":
+      return "connected";
+    case "idle":
+    default:
+      return "idle";
+  }
+}
+
+/**
+ * Worst-first count-by-state summary for the COLLAPSED dock bar (B5, design
+ * §6) — e.g. "2 connected · 1 reconnecting". Only categories that exist appear
+ * (all-healthy collapses to a single "N connected" chip). Callers with exactly
+ * one session should keep today's single-session pill copy instead of this
+ * summary (per the stage brief: "single session keeps today's copy").
+ */
+export function summarizeSessionStatuses(statuses: TerminalStatus[]): StatusSummaryChip[] {
+  const counts = new Map<SummaryCategory, number>();
+  for (const status of statuses) {
+    const cat = categoryOf(status);
+    counts.set(cat, (counts.get(cat) ?? 0) + 1);
+  }
+  const chips: StatusSummaryChip[] = [];
+  for (const cat of CATEGORY_ORDER) {
+    const count = counts.get(cat) ?? 0;
+    if (count === 0) continue;
+    const meta = CATEGORY_META[cat];
+    chips.push({ tone: meta.tone, glyph: meta.glyph, count, label: `${count} ${meta.word}` });
+  }
+  return chips;
+}
+
+// ── a11y: aria-live announcements for BACKGROUND tab state changes ─────────
+
+/**
+ * Only announce a background tab's own transition INTO an attention state —
+ * never the active tab (its state is already visible on screen, a live
+ * region would just double-speak it) and never a no-op re-render (guards
+ * against `prevStatus === nextStatus` re-firing on every unrelated update).
+ * `prevStatus === undefined` means "first report from a just-mounted tab" —
+ * never worth announcing (it isn't a transition).
+ */
+export function shouldAnnounceAttention(
+  prevStatus: TerminalStatus | undefined,
+  nextStatus: TerminalStatus,
+  isActiveTab: boolean,
+): boolean {
+  if (isActiveTab) return false;
+  if (prevStatus === undefined || prevStatus === nextStatus) return false;
+  return tabStatusMeta(nextStatus).needsAttention;
+}
+
+/** e.g. `Terminal "Fix login": reconnecting` — one shared announcer string shape. */
+export function formatAttentionAnnouncement(label: string, status: TerminalStatus): string {
+  return `Terminal "${label}": ${tabStatusMeta(status).ariaText}`;
+}

--- a/src/components/board/terminal-tabs.ts
+++ b/src/components/board/terminal-tabs.ts
@@ -46,7 +46,7 @@ export interface SessionEntry {
 // ── shared tone vocabulary (drives both the per-tab glyph and the collapsed
 // bar's summary chips — same colours, same meaning, everywhere) ──────────────
 
-export type TabTone = "ok" | "info" | "warn" | "err" | "mut";
+export type TabTone = "ok" | "info" | "warn" | "err" | "mut" | "popped";
 
 export interface TabStatusMeta {
   /** Shape-distinct glyph — never colour alone (B5 / design §2 callout 1). */
@@ -58,6 +58,19 @@ export interface TabStatusMeta {
   needsAttention: boolean;
 }
 
+/**
+ * What a tab can DISPLAY, layered on top of the underlying session's real
+ * `TerminalStatus` (multi-session stage 4, D2/D3). "popped-out" is NOT a
+ * connection-machine state — connection.ts is untouched — it's a dock-tracked
+ * fact ("the user popped this tab's session into its own window") that
+ * OVERRIDES the tab's glyph/tone regardless of what the underlying socket is
+ * currently doing (which, moments after a pop-out, is usually the relay's
+ * 4001 "preempted" close — see terminal-dock.tsx's `poppedOutKeys` and
+ * src/lib/terminal/popout-channel.ts). Every `TerminalStatus` is already a
+ * valid `TabDisplayStatus`, so every existing caller keeps working unchanged.
+ */
+export type TabDisplayStatus = TerminalStatus | "popped-out";
+
 const STATUS_META: Record<TerminalStatus, TabStatusMeta> = {
   idle: { glyph: "○", tone: "mut", ariaText: "idle", needsAttention: false },
   connecting: { glyph: "◌", tone: "info", ariaText: "connecting", needsAttention: false },
@@ -68,8 +81,18 @@ const STATUS_META: Record<TerminalStatus, TabStatusMeta> = {
   error: { glyph: "▲", tone: "err", ariaText: "needs attention", needsAttention: true },
 };
 
-/** Per-tab glyph/tone/aria projection of a session's TerminalStatus (B5, design §5). */
-export function tabStatusMeta(status: TerminalStatus): TabStatusMeta {
+// Design §5's table: "popped out ... None — deliberate user state" — never an
+// attention treatment, it's something the user chose, not something wrong.
+const POPPED_OUT_META: TabStatusMeta = {
+  glyph: "⧉",
+  tone: "popped",
+  ariaText: "popped out",
+  needsAttention: false,
+};
+
+/** Per-tab glyph/tone/aria projection of a tab's display status (B5, design §5 + §10b). */
+export function tabStatusMeta(status: TabDisplayStatus): TabStatusMeta {
+  if (status === "popped-out") return POPPED_OUT_META;
   return STATUS_META[status] ?? STATUS_META.idle;
 }
 
@@ -172,15 +195,18 @@ export interface StatusSummaryChip {
   label: string;
 }
 
-type SummaryCategory = "error" | "disconnected" | "connecting" | "idle" | "ended" | "connected";
+type SummaryCategory = "error" | "disconnected" | "connecting" | "idle" | "ended" | "popped" | "connected";
 
 // Worst-first (design §6: "the first thing you read is the thing to act on").
+// "popped" sits with "connected" at the calm end — a pop-out is a deliberate
+// choice, never something to flag (same reasoning as POPPED_OUT_META above).
 const CATEGORY_ORDER: SummaryCategory[] = [
   "error",
   "disconnected",
   "connecting",
   "idle",
   "ended",
+  "popped",
   "connected",
 ];
 
@@ -190,11 +216,14 @@ const CATEGORY_META: Record<SummaryCategory, { tone: TabTone; glyph: string; wor
   connecting: { tone: "info", glyph: "◌", word: "connecting" },
   idle: { tone: "mut", glyph: "○", word: "idle" },
   ended: { tone: "mut", glyph: "■", word: "ended" },
+  popped: { tone: "popped", glyph: "⧉", word: "popped out" },
   connected: { tone: "ok", glyph: "●", word: "connected" },
 };
 
-function categoryOf(status: TerminalStatus): SummaryCategory {
+function categoryOf(status: TabDisplayStatus): SummaryCategory {
   switch (status) {
+    case "popped-out":
+      return "popped";
     case "error":
       return "error";
     case "disconnected":
@@ -217,9 +246,12 @@ function categoryOf(status: TerminalStatus): SummaryCategory {
  * §6) — e.g. "2 connected · 1 reconnecting". Only categories that exist appear
  * (all-healthy collapses to a single "N connected" chip). Callers with exactly
  * one session should keep today's single-session pill copy instead of this
- * summary (per the stage brief: "single session keeps today's copy").
+ * summary (per the stage brief: "single session keeps today's copy"). Callers
+ * pass a tab's DISPLAY status (terminal-dock.tsx substitutes "popped-out" for
+ * any tab in its `poppedOutKeys`) so a preempted-by-design 4001 close never
+ * misreads as "needs attention" in the summary.
  */
-export function summarizeSessionStatuses(statuses: TerminalStatus[]): StatusSummaryChip[] {
+export function summarizeSessionStatuses(statuses: TabDisplayStatus[]): StatusSummaryChip[] {
   const counts = new Map<SummaryCategory, number>();
   for (const status of statuses) {
     const cat = categoryOf(status);

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -1,0 +1,284 @@
+// Behavioural regression net for the pure refactor that extracted
+// use-terminal-session.ts out of terminal-dock.tsx (multi-session stage 1). These
+// tests exercise the hook's session mechanics — mint → open → data → connected,
+// read-only gating, user-end, mint failure, and the grace-window reconnect — via a
+// mocked fetch + WebSocket, standing in for terminal-dock.tsx's previous inline
+// tests-by-manual-verification of the same paths. connection.ts's OWN pure logic
+// (terminalReducer, mapCloseCode, decideResize, …) is unit-tested independently in
+// connection.test.ts and is NOT re-tested here — this file is about the wiring.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTerminalSession, type TerminalSessionDescriptor } from "./use-terminal-session";
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    onData() {}
+    open() {}
+    loadAddon() {}
+    write() {}
+    clear() {}
+    focus() {}
+    dispose() {}
+  },
+}));
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}));
+
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+  },
+}));
+
+// ── mock WebSocket ────────────────────────────────────────────────────────────
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readonly url: string;
+  readyState = MockWebSocket.CONNECTING;
+  binaryType = "";
+  onopen: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onclose: ((ev: { code: number; reason: string }) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  sent: unknown[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    mockSockets.push(this);
+  }
+
+  send(data: unknown) {
+    this.sent.push(data);
+  }
+
+  close(code = 1000, reason = "") {
+    if (this.readyState === MockWebSocket.CLOSED) return;
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code, reason });
+  }
+
+  // test helpers — simulate the relay's side of the protocol
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.({});
+  }
+
+  simulateBinaryMessage(bytes: Uint8Array = new Uint8Array([1, 2, 3])) {
+    this.onmessage?.({ data: bytes.buffer });
+  }
+
+  simulateAbnormalDrop() {
+    // A real drop never calls close() first — the socket just dies. Mirror that:
+    // set CLOSED and fire onclose directly with an abnormal code, bypassing our
+    // own close() (which the dock's own teardown uses and would look identical).
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: 1006, reason: "" });
+  }
+}
+
+let mockSockets: MockWebSocket[] = [];
+function latestSocket(): MockWebSocket {
+  const s = mockSockets[mockSockets.length - 1];
+  if (!s) throw new Error("no WebSocket was constructed");
+  return s;
+}
+
+const descriptor: TerminalSessionDescriptor = {
+  ideaId: "idea-1",
+  ideaTitle: "Recipe Saver",
+  ideaGithubUrl: null,
+};
+
+function mintResponse(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    ok: true,
+    json: async () => ({
+      sessionId: "sid-abc123",
+      browserToken: "browser-token",
+      bridgeToken: "bridge-token",
+      expiresAt: Date.now() + 300_000,
+      ...overrides,
+    }),
+  };
+}
+
+describe("useTerminalSession", () => {
+  beforeEach(() => {
+    mockSockets = [];
+    toastError.mockClear();
+    toastSuccess.mockClear();
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal("fetch", vi.fn(async () => mintResponse()));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  function setup(expanded = true) {
+    const requestExpand = vi.fn();
+    const utils = renderHook(() =>
+      useTerminalSession(descriptor, { enabled: true, expanded, requestExpand }),
+    );
+    return { ...utils, requestExpand };
+  }
+
+  it("starts idle with no pair and read-write input", () => {
+    const { result } = setup();
+    expect(result.current.state.status).toBe("idle");
+    expect(result.current.pair).toBeNull();
+    expect(result.current.readOnly).toBe(false);
+    expect(result.current.inputEnabled).toBe(false); // not connected yet
+  });
+
+  it("connect() mints a session, opens the browser leg, and reaches connected on first byte", async () => {
+    const { result, requestExpand } = setup();
+
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+
+    expect(requestExpand).toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/terminal/session",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ ideaId: "idea-1" }) }),
+    );
+    expect(result.current.pair).toEqual({
+      sessionId: "sid-abc123",
+      bridgeToken: "bridge-token",
+      browserToken: "browser-token",
+    });
+    // buildRelayUrl shape: <base>/?session=<sid>&role=browser&token=<token>
+    expect(latestSocket().url).toBe(
+      "ws://127.0.0.1:8787/?session=sid-abc123&role=browser&token=browser-token",
+    );
+
+    act(() => latestSocket().simulateOpen());
+    expect(result.current.state.status).toBe("waiting-to-pair");
+
+    act(() => latestSocket().simulateBinaryMessage());
+    expect(result.current.state.status).toBe("connected");
+    expect(result.current.inputEnabled).toBe(true);
+    // First successful byte marks this browser paired (install-first gate, #87).
+    expect(window.localStorage.getItem("vibecodes:terminal:paired-v1")).toBe("1");
+  });
+
+  it("read-only gates inputEnabled while connected, independent of status", async () => {
+    const { result } = setup();
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+    act(() => latestSocket().simulateOpen());
+    act(() => latestSocket().simulateBinaryMessage());
+    expect(result.current.inputEnabled).toBe(true);
+
+    act(() => result.current.actions.setReadOnly(true));
+    expect(result.current.readOnly).toBe(true);
+    expect(result.current.inputEnabled).toBe(false);
+
+    act(() => result.current.actions.setReadOnly(false));
+    expect(result.current.inputEnabled).toBe(true);
+  });
+
+  it("end() closes the socket with a user-end reason and reaches session-ended", async () => {
+    const { result } = setup();
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+    act(() => latestSocket().simulateOpen());
+    act(() => latestSocket().simulateBinaryMessage());
+
+    const ws = latestSocket();
+    const closeSpy = vi.spyOn(ws, "close");
+    act(() => result.current.actions.end());
+
+    expect(closeSpy).toHaveBeenCalledWith(1000, "user-end");
+    expect(result.current.state.status).toBe("session-ended");
+    expect(result.current.state.endedReason).toBe("user");
+  });
+
+  it("a mint failure dispatches session-mint-failed and toasts, without opening a socket", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 500, json: async () => ({ error: "boom" }) })),
+    );
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+
+    expect(result.current.state.status).toBe("error");
+    expect(result.current.state.errorKind).toBe("session-mint-failed");
+    expect(result.current.pair).toBeNull();
+    expect(toastError).toHaveBeenCalled();
+    expect(mockSockets).toHaveLength(0);
+  });
+
+  it("an abnormal drop after a live stream reattaches within the grace window (same sid, no re-mint)", async () => {
+    vi.useFakeTimers();
+    const { result } = setup();
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+    act(() => latestSocket().simulateOpen());
+    act(() => latestSocket().simulateBinaryMessage());
+    expect(result.current.state.status).toBe("connected");
+
+    act(() => latestSocket().simulateAbnormalDrop());
+    expect(result.current.state.status).toBe("disconnected");
+    expect(mockSockets).toHaveLength(1); // no reattach socket yet — backoff pending
+
+    // First backoff attempt fires at ~1000ms + up to 250ms jitter.
+    await act(async () => {
+      vi.advanceTimersByTime(1300);
+    });
+    expect(mockSockets).toHaveLength(2);
+    expect(latestSocket().url).toContain("session=sid-abc123");
+    expect(latestSocket().url).toContain("token=browser-token"); // retained token, no re-mint
+    expect(global.fetch).toHaveBeenCalledTimes(1); // still just the original mint
+
+    act(() => latestSocket().simulateBinaryMessage());
+    expect(result.current.state.status).toBe("connected");
+  });
+
+  it("reconnect-exhausted (grace window spent) ends the session honestly, not as an error", async () => {
+    vi.useFakeTimers();
+    const { result } = setup();
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+    act(() => latestSocket().simulateOpen());
+    act(() => latestSocket().simulateBinaryMessage());
+    act(() => latestSocket().simulateAbnormalDrop());
+
+    // Exhaust the 90s grace window; the reconnect loop keeps reattaching (each new
+    // socket immediately drops again) until the deadline passes. Backoff is capped
+    // at 8s/attempt, so ~12 attempts comfortably clears the 90s window.
+    await act(async () => {
+      for (let i = 0; i < 16 && result.current.state.status !== "session-ended"; i++) {
+        vi.advanceTimersByTime(12_000);
+        const ws = mockSockets[mockSockets.length - 1];
+        if (ws.readyState !== MockWebSocket.CLOSED) ws.simulateAbnormalDrop();
+      }
+    });
+
+    expect(result.current.state.status).toBe("session-ended");
+    expect(result.current.state.endedReason).toBe("reconnect-failed");
+  });
+});

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -281,4 +281,48 @@ describe("useTerminalSession", () => {
     expect(result.current.state.status).toBe("session-ended");
     expect(result.current.state.endedReason).toBe("reconnect-failed");
   });
+
+  // Multi-session stage 2: `autoConnectWhenExpanded` stops a freshly-minted tab
+  // (mounted with `expanded` already true, delivering its own explicit launch in
+  // the same tick) from ALSO tripping the paired-auto-connect effect and minting
+  // a second, orphaned session. Requires a "supported" platform + a pre-paired
+  // browser, so these two stub navigator to a Mac UA.
+  describe("autoConnectWhenExpanded", () => {
+    const macUserAgent =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36";
+
+    beforeEach(() => {
+      vi.stubGlobal("navigator", { userAgent: macUserAgent, maxTouchPoints: 0 });
+      window.localStorage.setItem("vibecodes:terminal:paired-v1", "1");
+    });
+
+    it("auto-connects a paired, expanded, idle instance by default (unchanged P1 behaviour)", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, { enabled: true, expanded: true, requestExpand }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(global.fetch).toHaveBeenCalled();
+      expect(result.current.state.status).not.toBe("idle");
+    });
+
+    it("does NOT auto-connect when autoConnectWhenExpanded is false (a freshly-minted tab)", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result.current.state.status).toBe("idle");
+    });
+  });
 });

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -230,6 +230,115 @@ describe("useTerminalSession", () => {
     expect(mockSockets).toHaveLength(0);
   });
 
+  it("forwards taskId/taskTitle on mint when provided (C1)", async () => {
+    const fetchMock = vi.fn(async () => mintResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const requestExpand = vi.fn();
+    const { result } = renderHook(() =>
+      useTerminalSession(descriptor, {
+        enabled: true,
+        expanded: true,
+        requestExpand,
+        taskId: "task-1",
+        taskTitle: "Fix login",
+      }),
+    );
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/terminal/session",
+      expect.objectContaining({
+        body: JSON.stringify({ ideaId: "idea-1", taskId: "task-1", taskTitle: "Fix login" }),
+      }),
+    );
+  });
+
+  it("a 409 cap refusal shows the server's copy, fires the onCapExceeded callback, and never opens a socket", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          error: "You already have 5 terminals running — end one to start another.",
+          code: "cap_exceeded",
+          cap: 5,
+          active: [],
+        }),
+      })),
+    );
+    const onCapExceeded = vi.fn();
+    const requestExpand = vi.fn();
+    const { result } = renderHook(() =>
+      useTerminalSession(descriptor, { enabled: true, expanded: true, requestExpand, onCapExceeded }),
+    );
+
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+
+    expect(result.current.state.status).toBe("error");
+    expect(mockSockets).toHaveLength(0);
+    expect(toastError).toHaveBeenCalled();
+    const [title, opts] = toastError.mock.calls[0];
+    expect(title).toContain("You already have 5 terminals running");
+    expect(opts?.action?.label).toBe("View my sessions");
+    opts.action.onClick();
+    expect(onCapExceeded).toHaveBeenCalled();
+  });
+
+  it("a 429 rate-limit refusal shows distinct copy with no action button and never mentions ending a session", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 429,
+        json: async () => ({
+          error: "You're starting terminals too fast — wait a moment and try again.",
+          code: "rate_limited",
+        }),
+      })),
+    );
+    const onCapExceeded = vi.fn();
+    const requestExpand = vi.fn();
+    const { result } = renderHook(() =>
+      useTerminalSession(descriptor, { enabled: true, expanded: true, requestExpand, onCapExceeded }),
+    );
+
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+
+    expect(result.current.state.status).toBe("error");
+    expect(toastError).toHaveBeenCalledWith("You're starting terminals too fast — wait a moment and try again.");
+    expect(onCapExceeded).not.toHaveBeenCalled();
+  });
+
+  it("end() fire-and-forgets a POST to /api/terminal/session/end with the sid (C3 registry truth)", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "/api/terminal/session/end") return { ok: true, json: async () => ({ results: [] }) };
+      return mintResponse();
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = setup();
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+    act(() => latestSocket().simulateOpen());
+    act(() => latestSocket().simulateBinaryMessage());
+
+    act(() => result.current.actions.end());
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/terminal/session/end",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ sid: "sid-abc123" }),
+      }),
+    );
+  });
+
   it("an abnormal drop after a live stream reattaches within the grace window (same sid, no re-mint)", async () => {
     vi.useFakeTimers();
     const { result } = setup();

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -434,4 +434,121 @@ describe("useTerminalSession", () => {
       expect(result.current.state.status).toBe("idle");
     });
   });
+
+  async function flushEffects() {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  // Multi-session stage 4 (D1/D2, popout-channel.ts): the popped-out window's
+  // whole entry point — attach to an ALREADY-MINTED session with no mint, no
+  // deep link, no install-first gate.
+  describe("attachExisting", () => {
+    it("attaches directly to the transferred sid/browserToken — no mint, no deep link", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: { sessionId: "sid-popped", browserToken: "popped-browser-token" },
+        }),
+      );
+
+      await flushEffects();
+
+      // No mint round-trip at all — the whole point of attaching.
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result.current.state.status).toBe("connecting");
+      expect(result.current.pair).toEqual({
+        sessionId: "sid-popped",
+        browserToken: "popped-browser-token",
+      });
+      expect(latestSocket().url).toBe(
+        "ws://127.0.0.1:8787/?session=sid-popped&role=browser&token=popped-browser-token",
+      );
+
+      act(() => latestSocket().simulateOpen());
+      expect(result.current.state.status).toBe("waiting-to-pair");
+
+      act(() => latestSocket().simulateBinaryMessage());
+      expect(result.current.state.status).toBe("connected");
+      expect(result.current.inputEnabled).toBe(true);
+    });
+
+    it("reports the relay's 4001 preempted close via closeCode, distinct from every other close", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: { sessionId: "sid-popped", browserToken: "popped-browser-token" },
+        }),
+      );
+      await flushEffects();
+      act(() => latestSocket().simulateOpen());
+      act(() => latestSocket().simulateBinaryMessage());
+      expect(result.current.state.status).toBe("connected");
+
+      // The relay's DUP_BROWSER close — a "Bring back to dock" reattach
+      // preempted THIS window's leg.
+      act(() => latestSocket().close(4001, ""));
+      expect(result.current.state.status).toBe("error");
+      expect(result.current.state.errorKind).toBe("duplicate");
+      expect(result.current.state.closeCode).toBe(4001);
+    });
+
+    it("only attaches once per distinct transferred sessionId — a stable object on a later render is a no-op", async () => {
+      const requestExpand = vi.fn();
+      const attachExisting = { sessionId: "sid-popped", browserToken: "popped-browser-token" };
+      const { rerender } = renderHook(
+        (props: { attachExisting: typeof attachExisting | null }) =>
+          useTerminalSession(descriptor, {
+            enabled: true,
+            expanded: true,
+            requestExpand,
+            autoConnectWhenExpanded: false,
+            attachExisting: props.attachExisting,
+          }),
+        { initialProps: { attachExisting } },
+      );
+      await flushEffects();
+      expect(mockSockets).toHaveLength(1);
+
+      rerender({ attachExisting: { ...attachExisting } }); // same sessionId, new object identity
+      await flushEffects();
+      expect(mockSockets).toHaveLength(1); // no second socket opened
+    });
+
+    it("never trips the paired auto-connect effect, even on a browser that WOULD otherwise ambient-connect (would double-mint)", async () => {
+      // Same paired/supported setup the "autoConnectWhenExpanded" describe
+      // above uses to make the ambient auto-connect effect's guard pass —
+      // proving `autoConnectWhenExpanded: false` (a real popped window's
+      // actual wiring) is enough to stop it from ALSO firing connect()
+      // alongside attachToExisting and minting a second, orphaned session.
+      window.localStorage.setItem("vibecodes:terminal:paired-v1", "1");
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+        maxTouchPoints: 0,
+      });
+      const requestExpand = vi.fn();
+      renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: { sessionId: "sid-popped", browserToken: "popped-browser-token" },
+        }),
+      );
+      await flushEffects();
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockSockets).toHaveLength(1); // exactly the attach's own socket, nothing extra
+    });
+  });
 });

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -1,0 +1,1048 @@
+"use client";
+
+// In-app local Claude Code terminal — the PER-SESSION hook (SLICE: multi-session
+// stage 1, pure refactor).
+//
+// Extracted from terminal-dock.tsx (P1, single-session) with NO behaviour change:
+// every timer, ref and effect here is the same one that lived in the component,
+// just relocated behind a hook boundary so a future multi-session dock (stage 2+)
+// can mount one instance of this hook PER TAB. See
+// docs/design-terminal-multi-session-popout.html §4: "Each tab owns an independent
+// instance of P1's terminalReducer, buffer, heartbeat watchdog and grace-window
+// loop."
+//
+// Owns EVERYTHING one session needs:
+//   - the connection state machine (terminalReducer) + install-first gate inputs
+//     (platform / paired) + same-machine launch phase
+//   - the WebSocket browser leg (mint → open → heartbeat/watchdog → grace-window
+//     reattach → teardown)
+//   - the xterm.js Terminal instance + fit addon, attached to `containerRef`
+//   - resize handling (ResizeObserver + on-expand + on-connected retries)
+//   - focus management (first-connect + on-expand)
+//   - read-only gating (isInputEnabled)
+//   - the vibecodes:// deep-link fire (same-machine auto-launch) + its ~8s timeout
+//
+// What it deliberately does NOT own (stays with the caller/consumer):
+//   - `expanded` (is the dock panel open) — that's dock CHROME, shared by every
+//     tab in stage 2, not a per-session concern. Passed in as an option; the hook
+//     calls `requestExpand()` at the same points the old component called
+//     `setExpanded(true)`.
+//   - the launch-bus subscription (`subscribeBrowserLaunch`) — board-level wiring
+//     that decides WHICH session a bus event targets. The caller forwards a
+//     payload via `actions.launchFromBus`.
+//   - all rendering (pills, panels, buttons) — presentational, driven by this
+//     hook's return value.
+//
+// The connection STATE MACHINE + close-code mapping + framing are pure and live in
+// src/lib/terminal/connection.ts — UNCHANGED, not touched by this refactor.
+
+import "@xterm/xterm/css/xterm.css";
+import { useCallback, useEffect, useReducer, useRef, useState, type RefObject } from "react";
+import { toast } from "sonner";
+import { logger } from "@/lib/logger";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import type { FitAddon as XFitAddon } from "@xterm/addon-fit";
+import {
+  CONNECT_TIMEOUT_MS,
+  HEARTBEAT_INTERVAL_MS,
+  LINK_SILENT_CHECK_MS,
+  RECONNECT_GRACE_MS,
+  buildRelayUrl,
+  claimConnectGeneration,
+  decideResize,
+  isConnectSuperseded,
+  encodeHeartbeatFrame,
+  encodeResizeMessage,
+  initialConnectionState,
+  isHeartbeatAckFrame,
+  isInputEnabled,
+  isPeerDegradedFrame,
+  isPeerReattachedFrame,
+  mapCloseCode,
+  relayBaseUrl,
+  shouldDeclareLinkSilent,
+  terminalReducer,
+  type TerminalConnectionState,
+  type TerminalStatus,
+} from "@/lib/terminal/connection";
+import {
+  MAX_LAUNCH_URL_LENGTH,
+  buildLaunchDeepLink,
+  redactDeepLinkToken,
+} from "@/lib/terminal/deep-link";
+import { type BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
+import {
+  buildBoundedDeepLink,
+  buildCompactPromptEssentials,
+  resolveAppUrl,
+  resolveDefaultLaunchState,
+  resolveLaunchCwd,
+} from "@/lib/launch-claude-code";
+import {
+  type TerminalPlatform,
+  readPlatformSignals,
+  resolveTerminalPlatform,
+} from "@/lib/terminal/platform";
+import { isBrowserPaired, markBrowserPaired, resolveFirstRunEntry } from "@/lib/terminal/paired-flag";
+import { type LaunchPhase, nextLaunchPhaseOnTimeout } from "@/lib/terminal/first-run-flow";
+
+// How long we wait for the helper to attach after firing the deep link before
+// dropping to the calm fallback (~8s, per the approved UX). This is the safety net
+// for criterion #8: a custom-scheme link with no handler can't be reliably detected,
+// so we always fall through here rather than spin forever.
+const HELPER_OPEN_TIMEOUT_MS = 8000;
+
+/** What identifies the idea/board a session's launches are bootstrapped for. */
+export interface TerminalSessionDescriptor {
+  ideaId: string;
+  ideaTitle: string;
+  /**
+   * The idea's GitHub URL (or null). Needed so hook-initiated launches — paired
+   * auto-connect and Retry, which never pass through the launch button — can
+   * build the SAME board-level compact bootstrap prompt the button would
+   * (shared resolveDefaultLaunchState + buildCompactPromptEssentials).
+   */
+  ideaGithubUrl: string | null;
+}
+
+export interface UseTerminalSessionOptions {
+  /** Master feature gate — mirrors isTerminalEnabled(); effects no-op when false. */
+  enabled: boolean;
+  /** Is the dock panel currently open? Drives resize/focus/auto-connect timing. */
+  expanded: boolean;
+  /**
+   * Called at the same points the old component called `setExpanded(true)` —
+   * opening/reopening a session should bring the (shared) dock panel into view.
+   * `expanded` itself stays owned by the caller (dock chrome, not per-session).
+   */
+  requestExpand: () => void;
+}
+
+export interface PairInfo {
+  sessionId: string;
+  bridgeToken: string;
+  // Retained so a TRANSIENT drop can REATTACH to the SAME sid with no re-mint
+  // (grace-window reconnect). `browserToken` re-opens the browser leg. Reattach is
+  // bounded purely by RECONNECT_GRACE_MS — the relay waives token expiry for a
+  // same-owner reattach to a live session (fix/terminal-expired-reattach), so no
+  // client-side expiry gate exists here.
+  browserToken: string;
+}
+
+export interface TerminalSessionActions {
+  /** Mint a session and open the browser leg; autoLaunch fires the vibecodes:// deep link. */
+  connect: (options?: { autoLaunch?: boolean }) => Promise<void>;
+  /**
+   * Install-first entry gate. This is the ONE place a browser "open" is turned into
+   * either a setup panel, a coming-soon panel, or an auto-connect — the deep link is
+   * never fired for an unpaired browser here (criterion #2).
+   */
+  beginBrowserLaunch: () => void;
+  /**
+   * Record the launch-bus payload (the launch button's resolved compact prompt) for
+   * THIS session, then run the install-first gate. Keeping the mint in ONE place
+   * means the session — and its bridge token — is never created twice.
+   */
+  launchFromBus: (payload: BrowserLaunchPayload | null) => void;
+  /** Force an immediate reattach attempt (skip the backoff wait), or a fresh launch if the grace window is spent. */
+  reconnectNow: () => void;
+  /** User-initiated end. */
+  end: () => void;
+  setReadOnly: (value: boolean | ((prev: boolean) => boolean)) => void;
+  copyBridgeCommand: () => void;
+}
+
+export interface UseTerminalSessionResult {
+  /** Full connection state machine snapshot (status, sessionId, errorKind, endedReason, closeCode). */
+  state: TerminalConnectionState;
+  /** Same-machine auto-launch phase: "idle" | "opening" | "helper-timeout". */
+  launchPhase: LaunchPhase;
+  /** Grace-window "peer dropped, we're holding" hint. */
+  peerDegraded: boolean;
+  /** The minted session's ids/tokens (null before mint / after end). */
+  pair: PairInfo | null;
+  readOnly: boolean;
+  /** isInputEnabled(state, readOnly) — convenience, the same predicate xterm's onData gates on. */
+  inputEnabled: boolean;
+  /** Install-first gate inputs, corrected client-side on mount (SSR default: unsupported/unpaired). */
+  platform: TerminalPlatform;
+  paired: boolean;
+  /** True once the xterm instance is mounted into containerRef and ready to attach. */
+  xtermReady: boolean;
+  /** Attach this to the DOM node that should host the xterm viewport. */
+  containerRef: RefObject<HTMLDivElement | null>;
+  actions: TerminalSessionActions;
+}
+
+export function useTerminalSession(
+  descriptor: TerminalSessionDescriptor,
+  options: UseTerminalSessionOptions,
+): UseTerminalSessionResult {
+  const { ideaId, ideaTitle, ideaGithubUrl } = descriptor;
+  const { enabled, expanded, requestExpand } = options;
+
+  const [state, dispatch] = useReducer(terminalReducer, initialConnectionState);
+  const [readOnly, setReadOnly] = useState(false);
+  const [pair, setPair] = useState<PairInfo | null>(null);
+  const [xtermReady, setXtermReady] = useState(false);
+  // Same-machine auto-launch UI (the vibecodes:// deep-link path). "idle" = the
+  // manual cross-machine flow (copy a command); "opening" = we fired a deep link and
+  // are waiting on the local helper; "helper-timeout" = the calm ~8s fallback.
+  const [launchPhase, setLaunchPhase] = useState<LaunchPhase>("idle");
+  // Install-first gate inputs. Initialised SSR-safe (server → unsupported/unpaired)
+  // then corrected on mount; the dock body is only visible after an explicit open,
+  // which always re-reads these first.
+  const [platform, setPlatform] = useState<TerminalPlatform>(() =>
+    resolveTerminalPlatform(readPlatformSignals()),
+  );
+  const [paired, setPaired] = useState<boolean>(() => isBrowserPaired());
+  // Grace-window degrade hint: the relay told us our peer (the bridge) dropped and
+  // it's HOLDING the session. The terminal stays visible; we show a subtle
+  // "reconnecting" hint until peer-reattached (or the window expires).
+  const [peerDegraded, setPeerDegraded] = useState(false);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const termRef = useRef<XTerm | null>(null);
+  const fitRef = useRef<XFitAddon | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const connectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const helperTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const launchIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const lastDimsRef = useRef<string>("");
+  // Single-flight guard: every connect() bumps this and captures its value. If a
+  // newer connect() starts while an older one is still awaiting its session mint,
+  // the older one aborts before minting a 2nd session / firing a 2nd deep link —
+  // otherwise two sessions + two bridges race and the relay tears both down
+  // (single-attach / peer-gone). This is the fix for the "connect fires twice" bug.
+  const connectGenRef = useRef(0);
+  // Grace-window reconnect bookkeeping. `reconnectDeadlineRef.current === 0` means
+  // "healthy, not reconnecting"; it's set on the first transient drop and cleared
+  // once a byte proves the link healthy again. The pair (sid + retained tokens) is
+  // mirrored into a ref so the timer-driven reconnect loop reads current creds
+  // without re-binding. `scheduleReconnectRef` breaks the openBrowserLeg ⇄
+  // scheduleReconnect cycle. `degradeTimerRef` bounds the peer-degraded wait.
+  const reconnectDeadlineRef = useRef(0);
+  const reconnectAttemptRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const degradeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pairRef = useRef<PairInfo | null>(null);
+  const scheduleReconnectRef = useRef<() => void>(() => {});
+  // Silent-link watchdog bookkeeping (fix/terminal-dock-heartbeat).
+  // `lastInboundAtRef` is stamped on EVERY inbound frame (PTY bytes, control
+  // frames, hb-acks); `hbArmedRef` is a PER-SOCKET latch set on the socket's first
+  // hb-ack — an old relay never acks, so the watchdog stays disarmed there and the
+  // pre-watchdog behaviour is unchanged (version-skew gate). Both are reset in
+  // openBrowserLeg when a fresh socket is opened.
+  const lastInboundAtRef = useRef(0);
+  const hbArmedRef = useRef(false);
+  // The compact bootstrap prompt ESSENTIALS (BUG5 follow-through, 4th rework
+  // cycle) the LAST launch-bus event carried — i.e. what the launch button
+  // resolved. Hook-initiated launches with no bus payload (paired auto-connect
+  // on open, Retry) fall back to building the board-level essentials themselves
+  // via the same shared builder (see resolveLaunchPromptParts), so every launch
+  // is primed.
+  const promptPartsRef = useRef<BrowserLaunchPayload | null>(null);
+
+  // Mirror live state into refs so the stable xterm onData handler + socket handlers
+  // read current values without re-binding on every render.
+  const statusRef = useRef(state.status);
+  const readOnlyRef = useRef(readOnly);
+  const pairedRef = useRef(paired);
+  statusRef.current = state.status;
+  readOnlyRef.current = readOnly;
+  pairedRef.current = paired;
+  pairRef.current = pair;
+
+  // Previous connection status, updated ONLY by the first-connect focus effect
+  // below (fix/terminal-dock-launch-defects) — so it reflects status "as of the
+  // last time that effect ran" rather than every render, letting it tell a
+  // genuine first connect (prev connecting/waiting-to-pair) apart from a
+  // grace-window reattach (prev disconnected), which must NOT steal focus.
+  const prevStatusRef = useRef<TerminalStatus>(state.status);
+
+  // ── lazy, client-only xterm init ────────────────────────────────────────────
+  useEffect(() => {
+    if (!enabled) return;
+    let disposed = false;
+    let term: XTerm | null = null;
+
+    (async () => {
+      const [{ Terminal }, { FitAddon }] = await Promise.all([
+        import("@xterm/xterm"),
+        import("@xterm/addon-fit"),
+      ]);
+      if (disposed || !containerRef.current) return;
+
+      term = new Terminal({
+        convertEol: false,
+        cursorBlink: true,
+        fontFamily: 'ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace',
+        fontSize: 12.5,
+        theme: { background: "#0c0c0e", foreground: "#cfd8df", cursor: "#cfd8df" },
+        scrollback: 5000,
+      });
+      const fit = new FitAddon();
+      term.loadAddon(fit);
+      term.open(containerRef.current);
+      try {
+        fit.fit();
+      } catch {
+        /* container may be 0-size while collapsed — refit on expand */
+      }
+
+      // Keystrokes → relay (binary). Guarded by the pure input-enabled predicate so
+      // read-only / non-connected states never reach the PTY.
+      term.onData((data) => {
+        if (statusRef.current !== "connected" || readOnlyRef.current) return;
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(new TextEncoder().encode(data));
+        }
+      });
+
+      termRef.current = term;
+      fitRef.current = fit;
+      setXtermReady(true);
+    })().catch((err) => {
+      logger.error("Terminal xterm init failed", { error: err instanceof Error ? err.message : String(err) });
+    });
+
+    return () => {
+      disposed = true;
+      term?.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+    };
+  }, [enabled]);
+
+  // Correct the install-first gate inputs on mount (navigator is only reliable
+  // client-side; the SSR defaults above assume unsupported/unpaired).
+  useEffect(() => {
+    if (!enabled) return;
+    setPlatform(resolveTerminalPlatform(readPlatformSignals()));
+    setPaired(isBrowserPaired());
+  }, [enabled]);
+
+  // Fit + emit a resize control frame (TEXT) matching the bridge's framing.
+  //
+  // Deferred via decideResize (fix/terminal-dock-launch-defects,
+  // fix/terminal-dock-cold-launch-resize): a resize can only REACH the PTY once the
+  // socket is OPEN *and* the bridge/peer is attached (status "connected") — the
+  // relay drops browser→bridge frames with no buffering while unpaired, so socket
+  // OPEN alone is not sufficient (see the `ResizeDecision` doc comment in
+  // connection.ts). On a cold autolaunch the browser's wss handshake beats the
+  // helper→bridge attach by hundreds of ms to seconds, so the ResizeObserver /
+  // expand-rAF below fire while the socket is OPEN but still unpaired — sending
+  // then would be silently dropped by the relay. A "defer" leaves lastDimsRef
+  // untouched, so the SAME key resolves to a "send" once the connected-transition
+  // effect re-fires this (below).
+  const sendResize = useCallback(() => {
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit) return;
+    try {
+      fit.fit();
+    } catch {
+      return;
+    }
+    const msg = encodeResizeMessage(term.cols, term.rows);
+    if (!msg) return;
+    const key = `${term.cols}x${term.rows}`;
+    const ws = wsRef.current;
+    const isReachable = ws?.readyState === WebSocket.OPEN && statusRef.current === "connected";
+    const decision = decideResize(key, lastDimsRef.current, isReachable);
+    if (decision.action !== "send") return;
+    lastDimsRef.current = decision.nextLastKey;
+    ws?.send(msg);
+  }, []);
+
+  // Refit on container resize and whenever the dock expands.
+  useEffect(() => {
+    if (!xtermReady || !containerRef.current) return;
+    const ro = new ResizeObserver(() => sendResize());
+    ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, [xtermReady, sendResize]);
+
+  useEffect(() => {
+    if (expanded) {
+      // Next paint, once the body has non-zero size.
+      const id = window.requestAnimationFrame(() => sendResize());
+      return () => window.cancelAnimationFrame(id);
+    }
+  }, [expanded, sendResize]);
+
+  // Resend on the transition to "connected" (fix/terminal-dock-cold-launch-resize).
+  // The bridge/peer only becomes reachable the moment status flips to "connected"
+  // (first inbound PTY byte), so any resize computed BEFORE that point — the
+  // ResizeObserver / expand-rAF above fire well before this on a cold autolaunch —
+  // was deferred with its key un-advanced. Re-running sendResize() here is exactly
+  // the retry that resolves that deferred key to a real "send" now that it can
+  // reach the PTY. Fires on every transition INTO "connected", so it also covers a
+  // grace-window reattach; when dims are unchanged that's just a "skip" (harmless).
+  useEffect(() => {
+    if (state.status === "connected") sendResize();
+  }, [state.status, sendResize]);
+
+  // ── launch focus (fix/terminal-dock-launch-defects, Defect 2) ──────────────
+  // Nothing previously called termRef.current.focus() — a freshly connected
+  // terminal never had keyboard focus, so the first keystroke was silently lost
+  // (isInputEnabled gates on state.status === "connected", but the DOM node never
+  // had focus for the browser to route the keystroke to).
+  //
+  // First-connect focus: fires only on a genuine "we just reached the bridge for
+  // the first time" transition (prior status connecting/waiting-to-pair), never on
+  // a grace-window reattach (prior status disconnected) — a user typing mid-drop
+  // must not have their cursor/scroll position hijacked by an automatic reattach.
+  useEffect(() => {
+    const prev = prevStatusRef.current;
+    if (
+      state.status === "connected" &&
+      (prev === "connecting" || prev === "waiting-to-pair") &&
+      expanded
+    ) {
+      termRef.current?.focus();
+    }
+    prevStatusRef.current = state.status;
+  }, [state.status, expanded]);
+
+  // Expand focus: a user-initiated expand of an already-live session (e.g.
+  // collapse then re-expand while connected) should also land focus in the
+  // terminal. Keyed ONLY on `expanded` (not state.status) so a background status
+  // change — e.g. a reattach completing while the dock is already expanded —
+  // never re-triggers this and steals focus; it reads the current status from
+  // closure at the moment `expanded` itself transitions.
+  useEffect(() => {
+    if (!expanded || state.status !== "connected") return;
+    // Next paint, mirroring the expand-rAF resize above — the container must be
+    // un-hidden before focus() can land.
+    const id = window.requestAnimationFrame(() => termRef.current?.focus());
+    return () => window.cancelAnimationFrame(id);
+    // Deliberately excludes state.status: see comment above (must only re-run on
+    // `expanded` transitions, not on every status change, or a background
+    // reattach while already expanded would steal focus).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expanded]);
+
+  const clearConnectTimer = useCallback(() => {
+    if (connectTimerRef.current) {
+      clearTimeout(connectTimerRef.current);
+      connectTimerRef.current = null;
+    }
+  }, []);
+
+  const clearHelperTimer = useCallback(() => {
+    if (helperTimerRef.current) {
+      clearTimeout(helperTimerRef.current);
+      helperTimerRef.current = null;
+    }
+  }, []);
+
+  const clearReconnectTimer = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  }, []);
+
+  const clearDegradeTimer = useCallback(() => {
+    if (degradeTimerRef.current) {
+      clearTimeout(degradeTimerRef.current);
+      degradeTimerRef.current = null;
+    }
+  }, []);
+
+  // Remove the hidden probe iframe used to fire the deep link (see fireLaunchDeepLink).
+  const removeLaunchIframe = useCallback(() => {
+    const frame = launchIframeRef.current;
+    launchIframeRef.current = null;
+    if (frame && frame.parentNode) frame.parentNode.removeChild(frame);
+  }, []);
+
+  // The compact bootstrap prompt ESSENTIALS + cwd for THIS launch: the payload
+  // the launch button put on the bus (its exact resolved state — task- or
+  // board-level) or, for hook-initiated launches (paired auto-connect / Retry),
+  // the board-level essentials built here from the SAME shared state resolver +
+  // builder the button uses — so the in-browser prompt is byte-identical to the
+  // terminal-window deep link's for the same state, and never duplicated. BUG5
+  // follow-through (4th rework cycle): built as ESSENTIALS (buildCompactPromptEssentials),
+  // not the unconditional buildCompactBootstrapPromptParts this used to call —
+  // that builder bakes the worktree-isolation protocol into a never-trimmed
+  // head, so fireLaunchDeepLink's own budget clamp had no clean way to drop it
+  // on overflow. The fallback's cwd uses the same shared rule (resolveLaunchCwd);
+  // the hook has no recordedProjectPaths, so it passes no effective cwd — a
+  // pinned existing-mode folder still resolves (rule 1), while the
+  // recorded-path injection only flows through the button payload, exactly as
+  // the terminal-window default path would behave.
+  const resolveLaunchPromptParts = useCallback((): BrowserLaunchPayload => {
+    const carried = promptPartsRef.current;
+    if (carried) return carried;
+    const s = resolveDefaultLaunchState(ideaId, ideaTitle, ideaGithubUrl);
+    const essentials = buildCompactPromptEssentials({
+      appUrl: resolveAppUrl(),
+      ideaId,
+      ideaTitle,
+      mode: s.mode,
+      repoUrl: ideaGithubUrl,
+      newProject: s.mode === "new" ? { newProjectPath: s.path } : undefined,
+      // Parity with the launch button: a pinned existing folder emits the same
+      // verify-folder step. The hook has no recorded DB paths, so this only fires
+      // for a user-pinned localStorage path (resolveDefaultLaunchState → existing).
+      existingPath:
+        s.mode === "existing" && s.path.trim() ? s.path.trim() : undefined,
+    });
+    return { essentials, cwd: resolveLaunchCwd(s, undefined) };
+  }, [ideaId, ideaTitle, ideaGithubUrl]);
+
+  // Fire the signed vibecodes:// deep link so a same-machine helper attaches as the
+  // bridge leg with no copied command. The bridge token is a secret — it travels in
+  // the link but is NEVER logged (only the redacted form is). The link also carries
+  // the compact bootstrap prompt as an INERT string: the helper/bridge hold it and
+  // only pass it to a spawned claude AFTER the relay accepts the owner-bound token
+  // (R1); an old helper simply ignores the unknown param (graceful cold launch).
+  //
+  // BEST-EFFORT dialog mitigation (criterion #8): we fire via a hidden, detached
+  // iframe rather than a top-level window.location.assign. A top-level navigation to
+  // an unhandled custom scheme is the surest way to trigger macOS's "no application
+  // set / Search App Store" dialog; routing it through a probe iframe suppresses that
+  // dialog in most Chromium builds. It is NOT a cross-browser guarantee (Safari /
+  // Firefox may still surface a milder prompt) — the ~8s timeout below is the real
+  // safety net, and the authoritative success signal is the first byte from the
+  // bridge (ws.onmessage), which proves the helper actually opened AND attached.
+  const fireLaunchDeepLink = useCallback(
+    (sessionId: string, bridgeToken: string) => {
+      let link: string;
+      let urlChars = 0;
+      let hasCwd = false;
+      let droppedCwd = false;
+      try {
+        const { essentials, cwd } = resolveLaunchPromptParts();
+        hasCwd = !!cwd;
+        // Budget the prompt against the vibecodes:// URL ceiling via
+        // buildBoundedDeepLink (FIX A, QA BUG A) — the SAME shared helper the
+        // claude-cli:// deep link uses. BUG5 follow-through (4th rework
+        // cycle): it routes through fitCompactWorktreeProtocol so the
+        // worktree-isolation protocol rides the head only when it fits whole
+        // (never a half-truncated fragment, essentials always prioritised
+        // over the best-effort protocol). New this cycle: it ALSO guarantees
+        // the fired URL is never over-cap when `cwd` ITSELF (not just the
+        // prompt) is long enough to blow the cap alone — the vibecodes://
+        // `prompt=` param key is only present once the prompt is non-empty,
+        // so `promptKeyOverhead` reserves room for it up front (mirrors the
+        // manual `- "&prompt=".length` this replaces).
+        const result = buildBoundedDeepLink({
+          essentials,
+          cwd,
+          cap: MAX_LAUNCH_URL_LENGTH,
+          promptKeyOverhead: "&prompt=".length,
+          buildLink: ({ prompt, cwd: linkCwd }) =>
+            buildLaunchDeepLink({
+              relay: relayBaseUrl(),
+              session: sessionId,
+              token: bridgeToken,
+              cwd: linkCwd,
+              prompt,
+            }),
+        });
+        if (!result.ok) {
+          logger.error("Terminal deep-link build failed", {
+            reason: "path_too_long",
+          });
+          toast.error("Project path too long to launch — open the folder manually and run Claude Code there");
+          setLaunchPhase("helper-timeout");
+          return;
+        }
+        link = result.url;
+        droppedCwd = result.droppedCwd;
+        urlChars = link.length;
+      } catch (err) {
+        logger.error("Terminal deep-link build failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setLaunchPhase("helper-timeout");
+        return;
+      }
+      // redactDeepLinkToken elides BOTH the token (secret) and the prompt (user
+      // content); the cwd (a local filesystem path) is stripped here too — only
+      // its PRESENCE and the prompt's length are logged.
+      logger.info("Terminal firing launch deep link", {
+        sessionId,
+        url: redactDeepLinkToken(link).replace(/([?&]cwd=)[^&]*/g, "$1***"),
+        urlChars,
+        hasCwd,
+        droppedCwd,
+      });
+      setLaunchPhase("opening");
+
+      removeLaunchIframe();
+      try {
+        const frame = document.createElement("iframe");
+        frame.setAttribute("aria-hidden", "true");
+        frame.style.display = "none";
+        frame.src = link;
+        document.body.appendChild(frame);
+        launchIframeRef.current = frame;
+      } catch {
+        // Iframe path unavailable — fall back to a direct assign.
+        try {
+          window.location.assign(link);
+        } catch {
+          setLaunchPhase("helper-timeout");
+          return;
+        }
+      }
+
+      // If the helper doesn't stream within ~8s, drop to the calm fallback (never an
+      // infinite spinner — criterion #8).
+      clearHelperTimer();
+      helperTimerRef.current = setTimeout(() => {
+        removeLaunchIframe();
+        setLaunchPhase(nextLaunchPhaseOnTimeout);
+      }, HELPER_OPEN_TIMEOUT_MS);
+    },
+    [clearHelperTimer, removeLaunchIframe, resolveLaunchPromptParts],
+  );
+
+  const teardownSocket = useCallback(() => {
+    clearConnectTimer();
+    // Cancel any in-flight grace-window reconnect loop / degrade wait, and reset the
+    // reconnect budget. Nulling the socket's handlers below means a teardown-initiated
+    // close never re-triggers the reconnect loop (only genuine drops do).
+    clearReconnectTimer();
+    clearDegradeTimer();
+    reconnectDeadlineRef.current = 0;
+    reconnectAttemptRef.current = 0;
+    setPeerDegraded(false);
+    const ws = wsRef.current;
+    wsRef.current = null;
+    if (ws) {
+      ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+    }
+  }, [clearConnectTimer, clearReconnectTimer, clearDegradeTimer]);
+
+  // Open (or RE-open) the BROWSER leg to the relay and wire its handlers. Shared by
+  // connect() (fresh session) and the grace-window reconnect loop (same sid, retained
+  // token — NO re-mint). `reconnect` skips the hard 30s connect-timeout→error: while
+  // reconnecting the grace-window scheduler bounds the retries instead.
+  const openBrowserLeg = useCallback(
+    (sessionId: string, browserToken: string, opts?: { reconnect?: boolean }) => {
+      const reconnect = opts?.reconnect ?? false;
+      const url = buildRelayUrl(relayBaseUrl(), sessionId, browserToken);
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(url);
+      } catch (err) {
+        logger.error("Terminal relay socket open failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        dispatch({ type: "closed", code: 1006 });
+        return;
+      }
+      ws.binaryType = "arraybuffer";
+      wsRef.current = ws;
+      // Fresh socket → fresh watchdog: disarm until ITS first hb-ack and restart
+      // the silence clock (an inherited stale stamp must never condemn a new leg).
+      hbArmedRef.current = false;
+      lastInboundAtRef.current = Date.now();
+
+      if (!reconnect) {
+        connectTimerRef.current = setTimeout(() => {
+          dispatch({ type: "connect-timeout" });
+          teardownSocket();
+        }, CONNECT_TIMEOUT_MS);
+      }
+
+      ws.onopen = () => {
+        clearConnectTimer();
+        dispatch({ type: "relay-open" });
+        // No sendResize() retry here (fix/terminal-dock-cold-launch-resize): OPEN
+        // means the socket reached the relay, but the bridge/peer may not be
+        // attached yet, so decideResize would just "defer" again — a wasted call.
+        // The connected-transition effect (see sendResize's call sites) is the one
+        // retry that matters: it fires once reachability is actually true.
+      };
+      ws.onmessage = (ev) => {
+        // ANY inbound frame proves the link carried something just now — feed the
+        // silent-link watchdog before any classification.
+        lastInboundAtRef.current = Date.now();
+        // TEXT = relay control frame on the BROWSER leg. The grace-window notices
+        // arrive here (the R1 `attached` frame goes to the bridge leg only).
+        if (typeof ev.data === "string") {
+          if (isHeartbeatAckFrame(ev.data)) {
+            // The relay's liveness echo — arm the watchdog for THIS socket. Never
+            // written to the xterm and never logged as content.
+            hbArmedRef.current = true;
+            return;
+          }
+          if (isPeerDegradedFrame(ev.data)) {
+            // Our peer (the bridge) dropped; the relay is HOLDING the session. Keep
+            // the terminal, show a subtle hint, and bound the wait to the grace window.
+            setPeerDegraded(true);
+            if (!degradeTimerRef.current) {
+              degradeTimerRef.current = setTimeout(() => {
+                degradeTimerRef.current = null;
+                setPeerDegraded(false);
+                dispatch({ type: "reconnect-exhausted" });
+                try {
+                  wsRef.current?.close(1000, "reconnect-grace-expired");
+                } catch {
+                  /* already closing */
+                }
+              }, RECONNECT_GRACE_MS);
+            }
+          } else if (isPeerReattachedFrame(ev.data)) {
+            // The pair is whole again inside the window — resume. Proves the pipe is
+            // restored even before the next byte, so drop back to connected + reset
+            // the reconnect budget (a scenario-1 already-connected leg no-ops).
+            clearDegradeTimer();
+            setPeerDegraded(false);
+            reconnectDeadlineRef.current = 0;
+            reconnectAttemptRef.current = 0;
+            dispatch({ type: "data" });
+          }
+          return;
+        }
+        // BINARY = opaque PTY bytes → the bridge is streaming; the link is HEALTHY.
+        // Clear the launch nudges, mark paired on first success, and reset every
+        // reconnect/degrade timer + budget so a later drop starts a fresh window.
+        clearHelperTimer();
+        removeLaunchIframe();
+        setLaunchPhase("idle");
+        clearDegradeTimer();
+        setPeerDegraded(false);
+        reconnectDeadlineRef.current = 0;
+        reconnectAttemptRef.current = 0;
+        if (!pairedRef.current) {
+          markBrowserPaired();
+          setPaired(true);
+        }
+        dispatch({ type: "data" });
+        termRef.current?.write(new Uint8Array(ev.data as ArrayBuffer));
+      };
+      ws.onerror = () => {
+        logger.warn("Terminal relay socket error", { sessionId });
+      };
+      ws.onclose = (ev) => {
+        clearConnectTimer();
+        wsRef.current = null;
+        dispatch({ type: "closed", code: ev.code, reason: ev.reason });
+        // Grace-window reconnect: a transient drop AFTER a live stream (PEER_GONE /
+        // abnormal 1006) is recoverable → keep reattaching within the window. Any
+        // terminal / clean-end code maps to a non-disconnected state and stops here.
+        // A teardown-initiated close nulled these handlers, so it never reaches this.
+        const mapped = mapCloseCode(ev.code, ev.reason, statusRef.current);
+        if (mapped.status === "disconnected") scheduleReconnectRef.current();
+      };
+    },
+    [teardownSocket, clearConnectTimer, clearHelperTimer, removeLaunchIframe, clearDegradeTimer],
+  );
+
+  // Drive the grace-window reconnect loop: reattach to the SAME sid with the retained
+  // browser token, with jittered exponential backoff, bounded purely by the grace
+  // window (the relay waives token expiry for a same-owner reattach to a live
+  // session, so an AGED session reconnects too — fix/terminal-expired-reattach).
+  // When the window is spent with no reattach, end honestly (reconnect-exhausted →
+  // the calm "session ended, start a new one" overlay). No re-mint, no deep link —
+  // a bounded, silent reattach.
+  const scheduleReconnect = useCallback(() => {
+    clearDegradeTimer();
+    const p = pairRef.current;
+    const now = Date.now();
+    if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
+    if (!p || now >= reconnectDeadlineRef.current) {
+      reconnectDeadlineRef.current = 0;
+      reconnectAttemptRef.current = 0;
+      dispatch({ type: "reconnect-exhausted" });
+      return;
+    }
+    const attempt = reconnectAttemptRef.current++;
+    const delay = Math.min(1000 * 2 ** attempt, 8000) + Math.floor(Math.random() * 250);
+    clearReconnectTimer();
+    reconnectTimerRef.current = setTimeout(() => {
+      const pp = pairRef.current;
+      if (!pp || Date.now() >= reconnectDeadlineRef.current) {
+        reconnectDeadlineRef.current = 0;
+        reconnectAttemptRef.current = 0;
+        dispatch({ type: "reconnect-exhausted" });
+        return;
+      }
+      openBrowserLeg(pp.sessionId, pp.browserToken, { reconnect: true });
+    }, delay);
+  }, [openBrowserLeg, clearReconnectTimer, clearDegradeTimer]);
+  scheduleReconnectRef.current = scheduleReconnect;
+
+  // ── silent-link watchdog (fix/terminal-dock-heartbeat) ─────────────────────
+  // The watchdog verdict landed: the socket still LOOKS open but nothing inbound
+  // (PTY bytes or hb-acks) arrived for the whole silence threshold — a silent link
+  // death (wifi off / network switch; macOS never RSTs, so no close event ever
+  // fires). Tear down the ZOMBIE socket exactly like teardownSocket's socket step
+  // — null the handlers FIRST so its eventual close can't double-drive the state —
+  // then route into the EXISTING reattach machinery: disconnected + the
+  // grace-window reconnect loop (same sid, retained token, no re-mint).
+  const declareLinkSilent = useCallback(() => {
+    const ws = wsRef.current;
+    wsRef.current = null;
+    if (ws) {
+      ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+    }
+    clearDegradeTimer();
+    setPeerDegraded(false);
+    dispatch({ type: "link-silent" });
+    scheduleReconnectRef.current();
+  }, [clearDegradeTimer]);
+
+  // While CONNECTED: probe the relay with the app-level heartbeat every
+  // HEARTBEAT_INTERVAL_MS and run the silence check every LINK_SILENT_CHECK_MS.
+  // The check computes WALL-CLOCK elapsed (a hidden tab's clamped timers can only
+  // delay a tick, never fake recency) and re-runs immediately when the tab becomes
+  // visible or the browser flips online/offline — the moments a silent death is
+  // most likely to be discovered.
+  useEffect(() => {
+    if (!enabled || state.status !== "connected") return;
+
+    const sendHeartbeat = () => {
+      const ws = wsRef.current;
+      if (ws && ws.readyState === WebSocket.OPEN) ws.send(encodeHeartbeatFrame());
+    };
+    const check = () => {
+      if (statusRef.current !== "connected") return;
+      if (shouldDeclareLinkSilent(lastInboundAtRef.current, Date.now(), hbArmedRef.current)) {
+        logger.warn("Terminal link silent — declaring dead, reattaching", {
+          silentMs: Date.now() - lastInboundAtRef.current,
+        });
+        declareLinkSilent();
+      }
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") check();
+    };
+
+    // Probe immediately so the watchdog ARMS on the first ack instead of waiting a
+    // whole interval (matters when a drop happens right after connecting).
+    sendHeartbeat();
+    const sendTimer = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS);
+    const checkTimer = setInterval(check, LINK_SILENT_CHECK_MS);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("online", check);
+    window.addEventListener("offline", check);
+    return () => {
+      clearInterval(sendTimer);
+      clearInterval(checkTimer);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("online", check);
+      window.removeEventListener("offline", check);
+    };
+  }, [enabled, state.status, declareLinkSilent]);
+
+  // ── connect (browser leg) ───────────────────────────────────────────────────
+  // `autoLaunch` = the same-machine path: after minting, fire the vibecodes:// deep
+  // link so the local helper attaches automatically (no copied command). Without it
+  // (manual reconnect), we stay in the cross-machine "copy a command" flow. Callers
+  // must gate autoLaunch behind the install-first flow (setup Connect / paired
+  // auto-connect / Retry) — never on a bare "open" for an unpaired browser.
+  const connect = useCallback(async (opts?: { autoLaunch?: boolean }) => {
+    // Claim this attempt's generation. A later connect() bumps it, which makes this
+    // one abort at the post-mint checkpoint below instead of racing a 2nd session.
+    const gen = (connectGenRef.current = claimConnectGeneration(connectGenRef.current));
+    const autoLaunch = opts?.autoLaunch ?? false;
+    teardownSocket();
+    clearHelperTimer();
+    removeLaunchIframe();
+    setLaunchPhase(autoLaunch ? "opening" : "idle");
+    requestExpand();
+    lastDimsRef.current = "";
+    dispatch({ type: "connect" });
+
+    let data: { sessionId: string; browserToken: string; bridgeToken: string; expiresAt: number };
+    try {
+      const res = await fetch("/api/terminal/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ideaId }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error || `Session request failed (${res.status})`);
+      }
+      data = await res.json();
+    } catch (err) {
+      // Superseded while minting → let the newer attempt own the outcome.
+      if (isConnectSuperseded(gen, connectGenRef.current)) return;
+      logger.error("Terminal session mint failed (client)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      dispatch({ type: "session-mint-failed" });
+      toast.error("Couldn't start a terminal session", {
+        description: err instanceof Error ? err.message : undefined,
+      });
+      return;
+    }
+
+    // A newer connect() started while we awaited the mint → abort BEFORE firing a
+    // second deep link or opening a second socket. The newer attempt already ran
+    // teardownSocket() + dispatch(connect); doing anything here would orphan a
+    // bridge and trip the relay's single-attach. This is the double-connect fix.
+    if (isConnectSuperseded(gen, connectGenRef.current)) return;
+
+    dispatch({ type: "session-created", sessionId: data.sessionId });
+    // Retain the browser token too, so a transient drop can REATTACH to this same
+    // sid with no re-mint (grace-window reconnect).
+    setPair({
+      sessionId: data.sessionId,
+      bridgeToken: data.bridgeToken,
+      browserToken: data.browserToken,
+    });
+    // A fresh mint starts a fresh reconnect budget.
+    reconnectDeadlineRef.current = 0;
+    reconnectAttemptRef.current = 0;
+    termRef.current?.clear();
+
+    // Same-machine: hand the bridge token to the local helper via the deep link.
+    if (autoLaunch) fireLaunchDeepLink(data.sessionId, data.bridgeToken);
+
+    openBrowserLeg(data.sessionId, data.browserToken);
+  }, [
+    ideaId,
+    teardownSocket,
+    clearHelperTimer,
+    removeLaunchIframe,
+    requestExpand,
+    fireLaunchDeepLink,
+    openBrowserLeg,
+  ]);
+
+  // Manual "Reconnect now" — force an immediate reattach attempt (skip the backoff
+  // wait) using the retained token, or fall back to a clean fresh launch if the
+  // grace window is spent. Fixes the old button, which minted an EMPTY session with
+  // no autoLaunch and timed out after 30s.
+  const reconnectNow = useCallback(() => {
+    const p = pairRef.current;
+    const now = Date.now();
+    const withinWindow =
+      reconnectDeadlineRef.current === 0 || now < reconnectDeadlineRef.current;
+    if (p && withinWindow) {
+      clearReconnectTimer();
+      if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
+      openBrowserLeg(p.sessionId, p.browserToken, { reconnect: true });
+    } else {
+      void connect({ autoLaunch: true });
+    }
+  }, [openBrowserLeg, clearReconnectTimer, connect]);
+
+  // Install-first entry gate. This is the ONE place a browser "open" is turned into
+  // either a setup panel, a coming-soon panel, or an auto-connect — the deep link is
+  // never fired for an unpaired browser here (criterion #2).
+  const beginBrowserLaunch = useCallback(() => {
+    requestExpand();
+    const fresh = resolveTerminalPlatform(readPlatformSignals());
+    setPlatform(fresh);
+    const nowPaired = isBrowserPaired();
+    setPaired(nowPaired);
+    const entry = resolveFirstRunEntry({ supported: fresh.supported, paired: nowPaired });
+    if (entry === "connecting") {
+      // Paired browser deliberately reopening its session → auto-connect (fires the
+      // deep link). "setup" / "coming-soon" just show the overlay; no link fires.
+      void connect({ autoLaunch: true });
+    }
+  }, [connect, requestExpand]);
+
+  // The "In the browser" menu item (board toolbar) fires the launch bus; the caller
+  // forwards its payload here. The payload (the button's resolved compact prompt, as
+  // head/tail parts) is remembered so this launch AND a later Retry carry the exact
+  // prompt the user launched with; a payload-less event falls back to the
+  // hook-built board-level prompt.
+  const launchFromBus = useCallback(
+    (payload: BrowserLaunchPayload | null) => {
+      promptPartsRef.current = payload;
+      beginBrowserLaunch();
+    },
+    [beginBrowserLaunch],
+  );
+
+  const endSession = useCallback(() => {
+    dispatch({ type: "user-end" });
+    clearHelperTimer();
+    removeLaunchIframe();
+    setLaunchPhase("idle");
+    const ws = wsRef.current;
+    if (ws) {
+      try {
+        ws.close(1000, "user-end");
+      } catch {
+        /* already closing */
+      }
+    }
+    teardownSocket();
+  }, [teardownSocket, clearHelperTimer, removeLaunchIframe]);
+
+  // Clean up the socket + helper timer + probe iframe if the hook unmounts mid-flow.
+  useEffect(() => () => teardownSocket(), [teardownSocket]);
+  useEffect(() => () => clearHelperTimer(), [clearHelperTimer]);
+  useEffect(() => () => removeLaunchIframe(), [removeLaunchIframe]);
+
+  // The carried payload is scoped to ONE launch intent: it survives Retry (same
+  // intent, fresh session/token) but is dropped once the session ENDS (user End
+  // or a relay idle/max close), so a stale task prompt can never ride a later
+  // paired auto-connect — that launch rebuilds the board-level default instead.
+  useEffect(() => {
+    if (state.status === "session-ended") promptPartsRef.current = null;
+  }, [state.status]);
+
+  // Auto-connect a paired browser whenever the panel becomes visible while idle — so
+  // a returning user who simply expands the dock also skips the setup wall
+  // (criterion #6). Unpaired / unsupported browsers never satisfy this guard, so no
+  // deep link fires for them.
+  useEffect(() => {
+    if (!enabled) return;
+    if (
+      expanded &&
+      state.status === "idle" &&
+      platform.supported &&
+      paired &&
+      launchPhase === "idle"
+    ) {
+      void connect({ autoLaunch: true });
+    }
+  }, [enabled, expanded, state.status, platform.supported, paired, launchPhase, connect]);
+
+  const copyBridgeCommand = useCallback(() => {
+    if (!pair) return;
+    const cmd = `RELAY_URL=${relayBaseUrl()} SESSION_ID=${pair.sessionId} BRIDGE_TOKEN=${pair.bridgeToken} node terminal/bridge/src/index.js --cmd bash`;
+    navigator.clipboard
+      .writeText(cmd)
+      .then(() => toast.success("Bridge command copied"))
+      .catch(() => toast.error("Couldn't copy the command"));
+  }, [pair]);
+
+  return {
+    state,
+    launchPhase,
+    peerDegraded,
+    pair,
+    readOnly,
+    inputEnabled: isInputEnabled(state, readOnly),
+    platform,
+    paired,
+    xtermReady,
+    containerRef,
+    actions: {
+      connect,
+      beginBrowserLaunch,
+      launchFromBus,
+      reconnectNow,
+      end: endSession,
+      setReadOnly,
+      copyBridgeCommand,
+    },
+  };
+}

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -108,7 +108,17 @@ export interface TerminalSessionDescriptor {
 export interface UseTerminalSessionOptions {
   /** Master feature gate — mirrors isTerminalEnabled(); effects no-op when false. */
   enabled: boolean;
-  /** Is the dock panel currently open? Drives resize/focus/auto-connect timing. */
+  /**
+   * Is THIS instance's terminal currently visible? P1 (one hook): the dock
+   * panel's own open/closed state. Multi-session stage 2 (one hook per tab): the
+   * dock panel open AND this tab the active one — a background tab must never
+   * resize/refit or steal focus just because the dock is open on a DIFFERENT
+   * tab. Passing `dockExpanded && isActiveTab` here is what scopes those
+   * dock-wide P1 effects (resize-on-expand, focus-on-connect-or-expand, and —
+   * see `autoConnectWhenExpanded` below — the paired auto-connect gate) to the
+   * one tab actually on screen; switching tabs re-fires them for the newly
+   * active one exactly like re-expanding the P1 dock did.
+   */
   expanded: boolean;
   /**
    * Called at the same points the old component called `setExpanded(true)` —
@@ -116,6 +126,21 @@ export interface UseTerminalSessionOptions {
    * `expanded` itself stays owned by the caller (dock chrome, not per-session).
    */
   requestExpand: () => void;
+  /**
+   * Gates the "paired browser auto-connects when the panel opens while idle"
+   * effect (install-first criterion #6). Default true — unchanged P1 behaviour
+   * for a lone/pristine instance. Multi-session stage 2 sets this to `false` for
+   * every tab it creates via an EXPLICIT launch (task menu, toolbar, "+"): those
+   * tabs mount with `expanded` already true (the dock is already open) and
+   * deliver their own launch via `actions.launchFromBus` / `beginBrowserLaunch`
+   * in the same tick — without this flag, THIS effect would independently see
+   * "expanded, idle, paired" on that same mount and fire a SECOND, redundant
+   * `connect()`, minting and immediately orphaning an extra relay session. Only
+   * the board's one always-mounted pristine slot (never yet launched) needs this
+   * ambient auto-connect, so the dock only ever passes `false` for tabs it mints
+   * explicitly.
+   */
+  autoConnectWhenExpanded?: boolean;
 }
 
 export interface PairInfo {
@@ -179,7 +204,7 @@ export function useTerminalSession(
   options: UseTerminalSessionOptions,
 ): UseTerminalSessionResult {
   const { ideaId, ideaTitle, ideaGithubUrl } = descriptor;
-  const { enabled, expanded, requestExpand } = options;
+  const { enabled, expanded, requestExpand, autoConnectWhenExpanded = true } = options;
 
   const [state, dispatch] = useReducer(terminalReducer, initialConnectionState);
   const [readOnly, setReadOnly] = useState(false);
@@ -1003,7 +1028,7 @@ export function useTerminalSession(
   // (criterion #6). Unpaired / unsupported browsers never satisfy this guard, so no
   // deep link fires for them.
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || !autoConnectWhenExpanded) return;
     if (
       expanded &&
       state.status === "idle" &&
@@ -1013,7 +1038,16 @@ export function useTerminalSession(
     ) {
       void connect({ autoLaunch: true });
     }
-  }, [enabled, expanded, state.status, platform.supported, paired, launchPhase, connect]);
+  }, [
+    enabled,
+    autoConnectWhenExpanded,
+    expanded,
+    state.status,
+    platform.supported,
+    paired,
+    launchPhase,
+    connect,
+  ]);
 
   const copyBridgeCommand = useCallback(() => {
     if (!pair) return;

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -39,7 +39,9 @@
 import "@xterm/xterm/css/xterm.css";
 import { useCallback, useEffect, useReducer, useRef, useState, type RefObject } from "react";
 import { toast } from "sonner";
+import { usePostHog } from "posthog-js/react";
 import { logger } from "@/lib/logger";
+import { capReachedToastCopy, getTerminalSessionCap, RATE_LIMIT_MESSAGE } from "@/lib/terminal/session-cap";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import type { FitAddon as XFitAddon } from "@xterm/addon-fit";
 import {
@@ -92,6 +94,51 @@ import { type LaunchPhase, nextLaunchPhaseOnTimeout } from "@/lib/terminal/first
 // so we always fall through here rather than spin forever.
 const HELPER_OPEN_TIMEOUT_MS = 8000;
 
+/** The mint route's 409/429 refusal body shape (stage 3 — see route.ts). */
+interface MintErrorBody {
+  error?: string;
+  code?: string;
+  cap?: number;
+}
+
+/**
+ * Module-scope (not a useCallback) — takes everything it needs as arguments so
+ * it never has to be a dependency of `connect`. Shows the SERVER's error copy
+ * either way (E1/E2's whole point is that copy lives in one place — session-cap.ts
+ * — not duplicated client-side); the only client-side branching is which toast
+ * shape and whether a "View my sessions" action + a `terminal_cap_hit` PostHog
+ * event go with it.
+ */
+function reportMintFailure(
+  status: number,
+  body: MintErrorBody | null,
+  posthog: { capture: (event: string, props?: Record<string, unknown>) => void } | undefined,
+  onCapExceeded: (() => void) | undefined,
+) {
+  logger.error("Terminal session mint refused (client)", {
+    status,
+    code: body?.code,
+    error: body?.error,
+  });
+  if (body?.code === "cap_exceeded") {
+    const cap = typeof body.cap === "number" ? body.cap : getTerminalSessionCap();
+    posthog?.capture("terminal_cap_hit", { cap });
+    const copy = capReachedToastCopy(cap);
+    toast.error(body.error || copy.title, {
+      description: copy.description,
+      action: onCapExceeded ? { label: "View my sessions", onClick: () => onCapExceeded() } : undefined,
+    });
+    return;
+  }
+  if (body?.code === "rate_limited") {
+    toast.error(body.error || RATE_LIMIT_MESSAGE);
+    return;
+  }
+  toast.error("Couldn't start a terminal session", {
+    description: body?.error || `Session request failed (${status})`,
+  });
+}
+
 /** What identifies the idea/board a session's launches are bootstrapped for. */
 export interface TerminalSessionDescriptor {
   ideaId: string;
@@ -141,6 +188,22 @@ export interface UseTerminalSessionOptions {
    * explicitly.
    */
   autoConnectWhenExpanded?: boolean;
+  /**
+   * Multi-session stage 3 (C1/C4): this tab's task identity, when the launch
+   * was task-scoped — forwarded on mint so the `terminal_sessions` registry
+   * row (and, from it, "My sessions") can show a task label instead of just
+   * the idea. Undefined for a board-level launch.
+   */
+  taskId?: string;
+  taskTitle?: string;
+  /**
+   * Called when a mint is refused for having hit the cap (E1) — the caller
+   * (the dock) opens/points at the "My sessions" panel, the ONE place a
+   * blocked user can see and end what's counting against them (design §7b).
+   * Optional: a hook instance the dock doesn't wire this for just shows the
+   * toast with no action button.
+   */
+  onCapExceeded?: () => void;
 }
 
 export interface PairInfo {
@@ -204,7 +267,20 @@ export function useTerminalSession(
   options: UseTerminalSessionOptions,
 ): UseTerminalSessionResult {
   const { ideaId, ideaTitle, ideaGithubUrl } = descriptor;
-  const { enabled, expanded, requestExpand, autoConnectWhenExpanded = true } = options;
+  const {
+    enabled,
+    expanded,
+    requestExpand,
+    autoConnectWhenExpanded = true,
+    taskId,
+    taskTitle,
+    onCapExceeded,
+  } = options;
+  const posthog = usePostHog();
+  const posthogRef = useRef(posthog);
+  const onCapExceededRef = useRef(onCapExceeded);
+  posthogRef.current = posthog;
+  onCapExceededRef.current = onCapExceeded;
 
   const [state, dispatch] = useReducer(terminalReducer, initialConnectionState);
   const [readOnly, setReadOnly] = useState(false);
@@ -893,11 +969,20 @@ export function useTerminalSession(
       const res = await fetch("/api/terminal/session", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ideaId }),
+        body: JSON.stringify({
+          ideaId,
+          ...(taskId ? { taskId } : {}),
+          ...(taskTitle ? { taskTitle } : {}),
+        }),
       });
       if (!res.ok) {
-        const body = (await res.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(body?.error || `Session request failed (${res.status})`);
+        const body = (await res.json().catch(() => null)) as MintErrorBody | null;
+        // Superseded while minting → let the newer attempt own the outcome
+        // (a stale refusal toast for an attempt nobody's waiting on anymore).
+        if (isConnectSuperseded(gen, connectGenRef.current)) return;
+        dispatch({ type: "session-mint-failed" });
+        reportMintFailure(res.status, body, posthogRef.current, onCapExceededRef.current);
+        return;
       }
       data = await res.json();
     } catch (err) {
@@ -932,16 +1017,37 @@ export function useTerminalSession(
     reconnectAttemptRef.current = 0;
     termRef.current?.clear();
 
+    // Best-effort identity PATCH (C4): the browser already resolves a cwd to
+    // build the launch prompt — forward it to the registry row so "My
+    // sessions" can show it. Never awaited/blocking: a failure here changes
+    // nothing about the terminal itself, the identity line is just honestly
+    // blank until it lands (or forever, if there's no cwd to report).
+    try {
+      const { cwd } = resolveLaunchPromptParts();
+      if (cwd && cwd.trim()) {
+        void fetch(`/api/terminal/session/${encodeURIComponent(data.sessionId)}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cwd: cwd.trim() }),
+        }).catch(() => {});
+      }
+    } catch {
+      /* best-effort only — never blocks the terminal actually connecting */
+    }
+
     // Same-machine: hand the bridge token to the local helper via the deep link.
     if (autoLaunch) fireLaunchDeepLink(data.sessionId, data.bridgeToken);
 
     openBrowserLeg(data.sessionId, data.browserToken);
   }, [
     ideaId,
+    taskId,
+    taskTitle,
     teardownSocket,
     clearHelperTimer,
     removeLaunchIframe,
     requestExpand,
+    resolveLaunchPromptParts,
     fireLaunchDeepLink,
     openBrowserLeg,
   ]);
@@ -999,6 +1105,7 @@ export function useTerminalSession(
     clearHelperTimer();
     removeLaunchIframe();
     setLaunchPhase("idle");
+    const sid = pairRef.current?.sessionId;
     const ws = wsRef.current;
     if (ws) {
       try {
@@ -1008,6 +1115,17 @@ export function useTerminalSession(
       }
     }
     teardownSocket();
+    // Additive (C3): keep the registry truthful for "My sessions" — the socket
+    // teardown above is unchanged/authoritative for the terminal itself; this
+    // is fire-and-forget bookkeeping only, never awaited, never surfaced to
+    // the user on failure (the relay end route is itself skew-safe/best-effort).
+    if (sid) {
+      void fetch("/api/terminal/session/end", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sid }),
+      }).catch(() => {});
+    }
   }, [teardownSocket, clearHelperTimer, removeLaunchIframe]);
 
   // Clean up the socket + helper timer + probe iframe if the hook unmounts mid-flow.

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -204,11 +204,43 @@ export interface UseTerminalSessionOptions {
    * toast with no action button.
    */
   onCapExceeded?: () => void;
+  /**
+   * Multi-session stage 4 (D1/D2): attach directly to an ALREADY-MINTED
+   * session's browser leg — no mint, no first-run/launch flow. Set by the
+   * popped-out window (terminal-popout-view.tsx) once its hand-off payload
+   * arrives over the same-origin BroadcastChannel (see
+   * src/lib/terminal/popout-channel.ts) — this is exactly what a fresh
+   * `/terminal/popout` document needs, since it never launched anything
+   * itself and has no prior `pair`. Attaching with the SAME OWNER is what
+   * PREEMPTS whichever OTHER browser leg is currently attached at the relay
+   * — the existing 4001 "preempted" close (D1/F2); an expired token is fine,
+   * the relay waives expiry for a same-owner reattach to a live session
+   * (mirrors the grace-window reconnect's own waiver, fix/terminal-expired-reattach).
+   *
+   * Identity is keyed on `sessionId`: changing it (a NEW transferred pair)
+   * re-attaches; the SAME object/value on a later render is a no-op (callers
+   * don't need to memoize beyond keeping the sessionId stable).
+   */
+  attachExisting?: AttachExistingPair | null;
+}
+
+/** The minimum a popped-out window needs to attach to an existing session — see `attachExisting` above. */
+export interface AttachExistingPair {
+  sessionId: string;
+  browserToken: string;
 }
 
 export interface PairInfo {
   sessionId: string;
-  bridgeToken: string;
+  /**
+   * Undefined for a session this window ATTACHED to (attachExisting) rather
+   * than minted — a popped-out window never received the bridge token (it
+   * isn't part of the pop-out payload; only the browser leg's credentials
+   * cross the hand-off channel), so it can't offer "copy bridge command"
+   * (that advanced panel only ever renders for the legacy-waiting view, which
+   * an attached window has no path into a launch that would need it).
+   */
+  bridgeToken?: string;
   // Retained so a TRANSIENT drop can REATTACH to the SAME sid with no re-mint
   // (grace-window reconnect). `browserToken` re-opens the browser leg. Reattach is
   // bounded purely by RECONNECT_GRACE_MS — the relay waives token expiry for a
@@ -275,6 +307,7 @@ export function useTerminalSession(
     taskId,
     taskTitle,
     onCapExceeded,
+    attachExisting = null,
   } = options;
   const posthog = usePostHog();
   const posthogRef = useRef(posthog);
@@ -1052,6 +1085,58 @@ export function useTerminalSession(
     openBrowserLeg,
   ]);
 
+  // ── attach-existing (multi-session stage 4, D1/D2) ─────────────────────────
+  // The popped-out window's whole entry point: no fetch, no deep link, no
+  // install-first gate — just open the browser leg for a session that was
+  // ALREADY minted elsewhere (the dock tab that popped it out). Deliberately
+  // mirrors connect()'s bookkeeping (teardown, timer resets, dispatch
+  // sequence, setPair, fresh reconnect budget) minus everything that assumes
+  // this window is the one originating the session.
+  const attachToExisting = useCallback(
+    (p: AttachExistingPair) => {
+      const gen = (connectGenRef.current = claimConnectGeneration(connectGenRef.current));
+      teardownSocket();
+      clearHelperTimer();
+      removeLaunchIframe();
+      setLaunchPhase("idle");
+      lastDimsRef.current = "";
+      // Two dispatches back-to-back, no await between them — React folds them
+      // through the reducer IN ORDER against the queued (not the stale
+      // closure) state, so "session-created"'s `state.status !== "connecting"`
+      // guard sees the "connect" transition that just landed ahead of it.
+      // Same guarantee connect() relies on across its own await gap.
+      dispatch({ type: "connect" });
+      dispatch({ type: "session-created", sessionId: p.sessionId });
+      setPair({ sessionId: p.sessionId, browserToken: p.browserToken });
+      reconnectDeadlineRef.current = 0;
+      reconnectAttemptRef.current = 0;
+      termRef.current?.clear();
+      // A newer attach/connect raced this one while it was doing its
+      // (synchronous, but still checked for symmetry with connect()) setup —
+      // abort before opening a socket that a newer attempt would immediately
+      // have to tear down again.
+      if (isConnectSuperseded(gen, connectGenRef.current)) return;
+      openBrowserLeg(p.sessionId, p.browserToken);
+    },
+    [teardownSocket, clearHelperTimer, removeLaunchIframe, openBrowserLeg],
+  );
+
+  // Fire attachToExisting once per distinct transferred session id — the
+  // popped window's `attachExisting` prop starts `null` (no payload yet) and
+  // becomes non-null asynchronously, whenever the hand-off channel delivers it
+  // (see terminal-popout-view.tsx). NOT gated on xtermReady: connect() itself
+  // opens the browser leg with no such gate (an inbound byte arriving before
+  // xterm has mounted is already a pre-existing, harmless no-op there —
+  // `termRef.current?.write(...)` — so attach-existing keeps the same
+  // characteristics rather than inventing a stricter rule for one path).
+  const attachedSessionIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!enabled || !attachExisting) return;
+    if (attachedSessionIdRef.current === attachExisting.sessionId) return;
+    attachedSessionIdRef.current = attachExisting.sessionId;
+    attachToExisting(attachExisting);
+  }, [enabled, attachExisting, attachToExisting]);
+
   // Manual "Reconnect now" — force an immediate reattach attempt (skip the backoff
   // wait) using the retained token, or fall back to a clean fresh launch if the
   // grace window is spent. Fixes the old button, which minted an EMPTY session with
@@ -1168,7 +1253,11 @@ export function useTerminalSession(
   ]);
 
   const copyBridgeCommand = useCallback(() => {
-    if (!pair) return;
+    // No bridge token to copy for an attached (not minted) session — see
+    // PairInfo.bridgeToken's doc. The legacy-waiting panel that renders this
+    // button isn't reachable from attachExisting anyway, but stay honest
+    // rather than emit a command with a literal "undefined" in it.
+    if (!pair || !pair.bridgeToken) return;
     const cmd = `RELAY_URL=${relayBaseUrl()} SESSION_ID=${pair.sessionId} BRIDGE_TOKEN=${pair.bridgeToken} node terminal/bridge/src/index.js --cmd bash`;
     navigator.clipboard
       .writeText(cmd)

--- a/src/lib/terminal/launch-mode.ts
+++ b/src/lib/terminal/launch-mode.ts
@@ -1,10 +1,15 @@
 // In-app terminal — launch-mode selection + cross-component launch bus (SLICE 4).
 //
-// "Launch Claude Code" is a PICK-ONE control: Claude runs in exactly one place at a
-// time. This module owns the pure decision of WHICH modes the menu offers (gated on
-// the terminal flag) plus a tiny SSR-safe event bus so the toolbar's menu item can
-// ask the board's terminal dock (a separate, page-level component) to open in the
-// browser. Keeping the selection logic pure makes it unit-testable without React.
+// "Launch Claude Code" is a PICK-ONE-PER-CLICK control: each launch starts Claude in
+// exactly one destination (a terminal window OR a new browser tab). That is no longer
+// a claim about the app as a whole, though — multi-session (docs/design-terminal-multi-
+// session-popout.html) lets several sessions run at once, in any mix of terminal
+// windows and in-browser tabs (capped per user, see session-cap.ts; never re-derive
+// that number here — copy sweep A3). This module owns the pure decision of WHICH modes
+// the menu offers (gated on the terminal flag) plus a tiny SSR-safe event bus so the
+// toolbar's menu item can ask the board's terminal dock (a separate, page-level
+// component) to open a NEW tab in the browser. Keeping the selection logic pure makes
+// it unit-testable without React.
 
 import type { CompactPromptEssentials } from "@/lib/launch-claude-code";
 

--- a/src/lib/terminal/launch-mode.ts
+++ b/src/lib/terminal/launch-mode.ts
@@ -64,6 +64,17 @@ export interface BrowserLaunchPayload {
    * (repo-backed, or a brand-new ~/projects/<slug> the agent creates).
    */
   cwd?: string;
+  /**
+   * Multi-session stage 2 (B10 dedupe, B3 tab labels): the task this launch was
+   * scoped to, when it came from a task card ("task-icon" / "task-menu-item"
+   * variants of LaunchClaudeCodeButton) rather than the board toolbar. Undefined
+   * for board-level launches — those never carry a task identity, so B10's
+   * dedupe never applies to them (only a REAL task identity is keyed on; cwd/
+   * prompt equivalence is deliberately never treated as a match).
+   */
+  taskId?: string;
+  /** The task's title, for the tab label (B3) when `taskId` is present. */
+  taskTitle?: string;
 }
 
 /** Ask the board's terminal dock to open + auto-launch in the browser. */

--- a/src/lib/terminal/popout-channel.test.ts
+++ b/src/lib/terminal/popout-channel.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  popoutChannelName,
+  generatePopoutNonce,
+  parsePopoutChannelMessage,
+  reduceDockHandshake,
+  INITIAL_DOCK_HANDSHAKE_STATE,
+  isPreemptedClose,
+  hasPopoutHandoffTimedOut,
+  POPOUT_HANDOFF_TIMEOUT_MS,
+  type PopoutPayload,
+} from "./popout-channel";
+import { RELAY_CLOSE } from "./connection";
+
+const PAYLOAD: PopoutPayload = {
+  sid: "sid-123",
+  browserToken: "tok-abc",
+  relayUrl: "wss://relay.example",
+  ideaId: "idea-1",
+  ideaTitle: "Recipe Saver",
+  label: "Add pagination to the recipe list",
+  identity: "Recipe Saver · session sid-123",
+  readOnly: false,
+};
+
+describe("popoutChannelName", () => {
+  it("namespaces the nonce so it can't collide with anything else on the origin", () => {
+    expect(popoutChannelName("abc123")).toBe("vibecodes:terminal-popout:abc123");
+  });
+});
+
+describe("generatePopoutNonce", () => {
+  it("returns a non-empty, URL-hash-safe string", () => {
+    const nonce = generatePopoutNonce();
+    expect(nonce.length).toBeGreaterThan(8);
+    expect(nonce).toMatch(/^[a-z0-9]+$/i);
+  });
+
+  it("never repeats across calls", () => {
+    const seen = new Set(Array.from({ length: 50 }, () => generatePopoutNonce()));
+    expect(seen.size).toBe(50);
+  });
+});
+
+describe("parsePopoutChannelMessage", () => {
+  it("parses a ready message", () => {
+    expect(parsePopoutChannelMessage({ type: "ready" })).toEqual({ type: "ready" });
+  });
+
+  it("parses a closed message", () => {
+    expect(parsePopoutChannelMessage({ type: "closed" })).toEqual({ type: "closed" });
+  });
+
+  it("parses a well-formed payload message", () => {
+    expect(parsePopoutChannelMessage({ type: "payload", payload: PAYLOAD })).toEqual({
+      type: "payload",
+      payload: PAYLOAD,
+    });
+  });
+
+  it("rejects a payload message missing a required field", () => {
+    const { sid: _sid, ...rest } = PAYLOAD;
+    expect(parsePopoutChannelMessage({ type: "payload", payload: rest })).toBeNull();
+  });
+
+  it("rejects a payload message with the wrong type for readOnly", () => {
+    expect(
+      parsePopoutChannelMessage({ type: "payload", payload: { ...PAYLOAD, readOnly: "false" } }),
+    ).toBeNull();
+  });
+
+  it.each([undefined, null, 42, "hello", [], { type: "unknown" }, { no_type: true }])(
+    "returns null for garbage input %#",
+    (input) => {
+      expect(parsePopoutChannelMessage(input)).toBeNull();
+    },
+  );
+});
+
+describe("reduceDockHandshake", () => {
+  it("sends the payload on the first ready message", () => {
+    const result = reduceDockHandshake(INITIAL_DOCK_HANDSHAKE_STATE, { type: "ready" });
+    expect(result).toEqual({ state: "payload-sent", action: "send-payload" });
+  });
+
+  it("ignores a repeated ready once the payload has already been sent (retry-safe)", () => {
+    const result = reduceDockHandshake("payload-sent", { type: "ready" });
+    expect(result).toEqual({ state: "payload-sent", action: "none" });
+  });
+
+  it("always reattaches on a closed message, regardless of handshake phase", () => {
+    expect(reduceDockHandshake("waiting-for-ready", { type: "closed" })).toEqual({
+      state: "waiting-for-ready",
+      action: "reattach",
+    });
+    expect(reduceDockHandshake("payload-sent", { type: "closed" })).toEqual({
+      state: "payload-sent",
+      action: "reattach",
+    });
+  });
+
+  it("ignores a stray payload message on the dock's own channel", () => {
+    const result = reduceDockHandshake(INITIAL_DOCK_HANDSHAKE_STATE, {
+      type: "payload",
+      payload: PAYLOAD,
+    });
+    expect(result).toEqual({ state: INITIAL_DOCK_HANDSHAKE_STATE, action: "none" });
+  });
+});
+
+describe("isPreemptedClose", () => {
+  it("is true only for the relay's DUP_BROWSER close code", () => {
+    expect(isPreemptedClose(RELAY_CLOSE.DUP_BROWSER)).toBe(true);
+    expect(RELAY_CLOSE.DUP_BROWSER).toBe(4001);
+  });
+
+  it("is false for every other close code, including the sibling DUP_BRIDGE", () => {
+    expect(isPreemptedClose(RELAY_CLOSE.DUP_BRIDGE)).toBe(false);
+    expect(isPreemptedClose(1000)).toBe(false);
+    expect(isPreemptedClose(1006)).toBe(false);
+    expect(isPreemptedClose(null)).toBe(false);
+  });
+});
+
+describe("hasPopoutHandoffTimedOut", () => {
+  it("is false before the timeout elapses", () => {
+    expect(hasPopoutHandoffTimedOut(1000, 1000 + POPOUT_HANDOFF_TIMEOUT_MS - 1)).toBe(false);
+  });
+
+  it("is true once the timeout elapses (inclusive boundary)", () => {
+    expect(hasPopoutHandoffTimedOut(1000, 1000 + POPOUT_HANDOFF_TIMEOUT_MS)).toBe(true);
+  });
+
+  it("is true well past the timeout", () => {
+    expect(hasPopoutHandoffTimedOut(1000, 1000 + POPOUT_HANDOFF_TIMEOUT_MS * 3)).toBe(true);
+  });
+
+  it("supports a custom timeout", () => {
+    expect(hasPopoutHandoffTimedOut(0, 500, 1000)).toBe(false);
+    expect(hasPopoutHandoffTimedOut(0, 1000, 1000)).toBe(true);
+  });
+});

--- a/src/lib/terminal/popout-channel.ts
+++ b/src/lib/terminal/popout-channel.ts
@@ -1,0 +1,214 @@
+// In-app terminal — pop-out window hand-off, pure logic (multi-session stage 4,
+// docs/design-terminal-multi-session-popout.html §10, D1-D7).
+//
+// The dock and the popped-out window are TWO SEPARATE documents (a real browser
+// window opened via window.open) — there is no shared JS heap, no React context,
+// no window.opener reliance (we open with a feature string that omits it isn't
+// required either way, since nothing here reads `opener`). The only channel
+// between them is a same-origin `BroadcastChannel` named from a one-time NONCE
+// carried in the popped window's URL HASH (never sent to any server — hashes
+// never leave the browser) or, as a fallback, `window.name`. The nonce carries no
+// session meaning by itself (D4/AC16: "no tokens ever ride the URL") — it only
+// names a rendezvous channel; the actual session credentials (sid + browser
+// token) cross exclusively over that channel, as a "payload" message.
+//
+// Handshake (design §13 Flow 3):
+//   1. The dock calls window.open() SYNCHRONOUSLY from the click handler (popup
+//      policy — D7), then opens a BroadcastChannel(nonce) and waits.
+//   2. The popped window opens the SAME channel and posts "ready" the moment it
+//      mounts.
+//   3. On "ready", the dock posts "payload" (sid, browserToken, relayUrl, idea
+//      id/title, label, identity, readOnly).
+//   4. The popped window attaches with that pair — attaching with the SAME OWNER
+//      preempts whichever OTHER browser leg is currently attached at the relay
+//      (the existing 4001 "preempted" close, D1/F2). Both sides recognise that
+//      close by its CODE (not by messaging each other about it): the dock treats
+//      an expected preemption as "popped out" (tracked locally, see
+//      terminal-dock.tsx's `poppedOutKeys`); the popped window treats ITS OWN
+//      4001 close as "brought back to the dock" (see `isPreemptedClose` below) —
+//      the SAME mechanism serves the pop-out direction and the bring-back
+//      direction, just observed from opposite ends.
+//   5. When the popped window closes (`beforeunload`/`pagehide`), it posts
+//      "closed" on the SAME channel so the dock can auto-reattach (D3) without
+//      polling `window.closed` (which `noopener` would block anyway).
+//
+// This module holds every piece of that protocol that's expressible as pure data
+// + pure functions — channel naming, the payload shape, message parsing, the
+// dock's own tiny handshake reducer, and the 4001/"brought back" + hand-off
+// timeout predicates — so it's unit-tested without a DOM, a socket, or a real
+// BroadcastChannel.
+
+import { RELAY_CLOSE } from "@/lib/terminal/connection";
+
+/** Channel names are namespaced so nothing else on the origin could collide. */
+const POPOUT_CHANNEL_PREFIX = "vibecodes:terminal-popout:";
+
+/** The BroadcastChannel name for a given hand-off nonce. */
+export function popoutChannelName(nonce: string): string {
+  return `${POPOUT_CHANNEL_PREFIX}${nonce}`;
+}
+
+/**
+ * A one-time, meaningless-by-itself token that names the hand-off channel and
+ * rides the popped window's URL HASH (never the query string, never sent to any
+ * server). Uses `crypto.randomUUID()` where available (every supported browser);
+ * the fallback only matters for a non-secure-context edge case and still yields
+ * a channel name unique enough that a same-tab collision is not a real concern
+ * (this is a rendezvous id, not a security boundary — the actual secret is the
+ * browser token carried IN the payload message, never in the nonce or the URL).
+ */
+export function generatePopoutNonce(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID().replace(/-/g, "");
+  }
+  return (
+    Date.now().toString(36) +
+    Math.random().toString(36).slice(2) +
+    Math.random().toString(36).slice(2)
+  );
+}
+
+/** Everything the popped window needs to attach to the SAME relay session. */
+export interface PopoutPayload {
+  /** The session id (sid) — never in the URL, only ever carried here. */
+  sid: string;
+  /** The browser-leg token. An EXPIRED token is fine — the relay waives expiry
+   * for a same-owner reattach to a live session (D1's binding note). */
+  browserToken: string;
+  /**
+   * Carried for fidelity with the design's payload shape and potential future
+   * use (e.g. surfacing relay skew in logs); the popped window's own
+   * `useTerminalSession` currently resolves the relay URL itself from the SAME
+   * `NEXT_PUBLIC_TERMINAL_RELAY_URL` build-time env both documents share, so
+   * this field is not required to be threaded into the actual connection —
+   * see use-terminal-session.ts's `attachExisting` option doc.
+   */
+  relayUrl: string;
+  ideaId: string;
+  ideaTitle: string;
+  /** This tab's derived label (task title, or `<idea slug> · <sid-short>`) — becomes the popped window's title. */
+  label: string;
+  /** The identity line shown in both the dock header and the popped window's header. */
+  identity: string;
+  readOnly: boolean;
+}
+
+export type PopoutChannelMessage =
+  | { type: "ready" }
+  | { type: "payload"; payload: PopoutPayload }
+  | { type: "closed" };
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+function parsePopoutPayload(value: unknown): PopoutPayload | null {
+  if (!value || typeof value !== "object") return null;
+  const p = value as Record<string, unknown>;
+  if (
+    isNonEmptyString(p.sid) &&
+    isNonEmptyString(p.browserToken) &&
+    isNonEmptyString(p.relayUrl) &&
+    isNonEmptyString(p.ideaId) &&
+    typeof p.ideaTitle === "string" &&
+    isNonEmptyString(p.label) &&
+    typeof p.identity === "string" &&
+    typeof p.readOnly === "boolean"
+  ) {
+    return {
+      sid: p.sid,
+      browserToken: p.browserToken,
+      relayUrl: p.relayUrl,
+      ideaId: p.ideaId,
+      ideaTitle: p.ideaTitle,
+      label: p.label,
+      identity: p.identity,
+      readOnly: p.readOnly,
+    };
+  }
+  return null;
+}
+
+/**
+ * Validate + narrow a raw `BroadcastChannel` message event's `data` into a
+ * known message — never throws (a stray/foreign message on the channel just
+ * parses to `null` and is ignored), so callers never need a try/catch around a
+ * postMessage payload they don't fully control (structured-clone data is
+ * `unknown`, not `any`, by the time it reaches app code).
+ */
+export function parsePopoutChannelMessage(data: unknown): PopoutChannelMessage | null {
+  if (!data || typeof data !== "object") return null;
+  const msg = data as { type?: unknown; payload?: unknown };
+  if (msg.type === "ready") return { type: "ready" };
+  if (msg.type === "closed") return { type: "closed" };
+  if (msg.type === "payload") {
+    const payload = parsePopoutPayload(msg.payload);
+    return payload ? { type: "payload", payload } : null;
+  }
+  return null;
+}
+
+// ── the dock's handshake reducer ────────────────────────────────────────────
+
+/** The dock's side of the hand-off: has the payload been sent yet? */
+export type DockHandshakeState = "waiting-for-ready" | "payload-sent";
+
+export const INITIAL_DOCK_HANDSHAKE_STATE: DockHandshakeState = "waiting-for-ready";
+
+export type DockHandshakeAction = "none" | "send-payload" | "reattach";
+
+export interface DockHandshakeResult {
+  state: DockHandshakeState;
+  action: DockHandshakeAction;
+}
+
+/**
+ * Pure reducer over every message the dock's channel can receive. `"ready"`
+ * only triggers `send-payload` the FIRST time (idempotent against a retried
+ * "ready" — e.g. a slow-loading popped window firing more than one, or a
+ * message replayed after a hot-reload): once `payload-sent`, a later "ready" is
+ * a no-op rather than re-sending (and re-triggering) the pop-out. `"closed"` is
+ * the auto-reattach signal (D3) and is always actionable, regardless of
+ * handshake phase — a popped window can close before OR after it ever received
+ * the payload (e.g. the user closed it during the ~5s hand-off window), and the
+ * dock must reattach either way. A stray `"payload"` on the DOCK's own channel
+ * (it should never receive one — only send them) is ignored.
+ */
+export function reduceDockHandshake(
+  state: DockHandshakeState,
+  message: PopoutChannelMessage,
+): DockHandshakeResult {
+  if (message.type === "closed") return { state, action: "reattach" };
+  if (message.type === "ready" && state === "waiting-for-ready") {
+    return { state: "payload-sent", action: "send-payload" };
+  }
+  return { state, action: "none" };
+}
+
+// ── popped-window-side decisions ────────────────────────────────────────────
+
+/**
+ * The popped window's own browser leg was preempted by close code 4001 (the
+ * relay's DUP_BROWSER code — RELAY_CLOSE.DUP_BROWSER). Within this feature,
+ * that code has exactly ONE cause: the dock (or a later popped window) reattached
+ * with the same owner, i.e. a "Bring back to dock" — either explicit (the
+ * placeholder's button) or automatic (this window's own close-signal racing a
+ * manual bring-back). The popped window uses this to show a CALM "brought back"
+ * state instead of the generic P1 "duplicate session" error copy (binding
+ * note: "recognise its 4001 preempted close ... not an error").
+ */
+export function isPreemptedClose(closeCode: number | null): boolean {
+  return closeCode === RELAY_CLOSE.DUP_BROWSER;
+}
+
+/** How long the popped window waits for the hand-off payload before giving up honestly (D2/D7 fallback, "~5s" per the design). */
+export const POPOUT_HANDOFF_TIMEOUT_MS = 5_000;
+
+/** Pure boundary check for the ~5s hand-off wait, so the timing policy is testable without a real timer. */
+export function hasPopoutHandoffTimedOut(
+  startedAtMs: number,
+  nowMs: number,
+  timeoutMs: number = POPOUT_HANDOFF_TIMEOUT_MS,
+): boolean {
+  return nowMs - startedAtMs >= timeoutMs;
+}

--- a/src/lib/terminal/relay-http.test.ts
+++ b/src/lib/terminal/relay-http.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { toHttpRelayUrl, relayHttpBaseUrl } from "./relay-http";
+
+describe("toHttpRelayUrl", () => {
+  it("converts wss:// to https://", () => {
+    expect(toHttpRelayUrl("wss://vibecodes-terminal-relay.example.workers.dev")).toBe(
+      "https://vibecodes-terminal-relay.example.workers.dev",
+    );
+  });
+
+  it("converts ws:// to http://", () => {
+    expect(toHttpRelayUrl("ws://127.0.0.1:8787")).toBe("http://127.0.0.1:8787");
+  });
+
+  it("leaves an already-http(s) url untouched", () => {
+    expect(toHttpRelayUrl("https://example.com")).toBe("https://example.com");
+  });
+});
+
+describe("relayHttpBaseUrl", () => {
+  it("falls back to the dev default when unset", () => {
+    expect(relayHttpBaseUrl(undefined)).toBe("http://127.0.0.1:8787");
+  });
+
+  it("derives from NEXT_PUBLIC_TERMINAL_RELAY_URL", () => {
+    expect(relayHttpBaseUrl("wss://relay.example.com")).toBe("https://relay.example.com");
+  });
+});

--- a/src/lib/terminal/relay-http.ts
+++ b/src/lib/terminal/relay-http.ts
@@ -1,0 +1,27 @@
+// In-app terminal — the relay's plain-HTTP base URL (multi-session stage 3).
+//
+// The relay serves both a WebSocket upgrade (the browser/bridge legs) AND, as
+// of this stage, a plain HTTP POST /end (My-sessions "End" / "End all") from
+// the SAME Worker/host — see terminal/relay/src/index.js. The browser talks
+// to it over `wss://`/`ws://` (src/lib/terminal/connection.ts →
+// relayBaseUrl(), driven by NEXT_PUBLIC_TERMINAL_RELAY_URL); the end route
+// runs SERVER-SIDE and needs the plain-HTTP equivalent of that SAME url —
+// this is that one conversion, so the relay host is configured in exactly
+// ONE place (NEXT_PUBLIC_TERMINAL_RELAY_URL) rather than a second server-only
+// env var that could drift from it.
+
+import { DEFAULT_RELAY_URL } from "@/lib/terminal/connection";
+
+/** `wss://host` → `https://host`, `ws://host` → `http://host`. Pure. */
+export function toHttpRelayUrl(relayUrl: string): string {
+  if (relayUrl.startsWith("wss://")) return `https://${relayUrl.slice("wss://".length)}`;
+  if (relayUrl.startsWith("ws://")) return `http://${relayUrl.slice("ws://".length)}`;
+  return relayUrl;
+}
+
+/** The relay's plain-HTTP base URL, server-side. */
+export function relayHttpBaseUrl(
+  raw: string | undefined = process.env.NEXT_PUBLIC_TERMINAL_RELAY_URL,
+): string {
+  return toHttpRelayUrl(raw || DEFAULT_RELAY_URL);
+}

--- a/src/lib/terminal/session-cap.test.ts
+++ b/src/lib/terminal/session-cap.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect } from "vitest";
 import {
   DEFAULT_TERMINAL_SESSION_CAP,
+  DEFAULT_TERMINAL_MINT_RATE_LIMIT,
   getTerminalSessionCap,
+  getServerTerminalSessionCap,
+  getTerminalMintRateLimit,
   newSessionTooltip,
   isCapRefusalMessage,
   capReachedToastCopy,
+  capRefusalMessage,
+  RATE_LIMIT_MESSAGE,
+  CAP_REFUSAL_CODE,
+  RATE_LIMIT_CODE,
 } from "./session-cap";
 
 describe("getTerminalSessionCap", () => {
@@ -68,5 +75,57 @@ describe("capReachedToastCopy", () => {
       description: "That's the limit for now. End one to start another.",
     });
     expect(capReachedToastCopy(3).title).toBe("You already have 3 terminals running");
+  });
+});
+
+describe("getServerTerminalSessionCap", () => {
+  it("reads a SEPARATE env var from the client cap, same default", () => {
+    expect(getServerTerminalSessionCap(undefined)).toBe(DEFAULT_TERMINAL_SESSION_CAP);
+    expect(getServerTerminalSessionCap("2")).toBe(2);
+    expect(getServerTerminalSessionCap("0")).toBe(DEFAULT_TERMINAL_SESSION_CAP);
+    expect(getServerTerminalSessionCap("nope")).toBe(DEFAULT_TERMINAL_SESSION_CAP);
+  });
+});
+
+describe("getTerminalMintRateLimit", () => {
+  it("defaults to 10 and tolerates the same malformed inputs as the cap", () => {
+    expect(getTerminalMintRateLimit(undefined)).toBe(10);
+    expect(DEFAULT_TERMINAL_MINT_RATE_LIMIT).toBe(10);
+    expect(getTerminalMintRateLimit("4")).toBe(4);
+    expect(getTerminalMintRateLimit("-3")).toBe(DEFAULT_TERMINAL_MINT_RATE_LIMIT);
+    expect(getTerminalMintRateLimit("junk")).toBe(DEFAULT_TERMINAL_MINT_RATE_LIMIT);
+  });
+});
+
+describe("capRefusalMessage", () => {
+  it("templates the cap and pluralises correctly, matching the design copy", () => {
+    expect(capRefusalMessage(5)).toBe(
+      "You already have 5 terminals running — end one to start another.",
+    );
+    expect(capRefusalMessage(1)).toBe(
+      "You already have 1 terminal running — end one to start another.",
+    );
+  });
+
+  it("is recognised by isCapRefusalMessage", () => {
+    expect(isCapRefusalMessage(capRefusalMessage(5))).toBe(true);
+  });
+});
+
+describe("rate-limit copy stays distinct from the cap refusal (binding note)", () => {
+  it("never mentions ending a session", () => {
+    expect(RATE_LIMIT_MESSAGE.toLowerCase()).not.toContain("end");
+    expect(RATE_LIMIT_MESSAGE).toBe("You're starting terminals too fast — wait a moment and try again.");
+  });
+
+  it("is never misclassified as a cap refusal", () => {
+    expect(isCapRefusalMessage(RATE_LIMIT_MESSAGE)).toBe(false);
+  });
+});
+
+describe("error codes", () => {
+  it("are the exact strings the client branches on", () => {
+    expect(CAP_REFUSAL_CODE).toBe("cap_exceeded");
+    expect(RATE_LIMIT_CODE).toBe("rate_limited");
   });
 });

--- a/src/lib/terminal/session-cap.test.ts
+++ b/src/lib/terminal/session-cap.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_TERMINAL_SESSION_CAP,
+  getTerminalSessionCap,
+  newSessionTooltip,
+  isCapRefusalMessage,
+  capReachedToastCopy,
+} from "./session-cap";
+
+describe("getTerminalSessionCap", () => {
+  it("defaults to 5 when the env var is unset", () => {
+    expect(getTerminalSessionCap(undefined)).toBe(5);
+    expect(DEFAULT_TERMINAL_SESSION_CAP).toBe(5);
+  });
+
+  it("uses a positive integer override verbatim", () => {
+    expect(getTerminalSessionCap("3")).toBe(3);
+    expect(getTerminalSessionCap("10")).toBe(10);
+  });
+
+  it("falls back to the default for zero, negative, or non-numeric values", () => {
+    expect(getTerminalSessionCap("0")).toBe(DEFAULT_TERMINAL_SESSION_CAP);
+    expect(getTerminalSessionCap("-1")).toBe(DEFAULT_TERMINAL_SESSION_CAP);
+    expect(getTerminalSessionCap("abc")).toBe(DEFAULT_TERMINAL_SESSION_CAP);
+    expect(getTerminalSessionCap("")).toBe(DEFAULT_TERMINAL_SESSION_CAP);
+    expect(getTerminalSessionCap("3.5")).toBe(DEFAULT_TERMINAL_SESSION_CAP);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(getTerminalSessionCap("  7  ")).toBe(7);
+  });
+});
+
+describe("newSessionTooltip", () => {
+  it("templates the configured cap into the honesty copy", () => {
+    expect(newSessionTooltip(5)).toBe(
+      "New terminal — runs on your computer. Each session uses real resources. Up to 5 at once.",
+    );
+    expect(newSessionTooltip(3)).toContain("Up to 3 at once.");
+  });
+
+  it("defaults to the resolved env cap when called with no argument", () => {
+    expect(newSessionTooltip()).toContain(`Up to ${DEFAULT_TERMINAL_SESSION_CAP} at once.`);
+  });
+});
+
+describe("isCapRefusalMessage", () => {
+  it("recognises the documented refusal shapes", () => {
+    expect(isCapRefusalMessage("You already have 5 terminals running")).toBe(true);
+    expect(isCapRefusalMessage("You already have 3 terminal running")).toBe(true);
+    expect(isCapRefusalMessage("Terminal session cap reached")).toBe(true);
+    expect(isCapRefusalMessage("Too many active terminal sessions")).toBe(true);
+  });
+
+  it("does not misclassify unrelated failures", () => {
+    expect(isCapRefusalMessage("Not authenticated")).toBe(false);
+    expect(isCapRefusalMessage("Idea not found")).toBe(false);
+    expect(isCapRefusalMessage(undefined)).toBe(false);
+    expect(isCapRefusalMessage(null)).toBe(false);
+    expect(isCapRefusalMessage("")).toBe(false);
+  });
+});
+
+describe("capReachedToastCopy", () => {
+  it("templates the cap number into the title, never hardcoding it", () => {
+    expect(capReachedToastCopy(5)).toEqual({
+      title: "You already have 5 terminals running",
+      description: "That's the limit for now. End one to start another.",
+    });
+    expect(capReachedToastCopy(3).title).toBe("You already have 3 terminals running");
+  });
+});

--- a/src/lib/terminal/session-cap.ts
+++ b/src/lib/terminal/session-cap.ts
@@ -1,30 +1,66 @@
 // In-app terminal — the per-user in-browser session cap (multi-session stage 2,
 // OQ4: "Cap value display... Q3's env-tunable value must not be hardcoded in
-// copy"). Stage 2 only READS the cap for honest UI copy (the "+" tooltip, the
-// generic mint-failure toast) — the server-side ENFORCEMENT of this cap is stage
-// 3's job (the mint route doesn't reject on it yet). Keeping this in one pure,
-// unit-tested module now means stage 3 wires the *same* number into the actual
-// refusal path instead of a second hardcoded constant drifting from this one.
+// copy"). Stage 2 only READ the cap for honest UI copy (the "+" tooltip, the
+// generic mint-failure toast). Stage 3 wires the SAME default (5) into the
+// mint route's actual server-side refusal (see getServerTerminalSessionCap
+// below) instead of a second hardcoded constant drifting from this one.
 
-/** The cap when NEXT_PUBLIC_TERMINAL_SESSION_CAP is unset or unusable. */
+/** The cap when neither env var (client or server) is set or usable. */
 export const DEFAULT_TERMINAL_SESSION_CAP = 5;
 
+/** The mint rate limit when TERMINAL_MINT_RATE_LIMIT is unset or unusable (E2). */
+export const DEFAULT_TERMINAL_MINT_RATE_LIMIT = 10;
+
 /**
- * Resolve the configured in-browser session cap. Reads
+ * Parse an env var into a positive integer, falling back for anything unset,
+ * non-numeric, non-integer, or not positive — a misconfigured env var should
+ * never silently become "no cap" (0/negative) or a NaN that breaks copy
+ * templates. Shared by every env-tunable number this feature reads.
+ */
+function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return fallback;
+  const n = Number.parseInt(trimmed, 10);
+  return n > 0 ? n : fallback;
+}
+
+/**
+ * Resolve the configured in-browser session cap for CLIENT-SIDE copy. Reads
  * `NEXT_PUBLIC_TERMINAL_SESSION_CAP` (so it's inlined client-side same as every
- * other NEXT_PUBLIC_* flag this feature uses); falls back to
- * DEFAULT_TERMINAL_SESSION_CAP for anything unset, non-numeric, non-integer, or
- * not positive — a misconfigured env var should never silently become "no cap"
- * (0/negative) or a NaN that breaks copy templates.
+ * other NEXT_PUBLIC_* flag this feature uses).
  */
 export function getTerminalSessionCap(
   raw: string | undefined = process.env.NEXT_PUBLIC_TERMINAL_SESSION_CAP,
 ): number {
-  if (raw === undefined) return DEFAULT_TERMINAL_SESSION_CAP;
-  const trimmed = raw.trim();
-  if (!/^\d+$/.test(trimmed)) return DEFAULT_TERMINAL_SESSION_CAP;
-  const n = Number.parseInt(trimmed, 10);
-  return n > 0 ? n : DEFAULT_TERMINAL_SESSION_CAP;
+  return parsePositiveIntEnv(raw, DEFAULT_TERMINAL_SESSION_CAP);
+}
+
+/**
+ * The SERVER-SIDE enforcement cap (stage 3, mint route, requirement E1). A
+ * deliberately SEPARATE env var (`TERMINAL_SESSION_CAP`, no `NEXT_PUBLIC_`
+ * prefix) from the client's copy-only `NEXT_PUBLIC_TERMINAL_SESSION_CAP` — the
+ * client var is inlined into the JS bundle at build time (world-readable); the
+ * enforcement value is read at request time server-side and never shipped to
+ * the browser. Both fall back to the SAME `DEFAULT_TERMINAL_SESSION_CAP` (5,
+ * Nick's binding decision) so an unconfigured deployment stays internally
+ * consistent between the "+" tooltip's promise and the real limit.
+ */
+export function getServerTerminalSessionCap(
+  raw: string | undefined = process.env.TERMINAL_SESSION_CAP,
+): number {
+  return parsePositiveIntEnv(raw, DEFAULT_TERMINAL_SESSION_CAP);
+}
+
+/**
+ * The SERVER-SIDE mint rate limit (stage 3, mint route, requirement E2): max
+ * sessions a user may mint within a trailing 5-minute window. Reads
+ * `TERMINAL_MINT_RATE_LIMIT`, server-only (never shipped to the browser).
+ */
+export function getTerminalMintRateLimit(
+  raw: string | undefined = process.env.TERMINAL_MINT_RATE_LIMIT,
+): number {
+  return parsePositiveIntEnv(raw, DEFAULT_TERMINAL_MINT_RATE_LIMIT);
 }
 
 /**
@@ -61,3 +97,26 @@ export function capReachedToastCopy(cap: number = getTerminalSessionCap()): {
     description: "That's the limit for now. End one to start another.",
   };
 }
+
+// ── stage 3: server-side refusal bodies (mint route) ────────────────────────
+//
+// The mint route returns a distinct `code` per refusal reason so the client
+// never has to string-match a message to decide what UI to show (E1/E2) —
+// `isCapRefusalMessage` above stays only as a best-effort fallback for a
+// response that somehow lost its `code`. The two refusals are deliberately
+// DIFFERENT copy: the cap refusal names the fix (end a session) and is one
+// click from "My sessions"; the rate limit is a transient throttle with NO
+// mention of ending anything (a user hitting it hasn't necessarily hit the
+// cap — ending a session would not even be the right advice).
+
+export const CAP_REFUSAL_CODE = "cap_exceeded" as const;
+export const RATE_LIMIT_CODE = "rate_limited" as const;
+
+/** The mint route's 409 refusal copy (design §7b, cap number always templated). */
+export function capRefusalMessage(cap: number = getServerTerminalSessionCap()): string {
+  return `You already have ${cap} terminal${cap === 1 ? "" : "s"} running — end one to start another.`;
+}
+
+/** The mint route's 429 refusal copy — distinct state, never suggests ending a session. */
+export const RATE_LIMIT_MESSAGE =
+  "You're starting terminals too fast — wait a moment and try again.";

--- a/src/lib/terminal/session-cap.ts
+++ b/src/lib/terminal/session-cap.ts
@@ -1,0 +1,63 @@
+// In-app terminal — the per-user in-browser session cap (multi-session stage 2,
+// OQ4: "Cap value display... Q3's env-tunable value must not be hardcoded in
+// copy"). Stage 2 only READS the cap for honest UI copy (the "+" tooltip, the
+// generic mint-failure toast) — the server-side ENFORCEMENT of this cap is stage
+// 3's job (the mint route doesn't reject on it yet). Keeping this in one pure,
+// unit-tested module now means stage 3 wires the *same* number into the actual
+// refusal path instead of a second hardcoded constant drifting from this one.
+
+/** The cap when NEXT_PUBLIC_TERMINAL_SESSION_CAP is unset or unusable. */
+export const DEFAULT_TERMINAL_SESSION_CAP = 5;
+
+/**
+ * Resolve the configured in-browser session cap. Reads
+ * `NEXT_PUBLIC_TERMINAL_SESSION_CAP` (so it's inlined client-side same as every
+ * other NEXT_PUBLIC_* flag this feature uses); falls back to
+ * DEFAULT_TERMINAL_SESSION_CAP for anything unset, non-numeric, non-integer, or
+ * not positive — a misconfigured env var should never silently become "no cap"
+ * (0/negative) or a NaN that breaks copy templates.
+ */
+export function getTerminalSessionCap(
+  raw: string | undefined = process.env.NEXT_PUBLIC_TERMINAL_SESSION_CAP,
+): number {
+  if (raw === undefined) return DEFAULT_TERMINAL_SESSION_CAP;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return DEFAULT_TERMINAL_SESSION_CAP;
+  const n = Number.parseInt(trimmed, 10);
+  return n > 0 ? n : DEFAULT_TERMINAL_SESSION_CAP;
+}
+
+/**
+ * The "+" affordance's honesty tooltip (design §2 callout 4, requirement R4),
+ * extended with the configured cap so the number is never a separate hardcoded
+ * string anywhere it's surfaced. The "+" is NEVER disabled at this cap — stage 3
+ * enforces it server-side; this copy just sets expectations up front.
+ */
+export function newSessionTooltip(cap: number = getTerminalSessionCap()): string {
+  return `New terminal — runs on your computer. Each session uses real resources. Up to ${cap} at once.`;
+}
+
+/**
+ * Best-effort client-side guess at whether a mint failure's message was the cap
+ * refusal (stage 3 will give this a distinct error code; until then we match the
+ * shape of the server's plain-English refusal so the toast reads the same either
+ * way). Returns false — never throws — for anything that doesn't look cap-shaped,
+ * so an unrelated mint failure keeps its own honest message.
+ */
+export function isCapRefusalMessage(message: string | undefined | null): boolean {
+  if (!message) return false;
+  return /already have\s+\d+\s+terminals? running|terminal session cap|too many (active )?terminal sessions/i.test(
+    message,
+  );
+}
+
+/** Toast copy for a cap refusal, templated from config (never a hardcoded number). */
+export function capReachedToastCopy(cap: number = getTerminalSessionCap()): {
+  title: string;
+  description: string;
+} {
+  return {
+    title: `You already have ${cap} terminals running`,
+    description: "That's the limit for now. End one to start another.",
+  };
+}

--- a/src/lib/terminal/session-registry.test.ts
+++ b/src/lib/terminal/session-registry.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import {
+  REGISTRY_SESSION_TTL_MS,
+  RATE_LIMIT_WINDOW_MS,
+  computeSessionExpiresAt,
+  isSessionExpired,
+  rateLimitWindowStart,
+  decideCap,
+  decideRateLimit,
+  formatSessionAge,
+  formatSessionIdentity,
+} from "./session-registry";
+
+const NOW = Date.parse("2026-07-20T12:00:00.000Z");
+
+describe("computeSessionExpiresAt", () => {
+  it("adds the 4h TTL to the mint time", () => {
+    expect(REGISTRY_SESSION_TTL_MS).toBe(4 * 60 * 60 * 1000);
+    expect(computeSessionExpiresAt(NOW)).toBe(new Date(NOW + REGISTRY_SESSION_TTL_MS).toISOString());
+  });
+
+  it("honors a custom TTL", () => {
+    expect(computeSessionExpiresAt(NOW, 1000)).toBe(new Date(NOW + 1000).toISOString());
+  });
+});
+
+describe("isSessionExpired", () => {
+  it("is false while expires_at is in the future", () => {
+    const future = new Date(NOW + 60_000).toISOString();
+    expect(isSessionExpired(future, NOW)).toBe(false);
+  });
+
+  it("is true once expires_at has passed, including exactly at the boundary", () => {
+    const past = new Date(NOW - 1).toISOString();
+    expect(isSessionExpired(past, NOW)).toBe(true);
+    expect(isSessionExpired(new Date(NOW).toISOString(), NOW)).toBe(true);
+  });
+
+  it("never reaps on a malformed timestamp", () => {
+    expect(isSessionExpired("not-a-date", NOW)).toBe(false);
+    expect(isSessionExpired("", NOW)).toBe(false);
+  });
+});
+
+describe("rateLimitWindowStart", () => {
+  it("subtracts the trailing window", () => {
+    expect(RATE_LIMIT_WINDOW_MS).toBe(5 * 60 * 1000);
+    expect(rateLimitWindowStart(NOW)).toBe(new Date(NOW - RATE_LIMIT_WINDOW_MS).toISOString());
+  });
+});
+
+describe("decideCap", () => {
+  it("allows a mint strictly below the cap", () => {
+    expect(decideCap(4, 5)).toEqual({ ok: true });
+    expect(decideCap(0, 5)).toEqual({ ok: true });
+  });
+
+  it("refuses AT the cap, not just over it", () => {
+    expect(decideCap(5, 5)).toEqual({ ok: false, active: 5, cap: 5 });
+  });
+
+  it("refuses over the cap", () => {
+    expect(decideCap(9, 5)).toEqual({ ok: false, active: 9, cap: 5 });
+  });
+});
+
+describe("decideRateLimit", () => {
+  it("allows below the limit", () => {
+    expect(decideRateLimit(9, 10)).toEqual({ ok: true });
+  });
+
+  it("refuses AT and over the limit", () => {
+    expect(decideRateLimit(10, 10)).toEqual({ ok: false, recent: 10, limit: 10 });
+    expect(decideRateLimit(15, 10)).toEqual({ ok: false, recent: 15, limit: 10 });
+  });
+});
+
+describe("formatSessionAge", () => {
+  it("formats sub-hour ages in minutes", () => {
+    expect(formatSessionAge(new Date(NOW - 0).toISOString(), NOW)).toBe("0m");
+    expect(formatSessionAge(new Date(NOW - 12 * 60_000).toISOString(), NOW)).toBe("12m");
+    expect(formatSessionAge(new Date(NOW - 59 * 60_000).toISOString(), NOW)).toBe("59m");
+  });
+
+  it("formats hour-plus ages, dropping zero minutes", () => {
+    expect(formatSessionAge(new Date(NOW - 60 * 60_000).toISOString(), NOW)).toBe("1h");
+    expect(formatSessionAge(new Date(NOW - 120 * 60_000).toISOString(), NOW)).toBe("2h");
+    expect(formatSessionAge(new Date(NOW - 230 * 60_000).toISOString(), NOW)).toBe("3h 50m");
+  });
+
+  it("never goes negative for a clock-skewed 'future' timestamp", () => {
+    expect(formatSessionAge(new Date(NOW + 60_000).toISOString(), NOW)).toBe("0m");
+  });
+
+  it("treats a malformed timestamp as age zero rather than throwing", () => {
+    expect(formatSessionAge("garbage", NOW)).toBe("0m");
+  });
+});
+
+describe("formatSessionIdentity", () => {
+  it("joins whichever parts are non-null, sid always last", () => {
+    expect(
+      formatSessionIdentity({ machineLabel: "Nick's MacBook Pro", cwd: "~/projects/recipe-saver", sid: "a3f9beef" }),
+    ).toBe("Nick's MacBook Pro · ~/projects/recipe-saver · a3f9beef");
+  });
+
+  it("falls back to just the short sid (first 8 chars) when nothing else is known", () => {
+    expect(formatSessionIdentity({ machineLabel: null, cwd: null, sid: "a3f9beef1234" })).toBe("a3f9beef");
+  });
+
+  it("omits a missing cwd but keeps a known machine label", () => {
+    expect(formatSessionIdentity({ machineLabel: "Nick's MacBook Pro", cwd: null, sid: "a3f9beef" })).toBe(
+      "Nick's MacBook Pro · a3f9beef",
+    );
+  });
+});

--- a/src/lib/terminal/session-registry.ts
+++ b/src/lib/terminal/session-registry.ts
@@ -1,0 +1,102 @@
+// In-app terminal — pure registry decisions (multi-session stage 3).
+//
+// The `terminal_sessions` table (migration 00141) is a BEST-EFFORT registry —
+// the relay (one Durable Object per sid) is the actual source of truth for
+// whether a session is alive, and rows can drift (design doc §9, R2: "a row
+// the relay reports gone renders as 'Already ended'"). Every decision that can
+// be expressed as a pure function over plain data lives here, unit-tested
+// without a Supabase client, so the mint/end/list routes stay thin composition
+// over these + the DB calls.
+
+/**
+ * Mint sets `expires_at = created_at + 4h`, mirroring the relay's own
+ * max-duration horizon (terminal/relay/src/pairing.js → DEFAULT_MAX_MS). A row
+ * can never legitimately still be "active" once this passes, so the mint
+ * route's reap step (R2 mitigation) uses this to mark stale rows ended WITHOUT
+ * ever having to ask the relay.
+ */
+export const REGISTRY_SESSION_TTL_MS = 4 * 60 * 60 * 1000;
+
+/** The trailing window the mint rate limit (E2) counts recent mints over. */
+export const RATE_LIMIT_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * `expires_at` for a freshly-minted registry row, as an ISO string ready for
+ * the `terminal_sessions` insert.
+ */
+export function computeSessionExpiresAt(
+  nowMs: number = Date.now(),
+  ttlMs: number = REGISTRY_SESSION_TTL_MS,
+): string {
+  return new Date(nowMs + ttlMs).toISOString();
+}
+
+/** Whether a registry row's `expires_at` has passed — the reap-step predicate. */
+export function isSessionExpired(expiresAt: string, nowMs: number = Date.now()): boolean {
+  const t = Date.parse(expiresAt);
+  if (Number.isNaN(t)) return false; // malformed timestamp — never falsely reap
+  return t <= nowMs;
+}
+
+/** The start of the trailing rate-limit window, as an ISO string for a `.gte()` filter. */
+export function rateLimitWindowStart(
+  nowMs: number = Date.now(),
+  windowMs: number = RATE_LIMIT_WINDOW_MS,
+): string {
+  return new Date(nowMs - windowMs).toISOString();
+}
+
+export type CapDecision = { ok: true } | { ok: false; active: number; cap: number };
+
+/**
+ * E1: refuse a mint once the user's remaining ACTIVE (post-reap) row count
+ * meets or exceeds the cap. `activeCount` must already exclude rows this
+ * request just reaped.
+ */
+export function decideCap(activeCount: number, cap: number): CapDecision {
+  if (activeCount >= cap) return { ok: false, active: activeCount, cap };
+  return { ok: true };
+}
+
+export type RateLimitDecision = { ok: true } | { ok: false; recent: number; limit: number };
+
+/** E2: refuse a mint once the user's mints in the trailing window meet/exceed the limit. */
+export function decideRateLimit(recentCount: number, limit: number): RateLimitDecision {
+  if (recentCount >= limit) return { ok: false, recent: recentCount, limit };
+  return { ok: true };
+}
+
+/**
+ * Compact "age" string for the My-sessions list (design §9: "12m", "41m",
+ * "2h", "3h 50m"). Minutes below 60; hours + minutes above, dropping the
+ * minutes once they round to 0; a floor of "0m" for a just-created row (never
+ * negative, never blank, even if the clock is slightly behind the server's).
+ */
+export function formatSessionAge(createdAt: string, nowMs: number = Date.now()): string {
+  const created = Date.parse(createdAt);
+  const totalMinutes = Number.isNaN(created) ? 0 : Math.max(0, Math.floor((nowMs - created) / 60_000));
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+}
+
+/**
+ * The My-sessions identity line (design §9: "machine · cwd · short sid,
+ * whatever's non-null"). `machine_label` is never actually populated today
+ * (no browser API can read it — see the PATCH route's doc comment), but the
+ * shape stays ready for whenever a real signal exists; `cwd` is set
+ * best-effort post-connect. The short sid is always present so a row is never
+ * a blank line.
+ */
+export function formatSessionIdentity(input: {
+  machineLabel?: string | null;
+  cwd?: string | null;
+  sid: string;
+}): string {
+  const parts: string[] = [];
+  if (input.machineLabel) parts.push(input.machineLabel);
+  if (input.cwd) parts.push(input.cwd);
+  parts.push(input.sid.slice(0, 8));
+  return parts.join(" · ");
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2700,6 +2700,70 @@ export type Database = {
         },
       ];
     };
+    // In-app terminal — multi-session registry (stage 3, migration 00141).
+    // Best-effort: the relay (one Durable Object per sid) is the source of
+    // truth for whether a session is actually alive; this table is what the
+    // mint route, cap/rate-limit checks, and "My sessions" read/write.
+    terminal_sessions: {
+      Row: {
+        id: string;
+        sid: string;
+        user_id: string;
+        idea_id: string;
+        task_id: string | null;
+        task_title: string | null;
+        machine_label: string | null;
+        cwd: string | null;
+        status: "active" | "ended";
+        created_at: string;
+        ended_at: string | null;
+        expires_at: string;
+      };
+      Insert: {
+        id?: string;
+        sid: string;
+        user_id: string;
+        idea_id: string;
+        task_id?: string | null;
+        task_title?: string | null;
+        machine_label?: string | null;
+        cwd?: string | null;
+        status?: "active" | "ended";
+        created_at?: string;
+        ended_at?: string | null;
+        expires_at: string;
+      };
+      Update: {
+        id?: string;
+        sid?: string;
+        user_id?: string;
+        idea_id?: string;
+        task_id?: string | null;
+        task_title?: string | null;
+        machine_label?: string | null;
+        cwd?: string | null;
+        status?: "active" | "ended";
+        created_at?: string;
+        ended_at?: string | null;
+        expires_at?: string;
+      };
+      Relationships: [
+        {
+          foreignKeyName: "terminal_sessions_user_id_fkey";
+          columns: ["user_id"];
+          isOneToOne: false;
+          referencedRelation: "users";
+          referencedColumns: ["id"];
+        },
+        {
+          foreignKeyName: "terminal_sessions_idea_id_fkey";
+          columns: ["idea_id"];
+          isOneToOne: false;
+          referencedRelation: "ideas";
+          referencedColumns: ["id"];
+        },
+      ];
+    };
     };
     Views: {
       // P2c — self-reported tier-adherence reporting views (migration 00135).

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,9 @@ export type WorkflowAutoRule = Database["public"]["Tables"]["workflow_auto_rules
 export type WorkflowRun = Database["public"]["Tables"]["workflow_runs"]["Row"];
 export type WorkflowSuggestion = Database["public"]["Tables"]["workflow_suggestions"]["Row"];
 export type BoardTaskActivity = Database["public"]["Tables"]["board_task_activity"]["Row"];
+
+// In-app terminal — multi-session registry (stage 3)
+export type TerminalSession = Database["public"]["Tables"]["terminal_sessions"]["Row"];
 export type BoardTaskComment = Database["public"]["Tables"]["board_task_comments"]["Row"];
 export type BoardTaskAttachment = Database["public"]["Tables"]["board_task_attachments"]["Row"];
 export type IdeaAttachment = Database["public"]["Tables"]["idea_attachments"]["Row"];

--- a/supabase/migrations/00141_terminal_sessions.sql
+++ b/supabase/migrations/00141_terminal_sessions.sql
@@ -1,0 +1,58 @@
+-- In-app terminal multi-session registry (stage 3, docs/design-terminal-multi-session-popout.html §9).
+--
+-- The relay is opaque and per-session (one Durable Object per sid) — it has no
+-- notion of "all of a user's terminals". This table is the best-effort registry
+-- the mint route, cap/rate-limit checks, and the "My sessions" panel read/write
+-- against. It is deliberately NOT the source of truth for whether a relay
+-- session is actually alive (the relay is) — see R2 in the design doc: rows can
+-- drift (a relay session can end without this row being told), which is why the
+-- mint route REAPS expired rows before trusting the count (see route.ts).
+--
+-- `expires_at` is set by the mint route to created_at + 4h, mirroring the
+-- relay's own max-duration horizon (terminal/relay/src/pairing.js →
+-- DEFAULT_MAX_MS) — a session can never legitimately still be "active" past
+-- that wall-clock point, so the reap step can safely mark it ended without
+-- ever having to ask the relay.
+CREATE TABLE public.terminal_sessions (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  sid text NOT NULL UNIQUE,
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  idea_id uuid NOT NULL REFERENCES public.ideas(id) ON DELETE CASCADE,
+  task_id uuid NULL,
+  task_title text NULL,
+  machine_label text NULL,
+  cwd text NULL,
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'ended')),
+  created_at timestamptz DEFAULT now() NOT NULL,
+  ended_at timestamptz NULL,
+  expires_at timestamptz NOT NULL
+);
+
+-- RLS: every row is owner-only. The mint route, end route, and My-sessions list
+-- all run through the per-user Supabase client (createClient() from
+-- @/lib/supabase/server, cookie-scoped) so these policies are the actual
+-- enforcement — never raw SQL, per CLAUDE.md. The service-role client (used
+-- nowhere in this feature today, but potentially by future admin tooling)
+-- bypasses RLS automatically and needs no explicit policy.
+ALTER TABLE public.terminal_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own terminal sessions"
+  ON public.terminal_sessions FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own terminal sessions"
+  ON public.terminal_sessions FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own terminal sessions"
+  ON public.terminal_sessions FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own terminal sessions"
+  ON public.terminal_sessions FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- The mint route's cap/rate-limit reads and the My-sessions list both filter
+-- on (user_id, status) — this is the one index that matters.
+CREATE INDEX idx_terminal_sessions_user_status ON public.terminal_sessions(user_id, status);

--- a/terminal/relay/src/control-token.test.js
+++ b/terminal/relay/src/control-token.test.js
@@ -1,0 +1,69 @@
+// Unit tests for the relay's /end control-token verdicts (multi-session stage
+// 3, C3/F5). `handleEnd` in ./index.js is a thin composition over
+// `authorizeControl` (../../shared/session-token.mjs) — the FULL matrix of
+// valid/expired/wrong-sid/wrong-role/tampered verdicts is exercised here,
+// against the same shared module the Cloudflare DO and the Node stand-in both
+// import, so a verdict proven here is the verdict either relay produces.
+//
+// Run: cd terminal/relay && node --test   (or: npm test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mintControlToken, mintSessionTokens, authorizeControl, CONTROL_TTL_SECONDS } from "../../shared/session-token.mjs";
+
+const SECRET = "relay-control-token-test-secret";
+const NOW = 1_700_000_000;
+
+test("valid control token, matching sid → authorized", async () => {
+  const token = await mintControlToken({ sub: "user-A", sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeControl({ token, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(res.ok, true);
+  assert.equal(res.sub, "user-A");
+});
+
+test("expired control token → rejected (no reattach waiver for /end)", async () => {
+  assert.equal(CONTROL_TTL_SECONDS, 60);
+  const token = await mintControlToken({ sub: "user-A", sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeControl({ token, secret: SECRET, session: "sess-1", now: NOW + CONTROL_TTL_SECONDS + 1 });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "expired");
+});
+
+test("wrong sid (token minted for a different session) → rejected", async () => {
+  const token = await mintControlToken({ sub: "user-A", sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeControl({ token, secret: SECRET, session: "sess-2", now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "sid mismatch");
+});
+
+test("wrong role (a live bridge/browser leg token) → rejected", async () => {
+  const { bridge, browser } = await mintSessionTokens({ sub: "user-A", idea: "idea-1", sid: "sess-1", secret: SECRET, now: NOW });
+  const bridgeRes = await authorizeControl({ token: bridge, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(bridgeRes.ok, false);
+  assert.equal(bridgeRes.reason, "role mismatch");
+  const browserRes = await authorizeControl({ token: browser, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(browserRes.ok, false);
+  assert.equal(browserRes.reason, "role mismatch");
+});
+
+test("tampered control token (payload flipped, signature stale) → rejected", async () => {
+  const token = await mintControlToken({ sub: "user-A", sid: "sess-1", secret: SECRET, now: NOW });
+  const [payloadB64, sig] = token.split(".");
+  const forged = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+  forged.sub = "user-EVIL";
+  const forgedPayload = Buffer.from(JSON.stringify(forged)).toString("base64url");
+  const res = await authorizeControl({ token: `${forgedPayload}.${sig}`, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "bad signature");
+});
+
+test("missing token → rejected", async () => {
+  const res = await authorizeControl({ token: null, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(res.ok, false);
+});
+
+test("wrong secret (a foreign relay's control token) → rejected with bad signature", async () => {
+  const token = await mintControlToken({ sub: "user-A", sid: "sess-1", secret: "a-different-secret", now: NOW });
+  const res = await authorizeControl({ token, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "bad signature");
+});

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -41,7 +41,7 @@ import {
   maxCloseReason,
   resolveMs,
 } from "./pairing.js";
-import { authorizeAttach } from "../../shared/session-token.mjs";
+import { authorizeAttach, authorizeControl } from "../../shared/session-token.mjs";
 import {
   encodeAttachedFrame,
   encodePeerDegradedFrame,
@@ -54,6 +54,14 @@ import {
 /** Normal WebSocket closure code used for clean, server-initiated session ends. */
 const NORMAL_CLOSURE = 1000;
 
+/** @param {unknown} body @param {number} status @returns {Response} */
+function jsonResponse(body, status) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
 export default {
   /**
    * @param {Request} request
@@ -64,6 +72,21 @@ export default {
 
     if (url.pathname === "/healthz") {
       return new Response("ok", { status: 200 });
+    }
+
+    // Multi-session stage 3 (My-sessions "End" / "End all"): a plain HTTP POST,
+    // not a WebSocket upgrade — dispatch it BEFORE the Upgrade-header gate
+    // below. Auth (the control token) is checked inside the DO, where the
+    // session's live state actually lives; here we only need a shape-valid
+    // session id to route to the right DO instance (same as the WS path).
+    if (url.pathname === "/end" && request.method === "POST") {
+      const session = url.searchParams.get("session");
+      if (!isValidSession(session)) {
+        return jsonResponse({ ended: false, reason: "bad-session" }, 400);
+      }
+      const id = env.TERMINAL_RELAY.idFromName(session);
+      const stub = env.TERMINAL_RELAY.get(id);
+      return stub.fetch(request);
     }
 
     if (request.headers.get("Upgrade") !== "websocket") {
@@ -166,9 +189,44 @@ export class TerminalRelay {
     return { bridge, browser, owner };
   }
 
+  /**
+   * Multi-session stage 3 — My-sessions "End" / "End all" (C3, F5). A
+   * lifecycle-only HTTP action: authorize the control token, then close both
+   * legs exactly like an idle/max-duration end (same `endSession` helper, same
+   * NORMAL_CLOSURE code) — no content buffering, inspection, or logging beyond
+   * the metadata every other path here already logs (AC20/F3).
+   * @param {Request} request @param {URL} url
+   */
+  async handleEnd(request, url) {
+    const session = url.searchParams.get("session");
+    const authHeader = request.headers.get("Authorization") || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : null;
+    const auth = await authorizeControl({ token, secret: this.env.TERMINAL_SESSION_SECRET, session });
+    if (!auth.ok) {
+      this.log("end rejected (auth)", { session, reason: auth.reason });
+      return jsonResponse({ ended: false, reason: "unauthorized" }, 401);
+    }
+
+    const state = await this.computeAttachState();
+    if (!state.bridge && !state.browser) {
+      // Nothing live to end — an honest, non-probing 200 (the caller already
+      // proved authorization via the control token, so there is no liveness
+      // leak in telling them truthfully that there's nothing here).
+      this.log("end: no live session", { session });
+      return jsonResponse({ ended: false, reason: "no-session" }, 200);
+    }
+
+    await this.endSession("ended-by-user");
+    this.log("end: session ended", { session });
+    return jsonResponse({ ended: true }, 200);
+  }
+
   /** @param {Request} request */
   async fetch(request) {
     const url = new URL(request.url);
+    if (url.pathname === "/end" && request.method === "POST") {
+      return this.handleEnd(request, url);
+    }
     const role = url.searchParams.get("role");
     const session = url.searchParams.get("session");
     const token = url.searchParams.get("token");

--- a/terminal/shared/session-token.mjs
+++ b/terminal/shared/session-token.mjs
@@ -29,7 +29,21 @@
 // never waived, and a belt-and-braces cap rejects tokens older than the max
 // session age. `verifyToken` itself stays strict (expired is always a failure).
 
-/** @typedef {"bridge"|"browser"} Role */
+/**
+ * @typedef {"bridge"|"browser"|"control"} Role
+ *
+ * "control" (multi-session stage 3, terminal/api/session/end) is a THIRD kind
+ * of leg: it never opens a WebSocket. It authorizes a single HTTP call — the
+ * VibeCodes end route (POST /end?session=<sid>) telling the relay's Durable
+ * Object to close both legs of a specific session. It reuses this exact
+ * sign/verify machinery (same secret, same HMAC, same shape checks) so the
+ * relay verifies it with the SAME code path as bridge/browser tokens —
+ * `authorizeControl` below is the strict (non-waived) counterpart to
+ * `authorizeAttach`: a control token is always short-lived (60s) and NEVER
+ * gets the reattach expiry waiver a live session's owner gets on bridge/
+ * browser tokens, because there is no "session" for a control call to be
+ * live inside of — it's a one-shot admin action, not a leg that attaches.
+ */
 
 /**
  * @typedef {Object} SessionClaims
@@ -53,7 +67,10 @@ export const DEFAULT_TTL_SECONDS = 300;
  */
 export const DEFAULT_MAX_SESSION_MS = 4 * 60 * 60 * 1000;
 
-const ROLES = Object.freeze(["bridge", "browser"]);
+const ROLES = Object.freeze(["bridge", "browser", "control"]);
+
+/** Control-token lifetime (multi-session stage 3): short-lived, one-shot. */
+export const CONTROL_TTL_SECONDS = 60;
 const enc = new TextEncoder();
 const dec = new TextDecoder();
 
@@ -261,4 +278,53 @@ export async function mintSessionTokens({
     signToken({ ...base, role: "bridge" }, secret),
   ]);
   return { sid, idea, sub, exp, browser, bridge };
+}
+
+/**
+ * Mint a short-lived "control" token authorizing ONE HTTP call to the relay's
+ * `POST /end?session=<sid>` endpoint (multi-session stage 3, terminal/api/
+ * session/end). Minted SERVER-SIDE by the VibeCodes end route — never handed
+ * to the browser — immediately before that server-to-server fetch, so its 60s
+ * TTL only ever needs to cover one outbound request. `idea` is carried for
+ * parity with the other mint helper and for relay-side logging; it is not
+ * checked by `authorizeControl`.
+ *
+ * @param {{ sub: string, sid: string, idea?: string, secret: string, ttlSeconds?: number, now?: number }} args
+ * @returns {Promise<string>} the signed control token
+ */
+export async function mintControlToken({
+  sub,
+  sid,
+  idea = "",
+  secret,
+  ttlSeconds = CONTROL_TTL_SECONDS,
+  now = Math.floor(Date.now() / 1000),
+}) {
+  const exp = now + ttlSeconds;
+  return signToken({ sub, sid, idea, role: "control", iat: now, exp }, secret);
+}
+
+/**
+ * Verify a control token for the relay's `/end` HTTP endpoint. Deliberately
+ * STRICT — unlike {@link authorizeAttach}, there is no reattach waiver: a
+ * control call is a one-shot admin action, never a leg of a live session, so
+ * an expired token is always rejected outright. Checks signature, shape,
+ * `role === "control"`, and `sid` match; does NOT check `sub` against
+ * anything — the caller (the end route) already verified the sid belongs to
+ * the requesting user via the `terminal_sessions` registry BEFORE minting
+ * this token, so by the time the relay sees it, authorization already
+ * happened upstream. This function exists so the relay never has to trust an
+ * unsigned `session` query param alone — the control token proves the call
+ * came from VibeCodes' own server, not an arbitrary client guessing a sid.
+ *
+ * @param {{ token: unknown, secret: string, session: unknown, now?: number }} args
+ * @returns {Promise<{ ok: true, sub: string, claims: SessionClaims } | { ok: false, reason: string }>}
+ */
+export async function authorizeControl({ token, secret, session, now }) {
+  const res = await verifyToken(token, secret, { now });
+  if (!res.ok) return res;
+  const c = res.claims;
+  if (c.role !== "control") return { ok: false, reason: "role mismatch" };
+  if (c.sid !== session) return { ok: false, reason: "sid mismatch" };
+  return { ok: true, sub: c.sub, claims: c };
 }

--- a/terminal/shared/session-token.test.mjs
+++ b/terminal/shared/session-token.test.mjs
@@ -7,8 +7,11 @@ import {
   verifyToken,
   authorizeAttach,
   mintSessionTokens,
+  mintControlToken,
+  authorizeControl,
   newSessionId,
   DEFAULT_TTL_SECONDS,
+  CONTROL_TTL_SECONDS,
 } from "./session-token.mjs";
 
 const SECRET = "test-secret-do-not-ship";
@@ -206,4 +209,53 @@ test("mintSessionTokens mints both legs sharing one sid + sub", async () => {
 test("newSessionId produces a relay-safe id", () => {
   const id = newSessionId();
   assert.match(id, /^[A-Za-z0-9._-]+$/);
+});
+
+// ── control tokens (multi-session stage 3, relay POST /end) ─────────────────
+
+test("mintControlToken → authorizeControl happy path", async () => {
+  assert.equal(CONTROL_TTL_SECONDS, 60);
+  const token = await mintControlToken({ sub: "user-A", sid: "sess-1", idea: "idea-1", secret: SECRET, now: NOW });
+  const res = await authorizeControl({ token, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(res.ok, true);
+  assert.equal(res.sub, "user-A");
+  assert.equal(res.claims.role, "control");
+});
+
+test("authorizeControl: sid mismatch is rejected", async () => {
+  const token = await mintControlToken({ sub: "user-A", sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeControl({ token, secret: SECRET, session: "sess-OTHER", now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "sid mismatch");
+});
+
+test("authorizeControl: a bridge/browser token is rejected with role mismatch", async () => {
+  const { browser } = await mintSessionTokens({ sub: "user-A", idea: "idea-1", sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeControl({ token: browser, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "role mismatch");
+});
+
+test("authorizeControl: expiry is ALWAYS strict — no reattach waiver exists for control tokens", async () => {
+  const token = await mintControlToken({ sub: "user-A", sid: "sess-1", secret: SECRET, now: NOW });
+  const stillGood = await authorizeControl({ token, secret: SECRET, session: "sess-1", now: NOW + CONTROL_TTL_SECONDS - 1 });
+  assert.equal(stillGood.ok, true);
+  const expired = await authorizeControl({ token, secret: SECRET, session: "sess-1", now: NOW + CONTROL_TTL_SECONDS + 1 });
+  assert.equal(expired.ok, false);
+  assert.equal(expired.reason, "expired");
+});
+
+test("authorizeControl: a tampered control token is rejected (bad signature)", async () => {
+  const token = await mintControlToken({ sub: "user-A", sid: "sess-1", secret: SECRET, now: NOW });
+  // Forge the payload (a different sid, trying to redirect this control token at
+  // ANOTHER session) while keeping the original signature — guaranteed to fail
+  // the HMAC check, unlike flipping trailing base64 characters (whose last
+  // symbol carries unused padding bits and can coincidentally decode unchanged).
+  const [payloadB64, sig] = token.split(".");
+  const forged = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+  forged.sid = "sess-EVIL";
+  const forgedPayload = Buffer.from(JSON.stringify(forged)).toString("base64url");
+  const res = await authorizeControl({ token: `${forgedPayload}.${sig}`, secret: SECRET, session: "sess-EVIL", now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "bad signature");
 });

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs zombie-bridge-reattach.test.mjs ../shared/session-token.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs zombie-bridge-reattach.test.mjs session-end.test.mjs ../shared/session-token.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/session-end.test.mjs
+++ b/terminal/test/session-end.test.mjs
@@ -1,0 +1,127 @@
+// Multi-session stage 3 — POST /end (My-sessions "End" / "End all", C3/F5).
+//
+// Proves the relay's lifecycle-only HTTP endpoint end-to-end against the Node
+// stand-in (shares the exact handler shape the Cloudflare DO uses — see
+// terminal/relay/src/index.js → TerminalRelay.handleEnd / standin-relay.mjs →
+// handleHttpRequest): a valid, sid-bound control token closes BOTH legs with
+// code 1000 "ended-by-user" and forgets the session; an invalid/foreign token
+// is rejected without touching a live session; a sid with nothing live gets an
+// honest `{ ended: false, reason: "no-session" }` without ever probing whether
+// a session with that id ever existed for someone else.
+//
+// Run: cd terminal/test && node --test session-end.test.mjs   (or: npm test)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens, mintControlToken } from "../shared/session-token.mjs";
+
+const SECRET = "session-end-test-secret";
+
+async function waitFor(pred, ms, label, pollMs = 25) {
+  const started = Date.now();
+  for (;;) {
+    const v = await pred();
+    if (v) return v;
+    if (Date.now() - started > ms) throw new Error(`timed out after ${ms}ms waiting for ${label}`);
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+/** Open a raw ws leg and record its eventual close code/reason. */
+async function openRawLeg(relayUrl, session, role, token) {
+  const ws = new WebSocket(`${relayUrl}/?session=${session}&role=${role}&token=${encodeURIComponent(token)}`);
+  const leg = { ws, closed: null };
+  ws.on("close", (code, reasonBuf) => {
+    leg.closed = [code, reasonBuf ? reasonBuf.toString() : ""];
+  });
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${role} open timeout`)), 5000)),
+  ]);
+  return leg;
+}
+
+test("POST /end with a valid control token closes both legs 1000 'ended-by-user' and forgets the session", { timeout: 15000 }, async (t) => {
+  const session = `end-a-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-END", sid: session, secret: SECRET });
+
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  await waitFor(() => relay.sessions.get(session)?.bridge && relay.sessions.get(session)?.browser, 5000, "pair live");
+
+  const control = await mintControlToken({ sub: owner, sid: session, secret: SECRET });
+  const res = await fetch(`${relay.httpUrl}/end?session=${session}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${control}` },
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body, { ended: true });
+
+  await waitFor(() => browser.closed != null && bridge.closed != null, 5000, "both legs closed");
+  assert.deepEqual(browser.closed, [1000, "ended-by-user"]);
+  assert.deepEqual(bridge.closed, [1000, "ended-by-user"]);
+  assert.equal(relay.sessions.has(session), false, "the stand-in's own registry forgets the session (mirrors clearSessionState)");
+  console.log("[end/a] PASS — valid control token ends both legs, session forgotten");
+});
+
+test("POST /end with a missing/foreign token is rejected 401 and the live session is untouched", { timeout: 15000 }, async (t) => {
+  const session = `end-b-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-END", sid: session, secret: SECRET });
+
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
+  await waitFor(() => relay.sessions.get(session)?.bridge && relay.sessions.get(session)?.browser, 5000, "pair live");
+
+  // No Authorization header at all.
+  const noAuth = await fetch(`${relay.httpUrl}/end?session=${session}`, { method: "POST" });
+  assert.equal(noAuth.status, 401);
+  assert.deepEqual(await noAuth.json(), { ended: false, reason: "unauthorized" });
+
+  // A control token minted for a DIFFERENT sid.
+  const foreignSid = await mintControlToken({ sub: owner, sid: `${session}-other`, secret: SECRET });
+  const wrongSid = await fetch(`${relay.httpUrl}/end?session=${session}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${foreignSid}` },
+  });
+  assert.equal(wrongSid.status, 401);
+
+  // A bridge/browser leg token is not a control token.
+  const wrongRole = await fetch(`${relay.httpUrl}/end?session=${session}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${tokens.browser}` },
+  });
+  assert.equal(wrongRole.status, 401);
+
+  await new Promise((r) => setTimeout(r, 150));
+  assert.equal(browser.ws.readyState, WebSocket.OPEN, "session untouched by every rejected /end call");
+  assert.ok(relay.sessions.has(session));
+  console.log("[end/b] PASS — unauthorized /end calls never touch a live session");
+});
+
+test("POST /end for a sid with nothing live returns an honest 200 { ended: false, reason: 'no-session' }", { timeout: 15000 }, async (t) => {
+  const session = `end-c-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+
+  const control = await mintControlToken({ sub: owner, sid: session, secret: SECRET });
+  const res = await fetch(`${relay.httpUrl}/end?session=${session}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${control}` },
+  });
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { ended: false, reason: "no-session" });
+  console.log("[end/c] PASS — no-session sid gets an honest 200, no liveness leak given a valid token");
+});

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -18,6 +18,7 @@
 //   const relay = await startStandinRelay({ port: 0, idleMs: 200 });
 //   ... relay.url ("ws://127.0.0.1:<port>") ... await relay.close();
 
+import http from "node:http";
 import { WebSocketServer } from "ws";
 import {
   decideAttach,
@@ -30,7 +31,7 @@ import {
   maxCloseReason,
   resolveMs,
 } from "../relay/src/pairing.js";
-import { authorizeAttach } from "../shared/session-token.mjs";
+import { authorizeAttach, authorizeControl } from "../shared/session-token.mjs";
 import {
   encodeAttachedFrame,
   encodePeerDegradedFrame,
@@ -69,7 +70,56 @@ export function startStandinRelay(opts = {}) {
   // (`peer-reattached`); the timer firing still-incomplete runs the OLD teardown.
   const sessions = new Map();
 
-  const wss = new WebSocketServer({ port: opts.port ?? 0 });
+  // Multi-session stage 3 (POST /end): the stand-in needs a plain HTTP
+  // endpoint alongside the WebSocket upgrade path, so — unlike the original
+  // `{ port }` shorthand — we own the http.Server explicitly and hand it to
+  // WebSocketServer via the `server` option (ws only intercepts the `upgrade`
+  // event on it; everything else is handled by our own request listener).
+  const httpServer = http.createServer((req, res) => {
+    handleHttpRequest(req, res).catch((err) => {
+      log("end handler crashed", { err: String(err) });
+      try {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ended: false, reason: "internal-error" }));
+      } catch { /* response already sent */ }
+    });
+  });
+  const wss = new WebSocketServer({ server: httpServer });
+
+  /** Faithful twin of the Cloudflare DO's handleEnd (relay/src/index.js). */
+  async function handleHttpRequest(req, res) {
+    const url = new URL(req.url, "http://localhost");
+    if (url.pathname !== "/end" || req.method !== "POST") {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "not found" }));
+      return;
+    }
+    const session = url.searchParams.get("session");
+    const authHeader = req.headers["authorization"] || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : null;
+    const auth = await authorizeControl({ token, secret, session });
+    if (!auth.ok) {
+      log("end rejected (auth)", { session, reason: auth.reason });
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ended: false, reason: "unauthorized" }));
+      return;
+    }
+    const legs = sessions.get(session);
+    const hasLive =
+      !!legs &&
+      ((legs.bridge && legs.bridge.readyState === legs.bridge.OPEN) ||
+        (legs.browser && legs.browser.readyState === legs.browser.OPEN));
+    if (!hasLive) {
+      log("end: no live session", { session });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ended: false, reason: "no-session" }));
+      return;
+    }
+    endSession(session, "ended-by-user");
+    log("end: session ended", { session });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ended: true }));
+  }
 
   /** Close both legs with code 1000 + a lifecycle reason, then forget the session. */
   function endSession(session, reason) {
@@ -239,10 +289,14 @@ export function startStandinRelay(opts = {}) {
   });
 
   return new Promise((resolve) => {
-    wss.on("listening", () => {
-      const { port } = wss.address();
+    httpServer.listen(opts.port ?? 0, () => {
+      const { port } = httpServer.address();
       resolve({
         url: `ws://127.0.0.1:${port}`,
+        // Multi-session stage 3: the HTTP base for POST /end (same host/port —
+        // ws upgrades and plain HTTP share one listener, exactly like the real
+        // Cloudflare Worker fronting one Durable Object namespace).
+        httpUrl: `http://127.0.0.1:${port}`,
         port,
         sessions,
         close: () =>
@@ -255,7 +309,7 @@ export function startStandinRelay(opts = {}) {
             for (const client of wss.clients) {
               try { client.terminate(); } catch { /* ignore */ }
             }
-            wss.close(() => res());
+            wss.close(() => httpServer.close(() => res()));
           }),
       });
     });


### PR DESCRIPTION
Implements board task cd0a9792 (multi-session phase of the in-app terminal). Built as 4 staged commits on top of the approved design (docs/design-terminal-multi-session-popout.html, cap 5 per Nick's Design Review approval).

## What's in here

1. **refactor(terminal): per-session hook** — `use-terminal-session.ts` extracted from the 1.5k-line dock; `connection.ts` untouched (AC20). All P1 fixes preserved (#87/#88/#94/#95). Q1 verified: the helper already forks one bridge per `vibecodes://launch` — no helper change, no re-notarization.
2. **feat: tabbed dock (B1–B10)** — VS Code-style tab strip, per-tab state machine/xterm/watchdog, background tabs stay attached with attention indicators, worst-first collapsed summary, B10 duplicate-task launch focuses the existing tab, WAI-ARIA tabs with manual activation.
3. **feat: registry + limits (C, E1–E2)** — new `terminal_sessions` table (migration 00141, RLS owner-only, **already applied to prod**), mint route reap→cap(5, env `TERMINAL_SESSION_CAP`)→rate-limit(10/5min, env `TERMINAL_MINT_RATE_LIMIT`) with distinct 409/429 copy, My sessions panel + End-all (inline confirm), relay `POST /end` with 60s control tokens (lifecycle-only relay change — no content inspection).
4. **feat: pop-out (D1–D7) + copy/guide (A3–A4) + telemetry (E5)** — opaque `/terminal/popout` route (no sid/tokens in URL; nonce + BroadcastChannel hand-off), attach-existing mode reusing owner-verified preemption, "Popped out" placeholder + Bring back, blocked-popup toast, scrollback-truncation notice, guide section, PostHog events (tab_opened, cap_hit, end_all_used, popout_used).

## Gates (all run in the branch worktree)

- `npx tsc --noEmit` clean · full vitest **2083/2083** (133 files) · lint 0 new · `terminal/relay` **26/26** · `terminal/test` **80/80** (includes the preemption round-trip pop-out relies on)

## Deploy notes

- Migration 00141 already applied to prod (Mgmt API, recorded as 20260720115356).
- Relay deploy (`terminal/relay`, new `/end` endpoint) pending — web degrades gracefully until it lands (End marks registry, can't force-close legs).
- New optional env vars: `TERMINAL_SESSION_CAP` (default 5), `TERMINAL_MINT_RATE_LIMIT` (default 10), `NEXT_PUBLIC_TERMINAL_SESSION_CAP` (default 5).
- Known Preview-deploy check failure (missing Supabase env) is pre-existing and not blocking per standing practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)