### PR TITLE
fix(terminal): helper 0.2.1 — ship proto-reg.js in the app bundle + version/arch-driven download route

### DIFF
--- a/src/app/download/terminal-helper/route.test.ts
+++ b/src/app/download/terminal-helper/route.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MINIMUM_RECOMMENDED_HELPER_VERSION } from "@/lib/terminal/helper-version";
+
+function req(url: string): Request {
+  return new Request(url);
+}
+
+describe("GET /download/terminal-helper", () => {
+  beforeEach(() => {
+    delete process.env.TERMINAL_HELPER_VERSION;
+  });
+
+  afterEach(() => {
+    delete process.env.TERMINAL_HELPER_VERSION;
+  });
+
+  it("defaults to MINIMUM_RECOMMENDED_HELPER_VERSION and arm64 with no query string", async () => {
+    const { GET } = await import("./route");
+    const res = GET(req("https://vibecodes.co.uk/download/terminal-helper"));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      `https://github.com/vibecodes-org/vibe-coding-ideas/releases/download/terminal-helper-v${MINIMUM_RECOMMENDED_HELPER_VERSION}/VibeCodes-${MINIMUM_RECOMMENDED_HELPER_VERSION}-arm64.dmg`,
+    );
+  });
+
+  it("overrides the version from TERMINAL_HELPER_VERSION when set", async () => {
+    process.env.TERMINAL_HELPER_VERSION = "9.9.9";
+    const { GET } = await import("./route");
+    const res = GET(req("https://vibecodes.co.uk/download/terminal-helper"));
+    expect(res.headers.get("location")).toBe(
+      "https://github.com/vibecodes-org/vibe-coding-ideas/releases/download/terminal-helper-v9.9.9/VibeCodes-9.9.9-arm64.dmg",
+    );
+  });
+
+  it("builds the x64 asset URL when ?arch=x64 is passed", async () => {
+    const { GET } = await import("./route");
+    const res = GET(req("https://vibecodes.co.uk/download/terminal-helper?arch=x64"));
+    expect(res.headers.get("location")).toBe(
+      `https://github.com/vibecodes-org/vibe-coding-ideas/releases/download/terminal-helper-v${MINIMUM_RECOMMENDED_HELPER_VERSION}/VibeCodes-${MINIMUM_RECOMMENDED_HELPER_VERSION}-x64.dmg`,
+    );
+  });
+
+  it("falls back to arm64 for any arch value outside the allowlist", async () => {
+    const { GET } = await import("./route");
+    for (const bogus of ["x86", "arm", "ARM64", "x64 ", "../../etc/passwd", ""]) {
+      const res = GET(req(`https://vibecodes.co.uk/download/terminal-helper?arch=${encodeURIComponent(bogus)}`));
+      expect(res.headers.get("location")).toContain(`-${MINIMUM_RECOMMENDED_HELPER_VERSION}-arm64.dmg`);
+    }
+  });
+
+  it("always sets Cache-Control: no-store so a version bump is picked up immediately", async () => {
+    const { GET } = await import("./route");
+    const res = GET(req("https://vibecodes.co.uk/download/terminal-helper"));
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("is a 302 (not a permanent redirect) so the target can keep changing", async () => {
+    const { GET } = await import("./route");
+    const res = GET(req("https://vibecodes.co.uk/download/terminal-helper"));
+    expect(res.status).toBe(302);
+  });
+});

--- a/src/app/download/terminal-helper/route.ts
+++ b/src/app/download/terminal-helper/route.ts
@@ -1,14 +1,42 @@
 import { NextResponse } from "next/server";
+import { MINIMUM_RECOMMENDED_HELPER_VERSION } from "@/lib/terminal/helper-version";
 
 // Stable, public download endpoint for the in-app terminal's macOS helper.
 // The signed + notarized installer is hosted as a GitHub Release asset (public
 // CDN); this route 302-redirects to it so the app can link to a clean, stable
-// path (`/download/terminal-helper`) and we can bump the target per release
-// without touching the UI. Bump the tag/filename below when publishing a new
-// helper build. Apple Silicon (arm64) only for now — Intel/x64 is a follow-up.
-const HELPER_DMG_URL =
-  "https://github.com/vibecodes-org/vibe-coding-ideas/releases/download/terminal-helper-v0.1.0/VibeCodes-0.1.0-arm64.dmg";
+// path (`/download/terminal-helper`) and we can ship a new release without
+// touching the UI or editing a hard-coded URL (see board card 3e9d525e: the
+// old hard-coded v0.1.0 URL is why a broken 0.2.0 build had to be clobbered
+// over the same asset instead of published as a real release).
+//
+// Version: `TERMINAL_HELPER_VERSION` env var overrides the default, which is
+// `MINIMUM_RECOMMENDED_HELPER_VERSION` (src/lib/terminal/helper-version.ts) —
+// the same constant that drives the "update your helper" nudge, so the
+// default download and the nudge threshold can never silently drift apart.
+// Bump that constant (in lockstep with terminal/helper/package.json) when
+// publishing a new helper release.
+const HELPER_ARCHS = ["arm64", "x64"] as const;
+type HelperArch = (typeof HELPER_ARCHS)[number];
 
-export function GET() {
-  return NextResponse.redirect(HELPER_DMG_URL, 302);
+/** Anything other than an exact "x64" match falls back to arm64 (today's default target). */
+function resolveArch(raw: string | null): HelperArch {
+  return raw === "x64" ? "x64" : "arm64";
+}
+
+export function helperDownloadUrl(version: string, arch: HelperArch): string {
+  return `https://github.com/vibecodes-org/vibe-coding-ideas/releases/download/terminal-helper-v${version}/VibeCodes-${version}-${arch}.dmg`;
+}
+
+export function GET(request: Request) {
+  const version = process.env.TERMINAL_HELPER_VERSION || MINIMUM_RECOMMENDED_HELPER_VERSION;
+  const { searchParams } = new URL(request.url);
+  const arch = resolveArch(searchParams.get("arch"));
+  const url = helperDownloadUrl(version, arch);
+
+  // no-store: a version bump must take effect on the very next click, never
+  // served stale from a browser/CDN redirect cache.
+  return NextResponse.redirect(url, {
+    status: 302,
+    headers: { "Cache-Control": "no-store" },
+  });
 }

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -606,6 +606,21 @@ function SetupPanel({ platform, onConnect }: { platform: TerminalPlatform; onCon
         >
           <Download className="h-4 w-4" /> {platform.downloadLabel}
         </a>
+        {/* We can't reliably tell Apple Silicon from Intel client-side (see
+            platform.ts), so the primary button always targets arm64 and Intel
+            users self-identify via this opt-in link rather than being silently
+            auto-detected onto a DMG that might be wrong. */}
+        <p className="mt-2 text-[12px] text-zinc-500">
+          Intel Mac?{" "}
+          <a
+            href={`${TERMINAL_HELPER_DOWNLOAD_URL}?arch=x64`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-zinc-300 underline decoration-zinc-600 underline-offset-2 hover:text-zinc-100"
+          >
+            Download the x64 version
+          </a>
+        </p>
       </SetupStep>
 
       <SetupStep n={2} title={copy.step2Title}>

--- a/src/lib/terminal/helper-version.ts
+++ b/src/lib/terminal/helper-version.ts
@@ -18,7 +18,7 @@
  *  Bump this in lockstep with terminal/helper/package.json's version — see
  *  that file's header comment and docs/release-process.md for the release
  *  checklist. */
-export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.2.0";
+export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.2.1";
 
 export type HelperVersionParts = readonly [number, number, number];
 

--- a/src/lib/terminal/platform.test.ts
+++ b/src/lib/terminal/platform.test.ts
@@ -40,18 +40,22 @@ describe("resolveTerminalPlatform — Apple Silicon Mac (supported)", () => {
   });
 });
 
-describe("resolveTerminalPlatform — Intel Mac (unsupported)", () => {
-  it("routes an x86 Mac to coming-soon with no download target", () => {
+describe("resolveTerminalPlatform — Intel Mac (supported, arm64 default download)", () => {
+  it("an x86 Mac is supported — we ship an x64 DMG now — but keeps the arm64 default target", () => {
     const p = resolveTerminalPlatform({ ...APPLE_SILICON_MAC, architecture: "x86" });
     expect(p.os).toBe("mac");
     expect(p.isAppleSilicon).toBe(false);
-    expect(p.supported).toBe(false);
-    expect(p.downloadUrl).toBeNull();
+    expect(p.supported).toBe(true);
+    // Deliberately NOT auto-switched to x64 — see resolveTerminalPlatform's doc
+    // comment; the UI surfaces a manual "Intel Mac?" opt-in link instead.
+    expect(p.downloadUrl).toBe(TERMINAL_HELPER_DOWNLOAD_URL);
+    expect(p.downloadLabel).toBe("Download for Mac (Apple Silicon)");
   });
 
   it("treats x86_64 the same as x86", () => {
     const p = resolveTerminalPlatform({ ...APPLE_SILICON_MAC, architecture: "x86_64" });
-    expect(p.supported).toBe(false);
+    expect(p.isAppleSilicon).toBe(false);
+    expect(p.supported).toBe(true);
   });
 });
 

--- a/src/lib/terminal/platform.ts
+++ b/src/lib/terminal/platform.ts
@@ -1,9 +1,10 @@
 // In-app terminal — client OS / architecture detection for the install-first flow.
 //
 // The in-browser terminal only works on machines we ship a helper for. Today that
-// is an Apple-Silicon Mac; everything else lands on a calm "coming soon" and NEVER
-// fires the `vibecodes://` deep link (so a non-Mac user is never ambushed by an OS
-// dialog for a scheme nothing can handle).
+// is any Mac — we publish both an arm64 (Apple Silicon) and an x64 (Intel) DMG per
+// release (see src/app/download/terminal-helper/route.ts); everything else lands
+// on a calm "coming soon" and NEVER fires the `vibecodes://` deep link (so a
+// non-Mac user is never ambushed by an OS dialog for a scheme nothing can handle).
 //
 // resolveTerminalPlatform() is PURE — it takes explicit signals so the whole
 // OS/arch policy is unit-testable without a real navigator. readPlatformSignals()
@@ -34,9 +35,9 @@ export interface PlatformSignals {
 
 export interface TerminalPlatform {
   os: TerminalOs;
-  /** Best-effort: is this an Apple-Silicon Mac (the shipped helper target)? */
+  /** Best-effort: is this an Apple-Silicon Mac (the default download target)? */
   isAppleSilicon: boolean;
-  /** Do we ship a helper this machine can run? (Apple-Silicon Mac only, today.) */
+  /** Do we ship a helper this machine can run? (Any Mac, today — arm64 or x64.) */
   supported: boolean;
   /** Download control label — information scent, never "Download" / "Submit". */
   downloadLabel: string;
@@ -74,15 +75,23 @@ function detectOs(signals: PlatformSignals): TerminalOs {
  *
  * Apple-Silicon caveat: browsers report "Intel Mac OS X" in the UA even on Apple
  * Silicon (a compatibility lie), so the UA alone can NEVER prove Apple Silicon. We
- * therefore treat any Mac as Apple Silicon — the only helper we ship is arm64 —
- * UNLESS a trustworthy UA-CH `architecture` says "x86"/"x86_64", the one case where
- * we can be reasonably sure it is an Intel Mac and route it to "coming soon".
+ * therefore treat any Mac as Apple Silicon by default — the primary download button
+ * targets arm64 — UNLESS a trustworthy UA-CH `architecture` says "x86"/"x86_64", the
+ * one case where we can be reasonably sure it is an Intel Mac.
+ *
+ * Every Mac is `supported` now (we ship an x64 DMG alongside arm64), so an Intel
+ * signal no longer routes to "coming soon" — it just flips `isAppleSilicon` to
+ * false. We deliberately do NOT auto-switch `downloadUrl`/`downloadLabel` off of
+ * this signal (UA-CH architecture is opt-in and often absent for the synchronous
+ * read, so silently trusting it here would default plenty of real Apple-Silicon
+ * users onto the wrong DMG); the UI instead surfaces a manual "Intel Mac?" link the
+ * user opts into themselves — see SetupPanel in terminal-session-view.tsx.
  */
 export function resolveTerminalPlatform(signals: PlatformSignals): TerminalPlatform {
   const os = detectOs(signals);
   const arch = signals.architecture?.toLowerCase();
   const isAppleSilicon = os === "mac" && arch !== "x86" && arch !== "x86_64";
-  const supported = os === "mac" && isAppleSilicon;
+  const supported = os === "mac";
 
   if (supported) {
     return {

--- a/terminal/helper/electron-builder.yml
+++ b/terminal/helper/electron-builder.yml
@@ -14,8 +14,14 @@ directories:
 # Only the helper's own code goes inside app.asar. The reused bridge + shared
 # modules are shipped as extraResources (below) so node-pty's native binaries
 # stay executable on disk — you cannot exec a spawn-helper from inside an asar.
+#
+# EVERY module main.js require()s with a "./" path MUST be listed here — a
+# missing entry is invisible in dev (`electron .` reads the real directory) and
+# fatal in the packed app ("Cannot find module" on first launch: the 0.2.0 DMG
+# shipped without proto-reg.js and crashed on install, board card 3e9d525e).
 files:
   - main.js
+  - proto-reg.js
   - package.json
 
 extraResources:

--- a/terminal/helper/package-lock.json
+++ b/terminal/helper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibecodes-terminal-helper",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8"
@@ -1530,7 +1530,7 @@
       }
     },
     "node_modules/chromium-pickle-js": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
       "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
       "dev": true,
@@ -2189,7 +2189,7 @@
       }
     },
     "node_modules/eastasianwidth": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,

--- a/terminal/helper/package.json
+++ b/terminal/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "macOS helper app: registers the vibecodes:// URL scheme and runs the terminal bridge (node-pty PTY -> relay) on launch. A thin, installable, signable wrapper around terminal/bridge (no logic duplication).",
   "author": "VibeCodes",


### PR DESCRIPTION
Board card 3e9d525e (helper release/download pipeline), made urgent today: the helper DMG currently served crashes on launch with `Cannot find module './proto-reg'` — Nick hit it installing the helper on 2026-08-09.

**Two commits:**

1. **Packaging fix (`933cb03`)** — `electron-builder.yml`'s `files:` list was never updated when `main.js` gained `require("./proto-reg")` in July, so every packed build since ships without the file and dies at startup (invisible in dev, where `electron .` reads the real directory). `proto-reg.js` is now bundled, with a warning comment explaining the failure mode; helper version bumped to 0.2.1.

2. **Download route fix (`fa7d1d0`)** — `/download/terminal-helper` no longer hard-codes the `terminal-helper-v0.1.0` asset URL: it computes `tag terminal-helper-v${V} / VibeCodes-${V}-${arch}.dmg` from `TERMINAL_HELPER_VERSION` env (default: `MINIMUM_RECOMMENDED_HELPER_VERSION`, bumped to 0.2.1 — same threshold drives the update nudge, so they can't drift). `?arch=x64` serves the Intel build (allowlisted; garbage → arm64); `Cache-Control: no-store`. Intel Macs are un-blocked in the UI (`supported: true` now that an x64 DMG exists) with an explicit "Intel Mac?" secondary download link — no silent arch auto-detection.

**Tests:** new `route.test.ts` (6 tests: env override, arch allowlist, URL shape, no-store); `platform.test.ts` Intel cases updated. Gates: `tsc --noEmit` clean · full vitest 2458/2458.

**Release ops (outside this PR):** a fixed, signed + notarized 0.2.1 build is being published to release tag `terminal-helper-v0.2.1`, and the broken clobbered `VibeCodes-0.1.0-arm64.dmg` asset is being replaced with working bytes so the currently-deployed hard-coded route also serves a working installer immediately.

Note: the Vercel Preview check is known-broken on PRs (missing Supabase env) and does not block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)