### PR TITLE
fix(relay): send peer-reattached whenever an attach makes the pair whole, not only after a grace hold

### DIFF
--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -398,10 +398,22 @@ export class TerminalRelay {
       }
     }
 
-    // 6) If this attach restored the pair inside the grace window, tell BOTH legs
-    //    to resume. Sent AFTER the bridge's own `attached` frame; both are no-ops
-    //    for a leg that doesn't know them (skew-safe).
-    if (wasHeld && pairWhole) {
+    // 6) `peer-reattached` is the PAIR-IS-WHOLE signal, and it must fire for ALL
+    //    THREE ways a pair becomes whole — initial pairing (this attach is the
+    //    2nd leg on a virgin session), a grace-window reattach (wasHeld above),
+    //    and a same-owner PREEMPTION reattach (pop-out / bring-back-to-dock,
+    //    step 2b — no grace hold ever opens for those, since the pair never
+    //    stopped being whole). `pairWhole` alone is the correct condition:
+    //    `wasHeld` only matters for clearing the grace deadline above. A browser
+    //    leg attaching to a QUIET session has no other way to learn the bridge is
+    //    there — no PTY bytes flow, and unpaired input is dropped — so without
+    //    this broadcast on a preemption reattach the popped/re-docked window hangs
+    //    on "Reattaching…" forever (board card 4f9cf03d: pop-out hand-off reached
+    //    the relay and paired, but the dock's still-live browser leg was preempted
+    //    with no grace hold, so the popped window never got a signal to resume).
+    //    Sent AFTER the bridge's own `attached` frame; both are no-ops for a leg
+    //    that doesn't know them (skew-safe).
+    if (pairWhole) {
       this.broadcast(encodePeerReattachedFrame());
     }
 

--- a/terminal/test/heartbeat.test.mjs
+++ b/terminal/test/heartbeat.test.mjs
@@ -16,7 +16,12 @@
 //   preemption  — a same-owner browser attach while a (possibly silently dead)
 //                 browser leg is still registered now WINS: the stale leg is
 //                 closed 4001 "preempted", the new leg goes live, and NO grace
-//                 window opens (the pair never stopped being whole).
+//                 window opens (the pair never stopped being whole). Because no
+//                 grace hold opens, the pair-whole `peer-reattached` signal fires
+//                 straight off `pairWhole` (fix/relay-pair-whole-notify, board
+//                 card 4f9cf03d) — this is the same relay code path a pop-out /
+//                 bring-back-to-dock preemption takes, and without it the newly
+//                 attached leg has no way to learn a quiet peer is already there.
 //
 // Runs against the Node stand-in relay, which shares the exact decision logic
 // (pairing.js) and mirrors the DO's hb intercept. Every wait is hard-timeout
@@ -36,6 +41,7 @@ import {
   isHeartbeatAckFrame,
   isAttachedFrame,
   isPeerDegradedFrame,
+  isPeerReattachedFrame,
 } from "../shared/control-frames.mjs";
 
 const SECRET = "heartbeat-test-secret";
@@ -87,9 +93,11 @@ test("(a) browser hb is acked to the browser only — never forwarded to the bri
   await waitFor(() => hasFrame(browser, isHeartbeatAckFrame), HARD_TIMEOUT_MS, "hb-ack to the probing browser leg");
 
   // Let anything wrongly forwarded arrive, then assert the bridge saw NOTHING but
-  // its own R1 `attached` confirmation — no hb, no hb-ack, no bytes.
+  // its own R1 `attached` confirmation and the initial-pairing `peer-reattached`
+  // (fix/relay-pair-whole-notify — the bridge's own attach is what completes the
+  // pair here, so it legitimately gets both) — no hb, no hb-ack, no bytes.
   await new Promise((r) => setTimeout(r, 200));
-  const unexpected = bridge.texts.filter((f) => !isAttachedFrame(f));
+  const unexpected = bridge.texts.filter((f) => !isAttachedFrame(f) && !isPeerReattachedFrame(f));
   assert.deepEqual(unexpected, [], "the bridge leg received no heartbeat traffic");
   assert.equal(bridge.binary, "", "no bytes reached the bridge leg");
   console.log("[hb/a] PASS — hb acked to sender only, peer untouched");
@@ -136,6 +144,11 @@ test("(c) same-owner 2nd browser preempts the stale leg (4001 preempted) and goe
   const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
   t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
 
+  // `bridge` just saw ONE peer-reattached frame from the initial pairing above
+  // (fix/relay-pair-whole-notify fires it there too) — clear it BEFORE the swap
+  // below, so the check after the swap proves THAT broadcast, not this stale one.
+  bridge.texts = [];
+
   // The dock's watchdog fired and the reattach loop opens a NEW browser leg with
   // the SAME owner-bound token (no re-mint) — this used to bounce off DUP_BROWSER.
   const fresh = await openRawLeg(relay.url, session, "browser", tokens.browser);
@@ -152,6 +165,14 @@ test("(c) same-owner 2nd browser preempts the stale leg (4001 preempted) and goe
   await new Promise((r) => setTimeout(r, 200));
   assert.equal(hasFrame(bridge, isPeerDegradedFrame), false, "no peer-degraded to the bridge on a preemption swap");
   assert.ok(relay.sessions.has(session), "session retained across the swap");
+
+  // fix/relay-pair-whole-notify (board card 4f9cf03d): NO grace hold opened here,
+  // so before the fix neither leg would ever have learned the pair is whole
+  // again. The fresh (preempting) leg AND the untouched bridge leg must both get
+  // `peer-reattached` — this is the only signal a quiet session's browser leg
+  // has that its bridge peer is already there.
+  await waitFor(() => hasFrame(fresh, isPeerReattachedFrame), HARD_TIMEOUT_MS, "peer-reattached to the fresh browser leg");
+  assert.ok(hasFrame(bridge, isPeerReattachedFrame), "peer-reattached to the untouched bridge leg too");
 
   // Live end-to-end both ways through the new leg.
   const down = `DOWN-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs zombie-bridge-reattach.test.mjs session-end.test.mjs ../shared/session-token.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs zombie-bridge-reattach.test.mjs pair-whole-notify.test.mjs session-end.test.mjs ../shared/session-token.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/pair-whole-notify.test.mjs
+++ b/terminal/test/pair-whole-notify.test.mjs
@@ -1,0 +1,111 @@
+// `peer-reattached` fires on EVERY pair-whole transition — regression proof
+// (fix/relay-pair-whole-notify, board card 4f9cf03d).
+//
+// ROOT CAUSE (field test on the pop-out hand-off, PR #136 hand-off itself is
+// fine): the attach flow only broadcast `peer-reattached` when `wasHeld &&
+// pairWhole` — i.e. only when the attach ended a GRACE HOLD. Pop-out is a
+// same-owner PREEMPTION: the popped window's browser leg replaces the dock's
+// still-live browser socket, so `wasHeld` is false and the relay never told
+// either leg the pair was whole. The client only leaves "waiting-to-pair" on an
+// inbound PTY byte or a `peer-reattached` frame; an idle PTY emits neither, so
+// the popped window hung on "Reattaching…" until the connect-timeout fired. The
+// same gap breaks "Bring back to dock" (the dock's reattach preempts the popped
+// window — also no grace hold) and any browser-leg attach to a quiet session.
+//
+// THE FIX under test: broadcast `peer-reattached` whenever `pairWhole` alone —
+// covering initial pairing, a grace-window reattach, and a same-owner
+// preemption reattach — not only the `wasHeld` case. `wasHeld` still gates
+// nothing but clearing the grace deadline + its log line.
+//
+// The grace-window-reattach case (the old `wasHeld` behaviour) is already
+// covered by reconnect-reattach.test.mjs (b, d) and expired-reattach.test.mjs
+// (1); the preemption case is covered by heartbeat.test.mjs (c, browser) and
+// zombie-bridge-reattach.test.mjs (bridge). This file covers the two cases
+// those don't: a virgin session's INITIAL pairing, and a SOLO attach that must
+// NOT get the frame (no peer yet — there is no pair to be whole).
+//
+// Runs against the Node stand-in relay, which mirrors the exact `pairWhole`
+// broadcast condition the Cloudflare DO uses (../relay/src/index.js step 6).
+//
+// Run: cd terminal/test && node --test pair-whole-notify.test.mjs   (or: npm test)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintSessionTokens } from "../shared/session-token.mjs";
+import { isPeerReattachedFrame } from "../shared/control-frames.mjs";
+
+const SECRET = "pair-whole-notify-test-secret";
+const HARD_TIMEOUT_MS = 10_000;
+
+async function waitFor(pred, ms, label, pollMs = 25) {
+  const started = Date.now();
+  for (;;) {
+    const v = await pred();
+    if (v) return v;
+    if (Date.now() - started > ms) throw new Error(`timed out after ${ms}ms waiting for ${label}`);
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+/** Open a raw ws leg and collect its TEXT control frames + binary bytes. */
+async function openRawLeg(relayUrl, session, role, token) {
+  const ws = new WebSocket(`${relayUrl}/?session=${session}&role=${role}&token=${encodeURIComponent(token)}`);
+  const leg = { ws, texts: [], binary: "", closed: null };
+  ws.on("message", (data, isBinary) => {
+    if (isBinary) leg.binary += Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+    else leg.texts.push(Buffer.isBuffer(data) ? data.toString("utf8") : String(data));
+  });
+  ws.on("close", (code, reasonBuf) => { leg.closed = [code, reasonBuf ? reasonBuf.toString() : ""]; });
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${role} open timeout`)), 5000)),
+  ]);
+  return leg;
+}
+
+const hasFrame = (leg, pred) => leg.texts.some(pred);
+
+// ── (1) initial pairing on a virgin session → peer-reattached to BOTH legs ────
+test("(1) initial pairing (bridge attaches, then browser, no grace hold) → peer-reattached to both legs", { timeout: 15000 }, async (t) => {
+  const session = `pw-1-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-PW", sid: session, secret: SECRET });
+
+  // Bridge attaches first — solo, so it must NOT see peer-reattached yet (case 3
+  // below covers this directly; here we just move straight to pairing it up).
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
+
+  // The browser completes the pair for the FIRST time ever on this session — no
+  // grace hold was ever set, so the old `wasHeld && pairWhole` gate would have
+  // sent nothing.
+  const browser = await openRawLeg(relay.url, session, "browser", tokens.browser);
+  t.after(() => { try { browser.ws.terminate(); } catch { /* */ } });
+
+  await waitFor(() => hasFrame(browser, isPeerReattachedFrame), HARD_TIMEOUT_MS, "peer-reattached to the newly-attached browser leg");
+  assert.ok(hasFrame(bridge, isPeerReattachedFrame), "peer-reattached to the already-attached bridge leg too");
+  console.log("[pw/1] PASS — initial pairing broadcasts peer-reattached to both legs");
+});
+
+// ── (2) solo attach (only one leg present) → NO peer-reattached sent ──────────
+test("(2) a solo attach with no peer present → no peer-reattached is sent", { timeout: 15000 }, async (t) => {
+  const session = `pw-2-${Math.random().toString(36).slice(2, 8)}`;
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+  const tokens = await mintSessionTokens({ sub: owner, idea: "idea-PW", sid: session, secret: SECRET });
+
+  const bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
+  t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
+
+  // Give the relay a beat to (wrongly) broadcast, then assert it didn't — the
+  // pair is not whole with only one leg attached.
+  await new Promise((r) => setTimeout(r, 200));
+  assert.equal(hasFrame(bridge, isPeerReattachedFrame), false, "a solo leg must not see peer-reattached");
+  console.log("[pw/2] PASS — solo attach sends no peer-reattached");
+});

--- a/terminal/test/reconnect-reattach.test.mjs
+++ b/terminal/test/reconnect-reattach.test.mjs
@@ -105,6 +105,11 @@ test("(b) dropped leg reattaches (same sid+owner) within grace → both get peer
   bridge.ws.terminate();
   await waitFor(() => hasFrame(browser, isPeerDegradedFrame), 5000, "degraded");
 
+  // `browser` already saw ONE peer-reattached frame from the initial pairing
+  // above (fix/relay-pair-whole-notify fires it there too) — clear its texts so
+  // the check below proves THIS reattach's broadcast, not that stale one.
+  browser.texts = [];
+
   // Reattach the bridge with the SAME sid + owner token.
   bridge = await openRawLeg(relay.url, session, "bridge", tokens.bridge);
   t.after(() => { try { bridge.ws.terminate(); } catch { /* */ } });
@@ -253,6 +258,10 @@ test("(f1) transient relay drop with claude alive → bridge RECONNECTS to the s
   const firstBridgeWs = await waitFor(() => relay.sessions.get(session)?.bridge ?? null, 5000, "bridge attached server-side");
 
   // Force a TRANSIENT drop of the bridge's link (server-side terminate → client sees 1006).
+  // Clear the browser's seen texts first: fix/relay-pair-whole-notify means the
+  // INITIAL pairing above already sent one peer-reattached, so `hasFrame` below
+  // must only count a frame from THIS reconnect, not that stale one.
+  browser.texts = [];
   firstBridgeWs.terminate();
 
   // The bridge must RECONNECT (not reap): the relay re-pairs and broadcasts peer-reattached.

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -228,6 +228,7 @@ export function startStandinRelay(opts = {}) {
     }
 
     const firstLeg = legs.bridge === null && legs.browser === null;
+    const wasHeld = legs.graceTimer != null;
     if (legs.owner === null) legs.owner = auth.sub;
     legs[role] = ws;
     log("attached", { session, role });
@@ -256,15 +257,26 @@ export function startStandinRelay(opts = {}) {
     }
 
     // GRACE-WINDOW REATTACH reconciliation: if this session was being HELD for a
-    // dropped leg and BOTH legs are present again, cancel the grace hold and tell
-    // BOTH legs to resume. (Only one leg back → keep holding, wait for the other.)
-    if (legs.graceTimer && legs.bridge && legs.browser) {
+    // dropped leg and BOTH legs are present again, cancel the grace hold. (Only
+    // one leg back → keep holding, wait for the other.)
+    const pairWhole = legs.bridge && legs.browser;
+    if (wasHeld && pairWhole) {
       clearTimeout(legs.graceTimer);
       legs.graceTimer = null;
+      log("reattached — pair whole again", { session, role });
+    }
+
+    // `peer-reattached` is the PAIR-IS-WHOLE signal — mirrors the Cloudflare DO
+    // (relay/src/index.js step 6, fix/relay-pair-whole-notify): it fires
+    // whenever THIS attach makes the pair whole, not only after a grace hold —
+    // that also covers initial pairing and a same-owner PREEMPTION reattach
+    // (pop-out / bring-back-to-dock), neither of which ever opens a grace hold.
+    // A leg attaching to a quiet session has no other way to learn its peer is
+    // there (no bytes flow, and unpaired input is dropped).
+    if (pairWhole) {
       for (const leg of [legs.bridge, legs.browser]) {
         try { leg.send(encodePeerReattachedFrame()); } catch { /* closing */ }
       }
-      log("reattached — pair whole again", { session, role });
     }
 
     // Arm the max-duration cap once, on the first leg; arm/refresh idle now (unless


### PR DESCRIPTION
Second fix on board card 4f9cf03d (terminal pop-out). PR #136 fixed the hand-off (window.open/noopener); Nick's field retest then exposed this relay-side defect: the popped window attached to the relay and hung at "Waiting to pair / Reattaching…" forever.

**Root cause:** the relay broadcasts `peer-reattached` — the only signal that flips a browser leg out of `waiting-to-pair` without PTY bytes — only when an attach ends a grace hold (`wasHeld && pairWhole`). A pop-out (and bring-back-to-dock) is a same-owner *preemption*: no grace hold ever opens, so no frame is sent, and a quiet session (idle Claude Code) emits no bytes while unpaired input is dropped. Deadlock until connect-timeout.

**Fix:** broadcast on `pairWhole` alone — the frame now fires for all three ways a pair becomes whole (initial pairing, grace reattach, preemption reattach). Stand-in test relay updated in lockstep. Bridge already handles the frame explicitly (bridge/src/index.js:644) — skew-safe.

**Tests:** new `pair-whole-notify.test.mjs` + strengthened preemption/reattach assertions (with stale-frame clears — one pre-existing test had a latent race this exposed). Relay 31/31 · shared 21/21 · integration 85/85. No web-app (`src/`) changes.

**Deploy note:** requires `wrangler deploy` of the relay after merge (~1min propagation); restarts DOs, dropping live legs briefly — grace/reconnect machinery recovers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)