### PR TITLE
feat(terminal): helper lifecycle v1 — quit-when-idle, crash log-and-exit, control channel, always-on opt-in (card cc74a067)

### DIFF
--- a/src/app/api/terminal/helper/command/route.ts
+++ b/src/app/api/terminal/helper/command/route.ts
@@ -1,0 +1,84 @@
+// Terminal helper COMMAND — the Helper row's Stop/Update actions and the
+// "Keep helper ready" toggle (card cc74a067).
+//
+// `POST { cmd: "stop"|"quiesce"|"set-always-on", value? }` forwards the
+// command to the caller's own live helper leg via the relay's authenticated
+// POST /helper/command (same control-token pattern as
+// src/app/api/terminal/session/end/route.ts and the sibling status route).
+// `delivered:false` is an HONEST outcome (no live helper leg right now), not
+// an error — the Helper row's "may already be stopped" toast is exactly this.
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { mintControlToken, helperSessionId } from "../../../../../../terminal/shared/session-token.mjs";
+import { relayHttpBaseUrl } from "@/lib/terminal/relay-http";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.union([
+  z.object({ cmd: z.literal("stop") }),
+  z.object({ cmd: z.literal("quiesce") }),
+  z.object({ cmd: z.literal("set-always-on"), value: z.boolean() }),
+]);
+
+export async function POST(req: Request) {
+  try {
+    const secret = process.env.TERMINAL_SESSION_SECRET;
+    if (!secret) {
+      logger.error("Terminal helper command failed: TERMINAL_SESSION_SECRET not configured");
+      return NextResponse.json({ error: "Terminal sessions are not configured" }, { status: 503 });
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const parsed = BodySchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const sid = helperSessionId(user.id);
+    const control = await mintControlToken({ sub: user.id, sid, secret });
+    const httpBase = relayHttpBaseUrl();
+
+    let res: Response;
+    try {
+      res = await fetch(`${httpBase}/helper/command?session=${encodeURIComponent(sid)}`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${control}`, "content-type": "application/json" },
+        body: JSON.stringify(parsed.data),
+      });
+    } catch (err) {
+      logger.warn("Terminal helper command: relay unreachable", {
+        cmd: parsed.data.cmd,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return NextResponse.json({ error: "Couldn't reach the relay" }, { status: 502 });
+    }
+
+    if (!res.ok) {
+      logger.error("Terminal helper command: relay rejected the control call", {
+        cmd: parsed.data.cmd,
+        status: res.status,
+      });
+      return NextResponse.json({ error: "Couldn't reach the helper" }, { status: 502 });
+    }
+
+    const body = await res.json();
+    logger.info("Sent terminal helper command", { userId: user.id, cmd: parsed.data.cmd, delivered: body?.delivered });
+    return NextResponse.json(body);
+  } catch (err) {
+    logger.error("Terminal helper command error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
+  }
+}

--- a/src/app/api/terminal/helper/status/route.ts
+++ b/src/app/api/terminal/helper/status/route.ts
@@ -1,0 +1,73 @@
+// Terminal helper STATUS — the Helper row's status poll (card cc74a067).
+//
+// `GET` returns the caller's own helper leg's presence/version/machine-label/
+// always-on/"stopped unexpectedly" state, exactly as the relay's Durable
+// Object durably tracks it (see terminal/relay/src/helper-status.js →
+// computeHelperStatus). Mirrors src/app/api/terminal/session/end/route.ts's
+// auth shape: a short-lived, sid-bound CONTROL token
+// (terminal/shared/session-token.mjs → mintControlToken/authorizeControl)
+// minted server-side so the relay never has to trust a raw session id alone.
+//
+// The caller's helper session id is always `helperSessionId(user.id)` — one
+// reserved, deterministic id per owner (never per-launch random, unlike a
+// terminal session's sid) — so there is nothing for the request body to name;
+// a signed-in user can only ever ask about their OWN helper.
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { mintControlToken, helperSessionId } from "../../../../../../terminal/shared/session-token.mjs";
+import { relayHttpBaseUrl } from "@/lib/terminal/relay-http";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const secret = process.env.TERMINAL_SESSION_SECRET;
+    if (!secret) {
+      logger.error("Terminal helper status failed: TERMINAL_SESSION_SECRET not configured");
+      return NextResponse.json({ error: "Terminal sessions are not configured" }, { status: 503 });
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const sid = helperSessionId(user.id);
+    const control = await mintControlToken({ sub: user.id, sid, secret });
+    const httpBase = relayHttpBaseUrl();
+
+    let res: Response;
+    try {
+      res = await fetch(`${httpBase}/helper/status?session=${encodeURIComponent(sid)}`, {
+        headers: { Authorization: `Bearer ${control}` },
+      });
+    } catch (err) {
+      logger.warn("Terminal helper status: relay unreachable", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Honest "we don't know" rather than a fabricated not-running — the
+      // Helper row treats a fetch failure the same way (keeps its last known
+      // state / shows a retry), never as a confirmed "not running".
+      return NextResponse.json({ error: "Couldn't reach the relay" }, { status: 502 });
+    }
+
+    if (!res.ok) {
+      logger.error("Terminal helper status: relay rejected the control call", { status: res.status });
+      return NextResponse.json({ error: "Couldn't check the helper's status" }, { status: 502 });
+    }
+
+    const status = await res.json();
+    return NextResponse.json(status);
+  } catch (err) {
+    logger.error("Terminal helper status error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
+  }
+}

--- a/src/app/api/terminal/session/route.ts
+++ b/src/app/api/terminal/session/route.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 // One shared implementation of the token scheme — also imported by the relay.
-import { mintSessionTokens } from "../../../../../terminal/shared/session-token.mjs";
+import { mintSessionTokens, mintHelperToken } from "../../../../../terminal/shared/session-token.mjs";
 import {
   getServerTerminalSessionCap,
   getTerminalMintRateLimit,
@@ -217,7 +217,15 @@ export async function POST(req: Request) {
     }
 
     // ── (d) MINT + register. ────────────────────────────────────────────────
-    const tokens = await mintSessionTokens({ sub: user.id, idea: ideaId, secret });
+    // The bridge/browser pair (per-launch, random sid) and the helper's OWN
+    // standing control-connection credential (card cc74a067 — reserved,
+    // per-owner sid, see helperSessionId) are minted together so the SAME
+    // click that starts a terminal also (re)establishes the helper's control
+    // connection to the relay — see terminal/helper/main.js's handleLaunchUrl.
+    const [tokens, helperToken] = await Promise.all([
+      mintSessionTokens({ sub: user.id, idea: ideaId, secret }),
+      mintHelperToken({ sub: user.id, secret }),
+    ]);
 
     const { error: insertErr } = await supabase.from("terminal_sessions").insert({
       sid: tokens.sid,
@@ -248,12 +256,16 @@ export async function POST(req: Request) {
 
     // Return both leg tokens + the session id. The browser token is for the in-app
     // panel; the bridge token is handed to the local helper (slice 3 wiring).
+    // helperToken rides the SAME deep link (card cc74a067) so a same-machine
+    // launch also (re)establishes the helper's standing control connection —
+    // an already-connected helper treats a redundant one as a no-op.
     return NextResponse.json({
       sessionId: tokens.sid,
       ideaId: tokens.idea,
       expiresAt: tokens.exp,
       browserToken: tokens.browser,
       bridgeToken: tokens.bridge,
+      helperToken,
     });
   } catch (err) {
     logger.error("Terminal session mint error", {

--- a/src/components/board/terminal-my-sessions-panel.tsx
+++ b/src/components/board/terminal-my-sessions-panel.tsx
@@ -10,11 +10,12 @@
 //
 // Fetch-on-open + refresh-after-action (no realtime, per the stage brief).
 
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { usePostHog } from "posthog-js/react";
-import { Loader2, Power, Terminal as TerminalIcon } from "lucide-react";
+import { Loader2, Power, Terminal as TerminalIcon, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import {
   Popover,
   PopoverContent,
@@ -24,6 +25,40 @@ import { cn } from "@/lib/utils";
 import { slugifyIdeaTitle } from "@/lib/launch-claude-code";
 import { formatSessionAge, formatSessionIdentity } from "@/lib/terminal/session-registry";
 import { deriveTabLabel } from "./terminal-tabs";
+import {
+  MINIMUM_RECOMMENDED_HELPER_VERSION,
+  shouldShowHelperUpdateNudge,
+} from "@/lib/terminal/helper-version";
+import { TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
+import { recordHelperIdleQuitObserved } from "@/lib/terminal/helper-relaunch-signal";
+import {
+  ALWAYS_ON_CONSENT_BODY,
+  ALWAYS_ON_LABEL,
+  HELPER_ROW_STOP_FAILED_TOAST,
+  HELPER_ROW_STOP_TOAST,
+  STOP_CONFIRM_HEADING,
+  deriveHelperChip,
+  formatHelperEventAge,
+  shouldShowStopButton,
+  stopButtonLabel,
+  stopConfirmBody,
+  updateNudgeCopy,
+  type HelperChip,
+  type HelperChipKind,
+  type HelperStatus,
+} from "@/lib/terminal/helper-row";
+import {
+  INITIAL_UPDATE_FLOW_STATE,
+  QUIESCE_TIMEOUT_MS,
+  UPDATE_CONFIRM_ACCEPT_LABEL,
+  UPDATE_CONFIRM_CANCEL_LABEL,
+  UPDATE_CONFIRM_HEADING,
+  UPDATE_QUIESCE_TIMEOUT_COPY,
+  UPDATE_READY_COPY,
+  updateConfirmBody,
+  updateFlowReducer,
+  type UpdateFlowState,
+} from "@/lib/terminal/helper-update-flow";
 
 interface ListedSession {
   sid: string;
@@ -37,6 +72,21 @@ interface ListedSession {
 }
 
 type LoadState = "idle" | "loading" | "ready" | "error";
+
+/** Tailwind classes per chip kind (design §7: status is never colour-alone —
+ *  every chip here also carries an icon dot + text label). */
+function helperChipClassName(kind: HelperChipKind): string {
+  switch (kind) {
+    case "running":
+      return "border-emerald-500/50 bg-emerald-500/10 text-emerald-400";
+    case "winding-down":
+      return "border-amber-500/50 bg-amber-500/10 text-amber-400";
+    case "stopped-unexpectedly":
+      return "border-rose-500/55 bg-rose-500/10 text-rose-400";
+    case "not-running":
+      return "border-zinc-600 bg-zinc-800/60 text-zinc-300";
+  }
+}
 
 interface TerminalMySessionsPanelProps {
   /** Fires whenever the panel's session count is known/changes, so the dock's badge stays in sync. */
@@ -60,14 +110,52 @@ export function TerminalMySessionsPanel({
   const [endingAll, setEndingAll] = useState(false);
   const posthog = usePostHog();
 
+  // ── Helper row state (card cc74a067) ────────────────────────────────────────
+  const [helperStatus, setHelperStatus] = useState<HelperStatus | null>(null);
+  const [confirmingStopHelper, setConfirmingStopHelper] = useState(false);
+  const [stoppingHelper, setStoppingHelper] = useState(false);
+  const [dismissedHelperNudge, setDismissedHelperNudge] = useState(false);
+  const [updateFlow, setUpdateFlow] = useState<UpdateFlowState>(INITIAL_UPDATE_FLOW_STATE);
+  const [alwaysOnConsentOpen, setAlwaysOnConsentOpen] = useState(false);
+  const [togglingAlwaysOn, setTogglingAlwaysOn] = useState(false);
+  // Last chip kind we observed, so `load()` can notice a winding-down ->
+  // not-running transition (an idle-quit) across opens/refreshes — the panel
+  // never polls continuously (fetch-on-open + refresh-after-action, same as
+  // the session list above), so this is only ever compared across those.
+  const prevHelperChipKindRef = useRef<HelperChipKind | null>(null);
+  // Set true right before WE deliberately end the helper (Stop / an
+  // update-triggered quiesce) so that resulting transition is never
+  // mis-recorded as an "idle-quit" — see helper-relaunch-signal.ts's header
+  // comment on how this observation is derived.
+  const suppressIdleQuitSignalRef = useRef(false);
+
   const load = useCallback(async () => {
     setLoadState((s) => (s === "idle" ? "loading" : s));
     try {
-      const res = await fetch("/api/terminal/session/list");
-      if (!res.ok) throw new Error(`Failed to load sessions (${res.status})`);
-      const body = (await res.json()) as { sessions: ListedSession[] };
+      const [sessionsRes, helperRes] = await Promise.all([
+        fetch("/api/terminal/session/list"),
+        fetch("/api/terminal/helper/status"),
+      ]);
+      if (!sessionsRes.ok) throw new Error(`Failed to load sessions (${sessionsRes.status})`);
+      const body = (await sessionsRes.json()) as { sessions: ListedSession[] };
       setSessions(body.sessions);
       onCountChange?.(body.sessions.length);
+
+      if (helperRes.ok) {
+        const nextStatus = (await helperRes.json()) as HelperStatus;
+        const nextChip = deriveHelperChip(nextStatus, body.sessions.length);
+        const prevKind = prevHelperChipKindRef.current;
+        if (prevKind === "winding-down" && nextChip?.kind === "not-running") {
+          if (suppressIdleQuitSignalRef.current) suppressIdleQuitSignalRef.current = false;
+          else recordHelperIdleQuitObserved();
+        }
+        prevHelperChipKindRef.current = nextChip?.kind ?? null;
+        setHelperStatus(nextStatus);
+      }
+      // A helper-status fetch failure is non-fatal to the panel — the session
+      // list is the load-bearing part; the Helper row just keeps its last
+      // known state (or stays blank) until the next open/refresh succeeds.
+
       setLoadState("ready");
     } catch {
       setLoadState("error");
@@ -114,6 +202,144 @@ export function TerminalMySessionsPanel({
       void load();
     }
   }, [load, posthog, sessions.length]);
+
+  // ── Helper row actions (card cc74a067) ──────────────────────────────────────
+  const stopHelper = useCallback(async () => {
+    setStoppingHelper(true);
+    suppressIdleQuitSignalRef.current = true; // a deliberate Stop is never an "idle-quit"
+    try {
+      const res = await fetch("/api/terminal/helper/command", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cmd: "stop" }),
+      });
+      const body = (await res.json().catch(() => null)) as { delivered?: boolean } | null;
+      if (res.ok && body?.delivered) toast.success(HELPER_ROW_STOP_TOAST);
+      else toast.error(HELPER_ROW_STOP_FAILED_TOAST);
+    } catch {
+      toast.error(HELPER_ROW_STOP_FAILED_TOAST);
+    } finally {
+      setStoppingHelper(false);
+      setConfirmingStopHelper(false);
+      void load();
+    }
+  }, [load]);
+
+  const setAlwaysOnRemote = useCallback(
+    async (value: boolean) => {
+      setTogglingAlwaysOn(true);
+      try {
+        const res = await fetch("/api/terminal/helper/command", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cmd: "set-always-on", value }),
+        });
+        const body = (await res.json().catch(() => null)) as { delivered?: boolean } | null;
+        if (!res.ok || !body?.delivered) toast.error(HELPER_ROW_STOP_FAILED_TOAST);
+      } catch {
+        toast.error(HELPER_ROW_STOP_FAILED_TOAST);
+      } finally {
+        setTogglingAlwaysOn(false);
+        void load();
+      }
+    },
+    [load],
+  );
+
+  // The toggle's own click never flips the setting directly for the ON
+  // direction — turning it on always passes through the consent expansion
+  // first (design §3 flow F: "before anything changes"). Turning it OFF is
+  // reversible/low-stakes and needs no extra step.
+  const handleAlwaysOnToggle = useCallback((next: boolean) => {
+    if (next) setAlwaysOnConsentOpen(true);
+    else void setAlwaysOnRemote(false);
+  }, [setAlwaysOnRemote]);
+
+  const confirmAlwaysOn = useCallback(() => {
+    setAlwaysOnConsentOpen(false);
+    void setAlwaysOnRemote(true);
+  }, [setAlwaysOnRemote]);
+
+  const startHelperUpdate = useCallback(() => {
+    setUpdateFlow(updateFlowReducer(INITIAL_UPDATE_FLOW_STATE, { type: "update-clicked", sessionCount: sessions.length }));
+  }, [sessions.length]);
+
+  // Drive the "quiescing" phase: end any live sessions first (only reached via
+  // "confirming" when sessions existed), send the quiesce command, then poll
+  // helper status until it reports not-connected or QUIESCE_TIMEOUT_MS elapses
+  // (design §3 flow A's fallback notice) — the download starts regardless
+  // (§3 flow A caption), just with a different notice.
+  useEffect(() => {
+    if (updateFlow.phase !== "quiescing") return;
+    let cancelled = false;
+    suppressIdleQuitSignalRef.current = true; // an update-triggered quiesce is not an idle-quit
+    const hadSessions = sessions.length > 0;
+    (async () => {
+      if (hadSessions) {
+        try {
+          await fetch("/api/terminal/session/end", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ all: true }),
+          });
+        } catch {
+          /* best effort — the quiesce command below still proceeds */
+        }
+      }
+      try {
+        await fetch("/api/terminal/helper/command", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cmd: "quiesce" }),
+        });
+      } catch {
+        /* best effort — the poll below still resolves via timeout */
+      }
+
+      const deadline = Date.now() + QUIESCE_TIMEOUT_MS;
+      while (!cancelled) {
+        let settled = false;
+        try {
+          const res = await fetch("/api/terminal/helper/status");
+          if (res.ok) {
+            const status = (await res.json()) as HelperStatus;
+            settled = status.connected === false;
+          }
+        } catch {
+          /* transient — keep polling until the deadline */
+        }
+        if (cancelled) return;
+        if (settled) {
+          setUpdateFlow((s) => updateFlowReducer(s, { type: "quiesce-settled" }));
+          return;
+        }
+        if (Date.now() >= deadline) {
+          setUpdateFlow((s) => updateFlowReducer(s, { type: "quiesce-timed-out" }));
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [updateFlow.phase, sessions.length]);
+
+  // Either outcome of quiescing starts the download (design: the whole point
+  // is drag-to-Applications always succeeds because nothing is running by
+  // now) and refreshes the row so it reflects the now-quiesced helper.
+  useEffect(() => {
+    if (updateFlow.phase !== "ready" && updateFlow.phase !== "quiesce-timeout") return;
+    window.location.assign(TERMINAL_HELPER_DOWNLOAD_URL);
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [updateFlow.phase]);
+
+  const helperChip: HelperChip | null = deriveHelperChip(helperStatus, sessions.length);
+  const showHelperNudge =
+    updateFlow.phase === "idle" &&
+    !dismissedHelperNudge &&
+    shouldShowHelperUpdateNudge(helperStatus?.version ?? null);
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
@@ -234,6 +460,159 @@ export function TerminalMySessionsPanel({
                 </Button>
               </>
             )}
+          </div>
+        )}
+
+        {/* Helper row (design §5a) — lives beneath sessions, above nothing
+            else, so "what's running for me on this Mac" has one home. */}
+        {loadState === "ready" && helperChip && (
+          <div className="flex items-center gap-2.5 border-t border-zinc-800 bg-white/[0.015] px-3.5 py-2.5">
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11.5px] font-semibold",
+                    helperChipClassName(helperChip.kind),
+                  )}
+                >
+                  <span className="h-1.5 w-1.5 flex-none rounded-full bg-current" />
+                  {helperChip.label}
+                </span>
+                {helperChip.kind !== "not-running" && (helperStatus?.version || helperStatus?.machineLabel) && (
+                  <span className="text-[11.5px] text-zinc-500">
+                    {[helperStatus?.version ? `v${helperStatus.version}` : null, helperStatus?.machineLabel]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </span>
+                )}
+                {helperChip.kind === "stopped-unexpectedly" && helperStatus?.lastEventAt != null && (
+                  <span className="text-[11.5px] text-zinc-500">
+                    {formatHelperEventAge(helperStatus.lastEventAt)}
+                  </span>
+                )}
+              </div>
+              <div className="mt-0.5 text-[11.5px] text-zinc-500">{helperChip.subline}</div>
+            </div>
+            {shouldShowStopButton(helperChip) && (
+              <Button
+                variant="outline"
+                size="xs"
+                className="flex-none"
+                onClick={() => setConfirmingStopHelper(true)}
+                disabled={stoppingHelper}
+              >
+                {stopButtonLabel(helperChip)}
+              </Button>
+            )}
+          </div>
+        )}
+
+        {confirmingStopHelper && (
+          <div className="border-t border-l-2 border-l-rose-500 bg-rose-500/5 px-3.5 py-2.5">
+            <div className="text-[12.5px] font-bold text-rose-400">{STOP_CONFIRM_HEADING}</div>
+            <div className="text-[11px] text-zinc-500">{stopConfirmBody(sessions.length)}</div>
+            <div className="mt-2 flex items-center justify-end gap-2">
+              <Button variant="ghost" size="xs" onClick={() => setConfirmingStopHelper(false)} disabled={stoppingHelper}>
+                Cancel
+              </Button>
+              <Button
+                size="xs"
+                className="bg-rose-500 text-rose-950 hover:bg-rose-400"
+                onClick={() => void stopHelper()}
+                disabled={stoppingHelper}
+              >
+                {stoppingHelper ? <Loader2 className="h-3 w-3 animate-spin" /> : <Power className="h-3 w-3" />} Stop helper
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {showHelperNudge && (
+          <div className="flex items-center gap-2 border-t border-sky-500/30 bg-sky-500/5 px-3.5 py-1.5 text-[11.5px] text-sky-300">
+            <span className="flex-1">{updateNudgeCopy(MINIMUM_RECOMMENDED_HELPER_VERSION)}</span>
+            <Button size="xs" className="flex-none bg-sky-500 text-sky-950 hover:bg-sky-400" onClick={startHelperUpdate}>
+              Update now
+            </Button>
+            <button
+              type="button"
+              className="flex-none text-sky-400 hover:text-sky-200"
+              onClick={() => setDismissedHelperNudge(true)}
+              aria-label="Dismiss helper update notice"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        )}
+
+        {updateFlow.phase === "confirming" && (
+          <div className="border-t border-l-2 border-l-sky-500 bg-sky-500/5 px-3.5 py-2.5">
+            <div className="text-[12.5px] font-bold text-sky-300">{UPDATE_CONFIRM_HEADING}</div>
+            <div className="text-[11px] text-zinc-500">{updateConfirmBody(updateFlow.sessionCount)}</div>
+            <div className="mt-2 flex items-center justify-end gap-2">
+              <Button variant="ghost" size="xs" onClick={() => setUpdateFlow((s) => updateFlowReducer(s, { type: "cancelled" }))}>
+                {UPDATE_CONFIRM_CANCEL_LABEL}
+              </Button>
+              <Button
+                size="xs"
+                className="bg-sky-500 text-sky-950 hover:bg-sky-400"
+                onClick={() => setUpdateFlow((s) => updateFlowReducer(s, { type: "confirmed" }))}
+              >
+                {UPDATE_CONFIRM_ACCEPT_LABEL}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {updateFlow.phase === "quiescing" && (
+          <div className="flex items-center gap-2 border-t border-sky-500/30 bg-sky-500/5 px-3.5 py-1.5 text-[11.5px] text-sky-300">
+            <Loader2 className="h-3 w-3 flex-none animate-spin" /> Closing the helper…
+          </div>
+        )}
+
+        {(updateFlow.phase === "ready" || updateFlow.phase === "quiesce-timeout") && (
+          <div
+            className={cn(
+              "border-t px-3.5 py-2 text-[11.5px]",
+              updateFlow.phase === "ready"
+                ? "border-sky-500/30 bg-sky-500/5 text-sky-300"
+                : "border-amber-500/30 bg-amber-500/5 text-amber-300",
+            )}
+          >
+            {updateFlow.phase === "ready" ? UPDATE_READY_COPY : UPDATE_QUIESCE_TIMEOUT_COPY}
+          </div>
+        )}
+
+        {/* "Keep helper ready" — approved for v1 (card cc74a067's design-review
+            note). The consent expansion below is the moment before anything
+            changes (design §3 flow F); turning it off needs no such step. */}
+        {loadState === "ready" && helperStatus && (
+          <div className="flex items-center gap-2 border-t border-zinc-800 px-3.5 py-2">
+            <span className="flex-1 text-[12px] font-medium text-zinc-300">{ALWAYS_ON_LABEL}</span>
+            <Switch
+              size="sm"
+              checked={helperStatus.alwaysOn}
+              onCheckedChange={handleAlwaysOnToggle}
+              disabled={togglingAlwaysOn}
+              aria-label={ALWAYS_ON_LABEL}
+            />
+          </div>
+        )}
+        {alwaysOnConsentOpen && (
+          <div className="border-t border-l-2 border-l-emerald-500 bg-emerald-500/5 px-3.5 py-2.5">
+            <div className="text-[11px] text-zinc-400">{ALWAYS_ON_CONSENT_BODY}</div>
+            <div className="mt-2 flex items-center justify-end gap-2">
+              <Button variant="ghost" size="xs" onClick={() => setAlwaysOnConsentOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                size="xs"
+                className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400"
+                onClick={confirmAlwaysOn}
+                disabled={togglingAlwaysOn}
+              >
+                Turn on
+              </Button>
+            </div>
           </div>
         )}
       </PopoverContent>

--- a/src/components/board/terminal-my-sessions-panel.tsx
+++ b/src/components/board/terminal-my-sessions-panel.tsx
@@ -166,6 +166,15 @@ export function TerminalMySessionsPanel({
     if (open) void load();
   }, [open, load]);
 
+  // A stale "Ready to update" / timeout notice must not linger forever once
+  // the popover is closed and reopened later — the update flow's own state is
+  // otherwise held in this always-mounted component (PopoverContent unmounts
+  // on close, this doesn't), same as confirmingEndAll already does.
+  useEffect(() => {
+    if (!open) return;
+    setUpdateFlow((s) => (s.phase === "ready" || s.phase === "quiesce-timeout" ? INITIAL_UPDATE_FLOW_STATE : s));
+  }, [open]);
+
   const endOne = useCallback(
     async (sid: string) => {
       setEndingSid(sid);

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -95,6 +95,7 @@ import {
 } from "@/lib/terminal/platform";
 import { isBrowserPaired, markBrowserPaired, resolveFirstRunEntry } from "@/lib/terminal/paired-flag";
 import { type LaunchPhase, nextLaunchPhaseOnTimeout } from "@/lib/terminal/first-run-flow";
+import { consumeRecentHelperIdleQuit } from "@/lib/terminal/helper-relaunch-signal";
 
 // How long we wait for the helper to attach after firing the deep link before
 // dropping to the calm fallback (~8s, per the approved UX). This is the safety net
@@ -672,7 +673,7 @@ export function useTerminalSession(
   // safety net, and the authoritative success signal is the first byte from the
   // bridge (ws.onmessage), which proves the helper actually opened AND attached.
   const fireLaunchDeepLink = useCallback(
-    (sessionId: string, bridgeToken: string) => {
+    (sessionId: string, bridgeToken: string, helperToken?: string) => {
       let link: string;
       let urlChars = 0;
       let hasCwd = false;
@@ -702,6 +703,7 @@ export function useTerminalSession(
               relay: relayBaseUrl(),
               session: sessionId,
               token: bridgeToken,
+              helperToken,
               cwd: linkCwd,
               prompt,
             }),
@@ -1036,7 +1038,7 @@ export function useTerminalSession(
     setHelperVersion(null);
     dispatch({ type: "connect" });
 
-    let data: { sessionId: string; browserToken: string; bridgeToken: string; expiresAt: number };
+    let data: { sessionId: string; browserToken: string; bridgeToken: string; helperToken?: string; expiresAt: number };
     try {
       const res = await fetch("/api/terminal/session", {
         method: "POST",
@@ -1084,6 +1086,13 @@ export function useTerminalSession(
       bridgeToken: data.bridgeToken,
       browserToken: data.browserToken,
     });
+    // Cheap cross-component telemetry (card cc74a067, design §9): pairs THIS
+    // mint with a previously observed helper idle-quit (the Helper row's own
+    // status-transition detection — see helper-relaunch-signal.ts) if one
+    // happened within the last 2 minutes. Consumed at most once per pairing.
+    if (consumeRecentHelperIdleQuit()) {
+      posthogRef.current?.capture("terminal_helper_relaunch_within_2m");
+    }
     // A fresh mint starts a fresh reconnect budget.
     reconnectDeadlineRef.current = 0;
     reconnectAttemptRef.current = 0;
@@ -1108,7 +1117,7 @@ export function useTerminalSession(
     }
 
     // Same-machine: hand the bridge token to the local helper via the deep link.
-    if (autoLaunch) fireLaunchDeepLink(data.sessionId, data.bridgeToken);
+    if (autoLaunch) fireLaunchDeepLink(data.sessionId, data.bridgeToken, data.helperToken);
 
     openBrowserLeg(data.sessionId, data.browserToken);
   }, [

--- a/src/lib/terminal/deep-link.test.ts
+++ b/src/lib/terminal/deep-link.test.ts
@@ -58,6 +58,29 @@ describe("buildLaunchDeepLink", () => {
   });
 });
 
+describe("buildLaunchDeepLink with a helperToken (card cc74a067)", () => {
+  it("includes helperToken, positioned before prompt, and round-trips", () => {
+    const withHelper = { ...SAMPLE, helperToken: "eyJzdWIiOiJ1c2VyIn0.helperSig", prompt: "hello" };
+    const url = buildLaunchDeepLink(withHelper);
+    expect(url).toContain(`helperToken=${encodeURIComponent(withHelper.helperToken)}`);
+    expect(url.indexOf("helperToken=")).toBeLessThan(url.indexOf("prompt="));
+    expect(parseLaunchDeepLink(url)).toEqual(withHelper);
+  });
+
+  it("omits helperToken entirely when absent", () => {
+    const url = buildLaunchDeepLink(SAMPLE);
+    expect(url).not.toContain("helperToken=");
+    expect(parseLaunchDeepLink(url)).toEqual(SAMPLE);
+  });
+
+  it("is redacted by redactDeepLinkToken like the bridge token", () => {
+    const withHelper = { ...SAMPLE, helperToken: "super-secret-helper-token" };
+    const redacted = redactDeepLinkToken(buildLaunchDeepLink(withHelper));
+    expect(redacted).toContain("helperToken=***");
+    expect(redacted).not.toContain("super-secret-helper-token");
+  });
+});
+
 describe("redactDeepLinkToken", () => {
   it("replaces the token value with *** and never leaks the secret", () => {
     const url = buildLaunchDeepLink(SAMPLE);

--- a/src/lib/terminal/deep-link.ts
+++ b/src/lib/terminal/deep-link.ts
@@ -35,6 +35,14 @@ export interface LaunchDeepLinkParams {
   session: string;
   /** App-minted, HMAC-signed BRIDGE-role token (secret — keep out of logs). */
   token: string;
+  /**
+   * Optional app-minted HELPER-role token (card cc74a067), carried alongside
+   * the bridge token on every launch so the same click (re)establishes the
+   * helper's persistent control connection to the relay — see
+   * terminal/helper/main.js. A helper that's already connected treats a
+   * redundant one as a no-op. Secret — elided by redactDeepLinkToken.
+   */
+  helperToken?: string;
   /** Optional working directory for the spawned `claude`. */
   cwd?: string;
   /**
@@ -48,12 +56,13 @@ export interface LaunchDeepLinkParams {
 }
 
 /**
- * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…][&prompt=…]`
- * deep link. Throws when a required field is missing so a malformed link is
- * never fired. `prompt` is always the LAST param so the base-link length (and
- * therefore the prompt budget) is stable.
+ * Build a `vibecodes://launch?relay=…&session=…&token=…[&helperToken=…]
+ * [&cwd=…][&prompt=…]` deep link. Throws when a required field is missing so
+ * a malformed link is never fired. `prompt` is always the LAST param so the
+ * base-link length (and therefore the prompt budget) is stable — `helperToken`
+ * is inserted before it, alongside the other credentials.
  */
-export function buildLaunchDeepLink({ relay, session, token, cwd, prompt }: LaunchDeepLinkParams): string {
+export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt }: LaunchDeepLinkParams): string {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
   }
@@ -62,6 +71,7 @@ export function buildLaunchDeepLink({ relay, session, token, cwd, prompt }: Laun
     `session=${encodeURIComponent(session)}`,
     `token=${encodeURIComponent(token)}`,
   ];
+  if (helperToken) parts.push(`helperToken=${encodeURIComponent(helperToken)}`);
   if (cwd) parts.push(`cwd=${encodeURIComponent(cwd)}`);
   if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
@@ -69,12 +79,13 @@ export function buildLaunchDeepLink({ relay, session, token, cwd, prompt }: Laun
 
 /**
  * Redact the secret/user-content params from a launch link so it is safe to
- * log: the `token` (a credential) and the `prompt` (user task/idea content —
- * log only its length via a separate field if needed) both become `***` while
- * relay/session survive for debugging.
+ * log: the `token` and `helperToken` (both credentials) and the `prompt`
+ * (user task/idea content — log only its length via a separate field if
+ * needed) all become `***` while relay/session survive for debugging.
  */
 export function redactDeepLinkToken(url: string): string {
   return url
     .replace(/([?&]token=)[^&]*/g, "$1***")
+    .replace(/([?&]helperToken=)[^&]*/g, "$1***")
     .replace(/([?&]prompt=)[^&]*/g, "$1***");
 }

--- a/src/lib/terminal/helper-relaunch-signal.test.ts
+++ b/src/lib/terminal/helper-relaunch-signal.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  HELPER_IDLE_QUIT_OBSERVED_KEY,
+  RELAUNCH_WITHIN_MS,
+  recordHelperIdleQuitObserved,
+  consumeRecentHelperIdleQuit,
+} from "./helper-relaunch-signal";
+
+describe("helper idle-quit relaunch signal", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("nothing observed -> consume reports false", () => {
+    expect(consumeRecentHelperIdleQuit()).toBe(false);
+  });
+
+  it("records under the versioned key", () => {
+    recordHelperIdleQuitObserved(1_000);
+    expect(window.localStorage.getItem(HELPER_IDLE_QUIT_OBSERVED_KEY)).toBe("1000");
+  });
+
+  it("a mint within the window consumes the flag and reports true", () => {
+    recordHelperIdleQuitObserved(1_000);
+    expect(consumeRecentHelperIdleQuit(1_000 + RELAUNCH_WITHIN_MS - 1)).toBe(true);
+    // consumed — a second check right after finds nothing left to pair.
+    expect(consumeRecentHelperIdleQuit(1_000 + RELAUNCH_WITHIN_MS - 1)).toBe(false);
+  });
+
+  it("exactly at the window boundary no longer counts (strict <)", () => {
+    recordHelperIdleQuitObserved(1_000);
+    expect(consumeRecentHelperIdleQuit(1_000 + RELAUNCH_WITHIN_MS)).toBe(false);
+  });
+
+  it("a mint before the observed time (clock skew) is never treated as a match", () => {
+    recordHelperIdleQuitObserved(5_000);
+    expect(consumeRecentHelperIdleQuit(1_000)).toBe(false);
+  });
+
+  it("a stale flag is cleared even when it doesn't match (never leaks into a later unrelated mint)", () => {
+    recordHelperIdleQuitObserved(1_000);
+    consumeRecentHelperIdleQuit(1_000 + RELAUNCH_WITHIN_MS + 60_000);
+    expect(window.localStorage.getItem(HELPER_IDLE_QUIT_OBSERVED_KEY)).toBeNull();
+  });
+
+  it("garbage in storage is treated as absent, not a crash", () => {
+    window.localStorage.setItem(HELPER_IDLE_QUIT_OBSERVED_KEY, "not-a-number");
+    expect(consumeRecentHelperIdleQuit()).toBe(false);
+  });
+});

--- a/src/lib/terminal/helper-relaunch-signal.ts
+++ b/src/lib/terminal/helper-relaunch-signal.ts
@@ -1,0 +1,59 @@
+// In-app terminal — cheap cross-component signal for the
+// `terminal_helper_relaunch_within_2m` PostHog metric (card cc74a067, design
+// §9 "Linger length — agreed, or do we want telemetry first?").
+//
+// The metric pairs two events that happen in DIFFERENT components, possibly
+// different tabs/reloads apart: the Helper row (in "My sessions") OBSERVING
+// an idle-quit via its own status polling, and a terminal session being
+// MINTED later (use-terminal-session.ts's connect()). There is no shared
+// in-memory state between them, so — mirroring paired-flag.ts's existing
+// pattern for exactly this kind of cross-component, cross-reload signal — a
+// tiny localStorage flag carries the observation across the gap. This is the
+// "derive cheaply from Helper-row status transitions" the card asks for: no
+// new relay field, no server round trip, just a timestamp + a window check.
+//
+// An idle-quit is inferred CLIENT-SIDE from the Helper row's own chip history
+// (see terminal-my-sessions-panel.tsx): connected+winding-down transitioning
+// to not-connected, with no Stop/Update command issued by this client in the
+// interim. That inference lives in the component (it needs the chip
+// transition + "did I just click Stop" context); this module is only the
+// pure, SSR-safe store + the "was one observed recently" check.
+
+/** localStorage key for the last observed helper idle-quit timestamp (unix ms). */
+export const HELPER_IDLE_QUIT_OBSERVED_KEY = "vibecodes:terminal:helper-idle-quit-observed-at";
+
+/** The metric's own window: a session mint within this long of an observed
+ *  idle-quit counts as "the user came right back". */
+export const RELAUNCH_WITHIN_MS = 2 * 60 * 1000;
+
+/** Record that an idle-quit was just observed (the Helper row calls this on
+ *  the winding-down -> not-running transition, absent a local Stop/Update). */
+export function recordHelperIdleQuitObserved(nowMs: number = Date.now()): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(HELPER_IDLE_QUIT_OBSERVED_KEY, String(nowMs));
+  } catch {
+    // Storage disabled/full — worst case this one observation is never paired.
+  }
+}
+
+/**
+ * Check (and CONSUME — a single relaunch should only ever fire the metric
+ * once) whether a session mint happening right now falls within
+ * RELAUNCH_WITHIN_MS of a previously observed idle-quit. Always clears the
+ * stored timestamp when it's stale or consumed, so a second, unrelated mint
+ * later never double-counts the same idle-quit.
+ */
+export function consumeRecentHelperIdleQuit(nowMs: number = Date.now()): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = window.localStorage.getItem(HELPER_IDLE_QUIT_OBSERVED_KEY);
+    if (raw === null) return false;
+    window.localStorage.removeItem(HELPER_IDLE_QUIT_OBSERVED_KEY);
+    const observedAt = Number(raw);
+    if (!Number.isFinite(observedAt)) return false;
+    return nowMs - observedAt >= 0 && nowMs - observedAt < RELAUNCH_WITHIN_MS;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/terminal/helper-row.test.ts
+++ b/src/lib/terminal/helper-row.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveHelperChip,
+  shouldShowStopButton,
+  stopButtonLabel,
+  stopConfirmBody,
+  updateNudgeCopy,
+  formatHelperEventAge,
+  type HelperStatus,
+} from "./helper-row";
+
+function status(overrides: Partial<HelperStatus> = {}): HelperStatus {
+  return {
+    connected: false,
+    version: null,
+    machineLabel: null,
+    alwaysOn: false,
+    stoppedUnexpectedly: false,
+    lastEventAt: null,
+    ...overrides,
+  };
+}
+
+describe("deriveHelperChip", () => {
+  it("null status (still loading) -> null chip", () => {
+    expect(deriveHelperChip(null, 0)).toBeNull();
+  });
+
+  it("connected + sessions running -> running", () => {
+    const chip = deriveHelperChip(status({ connected: true }), 2);
+    expect(chip).toEqual({
+      kind: "running",
+      label: "Helper running",
+      subline: "The small app that connects terminals to this Mac.",
+    });
+  });
+
+  it("connected + zero sessions -> winding-down (the linger window)", () => {
+    const chip = deriveHelperChip(status({ connected: true }), 0);
+    expect(chip?.kind).toBe("winding-down");
+    expect(chip?.label).toBe("Winding down");
+  });
+
+  it("not connected, never flagged unclean -> not-running", () => {
+    const chip = deriveHelperChip(status({ connected: false, stoppedUnexpectedly: false }), 0);
+    expect(chip?.kind).toBe("not-running");
+  });
+
+  it("not connected + stoppedUnexpectedly -> stopped-unexpectedly, regardless of session count", () => {
+    const chip = deriveHelperChip(status({ connected: false, stoppedUnexpectedly: true }), 3);
+    expect(chip?.kind).toBe("stopped-unexpectedly");
+    expect(chip?.label).toBe("Stopped unexpectedly");
+  });
+});
+
+describe("shouldShowStopButton / stopButtonLabel", () => {
+  it("shows Stop while running", () => {
+    const chip = deriveHelperChip(status({ connected: true }), 1);
+    expect(shouldShowStopButton(chip)).toBe(true);
+    expect(stopButtonLabel(chip)).toBe("Stop");
+  });
+
+  it("shows 'Stop now' while winding down", () => {
+    const chip = deriveHelperChip(status({ connected: true }), 0);
+    expect(shouldShowStopButton(chip)).toBe(true);
+    expect(stopButtonLabel(chip)).toBe("Stop now");
+  });
+
+  it("hides the Stop button once the helper isn't connected", () => {
+    const notRunning = deriveHelperChip(status({ connected: false }), 0);
+    const crashed = deriveHelperChip(status({ connected: false, stoppedUnexpectedly: true }), 0);
+    expect(shouldShowStopButton(notRunning)).toBe(false);
+    expect(shouldShowStopButton(crashed)).toBe(false);
+  });
+
+  it("a null chip (loading) never shows Stop", () => {
+    expect(shouldShowStopButton(null)).toBe(false);
+  });
+});
+
+describe("copy strings", () => {
+  it("stopConfirmBody pluralizes correctly", () => {
+    expect(stopConfirmBody(1)).toBe(
+      "This ends your 1 session. Claude stops on your machine — your files and unpushed changes stay on disk.",
+    );
+    expect(stopConfirmBody(2)).toBe(
+      "This ends your 2 sessions. Claude stops on your machine — your files and unpushed changes stay on disk.",
+    );
+  });
+
+  it("updateNudgeCopy interpolates the reported version", () => {
+    expect(updateNudgeCopy("0.3.0")).toBe("A newer terminal helper is available (v0.3.0).");
+  });
+});
+
+describe("formatHelperEventAge", () => {
+  const NOW = 1_700_000_000_000;
+
+  it("under a minute -> 'just now'", () => {
+    expect(formatHelperEventAge(NOW - 30_000, NOW)).toBe("just now");
+  });
+
+  it("minutes -> 'Nm ago'", () => {
+    expect(formatHelperEventAge(NOW - 5 * 60_000, NOW)).toBe("5m ago");
+  });
+
+  it("hours -> 'Nh ago'", () => {
+    expect(formatHelperEventAge(NOW - 3 * 60 * 60_000, NOW)).toBe("3h ago");
+  });
+
+  it("a future timestamp (clock skew) clamps to 'just now', never negative", () => {
+    expect(formatHelperEventAge(NOW + 10_000, NOW)).toBe("just now");
+  });
+});

