### PR TITLE
fix(terminal): pop-out hand-off never started — drop noopener so window.open returns a handle

### DIFF
--- a/src/app/terminal/popout/terminal-popout-client.tsx
+++ b/src/app/terminal/popout/terminal-popout-client.tsx
@@ -6,14 +6,20 @@
 // arrives.
 //
 // Nonce resolution: the URL HASH first (what the dock's window.open() sets —
-// see terminal-dock.tsx's handlePopOut), falling back to `window.name` per
-// the stage brief ("NONCE comes from the URL hash or window.name") — a
-// fallback that matters if some intermediate navigation ever drops the hash
-// (e.g. a browser "restore session" round-trip); `window.name` persists
-// across navigations within the same tab/window in a way the hash doesn't
-// survive every code path. Either way the nonce carries NO session meaning by
-// itself (see popout-channel.ts's module doc) — it only names the rendezvous
-// channel.
+// see terminal-dock.tsx's handlePopOut / openPopoutWindow in
+// popout-channel.ts), falling back to `window.name` per the stage brief
+// ("NONCE comes from the URL hash or window.name") — a fallback that matters
+// if some intermediate navigation ever drops the hash (e.g. a browser
+// "restore session" round-trip); `window.name` persists across navigations
+// within the same tab/window in a way the hash doesn't survive every code
+// path. This fallback is only genuinely reachable now that the dock opens
+// WITHOUT `noopener` (board task 4f9cf03d): per the HTML spec, `noopener`
+// forces a new browsing context's name to the empty string, so while
+// `noopener` still shipped, `window.name` here was ALWAYS empty and this
+// fallback was silently dead code — the hash was the only nonce source that
+// could ever actually work. Either way the nonce carries NO session meaning
+// by itself (see popout-channel.ts's module doc) — it only names the
+// rendezvous channel.
 
 import { useEffect, useState } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
