### PR TITLE
fix(terminal): bring-back from pop-out stuck on duplicate-error — reset the state machine on deliberate reattach

### DIFF
--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -274,9 +274,15 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
 
   // Reattach the dock's OWN leg for this session (no re-mint — reconnectNow()
   // reuses the retained sid/browserToken, see use-terminal-session.ts) and
-  // drop the pop-out bookkeeping. This is what BOTH "Bring back to dock" and
-  // the popped window's close-signal do — the only difference is who
-  // triggered it (design §10b: "two paths, never a race").
+  // drop the pop-out bookkeeping. The dock's own leg was preempted the moment
+  // the pop-out attached (relay close 4001), so underneath the "Popped out"
+  // placeholder its connection state is stuck in "error" — reconnectNow()
+  // detects that (decideReconnectNow in connection.ts) and resets the state
+  // machine before reopening the socket, rather than silently reattaching into
+  // a state the reducer has no forward edge out of (fix/terminal-bringback-
+  // state-reset). This is what BOTH "Bring back to dock" and the popped
+  // window's close-signal do — the only difference is who triggered it
+  // (design §10b: "two paths, never a race").
   const bringBackToDock = useCallback(
     (key: string) => {
       actionsMapRef.current.get(key)?.reconnectNow();

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -56,6 +56,7 @@ import {
   RECONNECT_GRACE_MS,
   buildRelayUrl,
   claimConnectGeneration,
+  decideReconnectNow,
   decideResize,
   isConnectSuperseded,
   encodeHeartbeatFrame,
@@ -1180,19 +1181,60 @@ export function useTerminalSession(
   // wait) using the retained token, or fall back to a clean fresh launch if the
   // grace window is spent. Fixes the old button, which minted an EMPTY session with
   // no autoLaunch and timed out after 30s.
+  //
+  // A THIRD case (fix/terminal-bringback-state-reset): "Bring back to dock" after a
+  // pop-out also lands here. The dock's OWN leg was preempted when the pop-out
+  // attached (relay close 4001 → errorKind "duplicate") while the "Popped out"
+  // placeholder masked it, so the underlying state machine is stuck in "error".
+  // decideReconnectNow (connection.ts) routes THAT case to "fresh-attach-reset"
+  // instead of the ambient "grace-reconnect" path below — grace-reconnect opens
+  // with {reconnect:true} and dispatches nothing, which is exactly the bug: the
+  // reducer has no forward edge out of "error" for `relay-open`/`data` (see its
+  // comment on the "data" case), so the socket came back healthy while the UI
+  // stayed on the stale duplicate-error screen. The fresh-attach-reset branch is
+  // the ONE sanctioned exit from "error" — see connection.ts's decideReconnectNow
+  // doc for the full reasoning.
   const reconnectNow = useCallback(() => {
     const p = pairRef.current;
     const now = Date.now();
-    const withinWindow =
-      reconnectDeadlineRef.current === 0 || now < reconnectDeadlineRef.current;
-    if (p && withinWindow) {
-      clearReconnectTimer();
-      if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
-      openBrowserLeg(p.sessionId, p.browserToken, { reconnect: true });
-    } else {
+    const decision = decideReconnectNow(statusRef.current, !!p, now, reconnectDeadlineRef.current);
+
+    if (decision === "full-connect" || !p) {
       void connect({ autoLaunch: true });
+      return;
     }
-  }, [openBrowserLeg, clearReconnectTimer, connect]);
+
+    if (decision === "fresh-attach-reset") {
+      // Claim a fresh connect generation, exactly as attachToExisting does, so a
+      // newer connect()/reconnectNow() racing this one wins cleanly.
+      const gen = (connectGenRef.current = claimConnectGeneration(connectGenRef.current));
+      // Tear down first (mirrors attachToExisting): nulls the old socket's
+      // handlers so a lingering, already-dead socket can't fire a late event
+      // into this fresh attempt, and clears the reconnect timer/bookkeeping.
+      teardownSocket();
+      reconnectDeadlineRef.current = 0;
+      reconnectAttemptRef.current = 0;
+      // Two dispatches back-to-back, no await between them — the documented
+      // two-dispatch pattern (see attachToExisting): React folds them through
+      // the reducer in order against the queued state, so "session-created"'s
+      // `state.status !== "connecting"` guard sees the "connect" transition
+      // that just landed ahead of it.
+      dispatch({ type: "connect" });
+      dispatch({ type: "session-created", sessionId: p.sessionId });
+      if (isConnectSuperseded(gen, connectGenRef.current)) return;
+      // reconnect:false (the default) arms CONNECT_TIMEOUT_MS, so a dead relay
+      // produces an honest connect-timeout error instead of hanging in
+      // "connecting" forever — unlike grace-reconnect below, nothing else is
+      // bounding this attempt.
+      openBrowserLeg(p.sessionId, p.browserToken);
+      return;
+    }
+
+    // decision === "grace-reconnect" — unchanged, prod-proven path.
+    clearReconnectTimer();
+    if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
+    openBrowserLeg(p.sessionId, p.browserToken, { reconnect: true });
+  }, [openBrowserLeg, clearReconnectTimer, connect, teardownSocket]);
 
   // Install-first entry gate. This is the ONE place a browser "open" is turned into
   // either a setup panel, a coming-soon panel, or an auto-connect — the deep link is

--- a/src/lib/terminal/connection.test.ts
+++ b/src/lib/terminal/connection.test.ts
@@ -20,6 +20,7 @@ import {
   decideResize,
   claimConnectGeneration,
   isConnectSuperseded,
+  decideReconnectNow,
   type TerminalConnectionState,
   type TerminalEvent,
 } from "./connection";
@@ -487,5 +488,84 @@ describe("connect() single-flight generation guard (PR #88)", () => {
     // ever goes live (the "connect fires twice" fix).
     expect(isConnectSuperseded(aGen, counter)).toBe(true);
     expect(isConnectSuperseded(bGen, counter)).toBe(false);
+  });
+});
+
+describe("bring-back-from-pop-out state reset (fix/terminal-bringback-state-reset)", () => {
+  it("a stray `data` event is ignored while status is error (no reducer forward edge — see the 'data' case's comment)", () => {
+    const errored = run([{ type: "connect" }, { type: "session-mint-failed" }]);
+    expect(errored.status).toBe("error");
+    expect(terminalReducer(errored, { type: "data" })).toBe(errored);
+  });
+
+  it("the dock's own leg preempted by a pop-out (relay close 4001) lands in error/duplicate, and a stray data event there is still ignored", () => {
+    const live = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+    const preempted = terminalReducer(live, { type: "closed", code: RELAY_CLOSE.DUP_BROWSER });
+    expect(preempted.status).toBe("error");
+    expect(preempted.errorKind).toBe("duplicate");
+    // A late message from the socket the relay already closed must not revive it.
+    expect(terminalReducer(preempted, { type: "data" })).toBe(preempted);
+  });
+
+  it("the fresh-attach-reset sequence (connect → session-created → relay-open → data) reaches connected from error, sessionId retained", () => {
+    const live = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+    const preempted = terminalReducer(live, { type: "closed", code: RELAY_CLOSE.DUP_BROWSER });
+    expect(preempted.status).toBe("error");
+
+    // Exactly the sequence reconnectNow()'s "fresh-attach-reset" branch
+    // dispatches (mirrors attachToExisting's two-dispatch reset) before it
+    // reopens the browser leg — the relay's peer-reattached frame or the first
+    // real PTY byte then lands as this final `data`.
+    const reattached = run(
+      [
+        { type: "connect" },
+        { type: "session-created", sessionId: "a3f9" },
+        { type: "relay-open" },
+        { type: "data" },
+      ],
+      preempted,
+    );
+    expect(reattached.status).toBe("connected");
+    expect(reattached.sessionId).toBe("a3f9");
+    expect(reattached.errorKind).toBeNull();
+  });
+
+  it("grace path is unchanged: a live drop (disconnected) reaches connected on `data` alone, no reset dispatches needed", () => {
+    const dropped = run([
+      { type: "connect" },
+      { type: "relay-open" },
+      { type: "data" },
+      { type: "closed", code: RELAY_CLOSE.PEER_GONE },
+    ]);
+    expect(dropped.status).toBe("disconnected");
+    const reconnected = terminalReducer(dropped, { type: "data" });
+    expect(reconnected.status).toBe("connected");
+    expect(reconnected.sessionId).toBe(dropped.sessionId);
+  });
+});
+
+describe("decideReconnectNow (fix/terminal-bringback-state-reset)", () => {
+  it("no retained pair → full-connect, regardless of status", () => {
+    expect(decideReconnectNow("error", false, 1000, 0)).toBe("full-connect");
+    expect(decideReconnectNow("idle", false, 1000, 0)).toBe("full-connect");
+  });
+
+  it("status error with a pair → fresh-attach-reset, regardless of the deadline bookkeeping", () => {
+    // The ambient case: no prior drop ever routed through scheduleReconnect, so
+    // the deadline is still 0 (exactly what a pop-out preemption looks like).
+    expect(decideReconnectNow("error", true, 1000, 0)).toBe("fresh-attach-reset");
+    // Even a stale/spent or still-open deadline from an unrelated prior drop
+    // must not override an "error" status.
+    expect(decideReconnectNow("error", true, 5000, 1000)).toBe("fresh-attach-reset");
+    expect(decideReconnectNow("error", true, 1000, 5000)).toBe("fresh-attach-reset");
+  });
+
+  it("status disconnected with a pair, deadline unset or still open → grace-reconnect (unchanged ambient path)", () => {
+    expect(decideReconnectNow("disconnected", true, 1000, 0)).toBe("grace-reconnect");
+    expect(decideReconnectNow("disconnected", true, 1000, 5000)).toBe("grace-reconnect");
+  });
+
+  it("status disconnected with a pair, deadline already spent → full-connect (grace window exhausted)", () => {
+    expect(decideReconnectNow("disconnected", true, 5000, 1000)).toBe("full-connect");
   });
 });

--- a/src/lib/terminal/connection.ts
+++ b/src/lib/terminal/connection.ts
@@ -187,6 +187,17 @@ export function terminalReducer(
       if (state.status === "waiting-to-pair" || state.status === "disconnected" || state.status === "connecting") {
         return { ...state, status: "connected", errorKind: null, endedReason: null, closeCode: null };
       }
+      // Deliberately NOT "error" here (fix/terminal-bringback-state-reset): a
+      // genuine error (duplicate-preemption, owner-mismatch, connect-timeout, …)
+      // has no LIVE socket to deliver bytes on — the relay already closed it, or
+      // we never reached one — so a `data` event arriving while the reducer still
+      // reads "error" can only be a STALE socket's late message. Reviving that to
+      // "connected" would show a live terminal over a session this tab actually
+      // lost. The one sanctioned exit from "error" is the explicit
+      // connect → session-created reset `reconnectNow()` dispatches at the call
+      // site (see decideReconnectNow below + use-terminal-session.ts) BEFORE it
+      // reopens the socket — by the time real bytes can arrive, status is already
+      // "connecting", not "error". Keep this guard strict.
       return state;
 
     case "user-end":
@@ -324,6 +335,52 @@ export function claimConnectGeneration(current: number): number {
 /** True if `claimed` is no longer the current generation — a newer attempt superseded it. */
 export function isConnectSuperseded(claimed: number, current: number): boolean {
   return claimed !== current;
+}
+
+/**
+ * Decide what `reconnectNow()` should do, pure so the call-site policy is
+ * unit-tested without a socket/timer (fix/terminal-bringback-state-reset).
+ *
+ *   - "full-connect" — no retained pair (never minted, or the session already
+ *     ended) → mint a fresh session via connect({autoLaunch:true}); no reattach
+ *     is possible.
+ *   - "grace-reconnect" — the AMBIENT case: a transient drop (status
+ *     "disconnected", already being handled by the grace-window scheduler) or a
+ *     healthy pair that's never dropped (deadline still 0) → reopen the SAME sid
+ *     with the retained token via {reconnect:true} (skips CONNECT_TIMEOUT_MS —
+ *     the grace window bounds these retries instead) and dispatch NOTHING, since
+ *     the reducer is already in a state `relay-open`/`data` can drive forward.
+ *     UNCHANGED, prod-proven behaviour.
+ *   - "fresh-attach-reset" — status is "error" with a pair still on hand: the
+ *     bring-back-from-pop-out case, where the dock's OWN leg was preempted
+ *     (relay close 4001 → errorKind "duplicate") while the pop-out placeholder
+ *     masked it. `terminalReducer`'s "error" state has no forward edge for
+ *     `relay-open`/`data` (see the "data" case above), so silently reopening
+ *     the socket — what "grace-reconnect" does — leaves the UI stuck on the
+ *     stale error screen over a healthy link. The caller must dispatch an
+ *     explicit connect → session-created reset (mirroring attachToExisting)
+ *     BEFORE reopening, and open with {reconnect:false} so a dead relay
+ *     produces an honest connect-timeout instead of hanging in "connecting"
+ *     forever.
+ *
+ * `status` is checked BEFORE the grace-window deadline math: an error status
+ * can coexist with a spent-or-never-set deadline (a pop-out preemption never
+ * routes through scheduleReconnect, so reconnectDeadlineRef never gets set at
+ * all) — checking the deadline first would misroute this case into
+ * "grace-reconnect".
+ */
+export type ReconnectNowDecision = "full-connect" | "grace-reconnect" | "fresh-attach-reset";
+
+export function decideReconnectNow(
+  status: TerminalStatus,
+  hasPair: boolean,
+  now: number,
+  reconnectDeadline: number,
+): ReconnectNowDecision {
+  if (!hasPair) return "full-connect";
+  if (status === "error") return "fresh-attach-reset";
+  const withinGraceWindow = reconnectDeadline === 0 || now < reconnectDeadline;
+  return withinGraceWindow ? "grace-reconnect" : "full-connect";
 }
 
 /** Feature flag — OFF unless NEXT_PUBLIC_TERMINAL_ENABLED is exactly "true". */


### PR DESCRIPTION
Third and final defect on board card 4f9cf03d (terminal pop-out journey). PR #136 fixed the hand-off (window.open/noopener), PR #137 fixed the relay pair-whole notification — both field-proven on 2026-08-09 (pop-out now works end-to-end). This fixes the remaining failure: **"Bring back to dock" left the dock on the "This session is already open elsewhere" error while its socket was actually healthy.**

**Root cause:** pop-out preempts the dock's own leg (relay 4001 → `errorKind:"duplicate"`) beneath the "Popped out" placeholder. `bringBackToDock` → `reconnectNow()` reopened the socket via the ambient grace-reconnect path, which dispatches nothing — and the reducer has no forward edge out of `error` (`relay-open` requires `connecting`; `data` only fires from `waiting-to-pair`/`disconnected`/`connecting`). Healthy socket, dead UI. The popped window never hit this because `attachToExisting` resets the machine (`connect` + `session-created`) before opening.

**Fix:** new pure `decideReconnectNow()` in `connection.ts` routes `status:"error"` to a `fresh-attach-reset` branch in `reconnectNow` that mirrors `attachToExisting`: connect-generation guard, `teardownSocket()`, bookkeeping reset, the two-dispatch state reset, then open with `{reconnect:false}` so a dead relay times out honestly. The `disconnected` grace-reconnect path is byte-for-byte unchanged. Reducer deliberately stays strict (no `error → connected` on stray `data` — a late frame from a stale socket must not revive a preempted tab); documented at both sites and pinned by tests.

**Tests:** 8 new (4 reducer-sequence incl. the full bring-back dispatch chain; 4 for `decideReconnectNow`). Gates: `tsc --noEmit` clean · targeted 399/399 · full suite 2452/2452.

Note: the Vercel Preview check is known-broken on PRs (missing Supabase env) and does not block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)