--- a/src/lib/terminal/helper-row.ts
+++ b/src/lib/terminal/helper-row.ts
@@ -1,0 +1,117 @@
+// In-app terminal — the "My sessions" panel's Helper row (card cc74a067,
+// design §5a). Pure status→chip derivation + the exact copy strings from the
+// design doc, decoupled from the fetch/poll plumbing so it's fully
+// unit-testable without a network mock.
+//
+// The relay's GET /helper/status (see terminal/relay/src/helper-status.js →
+// computeHelperStatus, mirrored 1:1 by this HelperStatus type) already decides
+// "connected" vs "stopped unexpectedly" durably server-side. The ONE thing it
+// can't know is whether any SESSIONS are live right now — that's the My
+// sessions panel's own list, already fetched for the rest of the popover — so
+// the "winding down" (lingering) state is derived HERE, by combining the two:
+// connected + zero sessions is exactly the linger window (design §2's
+// Active → Lingering transition).
+
+/** Mirrors terminal/relay/src/helper-status.js's computeHelperStatus() output. */
+export interface HelperStatus {
+  connected: boolean;
+  version: string | null;
+  machineLabel: string | null;
+  alwaysOn: boolean;
+  stoppedUnexpectedly: boolean;
+  lastEventAt: number | null;
+}
+
+export type HelperChipKind = "running" | "winding-down" | "not-running" | "stopped-unexpectedly";
+
+export interface HelperChip {
+  kind: HelperChipKind;
+  /** The pill's own text (design §5 copy table — "Chip · …"). */
+  label: string;
+  /** The explanatory line under the chip. Never colour-alone (design §7). */
+  subline: string;
+}
+
+/**
+ * Derive the Helper row's chip from the relay's status + the panel's own live
+ * session count. `status === null` means "still loading" — the caller decides
+ * how to render that (e.g. nothing, or a neutral placeholder); this function
+ * only maps a SETTLED status.
+ */
+export function deriveHelperChip(status: HelperStatus | null, sessionCount: number): HelperChip | null {
+  if (!status) return null;
+  if (status.connected) {
+    return sessionCount > 0
+      ? {
+          kind: "running",
+          label: "Helper running",
+          subline: "The small app that connects terminals to this Mac.",
+        }
+      : {
+          kind: "winding-down",
+          label: "Winding down",
+          subline: "No sessions left — the helper quits itself in about a minute.",
+        };
+  }
+  return status.stoppedUnexpectedly
+    ? {
+        kind: "stopped-unexpectedly",
+        label: "Stopped unexpectedly",
+        subline: "It starts fresh next time you launch a terminal.",
+      }
+    : {
+        kind: "not-running",
+        label: "Helper not running",
+        subline: "It starts automatically next time you launch a terminal.",
+      };
+}
+
+/** Only "running" and "winding-down" offer a Stop affordance (design §4 mocks). */
+export function shouldShowStopButton(chip: HelperChip | null): boolean {
+  return chip?.kind === "running" || chip?.kind === "winding-down";
+}
+
+/** "Stop" while running, "Stop now" while lingering (design §5 copy table). */
+export function stopButtonLabel(chip: HelperChip | null): string {
+  return chip?.kind === "winding-down" ? "Stop now" : "Stop";
+}
+
+// ── exact copy strings (design §5) ────────────────────────────────────────────
+
+export const HELPER_ROW_STOP_TOAST = "Helper stopped. It starts again next time you launch a terminal.";
+export const HELPER_ROW_STOP_FAILED_TOAST =
+  "Couldn't reach the helper — it may already be stopped. Check again in a moment.";
+
+export const STOP_CONFIRM_HEADING = "Stop the helper?";
+export function stopConfirmBody(sessionCount: number): string {
+  return `This ends your ${sessionCount} session${sessionCount === 1 ? "" : "s"}. Claude stops on your machine — your files and unpushed changes stay on disk.`;
+}
+
+export function updateNudgeCopy(newVersion: string): string {
+  return `A newer terminal helper is available (v${newVersion}).`;
+}
+
+/** Relative age for the "stopped unexpectedly" chip's timestamp (design §5a
+ *  mock shows a clock time; this mirrors the panel's existing session-age
+ *  idiom — src/lib/terminal/session-registry.ts's formatSessionAge — for one
+ *  consistent "how long ago" vocabulary across the popover). */
+export function formatHelperEventAge(atMs: number, nowMs: number = Date.now()): string {
+  const totalMinutes = Math.max(0, Math.floor((nowMs - atMs) / 60_000));
+  if (totalMinutes < 1) return "just now";
+  if (totalMinutes < 60) return `${totalMinutes}m ago`;
+  const hours = Math.floor(totalMinutes / 60);
+  return `${hours}h ago`;
+}
+
+// ── always-on ("Keep helper ready") — approved for v1 (card cc74a067's
+// design-review note), despite the design doc's own "follow-up" label. ───────
+//
+// BINDING DEVIATION from the design doc's exact consent copy: the doc (§5,
+// "Always-on toggle") promises "terminals open instantly". Nick's approval
+// note for shipping this in v1 requires the WEAKER, honest claim "connect
+// faster" instead — v1 has no auto-discovery/zero-prompt start (explicitly
+// out of scope, see the card's "what NOT to build" list), so "open instantly"
+// would overpromise what always-on alone delivers this release.
+export const ALWAYS_ON_LABEL = "Keep helper ready";
+export const ALWAYS_ON_CONSENT_BODY =
+  "The helper starts when you log in to your Mac and stays running so terminals connect faster. It shows an icon in your menu bar, and you can turn this off or quit it there any time.";