@@ -25,9 +31,10 @@ import {
 import { TerminalPopoutView } from "@/components/board/terminal-popout-view";
 
 // The dock's window.open() target name is `vibecodes-terminal-<nonce>` (see
-// terminal-dock.tsx's handlePopOut) — that string becomes this window's OWN
-// `window.name` automatically, so the fallback strips the same prefix back
-// off rather than treating the whole target string as the nonce.
+// openPopoutWindow in popout-channel.ts) — NOW that the feature string omits
+// `noopener`, that string genuinely becomes this window's OWN `window.name`
+// automatically, so the fallback strips the same prefix back off rather than
+// treating the whole target string as the nonce.
 const WINDOW_NAME_PREFIX = "vibecodes-terminal-";
 
 function resolveNonce(): string | null {

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -65,6 +65,7 @@ import { newSessionTooltip } from "@/lib/terminal/session-cap";
 import {
   generatePopoutNonce,
   popoutChannelName,
+  openPopoutWindow,
   createDockPopoutMessageHandler,
   INITIAL_DOCK_HANDSHAKE_STATE,
   type DockHandshakeState,
@@ -298,11 +299,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       const nonce = generatePopoutNonce();
       // MUST be the direct, synchronous result of the click — no await before
       // this line — or popup blockers treat it as an unsolicited pop-up (D7).
-      const win = window.open(
-        `/terminal/popout#${nonce}`,
-        `vibecodes-terminal-${nonce}`,
-        "width=760,height=560,noopener",
-      );
+      // openPopoutWindow (popout-channel.ts) owns the feature string — see its
+      // doc for why `noopener` can NEVER go back in there: it shipped twice
+      // and made window.open() return null unconditionally, so this guard
+      // fired on every click even when the popup opened fine.
+      const win = openPopoutWindow(nonce, (url, target, features) => window.open(url, target, features));
       if (!win) {
         toast.error("Couldn't open the terminal window", {
           description: "Your browser blocked the pop-up. Allow pop-ups for vibecodes.co.uk and try again.",

--- a/src/lib/terminal/popout-channel.test.ts
+++ b/src/lib/terminal/popout-channel.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   popoutChannelName,
   generatePopoutNonce,
+  openPopoutWindow,
   parsePopoutChannelMessage,
   reduceDockHandshake,
   INITIAL_DOCK_HANDSHAKE_STATE,
@@ -44,6 +45,47 @@ describe("generatePopoutNonce", () => {
   it("never repeats across calls", () => {
     const seen = new Set(Array.from({ length: 50 }, () => generatePopoutNonce()));
     expect(seen.size).toBe(50);
+  });
+});
+
+describe("openPopoutWindow", () => {
+  it("never puts `noopener` in the feature string — regression pin for the field failure (board tasks cd0a9792 / 4f9cf03d): `window.open` returns null unconditionally whenever the feature string contains `noopener`, even on a successful open, which made the dock's `if (!win)` guard fire on EVERY click. If this assertion ever fails, someone added `noopener` back — don't", () => {
+    const windowOpen = vi.fn().mockReturnValue({ opener: "something" } as unknown as Window);
+    openPopoutWindow("nonce-abc", windowOpen);
+    const features = windowOpen.mock.calls[0][2];
+    expect(features).not.toMatch(/noopener/);
+  });
+
+  it("derives the URL and target from the nonce exactly as the client's resolveNonce() expects — hash primary, `vibecodes-terminal-` prefix for the window.name fallback", () => {
+    const windowOpen = vi.fn().mockReturnValue({ opener: "something" } as unknown as Window);
+    openPopoutWindow("abc123", windowOpen);
+    expect(windowOpen).toHaveBeenCalledWith("/terminal/popout#abc123", "vibecodes-terminal-abc123", expect.any(String));
+  });
+
+  it("on a successful open, returns the handle and severs its opener", () => {
+    const fakeWin = { opener: "should-be-nulled" } as unknown as Window;
+    const windowOpen = vi.fn().mockReturnValue(fakeWin);
+    const result = openPopoutWindow("nonce-abc", windowOpen);
+    expect(result).toBe(fakeWin);
+    expect(result?.opener).toBeNull();
+  });
+
+  it("still returns the handle when severing opener throws (cross-origin or already-detached)", () => {
+    const fakeWin = {} as Window;
+    Object.defineProperty(fakeWin, "opener", {
+      set() {
+        throw new Error("cannot set opener");
+      },
+    });
+    const windowOpen = vi.fn().mockReturnValue(fakeWin);
+    const result = openPopoutWindow("nonce-abc", windowOpen);
+    expect(result).toBe(fakeWin);
+  });
+
+  it("passes a genuine popup-block (null return) straight through — caller shows the blocked toast", () => {
+    const windowOpen = vi.fn().mockReturnValue(null);
+    const result = openPopoutWindow("nonce-abc", windowOpen);
+    expect(result).toBeNull();
   });
 });
 

--- a/src/lib/terminal/popout-channel.ts
+++ b/src/lib/terminal/popout-channel.ts
@@ -3,8 +3,10 @@
 //
 // The dock and the popped-out window are TWO SEPARATE documents (a real browser
 // window opened via window.open) — there is no shared JS heap, no React context,
-// no window.opener reliance (we open with a feature string that omits it isn't
-// required either way, since nothing here reads `opener`). The only channel
+// no window.opener reliance. Isolation is enforced EXPLICITLY: `openPopoutWindow`
+// below opens WITHOUT `noopener` in the feature string and then sets
+// `win.opener = null` itself once it has a handle — see that function's doc for
+// why the feature string can never carry `noopener` again. The only channel
 // between them is a same-origin `BroadcastChannel` named from a one-time NONCE
 // carried in the popped window's URL HASH (never sent to any server — hashes
 // never leave the browser) or, as a fallback, `window.name`. The nonce carries no
@@ -30,7 +32,9 @@
 //      direction, just observed from opposite ends.
 //   5. When the popped window closes (`beforeunload`/`pagehide`), it posts
 //      "closed" on the SAME channel so the dock can auto-reattach (D3) without
-//      polling `window.closed` (which `noopener` would block anyway).
+//      polling `window.closed` — unreliable across two separate windows either
+//      way, and outright blocked back when the feature string still carried
+//      `noopener` (see the REWORK addendum below).
 //
 // This module holds every piece of that protocol that's expressible as pure data
 // + pure functions — channel naming, the payload shape, message parsing, the
@@ -57,6 +61,23 @@
 // duplicate) payload re-sends — instead of "first one wins"
 // (`reduceDockHandshake`), and every rejection path now warns with its
 // reason instead of dropping silently.
+//
+// REWORK ADDENDUM (fix/terminal-popout-open-guard, board task 4f9cf03d): the
+// retried-handshake hardening above was necessary but NOT sufficient — it
+// shipped and the pop-out STILL failed 100% of the time in production,
+// because the actual field failure was one level up the call stack and
+// nothing above could ever reach it. `handlePopOut` (terminal-dock.tsx)
+// opened with `"width=760,height=560,noopener"`, and per the HTML spec,
+// `window.open()` returns `null` whenever the feature string contains
+// `noopener` — EVEN WHEN THE POPUP OPENS SUCCESSFULLY. So its `if (!win)`
+// guard fired on every single click, the popup-blocked-toast branch ran
+// unconditionally, and the function returned before ever reaching the
+// BroadcastChannel wiring above — the retried "ready"s the popped window
+// was faithfully sending landed on a dock that had never started listening.
+// Fixed here by dropping `noopener` from the feature string (see
+// `openPopoutWindow` below) and severing `win.opener` explicitly instead —
+// isolation is preserved, but no longer at the cost of a null return on
+// success.
 
 import { RELAY_CLOSE } from "@/lib/terminal/connection";
 
@@ -86,6 +107,44 @@ export function generatePopoutNonce(): string {
     Math.random().toString(36).slice(2) +
     Math.random().toString(36).slice(2)
   );
+}
+
+/** The signature of `window.open` — injectable so the call is testable without a real browser. */
+export type PopoutWindowOpener = (url: string, target: string, features: string) => Window | null;
+
+/**
+ * Opens the popped-out terminal window and severs its opener link — the
+ * exact sequence `terminal-dock.tsx`'s `handlePopOut` runs on click, extracted
+ * here (same rationale as `createDockPopoutMessageHandler` below) so it's
+ * unit-tested without a real `window.open`.
+ *
+ * THE FEATURE STRING BELOW MUST NEVER INCLUDE `noopener` — this is not a
+ * style preference, it's the root cause of two field failures (board tasks
+ * cd0a9792 and 4f9cf03d). Per the HTML spec, `window.open()` returns `null`
+ * whenever the feature string contains `noopener`, EVEN WHEN THE POPUP
+ * OPENS SUCCESSFULLY (the browsing context is still created; only the
+ * reference back to it is withheld). `handlePopOut`'s `if (!win)` guard is
+ * only a correct "was this genuinely popup-blocked?" check as long as a
+ * successful open yields a real handle — reintroduce `noopener` here and
+ * that guard fires on EVERY call again, exactly as it did in production.
+ * Isolation is enforced explicitly instead, below: once a real handle comes
+ * back, its `opener` is nulled out directly, so the popped window still has
+ * no way to script back into the tab that opened it.
+ */
+export function openPopoutWindow(nonce: string, windowOpen: PopoutWindowOpener): Window | null {
+  const win = windowOpen(
+    `/terminal/popout#${nonce}`,
+    `vibecodes-terminal-${nonce}`,
+    "width=760,height=560",
+  );
+  if (!win) return null; // genuinely popup-blocked — caller shows the toast (D7)
+  try {
+    win.opener = null;
+  } catch {
+    /* cross-origin or already-detached — nothing to sever, and the window
+     * itself is still perfectly usable, so this must never sink the open. */
+  }
+  return win;
 }
 
 /** Everything the popped window needs to attach to the SAME relay session. */


### PR DESCRIPTION
Fixes board task 4f9cf03d (follow-up to the multi-terminal feature, cd0a9792, whose pop-out failed both field tests).

**Root cause (proven by live in-browser reproduction against prod):** per the HTML spec, `window.open()` returns `null` whenever the feature string contains `noopener` — even on success. `handlePopOut`'s `if (!win)` popup-blocked guard therefore fired on **every** pop-out click, and the dock never created its side of the BroadcastChannel. The popped window's retried "ready" handshake (PR #124) was working fine against a channel nobody opened; it timed out after 5s with "Lost the session hand-off". 100% reproducible in every browser; invisible to unit gates because `terminal-dock.tsx` had zero test coverage.

**Fix:** drop `noopener` from the feature string (restoring a real handle — `null` now genuinely means popup-blocked) and sever `win.opener = null` explicitly, extracted into a tested `openPopoutWindow()` helper with a regression pin that fails loudly if `noopener` is ever reintroduced. Also corrects the misleading comments (including the `window.name` nonce fallback, which was spec-dead under `noopener`).

**Gates:** `tsc --noEmit` clean · vitest full suite 2370/2370 · targeted 391/391 · lint 0 errors.

Note: the Vercel Preview check is known-broken on PRs (missing Supabase env) and does not block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)