### PR TITLE
fix(terminal): pop-out hand-off never completed — one-shot ready with silent loss

### DIFF
--- a/src/app/terminal/popout/terminal-popout-client.tsx
+++ b/src/app/terminal/popout/terminal-popout-client.tsx
@@ -18,9 +18,8 @@
 import { useEffect, useState } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import {
-  hasPopoutHandoffTimedOut,
-  parsePopoutChannelMessage,
   popoutChannelName,
+  startPopoutClientHandshake,
   type PopoutPayload,
 } from "@/lib/terminal/popout-channel";
 import { TerminalPopoutView } from "@/components/board/terminal-popout-view";
@@ -56,20 +55,24 @@ export function TerminalPopoutClient() {
     window.name = nonce;
 
     const channel = new BroadcastChannel(popoutChannelName(nonce));
-    const startedAt = Date.now();
 
-    channel.onmessage = (ev) => {
-      const message = parsePopoutChannelMessage(ev.data);
-      if (message?.type === "payload") setPayload(message.payload);
-    };
-    channel.postMessage({ type: "ready" });
-
-    const pollTimer = window.setInterval(() => {
-      if (hasPopoutHandoffTimedOut(startedAt, Date.now())) {
-        setTimedOut(true);
-        window.clearInterval(pollTimer);
-      }
-    }, 250);
+    // Rework (fix/terminal-popout-handshake): this used to post "ready"
+    // exactly once. A Brave field test showed that one message can be lost
+    // (privacy/storage isolation around a `noopener` popup, or just an
+    // ordinary scheduling race) with NO way to recover — the dock's channel
+    // never hears anything, so it never sends the payload, and this window
+    // sits waiting for the full 5s before giving up. startPopoutClientHandshake
+    // re-announces "ready" every ~300ms until the payload arrives or the
+    // hand-off times out, and the dock now treats every "ready" as a reason
+    // to (re)send — see createDockPopoutMessageHandler / reduceDockHandshake.
+    const stopHandshake = startPopoutClientHandshake({
+      channel,
+      onPayload: (p) => setPayload(p),
+      // On timeout this ALSO posts "closed" on the channel (same module),
+      // so a dock that's still listening auto-reattaches instead of being
+      // stuck showing "Popped out" forever with nothing on the other end.
+      onTimeout: () => setTimedOut(true),
+    });
 
     const sendClosed = () => {
       try {
@@ -82,7 +85,7 @@ export function TerminalPopoutClient() {
     window.addEventListener("pagehide", sendClosed);
 
     return () => {
-      window.clearInterval(pollTimer);
+      stopHandshake();
       window.removeEventListener("beforeunload", sendClosed);
       window.removeEventListener("pagehide", sendClosed);
       // Deliberately NOT closing the channel or sending "closed" here — this

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -64,11 +64,11 @@ import { slugifyIdeaTitle } from "@/lib/launch-claude-code";
 import { newSessionTooltip } from "@/lib/terminal/session-cap";
 import {
   generatePopoutNonce,
-  parsePopoutChannelMessage,
   popoutChannelName,
-  reduceDockHandshake,
+  createDockPopoutMessageHandler,
   INITIAL_DOCK_HANDSHAKE_STATE,
   type DockHandshakeState,
+  type PopoutChannelLike,
   type PopoutPayload,
 } from "@/lib/terminal/popout-channel";
 import {
@@ -170,7 +170,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // from the moment "Pop out" is clicked until either "Bring back" or the
   // popped window's own close-signal).
   const [poppedOutKeys, setPoppedOutKeys] = useState<Set<string>>(() => new Set());
-  const popoutChannelsRef = useRef<Map<string, { channel: BroadcastChannel; handshake: DockHandshakeState }>>(
+  const popoutChannelsRef = useRef<Map<string, { channel: PopoutChannelLike; handshake: DockHandshakeState }>>(
     new Map(),
   );
   // Mirrors so `deliverLaunch` (used by both the launch-bus subscription and
@@ -309,9 +309,19 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
         });
         return; // D7: no state change on failure — the tab stays attached and streaming.
       }
-      posthogRef.current?.capture("terminal_popout_used", { origin: entry?.origin ?? "toolbar" });
-      setPoppedOutKeys((prev) => new Set(prev).add(key));
 
+      // Set up the hand-off channel FIRST, synchronously, before any other
+      // work (posthog, setPoppedOutKeys, building the payload) — so it's
+      // guaranteed to be a live listener the instant the popped window's
+      // "ready" (or one of its retries — see startPopoutClientHandshake)
+      // arrives. This was the root cause of the field failure (see this
+      // module's rework doc in popout-channel.ts): nothing here previously
+      // depended on ordering in a way that could race in a real browser, but
+      // keeping this first removes any doubt and matches the hardening in
+      // createDockPopoutMessageHandler, which now treats every "ready" —
+      // not just the first — as a reason to (re)send the payload.
+      const channel = new BroadcastChannel(popoutChannelName(nonce));
+      popoutChannelsRef.current.set(key, { channel, handshake: INITIAL_DOCK_HANDSHAKE_STATE });
       const payload: PopoutPayload = {
         sid: summary.sessionId,
         browserToken: summary.browserToken,
@@ -322,22 +332,18 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
         identity,
         readOnly: summary.readOnly,
       };
-      const channel = new BroadcastChannel(popoutChannelName(nonce));
-      popoutChannelsRef.current.set(key, { channel, handshake: INITIAL_DOCK_HANDSHAKE_STATE });
-      channel.onmessage = (ev) => {
-        const message = parsePopoutChannelMessage(ev.data);
-        if (!message) return;
-        const current = popoutChannelsRef.current.get(key);
-        if (!current) return; // already torn down (e.g. a racing bring-back)
-        const result = reduceDockHandshake(current.handshake, message);
-        popoutChannelsRef.current.set(key, { channel, handshake: result.state });
-        if (result.action === "send-payload") {
-          channel.postMessage({ type: "payload", payload });
-        } else if (result.action === "reattach") {
-          // The popped window told us it's closing (D3) — reattach automatically.
-          bringBackToDock(key);
-        }
-      };
+      channel.onmessage = createDockPopoutMessageHandler({
+        getEntry: () => popoutChannelsRef.current.get(key),
+        setEntry: (next) => popoutChannelsRef.current.set(key, next),
+        getPayload: () => payload,
+        // The popped window told us it's closing (D3) — OR its hand-off
+        // timed out and it's telling us to give up on its behalf (see
+        // startPopoutClientHandshake) — either way, reattach automatically.
+        onReattach: () => bringBackToDock(key),
+      });
+
+      posthogRef.current?.capture("terminal_popout_used", { origin: entry?.origin ?? "toolbar" });
+      setPoppedOutKeys((prev) => new Set(prev).add(key));
     },
     [ideaId, ideaTitle, ideaSlug, bringBackToDock],
   );

--- a/src/lib/terminal/popout-channel.test.ts
+++ b/src/lib/terminal/popout-channel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   popoutChannelName,
   generatePopoutNonce,
@@ -8,7 +8,12 @@ import {
   isPreemptedClose,
   hasPopoutHandoffTimedOut,
   POPOUT_HANDOFF_TIMEOUT_MS,
+  POPOUT_READY_RETRY_MS,
+  createDockPopoutMessageHandler,
+  startPopoutClientHandshake,
   type PopoutPayload,
+  type PopoutChannelLike,
+  type DockHandshakeState,
 } from "./popout-channel";
 import { RELAY_CLOSE } from "./connection";
 
@@ -83,9 +88,9 @@ describe("reduceDockHandshake", () => {
     expect(result).toEqual({ state: "payload-sent", action: "send-payload" });
   });
 
-  it("ignores a repeated ready once the payload has already been sent (retry-safe)", () => {
+  it("re-sends the payload on EVERY ready message, not just the first — idempotent, harmless duplicate (hardening for the Brave field failure: if the dock's first payload send was itself the message that got lost, a retried ready must still get a fresh send)", () => {
     const result = reduceDockHandshake("payload-sent", { type: "ready" });
-    expect(result).toEqual({ state: "payload-sent", action: "none" });
+    expect(result).toEqual({ state: "payload-sent", action: "send-payload" });
   });
 
   it("always reattaches on a closed message, regardless of handshake phase", () => {
@@ -138,5 +143,348 @@ describe("hasPopoutHandoffTimedOut", () => {
   it("supports a custom timeout", () => {
     expect(hasPopoutHandoffTimedOut(0, 500, 1000)).toBe(false);
     expect(hasPopoutHandoffTimedOut(0, 1000, 1000)).toBe(true);
+  });
+});
+
+// ── dock-side handler, in isolation ─────────────────────────────────────────
+
+function makeSpyChannel(): PopoutChannelLike & { posted: unknown[] } {
+  const spy: PopoutChannelLike & { posted: unknown[] } = {
+    posted: [],
+    onmessage: null,
+    postMessage(data: unknown) {
+      spy.posted.push(data);
+    },
+    close() {},
+  };
+  return spy;
+}
+
+describe("createDockPopoutMessageHandler", () => {
+  it("sends the payload the moment a ready message arrives", () => {
+    const channel = makeSpyChannel();
+    let entry: { channel: PopoutChannelLike; handshake: DockHandshakeState } | undefined = {
+      channel,
+      handshake: INITIAL_DOCK_HANDSHAKE_STATE,
+    };
+    const onReattach = vi.fn();
+    const handler = createDockPopoutMessageHandler({
+      getEntry: () => entry,
+      setEntry: (next) => {
+        entry = next;
+      },
+      getPayload: () => PAYLOAD,
+      onReattach,
+    });
+    handler({ data: { type: "ready" } } as MessageEvent);
+    expect(channel.posted).toEqual([{ type: "payload", payload: PAYLOAD }]);
+    expect(entry?.handshake).toBe("payload-sent");
+    expect(onReattach).not.toHaveBeenCalled();
+  });
+
+  it("re-sends on a second (retried) ready — idempotent, not 'first one wins'", () => {
+    const channel = makeSpyChannel();
+    let entry: { channel: PopoutChannelLike; handshake: DockHandshakeState } | undefined = {
+      channel,
+      handshake: INITIAL_DOCK_HANDSHAKE_STATE,
+    };
+    const handler = createDockPopoutMessageHandler({
+      getEntry: () => entry,
+      setEntry: (next) => {
+        entry = next;
+      },
+      getPayload: () => PAYLOAD,
+      onReattach: vi.fn(),
+    });
+    handler({ data: { type: "ready" } } as MessageEvent);
+    handler({ data: { type: "ready" } } as MessageEvent);
+    handler({ data: { type: "ready" } } as MessageEvent);
+    // Three readies, three (harmless, duplicate) payload sends — this is
+    // exactly what lets a lost PAYLOAD (not just a lost ready) recover: the
+    // client keeps announcing "ready" until ONE of the dock's resulting
+    // payload sends actually lands.
+    expect(channel.posted).toEqual([
+      { type: "payload", payload: PAYLOAD },
+      { type: "payload", payload: PAYLOAD },
+      { type: "payload", payload: PAYLOAD },
+    ]);
+  });
+
+  it("calls onReattach on closed, and does nothing further once torn down (getEntry returns undefined)", () => {
+    const channel = makeSpyChannel();
+    let entry: { channel: PopoutChannelLike; handshake: DockHandshakeState } | undefined = {
+      channel,
+      handshake: "payload-sent",
+    };
+    const onReattach = vi.fn();
+    const handler = createDockPopoutMessageHandler({
+      getEntry: () => entry,
+      setEntry: (next) => {
+        entry = next;
+      },
+      getPayload: () => PAYLOAD,
+      onReattach,
+    });
+    handler({ data: { type: "closed" } } as MessageEvent);
+    expect(onReattach).toHaveBeenCalledTimes(1);
+
+    // Simulate a racing "bring back" tearing this tab's bookkeeping down —
+    // a later message on the SAME (now-stale) channel object must be a
+    // total no-op, never touching onReattach or postMessage again.
+    entry = undefined;
+    handler({ data: { type: "ready" } } as MessageEvent);
+    handler({ data: { type: "closed" } } as MessageEvent);
+    expect(onReattach).toHaveBeenCalledTimes(1);
+    expect(channel.posted).toEqual([]);
+  });
+
+  it("ignores garbage / unparseable messages without throwing", () => {
+    const channel = makeSpyChannel();
+    const handler = createDockPopoutMessageHandler({
+      getEntry: () => ({ channel, handshake: INITIAL_DOCK_HANDSHAKE_STATE }),
+      setEntry: () => {},
+      getPayload: () => PAYLOAD,
+      onReattach: vi.fn(),
+    });
+    expect(() => handler({ data: "not a message" } as unknown as MessageEvent)).not.toThrow();
+    expect(channel.posted).toEqual([]);
+  });
+});
+
+// ── client-side handshake driver, in isolation (fake timers) ───────────────
+
+describe("startPopoutClientHandshake", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("announces ready immediately, then keeps retrying on the interval until a payload arrives", () => {
+    const channel = makeSpyChannel();
+    const onPayload = vi.fn();
+    const onTimeout = vi.fn();
+    startPopoutClientHandshake({ channel, onPayload, onTimeout });
+
+    expect(channel.posted).toEqual([{ type: "ready" }]);
+
+    vi.advanceTimersByTime(POPOUT_READY_RETRY_MS);
+    expect(channel.posted).toEqual([{ type: "ready" }, { type: "ready" }]);
+
+    vi.advanceTimersByTime(POPOUT_READY_RETRY_MS);
+    expect(channel.posted.length).toBe(3);
+
+    // The payload lands (dock replying on the shared channel) — retries stop.
+    channel.onmessage?.({ data: { type: "payload", payload: PAYLOAD } } as MessageEvent);
+    expect(onPayload).toHaveBeenCalledWith(PAYLOAD);
+
+    const postedBeforeMoreTime = channel.posted.length;
+    vi.advanceTimersByTime(POPOUT_READY_RETRY_MS * 5);
+    expect(channel.posted.length).toBe(postedBeforeMoreTime); // no more readies posted
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("gives up after the timeout, posts closed (so a listening dock auto-reattaches instead of staying stuck), and stops retrying", () => {
+    const channel = makeSpyChannel();
+    const onPayload = vi.fn();
+    const onTimeout = vi.fn();
+    startPopoutClientHandshake({ channel, onPayload, onTimeout });
+
+    vi.advanceTimersByTime(POPOUT_HANDOFF_TIMEOUT_MS + 250);
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onPayload).not.toHaveBeenCalled();
+    expect(channel.posted[channel.posted.length - 1]).toEqual({ type: "closed" });
+
+    const postedAtTimeout = channel.posted.length;
+    vi.advanceTimersByTime(POPOUT_READY_RETRY_MS * 5);
+    expect(channel.posted.length).toBe(postedAtTimeout); // fully stopped, no zombie retries
+  });
+
+  it("stop() tears down both timers silently (StrictMode-safe — no closed/ready leak on an ordinary unmount)", () => {
+    const channel = makeSpyChannel();
+    const stop = startPopoutClientHandshake({ channel, onPayload: vi.fn(), onTimeout: vi.fn() });
+    const postedAtStart = channel.posted.length;
+    stop();
+    vi.advanceTimersByTime(POPOUT_HANDOFF_TIMEOUT_MS + 1000);
+    expect(channel.posted.length).toBe(postedAtStart); // nothing more posted, ever
+  });
+});
+
+// ── end-to-end over a shared channel bus — reproduces the field failure ────
+//
+// A minimal same-origin `BroadcastChannel` model: `postMessage` delivers
+// SYNCHRONOUSLY to whichever OTHER channels already exist on the bus at call
+// time — a channel created AFTER a message was posted simply never sees it,
+// exactly like the real API (messages are never queued for a not-yet-open
+// channel). This is enough to model the general fragility class the field
+// failure belongs to: "the very first message on a fresh channel can be
+// lost" — regardless of whether the real-world cause was Brave's
+// privacy/storage isolation for a `noopener` popup, an ordinary scheduling
+// race, or something else entirely. That exact browser-level mechanism is
+// NOT reproducible here (see the root-cause write-up) — what IS reproducible,
+// and what this section pins, is that the shipped one-shot design had zero
+// recovery from that loss, and the reworked retry-based design does.
+
+function createMockBroadcastBus() {
+  const channels = new Set<PopoutChannelLike>();
+  function createChannel(): PopoutChannelLike {
+    const self: PopoutChannelLike = {
+      onmessage: null,
+      postMessage(data: unknown) {
+        for (const other of channels) {
+          if (other === self) continue;
+          other.onmessage?.({ data } as MessageEvent);
+        }
+      },
+      close() {
+        channels.delete(self);
+      },
+    };
+    channels.add(self);
+    return self;
+  }
+  return { createChannel };
+}
+
+describe("end-to-end hand-off over a shared channel bus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("completes normally when the dock is already listening before the client announces ready (the common case)", () => {
+    const bus = createMockBroadcastBus();
+    const dockChannel = bus.createChannel();
+    let dockEntry: { channel: PopoutChannelLike; handshake: DockHandshakeState } | undefined = {
+      channel: dockChannel,
+      handshake: INITIAL_DOCK_HANDSHAKE_STATE,
+    };
+    dockChannel.onmessage = createDockPopoutMessageHandler({
+      getEntry: () => dockEntry,
+      setEntry: (next) => {
+        dockEntry = next;
+      },
+      getPayload: () => PAYLOAD,
+      onReattach: vi.fn(),
+    });
+
+    const clientChannel = bus.createChannel();
+    const onPayload = vi.fn();
+    startPopoutClientHandshake({ channel: clientChannel, onPayload, onTimeout: vi.fn() });
+
+    expect(onPayload).toHaveBeenCalledWith(PAYLOAD);
+  });
+
+  it("REPRODUCES the shipped bug: a one-shot ready posted before the dock exists is lost forever, and the hand-off times out with no recovery", () => {
+    const bus = createMockBroadcastBus();
+
+    // The popped window wins the race and (as terminal-popout-client.tsx
+    // shipped) posts its ONE-SHOT "ready" before the dock has created its
+    // channel yet.
+    const clientChannel = bus.createChannel();
+    clientChannel.postMessage({ type: "ready" });
+
+    // The dock catches up moments later and starts listening — exactly like
+    // the old inline handler in terminal-dock.tsx's handlePopOut.
+    const dockChannel = bus.createChannel();
+    let dockEntry: { channel: PopoutChannelLike; handshake: DockHandshakeState } | undefined = {
+      channel: dockChannel,
+      handshake: INITIAL_DOCK_HANDSHAKE_STATE,
+    };
+    dockChannel.onmessage = createDockPopoutMessageHandler({
+      getEntry: () => dockEntry,
+      setEntry: (next) => {
+        dockEntry = next;
+      },
+      getPayload: () => PAYLOAD,
+      onReattach: vi.fn(),
+    });
+
+    // The one-shot ready is already gone (delivered to nobody, since the
+    // dock's channel didn't exist yet) — under the OLD design nothing else
+    // is EVER posted, so the dock never sends a payload...
+    expect(dockEntry?.handshake).toBe("waiting-for-ready");
+
+    // ...and the popped window's own 5s timer (modelled directly here,
+    // matching the OLD terminal-popout-client.tsx's setInterval+
+    // hasPopoutHandoffTimedOut poll) fires with nothing ever having arrived
+    // — "Lost the session hand-off", exactly as seen in the field.
+    const startedAt = Date.now();
+    vi.advanceTimersByTime(POPOUT_HANDOFF_TIMEOUT_MS + 250);
+    expect(hasPopoutHandoffTimedOut(startedAt, Date.now())).toBe(true);
+    expect(dockEntry?.handshake).toBe("waiting-for-ready"); // still never heard from
+  });
+
+  it("FIX: the same lost-first-message race self-heals via the client's retry loop, once the dock is listening", () => {
+    const bus = createMockBroadcastBus();
+
+    // Same race as above: the client's channel exists and (this time via
+    // startPopoutClientHandshake) posts its first "ready" immediately —
+    // before the dock's channel exists, so that first one is still lost.
+    const clientChannel = bus.createChannel();
+    const onPayload = vi.fn();
+    startPopoutClientHandshake({ channel: clientChannel, onPayload, onTimeout: vi.fn() });
+
+    // Confirm it really was lost — nobody was listening for it.
+    expect(onPayload).not.toHaveBeenCalled();
+
+    // The dock now comes online (still well within the 5s window).
+    const dockChannel = bus.createChannel();
+    let dockEntry: { channel: PopoutChannelLike; handshake: DockHandshakeState } | undefined = {
+      channel: dockChannel,
+      handshake: INITIAL_DOCK_HANDSHAKE_STATE,
+    };
+    dockChannel.onmessage = createDockPopoutMessageHandler({
+      getEntry: () => dockEntry,
+      setEntry: (next) => {
+        dockEntry = next;
+      },
+      getPayload: () => PAYLOAD,
+      onReattach: vi.fn(),
+    });
+
+    // Advance past ONE retry interval — the client's next "ready" announcement
+    // reaches the now-live dock, which replies with the payload immediately.
+    vi.advanceTimersByTime(POPOUT_READY_RETRY_MS + 10);
+
+    expect(onPayload).toHaveBeenCalledWith(PAYLOAD);
+    expect(dockEntry?.handshake).toBe("payload-sent");
+  });
+
+  it("FIX: also self-heals when it's the PAYLOAD (not the ready) that gets lost — a retried ready still gets a fresh send", () => {
+    const bus = createMockBroadcastBus();
+    const dockChannel = bus.createChannel();
+    let dockEntry: { channel: PopoutChannelLike; handshake: DockHandshakeState } | undefined = {
+      channel: dockChannel,
+      handshake: INITIAL_DOCK_HANDSHAKE_STATE,
+    };
+    const dockHandler = createDockPopoutMessageHandler({
+      getEntry: () => dockEntry,
+      setEntry: (next) => {
+        dockEntry = next;
+      },
+      getPayload: () => PAYLOAD,
+      onReattach: vi.fn(),
+    });
+
+    const clientChannel = bus.createChannel();
+    const onPayload = vi.fn();
+    startPopoutClientHandshake({ channel: clientChannel, onPayload, onTimeout: vi.fn() });
+    // The client's immediate "ready" was delivered (dock channel existed
+    // first here) — but pretend the dock's FIRST reply payload never made it
+    // back (e.g. the client's listener wasn't wired up yet on its end, or
+    // any other transient loss) by wiring the dock's onmessage only AFTER
+    // that first exchange.
+    dockChannel.onmessage = dockHandler;
+    expect(onPayload).not.toHaveBeenCalled(); // that first round-trip is gone
+
+    // The client's retry loop announces "ready" again — this time the dock
+    // IS listening, and under the new idempotent reducer it happily resends.
+    vi.advanceTimersByTime(POPOUT_READY_RETRY_MS + 10);
+    expect(onPayload).toHaveBeenCalledWith(PAYLOAD);
   });
 });

--- a/src/lib/terminal/popout-channel.ts
+++ b/src/lib/terminal/popout-channel.ts
@@ -37,6 +37,26 @@
 // dock's own tiny handshake reducer, and the 4001/"brought back" + hand-off
 // timeout predicates — so it's unit-tested without a DOM, a socket, or a real
 // BroadcastChannel.
+//
+// REWORK (fix/terminal-popout-handshake, board task cd0a9792): a Brave field
+// test showed the popped window timing out with "Lost the session hand-off"
+// while the dock's tab kept showing "Connected" — the hand-off never
+// completed. Root cause: the popped window posted "ready" EXACTLY ONCE
+// (terminal-popout-client.tsx), and neither side had any resilience to that
+// single BroadcastChannel message going missing — no retry, and every
+// rejection path (`parsePopoutPayload`/`parsePopoutChannelMessage`) failed
+// SILENTLY (`return null`, nothing logged), so a dropped or delayed message
+// left no trace anywhere. A one-shot post on a cross-window channel is not a
+// safe assumption in real browsers (strict privacy/storage-isolation modes —
+// Brave chief among them — plus ordinary scheduling races between a
+// `noopener` popup and its opener can all delay or drop the very first
+// message); this module now assumes every message CAN be lost and makes the
+// whole handshake self-healing instead: the client retries "ready" on an
+// interval until the payload lands or it gives up (`startPopoutClientHandshake`),
+// the dock treats "ready" as fully idempotent — N readies, N (harmless,
+// duplicate) payload re-sends — instead of "first one wins"
+// (`reduceDockHandshake`), and every rejection path now warns with its
+// reason instead of dropping silently.
 
 import { RELAY_CLOSE } from "@/lib/terminal/connection";
 
@@ -81,7 +101,10 @@ export interface PopoutPayload {
    * `useTerminalSession` currently resolves the relay URL itself from the SAME
    * `NEXT_PUBLIC_TERMINAL_RELAY_URL` build-time env both documents share, so
    * this field is not required to be threaded into the actual connection —
-   * see use-terminal-session.ts's `attachExisting` option doc.
+   * see use-terminal-session.ts's `attachExisting` option doc. Non-essential:
+   * an empty string is accepted (see `parsePopoutPayload`) — it's unused by
+   * the popped window either way, so treating it as required would only add
+   * one more way for a legitimate hand-off to be silently rejected.
    */
   relayUrl: string;
   ideaId: string;
@@ -102,31 +125,43 @@ function isNonEmptyString(v: unknown): v is string {
   return typeof v === "string" && v.length > 0;
 }
 
+/**
+ * Field-by-field validation so a rejection can say WHICH field was the
+ * problem (never silent — a dropped hand-off used to leave zero trace
+ * anywhere, which is exactly what made the Brave field failure so hard to
+ * place). `relayUrl` is intentionally the one non-essential field — see its
+ * doc on `PopoutPayload` — so an empty string there doesn't sink an
+ * otherwise-valid hand-off.
+ */
 function parsePopoutPayload(value: unknown): PopoutPayload | null {
-  if (!value || typeof value !== "object") return null;
-  const p = value as Record<string, unknown>;
-  if (
-    isNonEmptyString(p.sid) &&
-    isNonEmptyString(p.browserToken) &&
-    isNonEmptyString(p.relayUrl) &&
-    isNonEmptyString(p.ideaId) &&
-    typeof p.ideaTitle === "string" &&
-    isNonEmptyString(p.label) &&
-    typeof p.identity === "string" &&
-    typeof p.readOnly === "boolean"
-  ) {
-    return {
-      sid: p.sid,
-      browserToken: p.browserToken,
-      relayUrl: p.relayUrl,
-      ideaId: p.ideaId,
-      ideaTitle: p.ideaTitle,
-      label: p.label,
-      identity: p.identity,
-      readOnly: p.readOnly,
-    };
+  if (!value || typeof value !== "object") {
+    console.warn("[terminal-popout] rejected payload: not an object", value);
+    return null;
   }
-  return null;
+  const p = value as Record<string, unknown>;
+  const problems: string[] = [];
+  if (!isNonEmptyString(p.sid)) problems.push("sid");
+  if (!isNonEmptyString(p.browserToken)) problems.push("browserToken");
+  if (typeof p.relayUrl !== "string") problems.push("relayUrl");
+  if (!isNonEmptyString(p.ideaId)) problems.push("ideaId");
+  if (typeof p.ideaTitle !== "string") problems.push("ideaTitle");
+  if (!isNonEmptyString(p.label)) problems.push("label");
+  if (typeof p.identity !== "string") problems.push("identity");
+  if (typeof p.readOnly !== "boolean") problems.push("readOnly");
+  if (problems.length > 0) {
+    console.warn("[terminal-popout] rejected payload: invalid/missing field(s)", problems);
+    return null;
+  }
+  return {
+    sid: p.sid as string,
+    browserToken: p.browserToken as string,
+    relayUrl: p.relayUrl as string,
+    ideaId: p.ideaId as string,
+    ideaTitle: p.ideaTitle as string,
+    label: p.label as string,
+    identity: p.identity as string,
+    readOnly: p.readOnly as boolean,
+  };
 }
 
 /**
@@ -137,14 +172,19 @@ function parsePopoutPayload(value: unknown): PopoutPayload | null {
  * `unknown`, not `any`, by the time it reaches app code).
  */
 export function parsePopoutChannelMessage(data: unknown): PopoutChannelMessage | null {
-  if (!data || typeof data !== "object") return null;
+  if (!data || typeof data !== "object") {
+    console.warn("[terminal-popout] ignoring channel message: not an object", data);
+    return null;
+  }
   const msg = data as { type?: unknown; payload?: unknown };
   if (msg.type === "ready") return { type: "ready" };
   if (msg.type === "closed") return { type: "closed" };
   if (msg.type === "payload") {
+    // parsePopoutPayload already warns with the specific reason on rejection.
     const payload = parsePopoutPayload(msg.payload);
     return payload ? { type: "payload", payload } : null;
   }
+  console.warn("[terminal-popout] ignoring channel message: unrecognised type", msg.type);
   return null;
 }
 
@@ -164,25 +204,80 @@ export interface DockHandshakeResult {
 
 /**
  * Pure reducer over every message the dock's channel can receive. `"ready"`
- * only triggers `send-payload` the FIRST time (idempotent against a retried
- * "ready" — e.g. a slow-loading popped window firing more than one, or a
- * message replayed after a hot-reload): once `payload-sent`, a later "ready" is
- * a no-op rather than re-sending (and re-triggering) the pop-out. `"closed"` is
- * the auto-reattach signal (D3) and is always actionable, regardless of
- * handshake phase — a popped window can close before OR after it ever received
- * the payload (e.g. the user closed it during the ~5s hand-off window), and the
- * dock must reattach either way. A stray `"payload"` on the DOCK's own channel
- * (it should never receive one — only send them) is ignored.
+ * ALWAYS triggers `send-payload` — including every retry (see
+ * `startPopoutClientHandshake`, which now re-announces "ready" on an
+ * interval instead of posting it once). This is deliberately idempotent
+ * rather than "first one wins": re-sending the SAME payload on a duplicate
+ * "ready" is a harmless no-op for the popped window (it just overwrites its
+ * own not-yet-set state with an identical value), whereas the old "only the
+ * first ready counts" version meant that if the payload the dock sent in
+ * response to that first ready was itself the one that got lost — not the
+ * ready — every later retried "ready" was silently ignored and the hand-off
+ * could never recover. `state` still tracks whether a payload has EVER been
+ * sent (useful for tests/debugging), but no longer gates the action.
+ * `"closed"` is the auto-reattach signal (D3) and is always actionable,
+ * regardless of handshake phase — a popped window can close (or its own
+ * hand-off can time out, which now ALSO posts "closed" — see
+ * `startPopoutClientHandshake`) before OR after it ever received the
+ * payload, and the dock must reattach either way. A stray `"payload"` on the
+ * DOCK's own channel (it should never receive one — only send them) is
+ * ignored.
  */
 export function reduceDockHandshake(
   state: DockHandshakeState,
   message: PopoutChannelMessage,
 ): DockHandshakeResult {
   if (message.type === "closed") return { state, action: "reattach" };
-  if (message.type === "ready" && state === "waiting-for-ready") {
-    return { state: "payload-sent", action: "send-payload" };
-  }
+  if (message.type === "ready") return { state: "payload-sent", action: "send-payload" };
   return { state, action: "none" };
+}
+
+// ── dock-side channel wiring (extracted so it's unit-testable without
+//    mounting the whole terminal-dock.tsx component tree) ──────────────────
+
+/**
+ * The minimal shape terminal-dock.tsx's real `BroadcastChannel` and a test
+ * double both satisfy. `onmessage`'s event type is the real DOM
+ * `MessageEvent` (not a narrowed `{ data: unknown }`) deliberately — a
+ * narrower property type here would make `BroadcastChannel` itself fail to
+ * structurally satisfy this interface under `strictFunctionTypes`
+ * (parameters are contravariant for property-declared function types).
+ */
+export interface PopoutChannelLike {
+  postMessage(data: unknown): void;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  close(): void;
+}
+
+/**
+ * Builds the DOCK side's `channel.onmessage` handler — the exact logic
+ * terminal-dock.tsx's `handlePopOut` wires up, extracted so it can be driven
+ * by a test double instead of a real `BroadcastChannel` + React state. The
+ * per-tab bookkeeping (is this channel still the live one for this tab, or
+ * did a "Bring back" already tear it down?) stays with the CALLER via
+ * `getEntry`/`setEntry` — that's terminal-dock.tsx's `popoutChannelsRef` Map,
+ * not something this module should own.
+ */
+export function createDockPopoutMessageHandler(options: {
+  getEntry: () => { channel: PopoutChannelLike; handshake: DockHandshakeState } | undefined;
+  setEntry: (next: { channel: PopoutChannelLike; handshake: DockHandshakeState }) => void;
+  getPayload: () => PopoutPayload;
+  onReattach: () => void;
+}): (ev: MessageEvent) => void {
+  const { getEntry, setEntry, getPayload, onReattach } = options;
+  return (ev) => {
+    const message = parsePopoutChannelMessage(ev.data);
+    if (!message) return; // already warned with a reason
+    const current = getEntry();
+    if (!current) return; // already torn down (e.g. a racing bring-back)
+    const result = reduceDockHandshake(current.handshake, message);
+    setEntry({ channel: current.channel, handshake: result.state });
+    if (result.action === "send-payload") {
+      current.channel.postMessage({ type: "payload", payload: getPayload() });
+    } else if (result.action === "reattach") {
+      onReattach();
+    }
+  };
 }
 
 // ── popped-window-side decisions ────────────────────────────────────────────
@@ -204,6 +299,15 @@ export function isPreemptedClose(closeCode: number | null): boolean {
 /** How long the popped window waits for the hand-off payload before giving up honestly (D2/D7 fallback, "~5s" per the design). */
 export const POPOUT_HANDOFF_TIMEOUT_MS = 5_000;
 
+/**
+ * How often the popped window re-announces "ready" while it waits (hardening
+ * for the Brave field failure — see this module's header doc). One-shot was
+ * fragile by construction: if that single message never landed on a live
+ * dock listener, nothing would ever try again. ~300ms gives roughly 16
+ * attempts inside the 5s hand-off window.
+ */
+export const POPOUT_READY_RETRY_MS = 300;
+
 /** Pure boundary check for the ~5s hand-off wait, so the timing policy is testable without a real timer. */
 export function hasPopoutHandoffTimedOut(
   startedAtMs: number,
@@ -211,4 +315,96 @@ export function hasPopoutHandoffTimedOut(
   timeoutMs: number = POPOUT_HANDOFF_TIMEOUT_MS,
 ): boolean {
   return nowMs - startedAtMs >= timeoutMs;
+}
+
+// ── popped-window-side channel wiring (extracted, same rationale as the
+//    dock-side handler above) ───────────────────────────────────────────────
+
+export interface PopoutClientHandshakeOptions {
+  channel: PopoutChannelLike;
+  /** Called with the payload the moment a valid one arrives — retries stop immediately after. */
+  onPayload: (payload: PopoutPayload) => void;
+  /** Called once, if no payload arrives before the timeout — the caller renders the "Lost the session hand-off" state. */
+  onTimeout: () => void;
+  now?: () => number;
+  setIntervalFn?: (cb: () => void, ms: number) => ReturnType<typeof setInterval>;
+  clearIntervalFn?: (id: ReturnType<typeof setInterval>) => void;
+  retryIntervalMs?: number;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+
+/**
+ * The popped window's side of the hand-off: announce "ready" immediately,
+ * then keep re-announcing on `retryIntervalMs` until either a valid payload
+ * arrives (`onPayload`, retries stop) or `timeoutMs` elapses (`onTimeout`,
+ * retries stop AND a "closed" message goes out — see the module header doc:
+ * a failed hand-off must not leave the dock stuck showing "Popped out"
+ * forever with nothing on the other end, so a timeout is treated exactly
+ * like the window closing for real). Returns a `stop()` cleanup that clears
+ * both timers without sending anything (used on unmount/nonce-change, where
+ * nothing failed — the effect is just tearing down).
+ */
+export function startPopoutClientHandshake(options: PopoutClientHandshakeOptions): () => void {
+  const {
+    channel,
+    onPayload,
+    onTimeout,
+    now = Date.now,
+    setIntervalFn = (cb, ms) => setInterval(cb, ms),
+    clearIntervalFn = (id) => clearInterval(id),
+    retryIntervalMs = POPOUT_READY_RETRY_MS,
+    pollIntervalMs = 250,
+    timeoutMs = POPOUT_HANDOFF_TIMEOUT_MS,
+  } = options;
+  const startedAt = now();
+  let settled = false;
+
+  const postReady = () => {
+    try {
+      channel.postMessage({ type: "ready" });
+    } catch {
+      /* channel already gone — nothing to announce to */
+    }
+  };
+
+  channel.onmessage = (ev) => {
+    if (settled) return;
+    const message = parsePopoutChannelMessage(ev.data);
+    if (message?.type !== "payload") return;
+    settled = true;
+    clearIntervalFn(readyTimer);
+    clearIntervalFn(pollTimer);
+    onPayload(message.payload);
+  };
+
+  // Both timers are created BEFORE the first `postReady()` call, even though
+  // `postReady` doesn't fire on an interval tick until later — this is
+  // deliberate, not incidental: `onmessage` (above) closes over `readyTimer`
+  // / `pollTimer`, and on a delivery model where a message can be answered
+  // SYNCHRONOUSLY (true of this repo's own test doubles; never true of a
+  // real `BroadcastChannel`, whose dispatch is always a later task, but
+  // correctness here shouldn't depend on that), calling `postReady()` before
+  // both consts exist would let `onmessage` read them mid-initialization
+  // (a TDZ `ReferenceError`) the instant that first "ready" gets answered.
+  const readyTimer = setIntervalFn(postReady, retryIntervalMs);
+  const pollTimer = setIntervalFn(() => {
+    if (settled) return;
+    if (!hasPopoutHandoffTimedOut(startedAt, now(), timeoutMs)) return;
+    settled = true;
+    clearIntervalFn(readyTimer);
+    clearIntervalFn(pollTimer);
+    try {
+      channel.postMessage({ type: "closed" });
+    } catch {
+      /* channel already gone — nothing to signal */
+    }
+    onTimeout();
+  }, pollIntervalMs);
+  postReady();
+
+  return () => {
+    clearIntervalFn(readyTimer);
+    clearIntervalFn(pollTimer);
+  };
 }


### PR DESCRIPTION
Field-test failure on task cd0a9792: the popped window timed out ("Lost the session hand-off") because the handshake posted "ready" exactly once with no retry, the dock only answered the first ready, and every parse/rejection path was silent — any single lost BroadcastChannel message (observed in Brave/prod) killed the hand-off with zero trace.

Fix (closes the whole class):
- Client re-posts "ready" every 300ms until payload/timeout (`startPopoutClientHandshake`, extracted + tested).
- Dock handler extracted (`createDockPopoutMessageHandler`), channel + map entry set synchronously in the click handler; `reduceDockHandshake` now re-sends the payload on every ready (idempotent) — a lost *payload* also self-heals.
- All parse/rejection paths `console.warn` with the reason; `relayUrl` relaxed to allow empty (documented unused).
- New bus-level tests reproduce the shipped race (ready posted before dock channel exists → lost forever) and pin the fix (retry recovers; lost payload recovers).

Gates: tsc clean · full vitest 2094/2094 · targeted 341/341 · lint 0 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)