--- a/src/lib/terminal/helper-update-flow.test.ts
+++ b/src/lib/terminal/helper-update-flow.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  INITIAL_UPDATE_FLOW_STATE,
+  updateFlowReducer,
+  updateConfirmBody,
+  type UpdateFlowState,
+} from "./helper-update-flow";
+
+describe("updateFlowReducer", () => {
+  it("no live sessions -> update-clicked skips the confirm, straight to quiescing", () => {
+    const next = updateFlowReducer(INITIAL_UPDATE_FLOW_STATE, { type: "update-clicked", sessionCount: 0 });
+    expect(next).toEqual({ phase: "quiescing" });
+  });
+
+  it("live sessions -> update-clicked goes to confirming with the count carried", () => {
+    const next = updateFlowReducer(INITIAL_UPDATE_FLOW_STATE, { type: "update-clicked", sessionCount: 2 });
+    expect(next).toEqual({ phase: "confirming", sessionCount: 2 });
+  });
+
+  it("confirming -> confirmed -> quiescing", () => {
+    const confirming: UpdateFlowState = { phase: "confirming", sessionCount: 2 };
+    expect(updateFlowReducer(confirming, { type: "confirmed" })).toEqual({ phase: "quiescing" });
+  });
+
+  it("confirming -> cancelled -> idle (cancel is free, nothing happened yet)", () => {
+    const confirming: UpdateFlowState = { phase: "confirming", sessionCount: 2 };
+    expect(updateFlowReducer(confirming, { type: "cancelled" })).toEqual({ phase: "idle" });
+  });
+
+  it("quiescing -> quiesce-settled -> ready", () => {
+    const quiescing: UpdateFlowState = { phase: "quiescing" };
+    expect(updateFlowReducer(quiescing, { type: "quiesce-settled" })).toEqual({ phase: "ready" });
+  });
+
+  it("quiescing -> quiesce-timed-out -> quiesce-timeout", () => {
+    const quiescing: UpdateFlowState = { phase: "quiescing" };
+    expect(updateFlowReducer(quiescing, { type: "quiesce-timed-out" })).toEqual({ phase: "quiesce-timeout" });
+  });
+
+  it("reset returns to idle from any phase", () => {
+    expect(updateFlowReducer({ phase: "ready" }, { type: "reset" })).toEqual(INITIAL_UPDATE_FLOW_STATE);
+    expect(updateFlowReducer({ phase: "quiesce-timeout" }, { type: "reset" })).toEqual(INITIAL_UPDATE_FLOW_STATE);
+  });
+
+  it("out-of-phase events are no-ops (never transition from an unrelated phase)", () => {
+    expect(updateFlowReducer(INITIAL_UPDATE_FLOW_STATE, { type: "confirmed" })).toEqual(INITIAL_UPDATE_FLOW_STATE);
+    expect(updateFlowReducer(INITIAL_UPDATE_FLOW_STATE, { type: "quiesce-settled" })).toEqual(
+      INITIAL_UPDATE_FLOW_STATE,
+    );
+    const ready: UpdateFlowState = { phase: "ready" };
+    expect(updateFlowReducer(ready, { type: "cancelled" })).toEqual(ready);
+  });
+});
+
+describe("updateConfirmBody", () => {
+  it("pluralizes the session count", () => {
+    expect(updateConfirmBody(1)).toBe(
+      "Your 1 running session will end first — Claude stops on your machine, and your files stay where they are. You can start fresh sessions as soon as the update finishes.",
+    );
+    expect(updateConfirmBody(2)).toBe(
+      "Your 2 running sessions will end first — Claude stops on your machine, and your files stay where they are. You can start fresh sessions as soon as the update finishes.",
+    );
+  });
+});

--- a/src/lib/terminal/helper-update-flow.ts
+++ b/src/lib/terminal/helper-update-flow.ts
@@ -1,0 +1,82 @@
+// In-app terminal — the Helper row's "stand-down-first" update flow (card
+// cc74a067, design §3 flows A/D and §5c). Pure state machine: given the
+// current phase and an event, what's the next phase — decoupled from the
+// actual end-all/quiesce/download network calls, which the Helper row
+// component drives (each network step just dispatches the matching event).
+//
+// The flow (design §1 decision 4, "Update quiescence"):
+//   no live sessions  -> quiesce immediately, then download
+//   live sessions     -> inline confirm ("End sessions & update") -> end-all
+//                        -> quiesce -> download
+// Either path converges on "quiescing" before the download ever starts, so
+// the update never races a still-running helper (the whole point: drag-to-
+// Applications must always succeed, no Finder "in use" dialog).
+
+export type UpdateFlowPhase = "idle" | "confirming" | "quiescing" | "ready" | "quiesce-timeout";
+
+export type UpdateFlowState =
+  | { phase: "idle" }
+  | { phase: "confirming"; sessionCount: number }
+  | { phase: "quiescing" }
+  | { phase: "ready" }
+  | { phase: "quiesce-timeout" };
+
+export type UpdateFlowEvent =
+  | { type: "update-clicked"; sessionCount: number }
+  | { type: "confirmed" }
+  | { type: "cancelled" }
+  | { type: "quiesce-settled" }
+  | { type: "quiesce-timed-out" }
+  | { type: "reset" };
+
+export const INITIAL_UPDATE_FLOW_STATE: UpdateFlowState = { phase: "idle" };
+
+/** How long to wait for the helper to confirm quiesced before falling back to
+ *  the timeout copy (design §3 flow A caption: "within ~10 s"). The download
+ *  still starts either way — this only swaps which notice is shown. */
+export const QUIESCE_TIMEOUT_MS = 10_000;
+
+/**
+ * Advance the update flow. Pure — no I/O. The caller (the Helper row) is
+ * responsible for actually calling end-all / the quiesce command / the
+ * download route at the phase transitions that require it (idle->quiescing
+ * with no confirm needed, confirming->quiescing after end-all, quiescing->
+ * ready/quiesce-timeout once the quiesce settles or times out).
+ */
+export function updateFlowReducer(state: UpdateFlowState, event: UpdateFlowEvent): UpdateFlowState {
+  switch (event.type) {
+    case "update-clicked":
+      // No sessions -> skip the confirm entirely and go straight to quiescing
+      // (design flow D: "No sessions are running, so there is no confirmation
+      // step"). Sessions live -> the inline confirm first (flow A).
+      return event.sessionCount > 0
+        ? { phase: "confirming", sessionCount: event.sessionCount }
+        : { phase: "quiescing" };
+    case "confirmed":
+      return state.phase === "confirming" ? { phase: "quiescing" } : state;
+    case "cancelled":
+      return state.phase === "confirming" ? { phase: "idle" } : state;
+    case "quiesce-settled":
+      return state.phase === "quiescing" ? { phase: "ready" } : state;
+    case "quiesce-timed-out":
+      return state.phase === "quiescing" ? { phase: "quiesce-timeout" } : state;
+    case "reset":
+      return INITIAL_UPDATE_FLOW_STATE;
+    default:
+      return state;
+  }
+}
+
+// ── exact copy strings (design §5) ────────────────────────────────────────────
+
+export const UPDATE_CONFIRM_HEADING = "Update the helper?";
+export function updateConfirmBody(sessionCount: number): string {
+  return `Your ${sessionCount} running session${sessionCount === 1 ? "" : "s"} will end first — Claude stops on your machine, and your files stay where they are. You can start fresh sessions as soon as the update finishes.`;
+}
+export const UPDATE_CONFIRM_CANCEL_LABEL = "Not now";
+export const UPDATE_CONFIRM_ACCEPT_LABEL = "End sessions & update";
+
+export const UPDATE_READY_COPY =
+  "Ready to update — the helper has closed. Drag the new VibeCodes app into Applications to finish.";
+export const UPDATE_QUIESCE_TIMEOUT_COPY =
+  'The helper is taking a moment to close. If the install says the app is "in use", wait a few seconds and try again.';

--- a/src/lib/terminal/helper-version.ts
+++ b/src/lib/terminal/helper-version.ts
@@ -17,8 +17,10 @@
 /** The minimum helper version we no longer nudge the user to update away from.
  *  Bump this in lockstep with terminal/helper/package.json's version — see
  *  that file's header comment and docs/release-process.md for the release
- *  checklist. */
-export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.2.1";
+ *  checklist. 0.3.0 (card cc74a067) is the first release with the helper
+ *  lifecycle rework — quit-when-idle, crash log-and-exit, and the "Keep
+ *  helper ready" opt-in. */
+export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.0";
 
 export type HelperVersionParts = readonly [number, number, number];
 

--- a/terminal/helper/electron-builder.yml
+++ b/terminal/helper/electron-builder.yml
@@ -22,6 +22,8 @@ directories:
 files:
   - main.js
   - proto-reg.js
+  - lifecycle.js
+  - tray-icon.js
   - package.json
 
 extraResources:

--- a/terminal/helper/lifecycle.js
+++ b/terminal/helper/lifecycle.js
@@ -1,0 +1,53 @@
+// Pure quit-when-idle decision logic for the helper (card cc74a067).
+//
+// Extracted out of main.js's bridge-count bookkeeping — same reason proto-reg.js
+// is separate from main.js's protocol registration: a pure, dependency-free
+// module is trivially unit-testable under plain node (terminal/test/
+// helper-lifecycle-module.test.mjs), where main.js itself (an Electron entry
+// point) is not importable outside a running app.
+//
+// The rule (design §1, decision 2): "quit-when-idle by default" — a 60s linger
+// after the LAST bridge exits, cancelled by any new bridge attaching within the
+// window — UNLESS "Keep helper ready" (always-on) is on, in which case the
+// helper never lingers toward a quit at all. main.js owns the actual setTimeout;
+// this module only decides WHAT that timer should do, given the current bridge
+// count and the always-on setting — so the timing itself needs no test double.
+
+/** The linger window (design §1, decision 2): 60s after the last session ends. */
+const LINGER_MS = 60 * 1000;
+
+/**
+ * Decide what the linger timer should do right now. Called every time the live
+ * bridge count changes (a child bridge exits, a new one is forked) and every
+ * time the always-on setting itself changes.
+ *
+ * @param {{ bridgeCount: number, alwaysOn: boolean }} args
+ * @returns {"start"|"cancel"}
+ *   "start"  - (re)arm a fresh LINGER_MS timer: no bridges are live and
+ *              always-on is off, so the helper should start counting down
+ *              toward a clean quit.
+ *   "cancel" - clear any pending timer: either a bridge is live (Active), or
+ *              always-on is on (never linger toward quit while it's set).
+ */
+function decideLingerAction({ bridgeCount, alwaysOn }) {
+  if (alwaysOn) return "cancel";
+  return bridgeCount > 0 ? "cancel" : "start";
+}
+
+/**
+ * The linger timer just fired — should the helper actually quit? Re-checked
+ * against the CURRENT state rather than trusted from when the timer was set,
+ * because a new bridge can attach (or always-on can flip on) in the window
+ * between arming the timer and it firing; JS timers don't self-cancel on a
+ * state change, only `decideLingerAction`'s "cancel" result (acted on by the
+ * caller) does that; this is the belt-and-braces re-check for anything that
+ * slips through (e.g. a state change that raced the timer callback itself).
+ *
+ * @param {{ bridgeCount: number, alwaysOn: boolean }} args
+ * @returns {boolean}
+ */
+function shouldQuitOnLingerExpiry({ bridgeCount, alwaysOn }) {
+  return !alwaysOn && bridgeCount === 0;
+}
+
+module.exports = { LINGER_MS, decideLingerAction, shouldQuitOnLingerExpiry };

--- a/terminal/helper/main.js
+++ b/terminal/helper/main.js
@@ -1,36 +1,62 @@
-// VibeCodes macOS helper — SLICE 7 (the "install once" piece).
+// VibeCodes macOS helper — SLICE 7 (the "install once" piece) + card cc74a067
+// (helper lifecycle: quit-when-idle, crash handling, the standing control
+// connection, and the "Keep helper ready" always-on opt-in).
 //
 // A thin, installable, URL-scheme-registered wrapper around the existing
-// terminal/bridge. Its ONLY jobs:
+// terminal/bridge. Its jobs:
 //
 //   1. Register the `vibecodes://` URL scheme so the OS routes the app's signed
 //      deep link here (Info.plist CFBundleURLTypes is emitted by electron-builder
 //      from `protocols` — see electron-builder.yml; we also call
 //      app.setAsDefaultProtocolClient at runtime for dev/registration).
-//   2. On `vibecodes://launch?relay&session&token[&cwd]`, run the EXISTING bridge
-//      logic with that URL as `--launch-url`. We do NOT re-implement the PTY/relay
-//      plumbing — we `fork` terminal/bridge/src/index.js using Electron-as-Node
-//      (ELECTRON_RUN_AS_NODE=1). node-pty 1.x is N-API (ABI-stable across Node and
-//      Electron) so its prebuilt pty.node loads unchanged; the bridge itself does
-//      the macOS spawn-helper chmod.
+//   2. On `vibecodes://launch?relay&session&token[&helperToken][&cwd]`, run the
+//      EXISTING bridge logic with that URL as `--launch-url`. We do NOT
+//      re-implement the PTY/relay plumbing — we `fork` terminal/bridge/src/
+//      index.js using Electron-as-Node (ELECTRON_RUN_AS_NODE=1). node-pty 1.x
+//      is N-API (ABI-stable across Node and Electron) so its prebuilt pty.node
+//      loads unchanged; the bridge itself does the macOS spawn-helper chmod.
+//   3. Hold a SEPARATE, standing, per-owner CONTROL connection to the relay
+//      (design §2/§3) for the whole process lifetime — carrying stop/quiesce/
+//      set-always-on commands in and presence/version/always-on out. This is
+//      independent of any bridge child: it opens at launch (from a fresh deep
+//      link's `helperToken`, or a persisted one on a login-item restart) and
+//      stays open through both "Active" (bridges running) and "Lingering"
+//      (idle, counting down) states.
+//   4. Manage its own lifecycle (design §1 decision 2): quit-when-idle by
+//      default (a 60s linger after the last bridge exits — see lifecycle.js),
+//      or never quit while "Keep helper ready" (always-on) is on, in which
+//      case it also registers as a login item and shows a menu-bar icon
+//      (design §5b).
+//   5. Crash log-and-exit: an uncaught error is written to a log file, best-
+//      effort goodbye'd to the relay, and the process exits — never a native
+//      dialog (design §1 decision 5).
 //
-// Headless background helper: no window, no dock icon. It stays alive while a
-// bridge child is running and quits shortly after the last one exits, so it does
-// not linger as a resident process. A subsequent link just cold-launches it again.
+// Headless background helper: no window, no dock icon.
 
-const { app } = require("electron");
+const {
+  app,
+  dialog,
+  Menu,
+  nativeImage,
+  shell,
+  Tray,
+} = require("electron");
 const { fork } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
 const { shouldRegisterProtocolInDev } = require("./proto-reg");
+const lifecycle = require("./lifecycle");
+const { TRAY_ICON_PNG_BASE64 } = require("./tray-icon");
 
 const LAUNCH_PREFIX = "vibecodes://";
 
 // This helper's OWN version — the single source of truth for the update-nudge
-// feature (release-gate rework 2a/2b). Forked through to the bridge as
-// BRIDGE_HELPER_VERSION below; the bridge announces it to the relay, which
-// forwards it to the browser dock (src/lib/terminal/helper-version.ts decides
-// whether that's stale enough to nudge). Bump THIS package.json's `version` on
+// feature (release-gate rework 2a/2b) AND the version this helper announces on
+// its own control connection (helper/status's `version` field). Forked through
+// to the bridge as BRIDGE_HELPER_VERSION below; the bridge announces it to the
+// relay too, via its own bridge leg. Bump THIS package.json's `version` on
 // every release — nothing else needs touching for the announced version to
 // follow.
 const HELPER_VERSION = require("./package.json").version;
@@ -54,6 +80,28 @@ const SHARED_REAP = app.isPackaged
 const SHARED_ALLOWLIST = app.isPackaged
   ? path.join(process.resourcesPath, "shared", "relay-allowlist.mjs")
   : path.resolve(__dirname, "..", "shared", "relay-allowlist.mjs");
+
+// The helper role's mint/decode helpers (helperSessionId is baked into the
+// token's own `sid` claim by mintHelperToken, so decodeTokenClaims is all this
+// process needs to learn its own session id — see connectControl below).
+const SHARED_SESSION_TOKEN = app.isPackaged
+  ? path.join(process.resourcesPath, "shared", "session-token.mjs")
+  : path.resolve(__dirname, "..", "shared", "session-token.mjs");
+
+const SHARED_CONTROL_FRAMES = app.isPackaged
+  ? path.join(process.resourcesPath, "shared", "control-frames.mjs")
+  : path.resolve(__dirname, "..", "shared", "control-frames.mjs");
+
+// The control connection is plain `ws` — the SAME package the bridge already
+// depends on (terminal/bridge/package.json), shipped alongside it under
+// Resources/bridge/node_modules by the SAME extraResources copy that ships the
+// bridge itself (electron-builder.yml never excludes node_modules there). No
+// new dependency: this just resolves the one bridge/src/index.js already uses,
+// exactly like BRIDGE_ENTRY above reuses the bridge's own code.
+const WS_MODULE = app.isPackaged
+  ? path.join(process.resourcesPath, "bridge", "node_modules", "ws")
+  : path.resolve(__dirname, "..", "bridge", "node_modules", "ws");
+const WebSocket = require(WS_MODULE);
 
 // ── logging (metadata only — NEVER log the deep-link token) ───────────────────
 const t0 = Date.now();
@@ -84,7 +132,115 @@ async function allowlistMod() {
   return _allowlist;
 }
 
-// ── child-bridge bookkeeping + idle quit ─────────────────────────────────────
+let _sessionToken = null;
+async function sessionTokenMod() {
+  if (!_sessionToken) _sessionToken = await import(pathToFileURL(SHARED_SESSION_TOKEN).href);
+  return _sessionToken;
+}
+
+let _controlFrames = null;
+async function controlFramesMod() {
+  if (!_controlFrames) _controlFrames = await import(pathToFileURL(SHARED_CONTROL_FRAMES).href);
+  return _controlFrames;
+}
+
+// ── userData persistence (settings + the last control credentials) ───────────
+// Both are small, best-effort JSON files under the helper's own userData dir —
+// never anything sensitive beyond the short-lived control token itself (a
+// device credential, not a password). A missing/corrupt file is treated
+// exactly like "nothing persisted yet"; a write failure is logged and ignored
+// (nothing here is load-bearing for this launch — only for a LATER restart).
+function settingsPath() {
+  return path.join(app.getPath("userData"), "helper-settings.json");
+}
+function controlCredentialsPath() {
+  return path.join(app.getPath("userData"), "helper-control-credentials.json");
+}
+function crashLogPath() {
+  return path.join(app.getPath("userData"), "helper-crash.log");
+}
+
+/** @returns {{ alwaysOn: boolean }} */
+function loadSettings() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(settingsPath(), "utf8"));
+    return { alwaysOn: raw?.alwaysOn === true };
+  } catch {
+    return { alwaysOn: false };
+  }
+}
+function saveSettings(settings) {
+  try {
+    fs.mkdirSync(path.dirname(settingsPath()), { recursive: true });
+    fs.writeFileSync(settingsPath(), JSON.stringify(settings), "utf8");
+  } catch (e) {
+    log("warn", "could not persist helper settings", { err: String(e?.message || e) });
+  }
+}
+
+/** @returns {{ token: string, relay: string } | null} */
+function loadControlCredentials() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(controlCredentialsPath(), "utf8"));
+    if (typeof raw?.token === "string" && typeof raw?.relay === "string") return raw;
+    return null;
+  } catch {
+    return null;
+  }
+}
+function saveControlCredentials(creds) {
+  try {
+    fs.mkdirSync(path.dirname(controlCredentialsPath()), { recursive: true });
+    fs.writeFileSync(controlCredentialsPath(), JSON.stringify(creds), "utf8");
+  } catch (e) {
+    log("warn", "could not persist control credentials", { err: String(e?.message || e) });
+  }
+}
+
+// ── crash handling (design §1 decision 5: log-and-exit, never a dialog) ──────
+// Registered FIRST, before anything else runs, so even a startup-time throw is
+// caught. Node shows its own fatal-error stack trace + exit(1) ONLY when
+// `uncaughtException` has NO listener — attaching this one IS the suppression
+// (there is no separate Electron dialog to additionally silence for a plain
+// main-process JS exception; the risk this guards against is a future
+// dependency adding one, or a renderer-side crash reporter default).
+let crashing = false;
+function handleCrash(kind, err) {
+  if (crashing) return; // a crash during crash handling — don't loop
+  crashing = true;
+  const message = err?.stack || err?.message || String(err);
+  try {
+    fs.mkdirSync(path.dirname(crashLogPath()), { recursive: true });
+    fs.appendFileSync(
+      crashLogPath(),
+      `[${new Date().toISOString()}] ${kind}: ${message}\n`,
+      "utf8",
+    );
+  } catch {
+    /* best effort — a failed crash log must never block the exit below */
+  }
+  log("error", "crash — logging and exiting", { kind, err: message });
+  // Best-effort goodbye — no await (the event loop may be unhealthy); a failed
+  // send just means this disconnect is later classed "stopped unexpectedly",
+  // which is the honest outcome for an actual crash anyway.
+  try {
+    sendGoodbye("crash");
+  } catch {
+    /* ignore */
+  }
+  // Kill child bridges directly — no verified-kill escalation here (that's an
+  // async, multi-second process this handler cannot safely wait through); the
+  // crash log preserves diagnosability if a grandchild is left needing a
+  // manual sweep, which is the same trade-off an external `kill -9` already has.
+  for (const child of children) {
+    try { child.kill(); } catch { /* ignore */ }
+  }
+  app.exit(1);
+}
+process.on("uncaughtException", (err) => handleCrash("uncaughtException", err));
+process.on("unhandledRejection", (reason) => handleCrash("unhandledRejection", reason));
+
+// ── child-bridge bookkeeping + quit-when-idle (design §1/§2) ─────────────────
 const children = new Set();
 // bridge child -> its PTY child's pid (the grandchild — `claude`). Reported by
 // the bridge over IPC ({type:"pty-pid"}) right after its pty.spawn. Needed
@@ -92,28 +248,49 @@ const children = new Set();
 // if the bridge dies uncleanly (SIGKILL — it can run no cleanup), WE are the
 // only thing left that can verify the grandchild died and escalate if not.
 const ptyPids = new Map();
-// In-flight grandchild verifications. The idle-quit must NOT fire — and
-// before-quit must not let the process vanish — while one is pending.
+// In-flight grandchild verifications. The linger timer must not conclude the
+// helper is safe to quit — and before-quit must not let the process vanish —
+// while one is pending.
 const activeReaps = new Set();
 let quitting = false;
-let quitTimer = null;
-const IDLE_QUIT_MS = 2000; // grace after the last bridge exits before we quit
+let quitReason = "quit"; // default if app.quit() is ever reached some other way
+let lingerTimer = null;
 const REAP_HUP_WAIT_MS = 1000; // grandchild SIGHUP grace before SIGKILL(+group)
 
-function scheduleQuitIfIdle() {
+// "Keep helper ready" (design §1 decision 1/§3 follow-up, approved for v1 —
+// see the card's design-review note). Loaded synchronously at module load so
+// every code path below (including the very first updateLingerTimer() call)
+// sees the persisted value from the start, not a default that flips under it
+// a tick later.
+let alwaysOn = loadSettings().alwaysOn;
+
+/**
+ * (Re)decide the linger timer given the CURRENT bridge count + always-on
+ * setting — see lifecycle.js for the pure rule. Called on every bridge-count
+ * change and every always-on change.
+ */
+function updateLingerTimer() {
   if (quitting) return;
-  if (children.size > 0 || activeReaps.size > 0) {
-    if (quitTimer) { clearTimeout(quitTimer); quitTimer = null; }
+  const action = lifecycle.decideLingerAction({ bridgeCount: children.size, alwaysOn });
+  if (action === "cancel") {
+    if (lingerTimer) {
+      clearTimeout(lingerTimer);
+      lingerTimer = null;
+    }
     return;
   }
-  if (quitTimer) clearTimeout(quitTimer);
-  quitTimer = setTimeout(() => {
-    if (children.size === 0 && activeReaps.size === 0) {
-      log("info", "idle — no active sessions, quitting");
-      app.quit();
-    }
-  }, IDLE_QUIT_MS);
-  quitTimer.unref?.();
+  // action === "start": (re)arm a fresh window — a new deep link / session
+  // during an existing linger cancels then restarts it via this same path.
+  if (lingerTimer) clearTimeout(lingerTimer);
+  lingerTimer = setTimeout(() => {
+    lingerTimer = null;
+    if (activeReaps.size > 0) return; // still verifying a grandchild; its own
+    // completion below calls updateLingerTimer() again, which re-arms us.
+    if (!lifecycle.shouldQuitOnLingerExpiry({ bridgeCount: children.size, alwaysOn })) return;
+    log("info", "idle for the linger window — quitting", { ms: lifecycle.LINGER_MS });
+    beginCleanQuit("idle-quit");
+  }, lifecycle.LINGER_MS);
+  lingerTimer.unref?.();
 }
 
 /**
@@ -141,7 +318,8 @@ function reapGrandchild(pid, why) {
   activeReaps.add(p);
   p.finally(() => {
     activeReaps.delete(p);
-    scheduleQuitIfIdle();
+    updateLingerTimer();
+    refreshTray();
   });
   return p;
 }
@@ -150,7 +328,10 @@ function reapGrandchild(pid, why) {
  * Hand a `vibecodes://launch?…` URL to the existing bridge. Validates with the
  * SHARED parser first (so we never fork on garbage), then forks the bridge with
  * `--launch-url`. The bridge re-parses the same string (single source of truth)
- * and connects as the relay's bridge leg.
+ * and connects as the relay's bridge leg. Also (re)establishes the standing
+ * control connection from the link's `helperToken`, when present — see
+ * connectControl below; an already-connected helper treats a redundant one as
+ * a no-op (the deep-link module's own doc comment).
  */
 async function handleLaunchUrl(rawUrl) {
   const { parseLaunchDeepLink, redactDeepLinkToken } = await shared();
@@ -177,6 +358,14 @@ async function handleLaunchUrl(rawUrl) {
 
   log("info", "launching bridge for deep link", { url: redactDeepLinkToken(rawUrl) });
 
+  // Every launch that carries a helperToken (re)establishes/refreshes the
+  // control connection — persisting the credential so a later LaunchAgent
+  // restart (no deep link at all) can reconnect with the SAME token.
+  if (parsed.helperToken) {
+    saveControlCredentials({ token: parsed.helperToken, relay: parsed.relay });
+    void connectControl(parsed.relay, parsed.helperToken);
+  }
+
   // ELECTRON_RUN_AS_NODE=1 → the forked process is plain Node (Electron's bundled
   // runtime), so the bridge runs exactly as it does from the CLI. We pass our env
   // through verbatim so test seams (e.g. BRIDGE_CMD) keep working; in production
@@ -196,6 +385,8 @@ async function handleLaunchUrl(rawUrl) {
     stdio: ["ignore", "pipe", "pipe", "ipc"],
   });
   children.add(child);
+  updateLingerTimer();
+  refreshTray();
 
   // Surface the bridge's structured logs on our stderr (already token-redacted by
   // the bridge). Never touch stream content.
@@ -219,11 +410,13 @@ async function handleLaunchUrl(rawUrl) {
     log("info", "bridge exited", { code, signal, active: children.size });
     // Trust nothing: whatever the bridge's exit looked like, VERIFY the
     // grandchild is gone (reapGrandchild registers in activeReaps synchronously,
-    // so the idle-quit below cannot fire before the verification completes).
+    // so the linger timer's fire callback above cannot conclude "safe to quit"
+    // before the verification completes).
     const ptyPid = ptyPids.get(child);
     ptyPids.delete(child);
     if (ptyPid) reapGrandchild(ptyPid, `bridge-exit code=${code} signal=${signal}`);
-    scheduleQuitIfIdle();
+    updateLingerTimer();
+    refreshTray();
   });
   child.on("error", (err) => {
     children.delete(child);
@@ -231,7 +424,8 @@ async function handleLaunchUrl(rawUrl) {
     const ptyPid = ptyPids.get(child);
     ptyPids.delete(child);
     if (ptyPid) reapGrandchild(ptyPid, "bridge-error");
-    scheduleQuitIfIdle();
+    updateLingerTimer();
+    refreshTray();
   });
 }
 
@@ -239,6 +433,259 @@ async function handleLaunchUrl(rawUrl) {
 // Windows, and the second-instance forward).
 function urlFromArgv(argv) {
   return argv.find((a) => typeof a === "string" && a.startsWith(LAUNCH_PREFIX));
+}
+
+// ── the standing control connection (design §2/§3) ────────────────────────────
+// One WebSocket, role=helper, on the owner's reserved session id — opened at
+// launch (from a deep link's helperToken, or a persisted one) and held for the
+// whole process lifetime. Hibernation-friendly: no client-side keepalive
+// beyond what the relay's own WebSocket handling needs (mirrors the design's
+// explicit "no client-side keepalive" note) — we only reconnect on an
+// unexpected drop, with simple capped backoff, never a ping loop.
+let controlWs = null;
+let controlReconnectTimer = null;
+let controlReconnectAttempt = 0;
+const CONTROL_RECONNECT_BASE_MS = 2000;
+const CONTROL_RECONNECT_MAX_MS = 30_000;
+
+/** Best-effort: send a goodbye frame if the control connection is currently open. */
+async function sendGoodbye(reason) {
+  if (!controlWs) return;
+  try {
+    const { encodeGoodbyeFrame } = await controlFramesMod();
+    if (controlWs.readyState === WebSocket.OPEN) controlWs.send(encodeGoodbyeFrame(reason));
+  } catch (e) {
+    log("warn", "could not send goodbye frame", { reason, err: String(e?.message || e) });
+  }
+}
+
+function closeControlConnection() {
+  if (controlReconnectTimer) {
+    clearTimeout(controlReconnectTimer);
+    controlReconnectTimer = null;
+  }
+  const ws = controlWs;
+  controlWs = null;
+  if (ws) {
+    ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
+    try { ws.close(); } catch { /* already closing */ }
+  }
+}
+
+/**
+ * Open (or re-open) the control connection to `relay` with the given HELPER
+ * role token. A redundant call for the SAME (relay, token) while already open
+ * is a no-op (the deep-link module's own contract for a repeat launch).
+ */
+async function connectControl(relayBase, token) {
+  if (quitting) return;
+  if (controlWs && controlWs.readyState === WebSocket.OPEN && controlWs.__vcToken === token) {
+    return; // already connected with this exact credential — no-op
+  }
+  closeControlConnection();
+
+  const { decodeTokenClaims } = await sessionTokenMod();
+  const claims = decodeTokenClaims(token);
+  if (!claims?.sid) {
+    log("error", "control token unparseable — cannot open control connection");
+    return;
+  }
+
+  const params = new URLSearchParams({
+    session: claims.sid,
+    role: "helper",
+    token,
+    helperVersion: HELPER_VERSION,
+    machineLabel: os.hostname(),
+    alwaysOn: alwaysOn ? "1" : "0",
+  });
+  const url = `${relayBase.replace(/\/$/, "")}/?${params}`;
+  log("info", "opening control connection", { host: (() => { try { return new URL(relayBase).host; } catch { return "unparseable"; } })() });
+
+  const ws = new WebSocket(url);
+  ws.__vcToken = token;
+  controlWs = ws;
+
+  ws.on("open", () => {
+    controlReconnectAttempt = 0;
+    log("info", "control connection open");
+  });
+  ws.on("message", async (data, isBinary) => {
+    if (isBinary) return; // the control leg never receives binary
+    const text = data.toString();
+    const { parseHelperCommandFrame } = await controlFramesMod();
+    const cmd = parseHelperCommandFrame(text);
+    if (!cmd) return;
+    log("info", "received helper command", { cmd: cmd.cmd });
+    if (cmd.cmd === "stop") beginCleanQuit("stop");
+    else if (cmd.cmd === "quiesce") beginCleanQuit("quiesce");
+    else if (cmd.cmd === "set-always-on") await setAlwaysOn(cmd.value, { echo: false });
+  });
+  ws.on("error", (err) => {
+    log("warn", "control connection error", { err: String(err?.message || err) });
+  });
+  ws.on("close", () => {
+    if (controlWs !== ws) return; // superseded by a newer connect
+    controlWs = null;
+    if (quitting) return; // an intentional close during quit — never reconnect
+    scheduleControlReconnect(relayBase, token);
+  });
+}
+
+function scheduleControlReconnect(relayBase, token) {
+  if (controlReconnectTimer) return;
+  const delay = Math.min(
+    CONTROL_RECONNECT_BASE_MS * 2 ** controlReconnectAttempt,
+    CONTROL_RECONNECT_MAX_MS,
+  );
+  controlReconnectAttempt += 1;
+  log("warn", "control connection dropped — reconnecting", { delayMs: delay });
+  controlReconnectTimer = setTimeout(() => {
+    controlReconnectTimer = null;
+    void connectControl(relayBase, token);
+  }, delay);
+  controlReconnectTimer.unref?.();
+}
+
+/** Load persisted control credentials (if any) and connect proactively — the
+ *  path a LaunchAgent restart takes with no deep link at all. */
+async function maybeConnectControlFromPersisted() {
+  const creds = loadControlCredentials();
+  if (creds) void connectControl(creds.relay, creds.token);
+}
+
+// ── always-on / login item / tray (design §1 decision 1, §5b — approved for v1) ──
+let tray = null;
+
+/** Apply everything "Keep helper ready" implies: login item, tray, the linger timer. */
+function applyAlwaysOnEffects() {
+  try {
+    app.setLoginItemSettings({ openAtLogin: alwaysOn });
+  } catch (e) {
+    // Non-fatal (e.g. sandboxed/dev environments can reject this) — the
+    // setting itself still governs the linger timer either way.
+    log("warn", "could not update login item", { err: String(e?.message || e) });
+  }
+  if (alwaysOn) createTray();
+  else destroyTray();
+  updateLingerTimer();
+}
+
+/**
+ * Change the always-on setting: persist it, apply its effects, and — unless
+ * this call itself IS the echo of an inbound `set-always-on` command — report
+ * the new value back over the control connection (design: "reporting its
+ * persisted setting... and again whenever the setting changes locally").
+ */
+async function setAlwaysOn(value, { echo = true } = {}) {
+  alwaysOn = !!value;
+  saveSettings({ alwaysOn });
+  applyAlwaysOnEffects();
+  if (echo && controlWs && controlWs.readyState === WebSocket.OPEN) {
+    try {
+      const { encodeAlwaysOnFrame } = await controlFramesMod();
+      controlWs.send(encodeAlwaysOnFrame(alwaysOn));
+    } catch (e) {
+      log("warn", "could not report always-on change", { err: String(e?.message || e) });
+    }
+  }
+}
+
+function trayStatusLabel() {
+  const n = children.size;
+  if (n === 0) return "Ready";
+  return `${n} session${n === 1 ? "" : "s"} running`;
+}
+
+function quitFromTray() {
+  if (children.size > 0) {
+    const n = children.size;
+    const choice = dialog.showMessageBoxSync({
+      type: "question",
+      buttons: ["Cancel", "Quit"],
+      defaultId: 0,
+      cancelId: 0,
+      message: `Quit and end ${n} running session${n === 1 ? "" : "s"}?`,
+    });
+    if (choice !== 1) return; // cancelled
+  }
+  beginCleanQuit("quit");
+}
+
+function buildTrayMenu() {
+  return Menu.buildFromTemplate([
+    { label: trayStatusLabel(), enabled: false },
+    { type: "separator" },
+    {
+      label: "Open VibeCodes",
+      click: () => { void shell.openExternal(process.env.VIBECODES_APP_URL || "https://vibecodes.co.uk"); },
+    },
+    {
+      label: "Keep helper ready",
+      type: "checkbox",
+      checked: alwaysOn,
+      // Toggle off the CURRENT value — Electron's own checkbox visual state
+      // updates from the next buildTrayMenu() call (refreshTray, triggered by
+      // setAlwaysOn -> applyAlwaysOnEffects), not from this click flipping it
+      // itself.
+      click: () => { void setAlwaysOn(!alwaysOn, { echo: true }); },
+    },
+    {
+      label: "Quit VibeCodes Helper",
+      click: () => quitFromTray(),
+    },
+  ]);
+}
+
+// Rebuilding the whole template (rather than mutating items in place) keeps
+// the checkbox's `checked` and the status label always in sync with current
+// state — this menu is tiny, so a rebuild on every change is simplest and
+// cheap (design §5b: "minimal by design").
+function refreshTray() {
+  if (!tray) return;
+  tray.setToolTip(`VibeCodes Helper — ${trayStatusLabel()}`);
+  tray.setContextMenu(buildTrayMenu());
+}
+
+function createTray() {
+  if (tray) {
+    refreshTray();
+    return;
+  }
+  const icon = nativeImage.createFromBuffer(Buffer.from(TRAY_ICON_PNG_BASE64, "base64"));
+  icon.setTemplateImage(true);
+  tray = new Tray(icon);
+  refreshTray();
+}
+
+function destroyTray() {
+  if (!tray) return;
+  tray.destroy();
+  tray = null;
+}
+
+// ── clean-quit orchestration ──────────────────────────────────────────────────
+/**
+ * Start a clean shutdown: send the goodbye frame (best effort — see
+ * sendGoodbye), then hand off to Electron's normal quit sequence, which the
+ * `before-quit` handler below turns into "kill children, verify every
+ * grandchild is really dead, then exit(0)". Idempotent — a second call while
+ * one is already underway is a no-op (mirrors the design's "a second Stop is a
+ * no-op").
+ * @param {"idle-quit"|"stop"|"quiesce"|"quit"} reason
+ */
+function beginCleanQuit(reason) {
+  if (quitting) return;
+  quitting = true;
+  quitReason = reason;
+  if (lingerTimer) {
+    clearTimeout(lingerTimer);
+    lingerTimer = null;
+  }
+  void sendGoodbye(reason).finally(() => {
+    closeControlConnection();
+    app.quit();
+  });
 }
 
 // ── single-instance: forward a second click's URL to the running helper ──────
@@ -279,20 +726,43 @@ if (!gotLock) {
       ]);
     }
 
+    // Apply whatever was persisted BEFORE this launch (login item / tray) —
+    // covers a LaunchAgent restart, and repairs drift if the OS-level login
+    // item state ever fell out of sync with our own settings file.
+    applyAlwaysOnEffects();
+    // Reconnect the control connection from a persisted credential (the
+    // LaunchAgent-restart path with no deep link at all). A deep link that
+    // arrives moments later (below) will simply no-op against this if its
+    // helperToken matches, or supersede it if the app was reinstalled/re-auth'd.
+    void maybeConnectControlFromPersisted();
+
     // Drain anything that arrived pre-ready, then a cold-launch argv URL (covers
     // the dev/verify path where the link is passed on the command line).
     for (const u of pending.splice(0)) handleLaunchUrl(u);
     const argvUrl = urlFromArgv(process.argv);
     if (argvUrl) handleLaunchUrl(argvUrl);
 
-    scheduleQuitIfIdle();
+    updateLingerTimer();
   });
 
   // We never open a window; keep the app alive on our own terms.
-  app.on("window-all-closed", () => { /* no-op: managed via scheduleQuitIfIdle */ });
+  app.on("window-all-closed", () => { /* no-op: managed via updateLingerTimer */ });
 
+  let cleanupStarted = false;
   app.on("before-quit", (event) => {
-    if (quitting) return; // our own deferred quit path re-entering — let it go
+    if (!quitting) {
+      // A quit was requested through some path that didn't go via
+      // beginCleanQuit (e.g. an OS session-end/logout signal to app.quit()) —
+      // treat it as the generic "quit" reason so the relay still gets an
+      // honest goodbye rather than being left to infer "stopped unexpectedly".
+      quitting = true;
+      void sendGoodbye(quitReason);
+    }
+    // Re-entrancy guard for the async cleanup below only (sendGoodbye above is
+    // safe to call multiple times; the child-kill + verified-reap block is not
+    // — and Electron hands this listener a FRESH event object on every fire,
+    // so the guard has to live on the module, not on `event`).
+    if (cleanupStarted) return;
     for (const child of children) {
       try { child.kill(); } catch { /* ignore */ }
     }
@@ -301,7 +771,7 @@ if (!gotLock) {
     // Hold the quit until every known grandchild is VERIFIED dead (bounded:
     // ~1s SIGHUP grace then SIGKILL(+group), per pid, in parallel) and any
     // in-flight reaps have finished — then exit for real.
-    quitting = true;
+    cleanupStarted = true;
     event.preventDefault();
     (async () => {
       try {

--- a/terminal/helper/package-lock.json
+++ b/terminal/helper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibecodes-terminal-helper",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "devDependencies": {
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8"

--- a/terminal/helper/package.json
+++ b/terminal/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "description": "macOS helper app: registers the vibecodes:// URL scheme and runs the terminal bridge (node-pty PTY -> relay) on launch. A thin, installable, signable wrapper around terminal/bridge (no logic duplication).",
   "author": "VibeCodes",

--- a/terminal/helper/tray-icon.js
+++ b/terminal/helper/tray-icon.js
@@ -1,0 +1,18 @@
+// The menu-bar (Tray) icon's pixel data (card cc74a067, always-on follow-up).
+//
+// Ships only when "Keep helper ready" is on (design §5b) — a resident
+// background app should always show a menu-bar presence (Docker Desktop /
+// Tailscale convention), never a permanent surface under quit-when-idle.
+//
+// A single small, self-contained asset: 16x16 RGBA PNG, opaque black filled
+// circle on a transparent background, base64-encoded so main.js needs no
+// extra build step or bundled image file (electron-builder's `files` list
+// stays exactly what main.js require()s — see that file's header comment).
+// Passed to Electron as a TEMPLATE image (nativeImage.setTemplateImage(true)
+// in main.js): macOS re-tints template images automatically for the active
+// menu-bar theme, so one flat black shape is all a monochrome tray icon ever
+// needs — no separate light/dark asset.
+const TRAY_ICON_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAJklEQVR42mNgGKzgPw5MtkaiDaLIgP8k4lEDaGHAwKcDqiRl+gMAPZB7hbRsUn0AAAAASUVORK5CYII=";
+
+module.exports = { TRAY_ICON_PNG_BASE64 };

--- a/terminal/relay/src/helper-status.js
+++ b/terminal/relay/src/helper-status.js
@@ -1,0 +1,64 @@
+// Pure helper-leg status derivation (card cc74a067, helper lifecycle) — factored
+// out of the DO/stand-in relay attach logic the SAME way pairing.js and
+// activity-throttle.js are, so the "stopped unexpectedly" rule is unit-tested
+// without a socket or workerd.
+//
+// Shared by:
+//   - relay/src/index.js        (Cloudflare Worker + Durable Object)
+//   - test/standin-relay.mjs    (plain-ws Node stand-in used by the automated tests)
+//
+// A helper leg is a single, PER-OWNER control connection (see
+// ../../shared/session-token.mjs's "helper" role doc comment) — nothing here
+// tracks pairing; it just answers "is my Mac's helper reachable, and did it
+// leave cleanly?" for the web app's Helper row (design §5a).
+
+/**
+ * "Stopped unexpectedly" (the rose chip) clears on its own after this long,
+ * even if nobody ever reconnects — a disconnect from months ago shouldn't
+ * haunt the row forever (design §3's "Update quiescence" review rule).
+ */
+export const STOPPED_UNEXPECTEDLY_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * @typedef {Object} HelperStatus
+ * @property {boolean} connected
+ * @property {string|null} version
+ * @property {string|null} machineLabel
+ * @property {boolean} alwaysOn
+ * @property {boolean} stoppedUnexpectedly
+ * @property {number|null} lastEventAt - unix ms of the unclean disconnect, only
+ *   set while `stoppedUnexpectedly` is true (drives the chip's "3:42 pm" line).
+ */
+
+/**
+ * Derive the Helper row's status from durable DO storage + the live-socket
+ * check the caller already did. Pure: no storage access, no clock reads beyond
+ * the `now` the caller supplies.
+ *
+ * @param {{ connected: boolean, version?: string|null, machineLabel?: string|null,
+ *           alwaysOn?: boolean, uncleanAt?: number|null, now: number,
+ *           unexpectedTtlMs?: number }} args
+ *   `uncleanAt` — set by the caller whenever a helper leg's socket closed
+ *   WITHOUT a preceding goodbye frame; cleared on the next successful attach
+ *   (see relay/src/index.js's helper-leg fetch path).
+ * @returns {HelperStatus}
+ */
+export function computeHelperStatus({
+  connected,
+  version = null,
+  machineLabel = null,
+  alwaysOn = false,
+  uncleanAt = null,
+  now,
+  unexpectedTtlMs = STOPPED_UNEXPECTEDLY_TTL_MS,
+}) {
+  const stoppedUnexpectedly = !connected && uncleanAt != null && now - uncleanAt < unexpectedTtlMs;
+  return {
+    connected: !!connected,
+    version,
+    machineLabel,
+    alwaysOn: !!alwaysOn,
+    stoppedUnexpectedly,
+    lastEventAt: stoppedUnexpectedly ? uncleanAt : null,
+  };
+}

--- a/terminal/relay/src/helper-status.test.js
+++ b/terminal/relay/src/helper-status.test.js
@@ -1,0 +1,66 @@
+// Unit tests for the pure helper-status derivation (card cc74a067).
+//
+// Run: cd terminal/relay && node --test   (or: npm test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeHelperStatus, STOPPED_UNEXPECTEDLY_TTL_MS } from "./helper-status.js";
+
+const NOW = 1_700_000_000_000;
+
+test("connected: reports the live fields, never stoppedUnexpectedly", () => {
+  const status = computeHelperStatus({
+    connected: true,
+    version: "0.3.0",
+    machineLabel: "Nick's MacBook Pro",
+    alwaysOn: true,
+    uncleanAt: NOW - 5000, // stale from a PRIOR disconnect — connected now overrides it
+    now: NOW,
+  });
+  assert.deepEqual(status, {
+    connected: true,
+    version: "0.3.0",
+    machineLabel: "Nick's MacBook Pro",
+    alwaysOn: true,
+    stoppedUnexpectedly: false,
+    lastEventAt: null,
+  });
+});
+
+test("not connected, no unclean disconnect on file -> plain 'not running'", () => {
+  const status = computeHelperStatus({ connected: false, now: NOW });
+  assert.equal(status.stoppedUnexpectedly, false);
+  assert.equal(status.lastEventAt, null);
+});
+
+test("not connected + a recent unclean disconnect -> stoppedUnexpectedly with its timestamp", () => {
+  const uncleanAt = NOW - 1000;
+  const status = computeHelperStatus({ connected: false, uncleanAt, now: NOW });
+  assert.equal(status.stoppedUnexpectedly, true);
+  assert.equal(status.lastEventAt, uncleanAt);
+});
+
+test("the unclean flag clears on its own after STOPPED_UNEXPECTEDLY_TTL_MS (design's 24h rule)", () => {
+  const uncleanAt = NOW - STOPPED_UNEXPECTEDLY_TTL_MS - 1;
+  const status = computeHelperStatus({ connected: false, uncleanAt, now: NOW });
+  assert.equal(status.stoppedUnexpectedly, false);
+  assert.equal(status.lastEventAt, null);
+});
+
+test("exactly at the TTL boundary is no longer stoppedUnexpectedly (strict <)", () => {
+  const uncleanAt = NOW - STOPPED_UNEXPECTEDLY_TTL_MS;
+  const status = computeHelperStatus({ connected: false, uncleanAt, now: NOW });
+  assert.equal(status.stoppedUnexpectedly, false);
+});
+
+test("defaults: version/machineLabel null, alwaysOn false when omitted", () => {
+  const status = computeHelperStatus({ connected: true, now: NOW });
+  assert.equal(status.version, null);
+  assert.equal(status.machineLabel, null);
+  assert.equal(status.alwaysOn, false);
+});
+
+test("a custom unexpectedTtlMs overrides the default (relay env override parity)", () => {
+  const uncleanAt = NOW - 1000;
+  const status = computeHelperStatus({ connected: false, uncleanAt, now: NOW, unexpectedTtlMs: 500 });
+  assert.equal(status.stoppedUnexpectedly, false, "1000ms ago is past a 500ms TTL");
+});

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -42,7 +42,8 @@ import {
   resolveMs,
 } from "./pairing.js";
 import { shouldPersistActivity, DEFAULT_ACTIVITY_PERSIST_THROTTLE_MS } from "./activity-throttle.js";
-import { authorizeAttach, authorizeControl } from "../../shared/session-token.mjs";
+import { computeHelperStatus } from "./helper-status.js";
+import { authorizeAttach, authorizeControl, HELPER_MAX_BOUND_MS } from "../../shared/session-token.mjs";
 import {
   encodeAttachedFrame,
   encodePeerDegradedFrame,
@@ -52,6 +53,12 @@ import {
   isHeartbeatFrame,
   encodeBridgeVersionFrame,
   sanitizeHelperVersion,
+  sanitizeMachineLabel,
+  encodeHelperCommandFrame,
+  isGoodbyeFrame,
+  parseGoodbyeReason,
+  isAlwaysOnFrame,
+  parseAlwaysOnValue,
 } from "../../shared/control-frames.mjs";
 
 /** Normal WebSocket closure code used for clean, server-initiated session ends. */
@@ -86,6 +93,25 @@ export default {
       const session = url.searchParams.get("session");
       if (!isValidSession(session)) {
         return jsonResponse({ ended: false, reason: "bad-session" }, 400);
+      }
+      const id = env.TERMINAL_RELAY.idFromName(session);
+      const stub = env.TERMINAL_RELAY.get(id);
+      return stub.fetch(request);
+    }
+
+    // Helper lifecycle (card cc74a067): the Helper row's status poll and its
+    // Stop/Update commands, exactly like /end above — a plain HTTP call routed
+    // to the SAME per-session-id DO instance (here, the owner's reserved
+    // `helper-<sub>` id — see shared/session-token.mjs → helperSessionId). Auth
+    // (the control token) is checked inside the DO; a shape-valid session id is
+    // all that's needed to route.
+    if (
+      (url.pathname === "/helper/status" && request.method === "GET") ||
+      (url.pathname === "/helper/command" && request.method === "POST")
+    ) {
+      const session = url.searchParams.get("session");
+      if (!isValidSession(session)) {
+        return jsonResponse({ error: "bad-session" }, 400);
       }
       const id = env.TERMINAL_RELAY.idFromName(session);
       const stub = env.TERMINAL_RELAY.get(id);
@@ -243,15 +269,206 @@ export class TerminalRelay {
     return jsonResponse({ ended: true }, 200);
   }
 
+  // ── Helper lifecycle (card cc74a067) ──────────────────────────────────────
+  //
+  // A `helper` leg is structurally different from bridge/browser: it's a
+  // single, standing, PER-OWNER control connection with no peer to pair with
+  // — so it deliberately bypasses decideAttach/armAlarm/the idle-max alarm
+  // entirely (see fetchHelperLeg, webSocketMessage, handleHelperDetach below).
+  // Its owner binding is STICKY: unlike clearSessionState() for a terminal
+  // session, nothing here ever deletes the "owner" key on disconnect — the
+  // helper is a standing identity for this Mac, not a bounded session, and the
+  // long reattach waiver (HELPER_MAX_BOUND_MS) depends on that binding
+  // surviving the gap between helper process restarts.
+
+  /**
+   * `GET /helper/status?session=<helperSid>` — the Helper row's status poll.
+   * Control-token auth, same pattern as handleEnd.
+   * @param {Request} request @param {URL} url
+   */
+  async handleHelperStatus(request, url) {
+    const session = url.searchParams.get("session");
+    const authHeader = request.headers.get("Authorization") || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : null;
+    const auth = await authorizeControl({ token, secret: this.env.TERMINAL_SESSION_SECRET, session });
+    if (!auth.ok) {
+      this.log("helper status rejected (auth)", { session, reason: auth.reason });
+      return jsonResponse({ error: "unauthorized" }, 401);
+    }
+
+    const connected = this.state.getWebSockets("role:helper").length > 0;
+    const [version, machineLabel, alwaysOn, uncleanAt] = await Promise.all([
+      this.state.storage.get("helperVersion"),
+      this.state.storage.get("helperMachineLabel"),
+      this.state.storage.get("helperAlwaysOn"),
+      this.state.storage.get("helperUncleanAt"),
+    ]);
+    const status = computeHelperStatus({
+      connected,
+      version: version ?? null,
+      machineLabel: machineLabel ?? null,
+      alwaysOn: alwaysOn ?? false,
+      uncleanAt: uncleanAt ?? null,
+      now: Date.now(),
+    });
+    return jsonResponse(status, 200);
+  }
+
+  /**
+   * `POST /helper/command?session=<helperSid>` body `{ cmd, value? }` — the
+   * Helper row's Stop/Update actions and the always-on toggle. A dumb
+   * forwarder (mirrors the bridge-version frame's relay role): if a helper
+   * leg is live, hand it the encoded command frame and report delivery;
+   * otherwise report `delivered:false` so the web app can treat it as
+   * "already gone" (design's "may already be stopped" toast).
+   * @param {Request} request @param {URL} url
+   */
+  async handleHelperCommand(request, url) {
+    const session = url.searchParams.get("session");
+    const authHeader = request.headers.get("Authorization") || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : null;
+    const auth = await authorizeControl({ token, secret: this.env.TERMINAL_SESSION_SECRET, session });
+    if (!auth.ok) {
+      this.log("helper command rejected (auth)", { session, reason: auth.reason });
+      return jsonResponse({ error: "unauthorized" }, 401);
+    }
+
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return jsonResponse({ error: "bad-body" }, 400);
+    }
+    const cmd = body?.cmd;
+    if (cmd !== "stop" && cmd !== "quiesce" && cmd !== "set-always-on") {
+      return jsonResponse({ error: "bad-command" }, 400);
+    }
+    if (cmd === "set-always-on" && typeof body?.value !== "boolean") {
+      return jsonResponse({ error: "bad-value" }, 400);
+    }
+
+    const helper = this.state.getWebSockets("role:helper")[0] ?? null;
+    if (!helper) {
+      this.log("helper command: no live helper leg", { session, cmd });
+      return jsonResponse({ delivered: false }, 200);
+    }
+    try {
+      helper.send(encodeHelperCommandFrame(cmd, cmd === "set-always-on" ? body.value : undefined));
+    } catch (e) {
+      this.log("helper command send failed", { session, cmd, err: String(e) });
+      return jsonResponse({ delivered: false }, 200);
+    }
+    this.log("helper command delivered", { session, cmd });
+    return jsonResponse({ delivered: true }, 200);
+  }
+
+  /**
+   * The WebSocket-attach path for `role=helper`. Bypasses decideAttach (no
+   * pairing — a helper has no peer) but reuses authorizeAttach exactly like
+   * bridge/browser, including its reattach-expiry waiver — here bounded by
+   * HELPER_MAX_BOUND_MS (passed by the caller) rather than the session
+   * max-duration cap, since a helper is a standing identity, not a bounded
+   * session.
+   * @param {Request} request @param {URL} url @param {string} session
+   *   @param {string} role @param {string} token
+   */
+  async fetchHelperLeg(request, url, session, role, token) {
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+
+    const boundOwner = (await this.state.storage.get("owner")) ?? null;
+    const auth = await authorizeAttach({
+      token,
+      secret: this.env.TERMINAL_SESSION_SECRET,
+      session,
+      role,
+      boundOwner,
+      // A much longer waiver than a terminal session's (see the "helper" role
+      // doc comment in shared/session-token.mjs): this is a standing device
+      // credential, not a bounded session.
+      maxSessionMs: resolveMs(this.env.TERMINAL_HELPER_MAX_BOUND_MS, HELPER_MAX_BOUND_MS),
+    });
+    if (!auth.ok) {
+      this.log("helper attach rejected (auth)", { session, reason: auth.reason });
+      server.accept();
+      server.close(CLOSE.BAD_TOKEN.code, CLOSE.BAD_TOKEN.reason);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    // Same-owner PREEMPTION (mirrors bridge/browser step 2b): a second helper
+    // leg for the SAME owner (a relaunch racing an old, not-yet-detected-dead
+    // connection) wins latest-first; the stale leg is closed, not left to rot.
+    // A foreign owner can never reach here — authorizeAttach's boundOwner
+    // waiver only accepts a token whose `sub` already matches, and the sid
+    // itself is derived from `sub` (helperSessionId), so cross-owner attach
+    // would already fail at the token/sid level.
+    for (const stale of this.state.getWebSockets("role:helper")) {
+      try {
+        stale.close(CLOSE.PREEMPTED.code, CLOSE.PREEMPTED.reason);
+      } catch { /* already closing */ }
+    }
+
+    this.state.acceptWebSocket(server, ["role:helper", `sub:${auth.sub}`]);
+    server.serializeAttachment({ role: "helper", sub: auth.sub, goodbye: false });
+
+    if ((await this.state.storage.get("owner")) === null) {
+      await this.state.storage.put("owner", auth.sub);
+    }
+    const version = sanitizeHelperVersion(url.searchParams.get("helperVersion"));
+    const machineLabel = sanitizeMachineLabel(url.searchParams.get("machineLabel"));
+    const alwaysOn = url.searchParams.get("alwaysOn") === "1";
+    await Promise.all([
+      version ? this.state.storage.put("helperVersion", version) : Promise.resolve(),
+      machineLabel ? this.state.storage.put("helperMachineLabel", machineLabel) : Promise.resolve(),
+      this.state.storage.put("helperAlwaysOn", alwaysOn),
+      // Design rule: a fresh attach clears any "stopped unexpectedly" flag.
+      this.state.storage.delete("helperUncleanAt"),
+    ]);
+
+    this.log("helper attached", { session, version, alwaysOn });
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  /**
+   * A helper leg's socket closed. If it never sent a goodbye frame first, mark
+   * the disconnect UNCLEAN (drives the Helper row's "stopped unexpectedly"
+   * chip via computeHelperStatus) — otherwise leave the bookkeeping as the
+   * goodbye handler in webSocketMessage already left it. No pairing, no
+   * grace window, no alarm: a helper simply reconnects (or doesn't) on its
+   * own schedule.
+   * @param {WebSocket} ws
+   */
+  async handleHelperDetach(ws) {
+    let goodbye = false;
+    try {
+      goodbye = !!ws.deserializeAttachment()?.goodbye;
+    } catch { /* attachment may be gone */ }
+    this.log("helper detached", { goodbye });
+    if (!goodbye) {
+      await this.state.storage.put("helperUncleanAt", Date.now());
+    }
+  }
+
   /** @param {Request} request */
   async fetch(request) {
     const url = new URL(request.url);
     if (url.pathname === "/end" && request.method === "POST") {
       return this.handleEnd(request, url);
     }
+    if (url.pathname === "/helper/status" && request.method === "GET") {
+      return this.handleHelperStatus(request, url);
+    }
+    if (url.pathname === "/helper/command" && request.method === "POST") {
+      return this.handleHelperCommand(request, url);
+    }
     const role = url.searchParams.get("role");
     const session = url.searchParams.get("session");
     const token = url.searchParams.get("token");
+
+    if (role === "helper") {
+      return this.fetchHelperLeg(request, url, session, role, token);
+    }
 
     const pair = new WebSocketPair();
     const client = pair[0];
@@ -442,6 +659,15 @@ export class TerminalRelay {
 
     const att = ws.deserializeAttachment() || {};
     const role = att.role;
+
+    // A helper leg has no peer to forward to — it only ever sends its own
+    // small control frames (goodbye, always-on). Branch off BEFORE the
+    // bridge/browser forwarding logic below, which a helper never reaches.
+    if (role === "helper") {
+      await this.handleHelperMessage(ws, message);
+      return;
+    }
+
     if (role !== "bridge" && role !== "browser") return;
 
     // Forward verbatim + opaque. Never inspect or log the payload.
@@ -472,15 +698,64 @@ export class TerminalRelay {
   }
 
   /**
+   * A helper leg's own control-frame handling: `goodbye` marks THIS socket's
+   * attachment so the close handler below knows the exit was clean (and
+   * clears any stale "stopped unexpectedly" flag right away — no need to
+   * wait for the close event); `always-on` mirrors the setting into storage
+   * so a `GET /helper/status` right after a toggle is already current. Any
+   * other/malformed frame is a logged no-op (skew-safe, mirrors every other
+   * control frame in this file).
+   * @param {WebSocket} ws @param {string|ArrayBuffer} message
+   */
+  async handleHelperMessage(ws, message) {
+    if (typeof message !== "string") return; // a helper leg never sends binary
+    if (isGoodbyeFrame(message)) {
+      const reason = parseGoodbyeReason(message);
+      if (!reason) return;
+      try {
+        ws.serializeAttachment({ ...(ws.deserializeAttachment() || {}), goodbye: true });
+      } catch { /* attachment already gone (socket closing) */ }
+      await this.state.storage.delete("helperUncleanAt");
+      this.log("helper goodbye", { reason });
+      return;
+    }
+    if (isAlwaysOnFrame(message)) {
+      const value = parseAlwaysOnValue(message);
+      if (value === null) return;
+      await this.state.storage.put("helperAlwaysOn", value);
+      this.log("helper always-on updated", { value });
+      return;
+    }
+    this.log("helper: ignored unknown control frame");
+  }
+
+  /**
    * @param {WebSocket} ws @param {number} code @param {string} reason @param {boolean} wasClean
    */
   async webSocketClose(ws, code, reason, wasClean) {
+    if (this.roleOf(ws) === "helper") {
+      await this.handleHelperDetach(ws);
+      return;
+    }
     await this.handleDetach(ws, "close", { code, wasClean });
   }
 
   /** @param {WebSocket} ws @param {unknown} error */
   async webSocketError(ws, error) {
+    if (this.roleOf(ws) === "helper") {
+      await this.handleHelperDetach(ws);
+      return;
+    }
     await this.handleDetach(ws, "error", { err: String(error) });
+  }
+
+  /** Best-effort read of a socket's own attached role. Never throws. */
+  roleOf(ws) {
+    try {
+      return ws.deserializeAttachment()?.role ?? null;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/terminal/shared/control-frames.mjs
+++ b/terminal/shared/control-frames.mjs
@@ -63,6 +63,41 @@
 //     helper-version.ts). Skew-safe: an OLD bridge never sends `helperVersion` (the
 //     relay simply has nothing to forward), and a dock that predates this frame
 //     ignores an unknown `t` tag exactly like it already does for any other one.
+//
+// HELPER LIFECYCLE (card cc74a067) adds three more control frames, all scoped to
+// the NEW `helper` leg (terminal/helper/main.js's persistent control connection —
+// see session-token.mjs's "helper" role) — never sent on a bridge/browser leg:
+//   - `{"t":"helper-cmd","cmd":"stop"|"quiesce"|"set-always-on","value"?:boolean}`
+//     — sent by the relay to the HELPER leg, forwarding a web-originated command
+//     (POST /helper/command, see relay/src/index.js). `value` is present only for
+//     `set-always-on`. The relay never interprets `cmd` — it is a dumb forwarder,
+//     exactly like the bridge-version frame above; the helper decides what each
+//     command means.
+//   - `{"t":"goodbye","reason":"idle-quit"|"stop"|"quiesce"|"quit"|"crash"}` — sent
+//     by the HELPER to the relay immediately before every CLEAN exit (never on a
+//     crash-then-kill — there the process may not get a chance to flush). Its
+//     ABSENCE before a helper leg's socket closes is exactly what the relay/web
+//     app class as "stopped unexpectedly" (design §5a chip) — see
+//     HELPER_GOODBYE_REASONS below for the closed set of valid reasons.
+//   - `{"t":"always-on","value":boolean}` — sent by the HELPER to the relay right
+//     after attach (reporting its persisted setting) and again whenever the
+//     setting changes locally (the tray checkbox, or echoing a `set-always-on`
+//     command). The relay stores it durably so a `GET /helper/status` call always
+//     has a current answer without waking the helper.
+// All three are skew-safe the same way as every frame above: an old relay/helper
+// that doesn't know a tag treats it as an unknown control frame and ignores it.
+
+/** The closed set of reasons a helper's goodbye frame may carry (design §2 table). */
+export const HELPER_GOODBYE_REASONS = Object.freeze([
+  "idle-quit",
+  "stop",
+  "quiesce",
+  "quit",
+  "crash",
+]);
+
+/** The closed set of commands the web app may forward to a helper leg. */
+export const HELPER_COMMANDS = Object.freeze(["stop", "quiesce", "set-always-on"]);
 
 /** Detect any control TEXT frame with a given `t` tag. Cheap + strict + bounded. */
 function isControlFrame(text, tag) {
@@ -175,4 +210,130 @@ export function sanitizeHelperVersion(raw) {
   if (typeof raw !== "string") return null;
   const trimmed = raw.trim();
   return SEMVER_RE.test(trimmed) ? trimmed : null;
+}
+
+/**
+ * Validate a raw machine-label value (e.g. `os.hostname()`, carried as a URL
+ * query param on the helper's connect URL) before it's stored/forwarded. Unlike
+ * the version, this is a free-form display string — the only gate is "not
+ * absurd": bounded length, trimmed, never a non-string. Never trust it as
+ * anything but display text (never used in a path, command, or comparison).
+ * @param {unknown} raw
+ * @returns {string | null}
+ */
+export function sanitizeMachineLabel(raw) {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.slice(0, 80);
+}
+
+// ── helper-command frame (web -> relay -> helper leg) ─────────────────────────
+
+/**
+ * The TEXT frame the relay forwards to a live `helper` leg. `value` is included
+ * only for `set-always-on` (a boolean); omitted for `stop`/`quiesce`.
+ * @param {"stop"|"quiesce"|"set-always-on"} cmd
+ * @param {boolean} [value]
+ * @returns {string}
+ */
+export function encodeHelperCommandFrame(cmd, value) {
+  return JSON.stringify(value === undefined ? { t: "helper-cmd", cmd } : { t: "helper-cmd", cmd, value });
+}
+
+/** @param {unknown} text @returns {boolean} */
+export function isHelperCommandFrame(text) {
+  return isControlFrame(text, "helper-cmd");
+}
+
+/**
+ * Extract + validate a helper-command frame's `cmd` (and `value` for
+ * `set-always-on`). Returns null for anything not shaped like a known command —
+ * a malformed or hostile frame is treated identically to "no command", never
+ * forwarded to helper-side logic that could misinterpret it.
+ * @param {unknown} text
+ * @returns {{ cmd: "stop"|"quiesce"|"set-always-on", value?: boolean } | null}
+ */
+export function parseHelperCommandFrame(text) {
+  if (!isHelperCommandFrame(text)) return null;
+  try {
+    const msg = JSON.parse(text);
+    if (typeof msg.cmd !== "string" || !HELPER_COMMANDS.includes(msg.cmd)) return null;
+    if (msg.cmd === "set-always-on") {
+      return typeof msg.value === "boolean" ? { cmd: msg.cmd, value: msg.value } : null;
+    }
+    return { cmd: msg.cmd };
+  } catch {
+    return null;
+  }
+}
+
+// ── goodbye frame (helper leg -> relay, sent immediately before every clean exit) ──
+
+/**
+ * The TEXT frame a helper sends the relay right before a CLEAN close. Its
+ * absence before the socket actually closes is what marks a disconnect
+ * "stopped unexpectedly" (design §5a) — see HELPER_GOODBYE_REASONS.
+ * @param {"idle-quit"|"stop"|"quiesce"|"quit"|"crash"} reason
+ * @returns {string}
+ */
+export function encodeGoodbyeFrame(reason) {
+  return JSON.stringify({ t: "goodbye", reason });
+}
+
+/** @param {unknown} text @returns {boolean} */
+export function isGoodbyeFrame(text) {
+  return isControlFrame(text, "goodbye");
+}
+
+/**
+ * Extract + validate a goodbye frame's reason. Null for anything outside the
+ * closed HELPER_GOODBYE_REASONS set — an unrecognised reason is treated the
+ * same as no goodbye at all (never invent a lifecycle state the UI can't show).
+ * @param {unknown} text
+ * @returns {"idle-quit"|"stop"|"quiesce"|"quit"|"crash"|null}
+ */
+export function parseGoodbyeReason(text) {
+  if (!isGoodbyeFrame(text)) return null;
+  try {
+    const msg = JSON.parse(text);
+    return typeof msg.reason === "string" && HELPER_GOODBYE_REASONS.includes(msg.reason) ? msg.reason : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── always-on frame (helper leg -> relay, on attach + whenever the setting changes) ──
+
+/**
+ * The TEXT frame a helper sends the relay to report its current "Keep helper
+ * ready" setting — once right after attach, and again whenever it changes
+ * locally (the tray checkbox, or echoing a `set-always-on` command).
+ * @param {boolean} value
+ * @returns {string}
+ */
+export function encodeAlwaysOnFrame(value) {
+  return JSON.stringify({ t: "always-on", value: !!value });
+}
+
+/** @param {unknown} text @returns {boolean} */
+export function isAlwaysOnFrame(text) {
+  return isControlFrame(text, "always-on");
+}
+
+/**
+ * Extract + validate an always-on frame's boolean value. Null for anything
+ * malformed — the caller keeps whatever value it last had rather than trusting
+ * a non-boolean.
+ * @param {unknown} text
+ * @returns {boolean | null}
+ */
+export function parseAlwaysOnValue(text) {
+  if (!isAlwaysOnFrame(text)) return null;
+  try {
+    const msg = JSON.parse(text);
+    return typeof msg.value === "boolean" ? msg.value : null;
+  } catch {
+    return null;
+  }
 }

--- a/terminal/shared/deep-link.mjs
+++ b/terminal/shared/deep-link.mjs
@@ -15,14 +15,23 @@
 //   session — relay session id (sid)
 //   token   — the app-minted, HMAC-signed BRIDGE-role token (this IS the launch's
 //             credential; the relay verifies it, so no extra signature is needed)
+//   helperToken — OPTIONAL: an app-minted HELPER-role token (session-token.mjs →
+//             mintHelperToken), carried alongside the bridge token on every
+//             launch (card cc74a067) so the SAME click that starts a bridge also
+//             (re)establishes the helper's own persistent control connection to
+//             the relay — see terminal/helper/main.js. A helper that's already
+//             connected treats a redundant one as a no-op.
 //   cwd     — optional working directory
 //   prompt  — optional compact bootstrap prompt for the spawned `claude`. INERT
 //             DATA: the bridge passes it as ONE argv element (never through
 //             shellSplit / a shell) and only spawns AFTER the relay has accepted
 //             the owner-bound token (R1 — see bridge/src/index.js).
 //
-// The `token` is a secret and the `prompt` is user content. NEVER log a raw
-// link — use redactDeepLinkToken first (it elides both).
+// `token` and `helperToken` are secrets and `prompt` is user content. NEVER log
+// a raw link — use redactDeepLinkToken first (it elides all three). `prompt` is
+// always the LAST param (the dock's URL-length budgeting relies on this — see
+// src/lib/terminal/deep-link.ts's doc comment) — `helperToken` is inserted
+// BEFORE it, alongside the other credentials, so that invariant holds.
 //
 // Pure + dependency-free (only the global WHATWG `URL`), so it runs unchanged in
 // Node (bridge) and is trivially unit-testable.
@@ -42,10 +51,10 @@ export const LAUNCH_HOST = "launch";
  * (and therefore the app-side prompt budget) is stable. Throws when a required
  * field is missing so a malformed link is never fired.
  *
- * @param {{ relay: string, session: string, token: string, cwd?: string, prompt?: string }} params
+ * @param {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string }} params
  * @returns {string}
  */
-export function buildLaunchDeepLink({ relay, session, token, cwd, prompt } = {}) {
+export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt } = {}) {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
   }
@@ -54,6 +63,7 @@ export function buildLaunchDeepLink({ relay, session, token, cwd, prompt } = {})
     `session=${encodeURIComponent(session)}`,
     `token=${encodeURIComponent(token)}`,
   ];
+  if (helperToken) parts.push(`helperToken=${encodeURIComponent(helperToken)}`);
   if (cwd) parts.push(`cwd=${encodeURIComponent(cwd)}`);
   if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
@@ -69,7 +79,7 @@ export function buildLaunchDeepLink({ relay, session, token, cwd, prompt } = {})
  * param existed (version-skew safe both ways).
  *
  * @param {unknown} url
- * @returns {{ relay: string, session: string, token: string, cwd?: string, prompt?: string } | null}
+ * @returns {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string } | null}
  */
 export function parseLaunchDeepLink(url) {
   if (typeof url !== "string" || url.length === 0) return null;
@@ -88,11 +98,13 @@ export function parseLaunchDeepLink(url) {
   const relay = parsed.searchParams.get("relay");
   const session = parsed.searchParams.get("session");
   const token = parsed.searchParams.get("token");
+  const helperToken = parsed.searchParams.get("helperToken") || undefined;
   const cwd = parsed.searchParams.get("cwd") || undefined;
   const prompt = parsed.searchParams.get("prompt") || undefined;
   if (!relay || !session || !token) return null;
 
   const out = { relay, session, token };
+  if (helperToken) out.helperToken = helperToken;
   if (cwd) out.cwd = cwd;
   if (prompt) out.prompt = prompt;
   return out;
@@ -100,9 +112,10 @@ export function parseLaunchDeepLink(url) {
 
 /**
  * Redact the secret/user-content params from a launch link so it is safe to
- * log: the `token` (a credential) and the `prompt` (user task/idea content)
- * both become `***` while relay/session survive for debugging. Callers that
- * want to debug prompt delivery log the prompt LENGTH as a separate field.
+ * log: the `token` and `helperToken` (both credentials) and the `prompt`
+ * (user task/idea content) all become `***` while relay/session survive for
+ * debugging. Callers that want to debug prompt delivery log the prompt
+ * LENGTH as a separate field.
  *
  * @param {unknown} url
  * @returns {string}
@@ -110,5 +123,6 @@ export function parseLaunchDeepLink(url) {
 export function redactDeepLinkToken(url) {
   return String(url)
     .replace(/([?&]token=)[^&]*/g, "$1***")
+    .replace(/([?&]helperToken=)[^&]*/g, "$1***")
     .replace(/([?&]prompt=)[^&]*/g, "$1***");
 }

--- a/terminal/shared/session-token.mjs
+++ b/terminal/shared/session-token.mjs
@@ -30,7 +30,7 @@
 // session age. `verifyToken` itself stays strict (expired is always a failure).
 
 /**
- * @typedef {"bridge"|"browser"|"control"} Role
+ * @typedef {"bridge"|"browser"|"control"|"helper"} Role
  *
  * "control" (multi-session stage 3, terminal/api/session/end) is a THIRD kind
  * of leg: it never opens a WebSocket. It authorizes a single HTTP call — the
@@ -43,6 +43,22 @@
  * gets the reattach expiry waiver a live session's owner gets on bridge/
  * browser tokens, because there is no "session" for a control call to be
  * live inside of — it's a one-shot admin action, not a leg that attaches.
+ *
+ * "helper" (card cc74a067, helper lifecycle) is a FOURTH kind of leg: a
+ * single, PER-OWNER (not per-session) WebSocket the packaged Electron helper
+ * opens at launch and holds for its whole process lifetime — the "control
+ * connection" that carries stop/quiesce/set-always-on commands and reports
+ * presence/version/always-on back to the relay (see relay/src/index.js and
+ * terminal/helper/main.js). It attaches through the SAME `authorizeAttach`
+ * used by bridge/browser (nothing role-specific in that function — it just
+ * compares `role` against the connection's own claim), always on the RESERVED
+ * session id `helperSessionId(sub)` — see below. Unlike a bridge/browser
+ * session, the relay's owner binding for a helper leg is STICKY (never
+ * cleared on disconnect — see relay/src/index.js's helper-leg fetch path), so
+ * `authorizeAttach`'s reattach-expiry waiver (normally scoped to a LIVE
+ * session) also covers a helper reconnecting long after its token's TTL
+ * lapsed — e.g. a LaunchAgent restart days later, using the SAME token it
+ * persisted in userData. `HELPER_MAX_BOUND_MS` bounds that waiver.
  */
 
 /**
@@ -67,10 +83,20 @@ export const DEFAULT_TTL_SECONDS = 300;
  */
 export const DEFAULT_MAX_SESSION_MS = 4 * 60 * 60 * 1000;
 
-const ROLES = Object.freeze(["bridge", "browser", "control"]);
+const ROLES = Object.freeze(["bridge", "browser", "control", "helper"]);
 
 /** Control-token lifetime (multi-session stage 3): short-lived, one-shot. */
 export const CONTROL_TTL_SECONDS = 60;
+
+/**
+ * Belt-and-braces cap on the HELPER reattach waiver (mirrors
+ * DEFAULT_MAX_SESSION_MS's role for bridge/browser, but much longer): a
+ * helper's control connection is a standing device credential, not a
+ * bounded session, so it needs to keep working across a laptop reboot or a
+ * few weeks away — but a token from a YEAR ago should still eventually stop
+ * working. 30 days is a boring, generous choice with no further meaning.
+ */
+export const HELPER_MAX_BOUND_MS = 30 * 24 * 60 * 60 * 1000;
 const enc = new TextEncoder();
 const dec = new TextDecoder();
 
@@ -327,4 +353,66 @@ export async function authorizeControl({ token, secret, session, now }) {
   if (c.role !== "control") return { ok: false, reason: "role mismatch" };
   if (c.sid !== session) return { ok: false, reason: "sid mismatch" };
   return { ok: true, sub: c.sub, claims: c };
+}
+
+/**
+ * The RESERVED relay session id a helper leg always connects on: one per
+ * owner, never a per-launch random id (a helper is a standing per-Mac
+ * connection, not a terminal session). Deterministic + collision-free with
+ * every real terminal session id (those are `crypto.randomUUID()`, which
+ * never produces the `helper-` prefix) — see relay/src/index.js's helper-leg
+ * fetch path, which routes `role=helper` to the Durable Object instance this
+ * id addresses (the SAME `TerminalRelay` class, a boring reuse: "one DO per
+ * session id" already holds, this is just a session id that happens to mean
+ * "this owner's helper" instead of "one terminal"). Supabase user ids are
+ * UUIDs, so the result already satisfies isValidSession's charset — no
+ * hashing needed.
+ * @param {string} sub
+ * @returns {string}
+ */
+export function helperSessionId(sub) {
+  return `helper-${sub}`;
+}
+
+/**
+ * Mint a HELPER-role token: the credential the packaged Electron helper
+ * carries on its `vibecodes://launch` payload (see terminal/shared/deep-link.mjs)
+ * and persists in userData so a later LaunchAgent restart can reconnect with
+ * the SAME token (the relay's sticky owner binding + HELPER_MAX_BOUND_MS
+ * waiver cover the gap — see the "helper" role's doc comment above). Minted
+ * alongside the bridge/browser tokens on every launch (POST /api/terminal/session)
+ * so the helper always has a fresh one, even though it usually only needs it
+ * once per boot.
+ * @param {{ sub: string, secret: string, ttlSeconds?: number, now?: number }} args
+ * @returns {Promise<string>}
+ */
+export async function mintHelperToken({
+  sub,
+  secret,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+  now = Math.floor(Date.now() / 1000),
+}) {
+  const exp = now + ttlSeconds;
+  return signToken({ sub, sid: helperSessionId(sub), idea: "", role: "helper", iat: now, exp }, secret);
+}
+
+/**
+ * Read a token's claims WITHOUT verifying its signature — used only so a
+ * receiver that doesn't hold the secret (the local helper process) can learn
+ * which sid its own freshly-minted token addresses before it ever talks to
+ * the relay. This is safe ONLY because the relay re-verifies the signature
+ * authoritatively on attach (authorizeAttach) — nothing here is ever treated
+ * as authorization. Returns null for anything unparseable; never throws.
+ * @param {unknown} token
+ * @returns {SessionClaims | null}
+ */
+export function decodeTokenClaims(token) {
+  if (typeof token !== "string") return null;
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot === token.length - 1) return null;
+  try {
+    return JSON.parse(dec.decode(base64urlToBytes(token.slice(0, dot))));
+  } catch {
+    return null;
+  }
 }

--- a/terminal/shared/session-token.test.mjs
+++ b/terminal/shared/session-token.test.mjs
@@ -12,6 +12,10 @@ import {
   newSessionId,
   DEFAULT_TTL_SECONDS,
   CONTROL_TTL_SECONDS,
+  helperSessionId,
+  mintHelperToken,
+  decodeTokenClaims,
+  HELPER_MAX_BOUND_MS,
 } from "./session-token.mjs";
 
 const SECRET = "test-secret-do-not-ship";
@@ -243,6 +247,78 @@ test("authorizeControl: expiry is ALWAYS strict — no reattach waiver exists fo
   const expired = await authorizeControl({ token, secret: SECRET, session: "sess-1", now: NOW + CONTROL_TTL_SECONDS + 1 });
   assert.equal(expired.ok, false);
   assert.equal(expired.reason, "expired");
+});
+
+// ── helper tokens (card cc74a067, helper lifecycle) ────────────────────────
+
+test("helperSessionId is deterministic and relay-safe", () => {
+  assert.equal(helperSessionId("user-A"), "helper-user-A");
+  assert.match(helperSessionId("user-A"), /^[A-Za-z0-9._-]+$/);
+});
+
+test("mintHelperToken -> authorizeAttach happy path (role helper, reserved sid)", async () => {
+  const token = await mintHelperToken({ sub: "user-A", secret: SECRET, now: NOW });
+  const res = await authorizeAttach({
+    token, secret: SECRET, session: helperSessionId("user-A"), role: "helper", now: NOW,
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.sub, "user-A");
+  assert.equal(res.claims.role, "helper");
+});
+
+test("a helper token cannot attach as bridge/browser, and vice versa (role mismatch)", async () => {
+  const helperToken = await mintHelperToken({ sub: "user-A", secret: SECRET, now: NOW });
+  const asBridge = await authorizeAttach({
+    token: helperToken, secret: SECRET, session: helperSessionId("user-A"), role: "bridge", now: NOW,
+  });
+  assert.equal(asBridge.ok, false);
+  assert.equal(asBridge.reason, "role mismatch");
+
+  const { bridge } = await mintSessionTokens({ sub: "user-A", idea: "idea-1", secret: SECRET, now: NOW });
+  const bridgeAsHelper = await authorizeAttach({
+    token: bridge, secret: SECRET, session: helperSessionId("user-A"), role: "helper", now: NOW,
+  });
+  assert.equal(bridgeAsHelper.ok, false);
+  assert.equal(bridgeAsHelper.reason, "sid mismatch");
+});
+
+test("an expired helper token reattaches when the relay's sticky owner binding matches, within HELPER_MAX_BOUND_MS", async () => {
+  const token = await mintHelperToken({ sub: "user-A", secret: SECRET, now: NOW });
+  const justInside = NOW + Math.floor(HELPER_MAX_BOUND_MS / 1000) - 1;
+  const res = await authorizeAttach({
+    token, secret: SECRET, session: helperSessionId("user-A"), role: "helper",
+    now: justInside, boundOwner: "user-A", maxSessionMs: HELPER_MAX_BOUND_MS,
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.expired, true);
+
+  const justOutside = NOW + Math.ceil(HELPER_MAX_BOUND_MS / 1000) + 1;
+  const tooOld = await authorizeAttach({
+    token, secret: SECRET, session: helperSessionId("user-A"), role: "helper",
+    now: justOutside, boundOwner: "user-A", maxSessionMs: HELPER_MAX_BOUND_MS,
+  });
+  assert.equal(tooOld.ok, false);
+  assert.equal(tooOld.reason, "expired");
+});
+
+test("decodeTokenClaims reads claims without verifying — for the helper to learn its own sid before talking to the relay", async () => {
+  const token = await mintHelperToken({ sub: "user-A", secret: SECRET, now: NOW });
+  const claims = decodeTokenClaims(token);
+  assert.equal(claims.sub, "user-A");
+  assert.equal(claims.sid, helperSessionId("user-A"));
+  assert.equal(claims.role, "helper");
+  // Unverified: a tampered payload still decodes (never treated as authorization).
+  const [payloadB64, sig] = token.split(".");
+  const forged = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+  forged.sub = "user-EVIL";
+  const forgedToken = `${Buffer.from(JSON.stringify(forged)).toString("base64url")}.${sig}`;
+  assert.equal(decodeTokenClaims(forgedToken).sub, "user-EVIL");
+});
+
+test("decodeTokenClaims never throws on malformed input", () => {
+  for (const bad of ["", "noseparator", ".", "a.", ".b", null, undefined, 42, "not-json.sig"]) {
+    assert.equal(decodeTokenClaims(bad), null, `expected null for ${JSON.stringify(bad)}`);
+  }
 });
 
 test("authorizeControl: a tampered control token is rejected (bad signature)", async () => {

--- a/terminal/test/control-frames.test.mjs
+++ b/terminal/test/control-frames.test.mjs
@@ -23,6 +23,16 @@ import {
   isBridgeVersionFrame,
   parseBridgeVersionFrame,
   sanitizeHelperVersion,
+  sanitizeMachineLabel,
+  encodeHelperCommandFrame,
+  isHelperCommandFrame,
+  parseHelperCommandFrame,
+  encodeGoodbyeFrame,
+  isGoodbyeFrame,
+  parseGoodbyeReason,
+  encodeAlwaysOnFrame,
+  isAlwaysOnFrame,
+  parseAlwaysOnValue,
 } from "../shared/control-frames.mjs";
 import { parseControlMessage } from "../bridge/src/framing.js";
 
@@ -107,4 +117,83 @@ test("sanitizeHelperVersion accepts only strict x.y.z", () => {
   assert.equal(sanitizeHelperVersion("0.2"), null);
   assert.equal(sanitizeHelperVersion("v0.2.0"), null);
   assert.equal(sanitizeHelperVersion("0.2.0; DROP TABLE users;"), null);
+});
+
+test("sanitizeMachineLabel trims, bounds length, and rejects non-strings", () => {
+  assert.equal(sanitizeMachineLabel(" Nick's MacBook Pro "), "Nick's MacBook Pro");
+  assert.equal(sanitizeMachineLabel(""), null);
+  assert.equal(sanitizeMachineLabel("   "), null);
+  assert.equal(sanitizeMachineLabel(null), null);
+  assert.equal(sanitizeMachineLabel(undefined), null);
+  assert.equal(sanitizeMachineLabel(42), null);
+  assert.equal(sanitizeMachineLabel("x".repeat(200)).length, 80);
+});
+
+// ── helper lifecycle frames (card cc74a067) ────────────────────────────────
+
+test("helper-command frame encode ⇄ detect ⇄ parse round-trips for stop/quiesce", () => {
+  for (const cmd of ["stop", "quiesce"]) {
+    const frame = encodeHelperCommandFrame(cmd);
+    assert.equal(isHelperCommandFrame(frame), true);
+    assert.deepEqual(parseHelperCommandFrame(frame), { cmd });
+  }
+});
+
+test("helper-command frame carries a boolean value for set-always-on", () => {
+  const on = encodeHelperCommandFrame("set-always-on", true);
+  assert.deepEqual(parseHelperCommandFrame(on), { cmd: "set-always-on", value: true });
+  const off = encodeHelperCommandFrame("set-always-on", false);
+  assert.deepEqual(parseHelperCommandFrame(off), { cmd: "set-always-on", value: false });
+});
+
+test("parseHelperCommandFrame rejects unknown commands and a missing/non-boolean value", () => {
+  assert.equal(parseHelperCommandFrame(JSON.stringify({ t: "helper-cmd", cmd: "shutdown-everything" })), null);
+  assert.equal(parseHelperCommandFrame(JSON.stringify({ t: "helper-cmd", cmd: "set-always-on" })), null);
+  assert.equal(parseHelperCommandFrame(JSON.stringify({ t: "helper-cmd", cmd: "set-always-on", value: "yes" })), null);
+  assert.equal(parseHelperCommandFrame(JSON.stringify({ t: "helper-cmd" })), null);
+  assert.equal(parseHelperCommandFrame("not json"), null);
+  assert.equal(parseHelperCommandFrame(null), null);
+});
+
+test("goodbye frame encode ⇄ detect ⇄ parse round-trips for every valid reason", () => {
+  for (const reason of ["idle-quit", "stop", "quiesce", "quit", "crash"]) {
+    const frame = encodeGoodbyeFrame(reason);
+    assert.equal(isGoodbyeFrame(frame), true);
+    assert.equal(parseGoodbyeReason(frame), reason);
+  }
+});
+
+test("parseGoodbyeReason rejects a reason outside the closed set", () => {
+  assert.equal(parseGoodbyeReason(JSON.stringify({ t: "goodbye", reason: "bored" })), null);
+  assert.equal(parseGoodbyeReason(JSON.stringify({ t: "goodbye" })), null);
+  assert.equal(parseGoodbyeReason("not json"), null);
+});
+
+test("always-on frame encode ⇄ detect ⇄ parse round-trips both booleans", () => {
+  assert.equal(parseAlwaysOnValue(encodeAlwaysOnFrame(true)), true);
+  assert.equal(parseAlwaysOnValue(encodeAlwaysOnFrame(false)), false);
+  assert.equal(isAlwaysOnFrame(encodeAlwaysOnFrame(true)), true);
+});
+
+test("parseAlwaysOnValue rejects a non-boolean value", () => {
+  assert.equal(parseAlwaysOnValue(JSON.stringify({ t: "always-on", value: "true" })), null);
+  assert.equal(parseAlwaysOnValue(JSON.stringify({ t: "always-on" })), null);
+});
+
+test("the three new helper frames stay mutually disjoint and disjoint from every existing frame", () => {
+  const frames = [
+    encodeHelperCommandFrame("stop"),
+    encodeGoodbyeFrame("crash"),
+    encodeAlwaysOnFrame(true),
+  ];
+  const detectors = [isHelperCommandFrame, isGoodbyeFrame, isAlwaysOnFrame];
+  for (let i = 0; i < frames.length; i++) {
+    for (let j = 0; j < detectors.length; j++) {
+      assert.equal(detectors[j](frames[i]), i === j, `frame ${i} vs detector ${j}`);
+    }
+    assert.equal(isAttachedFrame(frames[i]), false);
+    assert.equal(isHeartbeatFrame(frames[i]), false);
+    assert.equal(isBridgeVersionFrame(frames[i]), false);
+    assert.equal(parseControlMessage(frames[i]), null);
+  }
 });

--- a/terminal/test/deep-link.test.mjs
+++ b/terminal/test/deep-link.test.mjs
@@ -82,6 +82,30 @@ test("promptless links keep today's exact shape — no prompt key, no prompt par
   assert.ok(!("prompt" in parsed), "no prompt key on a promptless link");
 });
 
+// ── helper token param (card cc74a067, helper lifecycle) ──────────────────────
+
+test("build ⇄ parse round-trips helperToken, positioned before prompt", () => {
+  const withHelper = { ...SAMPLE, helperToken: "eyJzdWIiOiJ1c2VyIn0.helperSig", prompt: "hello" };
+  const url = buildLaunchDeepLink(withHelper);
+  assert.ok(url.includes("helperToken="));
+  assert.ok(url.indexOf("helperToken=") < url.indexOf("prompt="), "helperToken precedes the LAST param, prompt");
+  assert.deepEqual(parseLaunchDeepLink(url), withHelper);
+});
+
+test("omits helperToken entirely when absent", () => {
+  const url = buildLaunchDeepLink(SAMPLE);
+  assert.ok(!url.includes("helperToken="));
+  assert.ok(!("helperToken" in parseLaunchDeepLink(url)));
+});
+
+test("redactDeepLinkToken hides helperToken as well as token", () => {
+  const withHelper = { ...SAMPLE, helperToken: "super-secret-helper-token" };
+  const redacted = redactDeepLinkToken(buildLaunchDeepLink(withHelper));
+  assert.match(redacted, /helperToken=\*\*\*/);
+  assert.ok(!redacted.includes("super-secret-helper-token"));
+  assert.ok(redacted.includes(`session=${SAMPLE.session}`));
+});
+
 test("redactDeepLinkToken elides the prompt (user content) as well as the token", () => {
   const url = buildLaunchDeepLink({ ...SAMPLE, prompt: HOSTILE_PROMPT });
   const redacted = redactDeepLinkToken(url);

--- a/terminal/test/helper-lifecycle-module.test.mjs
+++ b/terminal/test/helper-lifecycle-module.test.mjs
@@ -1,0 +1,47 @@
+// Unit tests for the pure quit-when-idle decision module (terminal/helper/lifecycle.js).
+//
+// Mirrors proto-reg.test.mjs's pattern: a plain CJS module under terminal/helper,
+// required here via createRequire and exercised without an Electron runtime.
+//
+// Run: cd terminal/test && node helper-lifecycle-module.test.mjs   (or via `npm test`)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { LINGER_MS, decideLingerAction, shouldQuitOnLingerExpiry } = require("../helper/lifecycle.js");
+
+test("LINGER_MS is the design's 60s window", () => {
+  assert.equal(LINGER_MS, 60_000);
+});
+
+test("decideLingerAction: no bridges, always-on off -> start", () => {
+  assert.equal(decideLingerAction({ bridgeCount: 0, alwaysOn: false }), "start");
+});
+
+test("decideLingerAction: any live bridge -> cancel, regardless of always-on", () => {
+  assert.equal(decideLingerAction({ bridgeCount: 1, alwaysOn: false }), "cancel");
+  assert.equal(decideLingerAction({ bridgeCount: 3, alwaysOn: false }), "cancel");
+  assert.equal(decideLingerAction({ bridgeCount: 1, alwaysOn: true }), "cancel");
+});
+
+test("decideLingerAction: always-on on, no bridges -> cancel (never linger toward quit)", () => {
+  assert.equal(decideLingerAction({ bridgeCount: 0, alwaysOn: true }), "cancel");
+});
+
+test("shouldQuitOnLingerExpiry: idle + always-on off -> true", () => {
+  assert.equal(shouldQuitOnLingerExpiry({ bridgeCount: 0, alwaysOn: false }), true);
+});
+
+test("shouldQuitOnLingerExpiry: a bridge re-attached before the timer fired -> false", () => {
+  assert.equal(shouldQuitOnLingerExpiry({ bridgeCount: 1, alwaysOn: false }), false);
+});
+
+test("shouldQuitOnLingerExpiry: always-on flipped on before the timer fired -> false", () => {
+  assert.equal(shouldQuitOnLingerExpiry({ bridgeCount: 0, alwaysOn: true }), false);
+});
+
+test("shouldQuitOnLingerExpiry: always-on on AND a bridge live -> false", () => {
+  assert.equal(shouldQuitOnLingerExpiry({ bridgeCount: 2, alwaysOn: true }), false);
+});

--- a/terminal/test/helper-lifecycle.test.mjs
+++ b/terminal/test/helper-lifecycle.test.mjs
@@ -1,0 +1,236 @@
+// Helper lifecycle relay integration tests (card cc74a067).
+//
+// Proves the relay's `role=helper` leg + its two HTTP endpoints end-to-end
+// against the Node stand-in (shares the exact handler shape the Cloudflare DO
+// uses — see terminal/relay/src/index.js → fetchHelperLeg/handleHelperStatus/
+// handleHelperCommand vs. standin-relay.mjs → handleHelperConnection/
+// handleHelperStatusHttp/handleHelperCommandHttp):
+//   (1) a helper attaches → GET /helper/status reports it running, with its
+//       announced version/machineLabel/alwaysOn
+//   (2) a clean goodbye then disconnect → status goes to not-connected, no
+//       "stopped unexpectedly"
+//   (3) a drop WITHOUT a goodbye → status flips to stoppedUnexpectedly, and a
+//       fresh attach clears it again
+//   (4) POST /helper/command forwards stop/quiesce/set-always-on frames to a
+//       live helper leg, and reports delivered:false when none is live
+//
+// Run: cd terminal/test && node --test helper-lifecycle.test.mjs   (or: npm test)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import WebSocket from "ws";
+import { startStandinRelay } from "./standin-relay.mjs";
+import { mintHelperToken, mintControlToken, helperSessionId } from "../shared/session-token.mjs";
+import { encodeGoodbyeFrame, parseHelperCommandFrame } from "../shared/control-frames.mjs";
+
+const SECRET = "helper-lifecycle-test-secret";
+
+async function waitFor(pred, ms, label, pollMs = 25) {
+  const started = Date.now();
+  for (;;) {
+    const v = await pred();
+    if (v) return v;
+    if (Date.now() - started > ms) throw new Error(`timed out after ${ms}ms waiting for ${label}`);
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+/** Open a raw helper-leg ws and collect its TEXT control frames. */
+async function openHelperLeg(relayUrl, session, token, { version, machineLabel, alwaysOn } = {}) {
+  const params = new URLSearchParams({ session, role: "helper", token });
+  if (version) params.set("helperVersion", version);
+  if (machineLabel) params.set("machineLabel", machineLabel);
+  if (alwaysOn) params.set("alwaysOn", "1");
+  const ws = new WebSocket(`${relayUrl}/?${params}`);
+  const leg = { ws, texts: [], closed: null };
+  ws.on("message", (data, isBinary) => {
+    if (!isBinary) leg.texts.push(Buffer.isBuffer(data) ? data.toString("utf8") : String(data));
+  });
+  ws.on("close", (code, reasonBuf) => { leg.closed = [code, reasonBuf ? reasonBuf.toString() : ""]; });
+  await Promise.race([
+    once(ws, "open"),
+    new Promise((_, rej) => setTimeout(() => rej(new Error("helper open timeout")), 5000)),
+  ]);
+  return leg;
+}
+
+async function getStatus(relay, session, control) {
+  const res = await fetch(`${relay.httpUrl}/helper/status?session=${session}`, {
+    headers: { Authorization: `Bearer ${control}` },
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+test("(1) helper attach → GET /helper/status reports connected with announced fields", { timeout: 15000 }, async (t) => {
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const session = helperSessionId(owner);
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+
+  const token = await mintHelperToken({ sub: owner, secret: SECRET });
+  const helper = await openHelperLeg(relay.url, session, token, {
+    version: "0.3.0",
+    machineLabel: "Nick's MacBook Pro",
+    alwaysOn: true,
+  });
+  t.after(() => { try { helper.ws.terminate(); } catch { /* */ } });
+
+  const control = await mintControlToken({ sub: owner, sid: session, secret: SECRET });
+  const { status, body } = await waitFor(
+    async () => {
+      const r = await getStatus(relay, session, control);
+      return r.body.connected ? r : null;
+    },
+    5000,
+    "status to report connected",
+  );
+  assert.equal(status, 200);
+  assert.deepEqual(body, {
+    connected: true,
+    version: "0.3.0",
+    machineLabel: "Nick's MacBook Pro",
+    alwaysOn: true,
+    stoppedUnexpectedly: false,
+    lastEventAt: null,
+  });
+  console.log("[helper/1] PASS — attach reports connected with announced version/machineLabel/alwaysOn");
+});
+
+test("(2) goodbye then disconnect → not connected, never stoppedUnexpectedly", { timeout: 15000 }, async (t) => {
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const session = helperSessionId(owner);
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+
+  const token = await mintHelperToken({ sub: owner, secret: SECRET });
+  const helper = await openHelperLeg(relay.url, session, token);
+  const control = await mintControlToken({ sub: owner, sid: session, secret: SECRET });
+  await waitFor(async () => (await getStatus(relay, session, control)).body.connected, 5000, "attach to land");
+
+  helper.ws.send(encodeGoodbyeFrame("idle-quit"));
+  await new Promise((r) => setTimeout(r, 100)); // let the goodbye land before closing
+  helper.ws.close();
+  await once(helper.ws, "close");
+
+  const { body } = await waitFor(
+    async () => {
+      const r = await getStatus(relay, session, control);
+      return r.body.connected === false ? r : null;
+    },
+    5000,
+    "status to report disconnected",
+  );
+  assert.equal(body.connected, false);
+  assert.equal(body.stoppedUnexpectedly, false, "a goodbye'd exit is never flagged unexpected");
+  console.log("[helper/2] PASS — goodbye + disconnect never flips stoppedUnexpectedly");
+});
+
+test("(3) drop without goodbye → stoppedUnexpectedly, cleared by a fresh attach", { timeout: 15000 }, async (t) => {
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const session = helperSessionId(owner);
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+
+  const token = await mintHelperToken({ sub: owner, secret: SECRET });
+  const helper = await openHelperLeg(relay.url, session, token);
+  const control = await mintControlToken({ sub: owner, sid: session, secret: SECRET });
+  await waitFor(async () => (await getStatus(relay, session, control)).body.connected, 5000, "attach to land");
+
+  // No goodbye — simulate a crash/kill by terminating the socket outright.
+  helper.ws.terminate();
+  await once(helper.ws, "close");
+
+  const dropped = await waitFor(
+    async () => {
+      const r = await getStatus(relay, session, control);
+      return r.body.connected === false ? r.body : null;
+    },
+    5000,
+    "status to report disconnected",
+  );
+  assert.equal(dropped.stoppedUnexpectedly, true, "a goodbye-less drop is flagged unexpected");
+  assert.ok(typeof dropped.lastEventAt === "number");
+
+  // A fresh attach clears it (design rule: reconnect wipes the rose chip).
+  const token2 = await mintHelperToken({ sub: owner, secret: SECRET });
+  const helper2 = await openHelperLeg(relay.url, session, token2);
+  t.after(() => { try { helper2.ws.terminate(); } catch { /* */ } });
+  const cleared = await waitFor(
+    async () => {
+      const r = await getStatus(relay, session, control);
+      return r.body.connected ? r.body : null;
+    },
+    5000,
+    "reattach to clear the flag",
+  );
+  assert.equal(cleared.stoppedUnexpectedly, false);
+  console.log("[helper/3] PASS — goodbye-less drop flags stoppedUnexpectedly; a fresh attach clears it");
+});
+
+test("(4) POST /helper/command forwards stop/quiesce/set-always-on; reports delivered:false with no live leg", { timeout: 15000 }, async (t) => {
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const session = helperSessionId(owner);
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+  const control = await mintControlToken({ sub: owner, sid: session, secret: SECRET });
+
+  // No live leg yet — delivery is honestly reported as false.
+  const noLeg = await fetch(`${relay.httpUrl}/helper/command?session=${session}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${control}`, "content-type": "application/json" },
+    body: JSON.stringify({ cmd: "stop" }),
+  });
+  assert.equal(noLeg.status, 200);
+  assert.deepEqual(await noLeg.json(), { delivered: false });
+
+  const token = await mintHelperToken({ sub: owner, secret: SECRET });
+  const helper = await openHelperLeg(relay.url, session, token);
+  t.after(() => { try { helper.ws.terminate(); } catch { /* */ } });
+  await waitFor(async () => (await getStatus(relay, session, control)).body.connected, 5000, "attach to land");
+
+  for (const [cmd, value] of [["stop", undefined], ["quiesce", undefined], ["set-always-on", true]]) {
+    const res = await fetch(`${relay.httpUrl}/helper/command?session=${session}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${control}`, "content-type": "application/json" },
+      body: JSON.stringify(value === undefined ? { cmd } : { cmd, value }),
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { delivered: true });
+    const frame = await waitFor(
+      () => helper.texts.map(parseHelperCommandFrame).find((f) => f?.cmd === cmd) ?? null,
+      5000,
+      `${cmd} frame to arrive`,
+    );
+    assert.deepEqual(frame, value === undefined ? { cmd } : { cmd, value });
+  }
+  console.log("[helper/4] PASS — commands forward to a live leg; delivered:false is honest with none live");
+});
+
+test("(5) an unauthorized status/command call is rejected without touching a live leg", { timeout: 15000 }, async (t) => {
+  const owner = `user-${Math.random().toString(36).slice(2, 8)}`;
+  const session = helperSessionId(owner);
+  const relay = await startStandinRelay({ port: 0, secret: SECRET });
+  t.after(() => relay.close());
+
+  const token = await mintHelperToken({ sub: owner, secret: SECRET });
+  const helper = await openHelperLeg(relay.url, session, token);
+  t.after(() => { try { helper.ws.terminate(); } catch { /* */ } });
+  const control = await mintControlToken({ sub: owner, sid: session, secret: SECRET });
+  await waitFor(async () => (await getStatus(relay, session, control)).body.connected, 5000, "attach to land");
+
+  const badStatus = await fetch(`${relay.httpUrl}/helper/status?session=${session}`);
+  assert.equal(badStatus.status, 401);
+
+  const foreignControl = await mintControlToken({ sub: owner, sid: `${session}-other`, secret: SECRET });
+  const badCommand = await fetch(`${relay.httpUrl}/helper/command?session=${session}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${foreignControl}`, "content-type": "application/json" },
+    body: JSON.stringify({ cmd: "stop" }),
+  });
+  assert.equal(badCommand.status, 401);
+
+  await new Promise((r) => setTimeout(r, 100));
+  assert.equal(helper.ws.readyState, WebSocket.OPEN, "rejected calls never touch the live helper leg");
+  console.log("[helper/5] PASS — unauthorized status/command calls are rejected, live leg untouched");
+});

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs zombie-bridge-reattach.test.mjs pair-whole-notify.test.mjs session-end.test.mjs helper-lifecycle.test.mjs ../shared/session-token.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs zombie-bridge-reattach.test.mjs pair-whole-notify.test.mjs session-end.test.mjs helper-lifecycle.test.mjs helper-lifecycle-module.test.mjs ../shared/session-token.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/package.json
+++ b/terminal/test/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Automated round-trip proof + stand-in relay + manual xterm page for the terminal slice 1.",
   "scripts": {
-    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs zombie-bridge-reattach.test.mjs pair-whole-notify.test.mjs session-end.test.mjs ../shared/session-token.test.mjs"
+    "test": "node --test --test-concurrency=1 roundtrip.test.mjs deep-link.test.mjs proto-reg.test.mjs lifecycle.test.mjs control-frames.test.mjs prompt-launch.test.mjs orphan-cleanup.test.mjs relay-allowlist.test.mjs reconnect-reattach.test.mjs heartbeat.test.mjs expired-reattach.test.mjs zombie-bridge-reattach.test.mjs pair-whole-notify.test.mjs session-end.test.mjs helper-lifecycle.test.mjs ../shared/session-token.test.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -31,7 +31,8 @@ import {
   maxCloseReason,
   resolveMs,
 } from "../relay/src/pairing.js";
-import { authorizeAttach, authorizeControl } from "../shared/session-token.mjs";
+import { computeHelperStatus } from "../relay/src/helper-status.js";
+import { authorizeAttach, authorizeControl, HELPER_MAX_BOUND_MS } from "../shared/session-token.mjs";
 import {
   encodeAttachedFrame,
   encodePeerDegradedFrame,
@@ -40,6 +41,12 @@ import {
   isHeartbeatFrame,
   encodeBridgeVersionFrame,
   sanitizeHelperVersion,
+  sanitizeMachineLabel,
+  encodeHelperCommandFrame,
+  isGoodbyeFrame,
+  parseGoodbyeReason,
+  isAlwaysOnFrame,
+  parseAlwaysOnValue,
 } from "../shared/control-frames.mjs";
 
 const NORMAL_CLOSURE = 1000;
@@ -72,6 +79,14 @@ export function startStandinRelay(opts = {}) {
   // (`peer-reattached`); the timer firing still-incomplete runs the OLD teardown.
   const sessions = new Map();
 
+  // Helper lifecycle (card cc74a067): a SEPARATE map, one entry per owner's
+  // reserved `helper-<sub>` session id — mirrors the Cloudflare DO's isolated
+  // per-instance storage (a helper leg never shares a `sessions` entry with a
+  // real bridge/browser pairing). `{ ws, owner, version, machineLabel,
+  // alwaysOn, uncleanAt }`; `uncleanAt` is set whenever a helper's socket
+  // closes without a preceding goodbye frame — see computeHelperStatus.
+  const helperLegs = new Map();
+
   // Multi-session stage 3 (POST /end): the stand-in needs a plain HTTP
   // endpoint alongside the WebSocket upgrade path, so — unlike the original
   // `{ port }` shorthand — we own the http.Server explicitly and hand it to
@@ -91,6 +106,12 @@ export function startStandinRelay(opts = {}) {
   /** Faithful twin of the Cloudflare DO's handleEnd (relay/src/index.js). */
   async function handleHttpRequest(req, res) {
     const url = new URL(req.url, "http://localhost");
+    if (url.pathname === "/helper/status" && req.method === "GET") {
+      return handleHelperStatusHttp(req, res, url);
+    }
+    if (url.pathname === "/helper/command" && req.method === "POST") {
+      return handleHelperCommandHttp(req, res, url);
+    }
     if (url.pathname !== "/end" || req.method !== "POST") {
       res.writeHead(404, { "content-type": "application/json" });
       res.end(JSON.stringify({ error: "not found" }));
@@ -121,6 +142,81 @@ export function startStandinRelay(opts = {}) {
     log("end: session ended", { session });
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify({ ended: true }));
+  }
+
+  /** Faithful twin of the Cloudflare DO's handleHelperStatus. */
+  async function handleHelperStatusHttp(req, res, url) {
+    const session = url.searchParams.get("session");
+    const authHeader = req.headers["authorization"] || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : null;
+    const auth = await authorizeControl({ token, secret, session });
+    if (!auth.ok) {
+      log("helper status rejected (auth)", { session, reason: auth.reason });
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "unauthorized" }));
+      return;
+    }
+    const leg = helperLegs.get(session);
+    const status = computeHelperStatus({
+      connected: !!leg?.ws && leg.ws.readyState === leg.ws.OPEN,
+      version: leg?.version ?? null,
+      machineLabel: leg?.machineLabel ?? null,
+      alwaysOn: leg?.alwaysOn ?? false,
+      uncleanAt: leg?.uncleanAt ?? null,
+      now: Date.now(),
+    });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(status));
+  }
+
+  /** Faithful twin of the Cloudflare DO's handleHelperCommand. */
+  async function handleHelperCommandHttp(req, res, url) {
+    const session = url.searchParams.get("session");
+    const authHeader = req.headers["authorization"] || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : null;
+    const auth = await authorizeControl({ token, secret, session });
+    if (!auth.ok) {
+      log("helper command rejected (auth)", { session, reason: auth.reason });
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "unauthorized" }));
+      return;
+    }
+    let body;
+    try {
+      const raw = await new Promise((resolve, reject) => {
+        let data = "";
+        req.on("data", (c) => { data += c; });
+        req.on("end", () => resolve(data));
+        req.on("error", reject);
+      });
+      body = JSON.parse(raw);
+    } catch {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "bad-body" }));
+      return;
+    }
+    const cmd = body?.cmd;
+    if (cmd !== "stop" && cmd !== "quiesce" && cmd !== "set-always-on") {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "bad-command" }));
+      return;
+    }
+    if (cmd === "set-always-on" && typeof body?.value !== "boolean") {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "bad-value" }));
+      return;
+    }
+    const leg = helperLegs.get(session);
+    const delivered = !!leg?.ws && leg.ws.readyState === leg.ws.OPEN;
+    if (delivered) {
+      try {
+        leg.ws.send(encodeHelperCommandFrame(cmd, cmd === "set-always-on" ? body.value : undefined));
+      } catch { /* leg already closing */ }
+    } else {
+      log("helper command: no live helper leg", { session, cmd });
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ delivered }));
   }
 
   /** Close both legs with code 1000 + a lifecycle reason, then forget the session. */
@@ -161,6 +257,79 @@ export function startStandinRelay(opts = {}) {
     legs.idleTimer.unref?.();
   }
 
+  /**
+   * Helper lifecycle (card cc74a067) — faithful twin of the Cloudflare DO's
+   * fetchHelperLeg + handleHelperMessage + handleHelperDetach: bypasses
+   * decideAttach (no pairing — a helper has no peer), reuses authorizeAttach
+   * with the SAME sticky-owner reattach waiver (bounded by HELPER_MAX_BOUND_MS),
+   * preempts a stale same-owner leg, and tracks version/machineLabel/alwaysOn
+   * + "stopped unexpectedly" (uncleanAt) durably per reserved session id.
+   */
+  async function handleHelperConnection(ws, url, session, token) {
+    const existing = helperLegs.get(session);
+    const auth = await authorizeAttach({
+      token,
+      secret,
+      session,
+      role: "helper",
+      boundOwner: existing?.owner ?? null,
+      maxSessionMs: HELPER_MAX_BOUND_MS,
+    });
+    if (!auth.ok) {
+      log("helper attach rejected (auth)", { session, reason: auth.reason });
+      ws.close(CLOSE.BAD_TOKEN.code, CLOSE.BAD_TOKEN.reason);
+      return;
+    }
+
+    // Same-owner PREEMPTION: a second helper leg for the same owner wins
+    // latest-first (mirrors the Cloudflare DO's fetchHelperLeg).
+    if (existing?.ws && existing.ws.readyState === existing.ws.OPEN) {
+      try { existing.ws.close(CLOSE.PREEMPTED.code, CLOSE.PREEMPTED.reason); } catch { /* closing */ }
+    }
+
+    const leg = {
+      ws,
+      owner: auth.sub,
+      version: sanitizeHelperVersion(url.searchParams.get("helperVersion")) ?? existing?.version ?? null,
+      machineLabel: sanitizeMachineLabel(url.searchParams.get("machineLabel")) ?? existing?.machineLabel ?? null,
+      alwaysOn: url.searchParams.get("alwaysOn") === "1",
+      // Design rule: a fresh attach clears any "stopped unexpectedly" flag.
+      uncleanAt: null,
+      goodbye: false,
+    };
+    helperLegs.set(session, leg);
+    log("helper attached", { session, version: leg.version, alwaysOn: leg.alwaysOn });
+
+    ws.on("message", (data, isBinary) => {
+      if (isBinary) return; // a helper leg never sends binary
+      const text = data.toString();
+      if (isGoodbyeFrame(text)) {
+        const reason = parseGoodbyeReason(text);
+        if (!reason) return;
+        leg.goodbye = true;
+        leg.uncleanAt = null;
+        log("helper goodbye", { session, reason });
+        return;
+      }
+      if (isAlwaysOnFrame(text)) {
+        const value = parseAlwaysOnValue(text);
+        if (value === null) return;
+        leg.alwaysOn = value;
+        log("helper always-on updated", { session, value });
+        return;
+      }
+      log("helper: ignored unknown control frame", { session });
+    });
+
+    const teardown = () => {
+      if (helperLegs.get(session) !== leg) return; // a superseding attach already owns this slot
+      log("helper detached", { session, goodbye: leg.goodbye });
+      if (!leg.goodbye) leg.uncleanAt = Date.now();
+    };
+    ws.on("close", teardown);
+    ws.on("error", teardown);
+  }
+
   wss.on("connection", async (ws, req) => {
     const url = new URL(req.url, "ws://localhost");
     const session = url.searchParams.get("session");
@@ -170,6 +339,13 @@ export function startStandinRelay(opts = {}) {
     if (!isValidSession(session)) {
       ws.close(CLOSE.BAD_SESSION.code, CLOSE.BAD_SESSION.reason);
       return;
+    }
+
+    // Helper lifecycle (card cc74a067): a `helper` leg is structurally
+    // different (single, per-owner, no peer) — dispatch to its own handler
+    // BEFORE the bridge/browser pairing logic below, which it never touches.
+    if (role === "helper") {
+      return handleHelperConnection(ws, url, session, token);
     }
 
     // Authenticate the leg with the SAME shared verifier the real relay uses.


### PR DESCRIPTION
Implements the approved design (docs/design-terminal-helper-lifecycle.html) for board card cc74a067, including Nick's binding approval-note change: **always-on ships in v1**.

**Helper (0.3.0)**: quit-when-idle default (60s linger after the last session, relaunch cancels it); crash = log-and-exit (Electron's blocking dialog suppressed — the exact trap from the 0.2.0 incident); a standing owner-bound control WebSocket to the relay for its whole life (goodbye frame on clean exit; receives stop/quiesce/set-always-on); "Keep helper ready" opt-in → login item (visible in System Settings) + menu-bar Tray icon with status/toggle/Quit.

**Relay**: new `role=helper` leg on a reserved per-owner id; `GET /helper/status` + `POST /helper/command` (control-token pattern); durable "stopped unexpectedly" flag (goodbye-less disconnect), clearing on next attach or 24h. Stand-in test relay mirrored.

**Web**: Helper row in My sessions (status chip / version / machine / Stop / integrated update nudge / always-on toggle with honest consent copy — "connect faster", not "open instantly"); stand-down-first update flow (quiesce before download; live sessions get an explicit "End sessions & update" confirm); new helper status/command API routes; relaunch-within-2m PostHog counter; `MINIMUM_RECOMMENDED_HELPER_VERSION` → 0.3.0.

**Tests**: 51 new across helper/relay/web pure modules + relay integration. Gates: tsc clean · web 2492/2492 · relay 38/38 · shared 27/27 · integration 116/116.

**Deploy order (handled out-of-band): relay deploy + notarized 0.3.0 release published BEFORE this merges' web deploy goes live.**

Note: the Vercel Preview check is known-broken on PRs (missing Supabase env) and does not block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)