### PR TITLE
fix(terminal): keep the xterm host mounted through pop-out — bring-back was blank and input-dead

### DIFF
--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -1,0 +1,193 @@
+// Regression net for fix/terminal-popout-host-mounted: bring-back used to
+// leave the dock terminal blank and input-dead because the poppedOut branch
+// early-returned a DIFFERENT tree (the placeholder only), unmounting the
+// xterm host div (`containerRef`) along with everything else. The hook's
+// xterm.js `Terminal` instance survives that unmount detached from any DOM
+// node, so nothing re-attaches on bring-back — buffer frozen, socket writing
+// invisibly, keyboard handler unreachable.
+//
+// `useTerminalSession` itself is mocked out entirely (it owns xterm.js/
+// WebSocket/posthog wiring already covered by use-terminal-session.test.ts)
+// so this file can focus purely on TerminalSessionView's own render
+// structure: does the host div's DOM node survive a poppedOut toggle, and is
+// visibility driven by CSS (`hidden`/`aria-hidden`) rather than mount/unmount?
+//
+// The mock hook calls a real `useRef` for `containerRef` — since it's invoked
+// in the same hook slot on every render of the SAME component instance,
+// React preserves that ref object across re-renders exactly like the real
+// hook would. Capturing `containerRef.current` (the actual DOM node React
+// assigns the ref to) lets the tests assert real node identity, not just
+// object-reference stability of the ref container.
+
+import { useRef } from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type {
+  UseTerminalSessionResult,
+  TerminalSessionActions,
+} from "./use-terminal-session";
+
+vi.mock("./use-terminal-session", () => ({
+  useTerminalSession: vi.fn(),
+}));
+
+import { useTerminalSession } from "./use-terminal-session";
+import { TerminalSessionView } from "./terminal-session-view";
+import type { SessionEntry } from "./terminal-tabs";
+
+const mockedUseTerminalSession = vi.mocked(useTerminalSession);
+
+// Captured on every mock hook invocation so tests can read the DOM node
+// React actually attached to `containerRef` after a render.
+let lastContainerRef: React.RefObject<HTMLDivElement | null> | null = null;
+
+function mockActions(): TerminalSessionActions {
+  return {
+    connect: vi.fn(),
+    beginBrowserLaunch: vi.fn(),
+    launchFromBus: vi.fn(),
+    reconnectNow: vi.fn(),
+    end: vi.fn(),
+    setReadOnly: vi.fn(),
+    copyBridgeCommand: vi.fn(),
+    refreshView: vi.fn(),
+  };
+}
+
+function installMockSession() {
+  mockedUseTerminalSession.mockImplementation((): UseTerminalSessionResult => {
+    // Same hook slot every render of the same fiber → React hands back the
+    // SAME ref object it did last render, exactly like the real hook.
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    lastContainerRef = containerRef;
+    return {
+      state: { status: "connected", sessionId: "sess-1", errorKind: null, endedReason: null, closeCode: null },
+      launchPhase: "idle",
+      peerDegraded: false,
+      helperVersion: null,
+      pair: { sessionId: "sess-1", bridgeToken: "bridge-tok", browserToken: "browser-tok" },
+      readOnly: false,
+      inputEnabled: true,
+      platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download", downloadUrl: null },
+      paired: true,
+      xtermReady: true,
+      containerRef,
+      actions: mockActions(),
+    };
+  });
+}
+
+function baseEntry(): SessionEntry {
+  return { key: "tab-1", origin: "toolbar", createdAt: Date.now(), launchSeq: 0, launchPayload: null };
+}
+
+function renderView(poppedOut: boolean) {
+  return render(
+    <TerminalSessionView
+      entry={baseEntry()}
+      descriptor={{ ideaId: "idea-1", ideaTitle: "My Idea", ideaGithubUrl: null }}
+      label="Session 1"
+      isActive
+      expanded
+      onRequestExpand={vi.fn()}
+      autoConnectWhenExpanded={false}
+      onReportSummary={vi.fn()}
+      onRegisterActions={vi.fn()}
+      onAnnounce={vi.fn()}
+      poppedOut={poppedOut}
+      onBringBack={vi.fn()}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  lastContainerRef = null;
+});
+
+describe("TerminalSessionView — pop-out host mounting", () => {
+  it("preserves the terminal host element's identity across a poppedOut true→false toggle", () => {
+    installMockSession();
+    const { rerender } = renderView(false);
+    const hostBeforePopout = lastContainerRef?.current;
+    expect(hostBeforePopout).not.toBeNull();
+
+    rerender(
+      <TerminalSessionView
+        entry={baseEntry()}
+        descriptor={{ ideaId: "idea-1", ideaTitle: "My Idea", ideaGithubUrl: null }}
+        label="Session 1"
+        isActive
+        expanded
+        onRequestExpand={vi.fn()}
+        autoConnectWhenExpanded={false}
+        onReportSummary={vi.fn()}
+        onRegisterActions={vi.fn()}
+        onAnnounce={vi.fn()}
+        poppedOut
+        onBringBack={vi.fn()}
+      />,
+    );
+    const hostWhilePoppedOut = lastContainerRef?.current;
+
+    rerender(
+      <TerminalSessionView
+        entry={baseEntry()}
+        descriptor={{ ideaId: "idea-1", ideaTitle: "My Idea", ideaGithubUrl: null }}
+        label="Session 1"
+        isActive
+        expanded
+        onRequestExpand={vi.fn()}
+        autoConnectWhenExpanded={false}
+        onReportSummary={vi.fn()}
+        onRegisterActions={vi.fn()}
+        onAnnounce={vi.fn()}
+        poppedOut={false}
+        onBringBack={vi.fn()}
+      />,
+    );
+    const hostAfterBringBack = lastContainerRef?.current;
+
+    // The bug this guards against: the old poppedOut early-return replaced
+    // the whole subtree, so the host div was a genuinely NEW DOM node after
+    // every toggle. It must now be the SAME node throughout.
+    expect(hostWhilePoppedOut).toBe(hostBeforePopout);
+    expect(hostAfterBringBack).toBe(hostBeforePopout);
+  });
+
+  it("keeps the host div in the document (merely hidden) while poppedOut, and shows the placeholder", () => {
+    installMockSession();
+    renderView(true);
+
+    expect(screen.getByText("Popped out")).toBeInTheDocument();
+    expect(
+      screen.getByText(/This session is open in another window/),
+    ).toBeInTheDocument();
+
+    const host = lastContainerRef?.current ?? null;
+    expect(host).not.toBeNull();
+    // Still mounted in the document...
+    expect(document.body.contains(host)).toBe(true);
+    // ...but under an ancestor the component has explicitly hidden.
+    expect(host?.closest('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it("shows the host (not hidden) and hides the placeholder once poppedOut is false", () => {
+    installMockSession();
+    renderView(false);
+
+    const host = lastContainerRef?.current ?? null;
+    expect(host).not.toBeNull();
+    expect(document.body.contains(host)).toBe(true);
+    // Nothing between the host and the outer (visible, active-tab) wrapper is
+    // aria-hidden — the normal body is the one showing.
+    expect(host?.closest('[aria-hidden="true"]')).toBeNull();
+
+    // The placeholder text is still in the DOM (never unmounted — see the
+    // component's "always mounted, CSS hidden" idiom) but sits behind an
+    // aria-hidden wrapper.
+    const placeholder = screen.getByText("Popped out");
+    expect(placeholder.closest('[aria-hidden="true"]')).not.toBeNull();
+  });
+});

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -244,6 +244,23 @@ export function TerminalSessionView({
   });
   useEffect(() => () => onRegisterActions(entry.key, null), [entry.key, onRegisterActions]);
 
+  // Bring-back reveal (fix/terminal-popout-host-mounted): the host div was
+  // `display:none` (0-size) for the whole time it was popped out, so the
+  // usual `expanded`-keyed resize/focus effects in the hook never re-fire on
+  // bring-back — `expanded` itself doesn't change, only `poppedOut` does.
+  // Force a refit + resize-frame send + focus on the true→false transition
+  // so typing works immediately without an extra click or window resize.
+  const prevPoppedOutRef = useRef(poppedOut);
+  useEffect(() => {
+    const wasPoppedOut = prevPoppedOutRef.current;
+    prevPoppedOutRef.current = poppedOut;
+    if (wasPoppedOut && !poppedOut) actions.refreshView();
+    // actions.refreshView is useCallback-stable (see resolveLaunchPromptParts-
+    // style deps in the hook); depending on the specific property rather than
+    // `actions` itself keeps this from re-running on unrelated renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poppedOut, actions.refreshView]);
+
   const view = resolveDockView(state.status, launchPhase, platform.supported, paired);
   const meta = dockStatusMeta(view, state.errorKind);
   const showStream = state.status === "connected" || state.status === "disconnected";
@@ -262,15 +279,23 @@ export function TerminalSessionView({
     view === "connecting-returning" ||
     view === "legacy-waiting";
 
-  // Multi-session stage 4 (D2/D3, design §10b): once this tab has been popped
-  // out, its whole body becomes the placeholder — no header/pill/stream/input.
-  // The underlying `useTerminalSession` instance above keeps running (its
-  // socket will shortly be preempted by the relay, or already has been); we
-  // just don't SHOW any of that here. The tab strip above this component is
-  // unaffected (owned by terminal-dock.tsx).
-  if (poppedOut) {
-    return (
-      <div className={cn(!isActive && "hidden")} aria-hidden={!isActive}>
+  return (
+    <div className={cn(!isActive && "hidden")} aria-hidden={!isActive}>
+      {/* Multi-session stage 4 (D2/D3, design §10b): once this tab has been
+          popped out, show the placeholder INSTEAD OF the normal
+          header/body/input. Both faces stay mounted here — only CSS `hidden`
+          toggles which one is visible — because the terminal host div below
+          must NEVER unmount: a `poppedOut` early-return used to tear down
+          this whole subtree (including the host), orphaning the xterm
+          instance the hook keeps alive underneath (buffer intact, socket
+          writing invisibly, keyboard handler unreachable) — bring-back had
+          nothing to re-attach to (fix/terminal-popout-host-mounted). The
+          underlying `useTerminalSession` instance keeps running unaffected
+          either way (its socket gets preempted by the relay moments after
+          the popped window attaches, exactly like any other 4001 close) —
+          this is purely this component's PRESENTATION. The tab strip above
+          this component is unaffected (owned by terminal-dock.tsx). */}
+      <div className={cn(!poppedOut && "hidden")} aria-hidden={!poppedOut}>
         <div className="flex h-[38vh] min-h-[220px] flex-col items-center justify-center gap-3 bg-[#0c0c0e] px-6 py-6 text-center">
           <span className="text-2xl text-violet-400" aria-hidden="true">
             ⧉
@@ -289,153 +314,151 @@ export function TerminalSessionView({
           </Button>
         </div>
       </div>
-    );
-  }
 
-  return (
-    <div className={cn(!isActive && "hidden")} aria-hidden={!isActive}>
-      {/* Header: state · identity · controls (safest → most destructive) */}
-      <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 bg-[#141417] px-3 py-2">
-        <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold", meta.className)}>
-          <meta.Icon className={cn("h-3 w-3", meta.spin && "animate-spin")} />
-          {meta.label}
-        </span>
-        {readOnly && state.status === "connected" && (
-          <span className="inline-flex items-center gap-1.5 rounded-md border border-violet-500/55 bg-violet-500/10 px-2 py-1 text-[11px] font-bold text-violet-300">
-            <Lock className="h-3 w-3" /> Read-only
+      <div className={cn(poppedOut && "hidden")} aria-hidden={poppedOut}>
+        {/* Header: state · identity · controls (safest → most destructive) */}
+        <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 bg-[#141417] px-3 py-2">
+          <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold", meta.className)}>
+            <meta.Icon className={cn("h-3 w-3", meta.spin && "animate-spin")} />
+            {meta.label}
           </span>
-        )}
-        <span className="hidden font-mono text-xs text-zinc-500 sm:inline">
-          {descriptor.ideaTitle}
-          {pair && <span className="text-zinc-600"> · session {pair.sessionId.slice(0, 8)}</span>}
-        </span>
-        <span className="ml-auto inline-flex items-center gap-1.5">
-          {/* Pop out (D1/D2, design §4 "one new header control, in the old
-              header") — left of Read-only/End, per the design's control
-              cluster ordering (safest → most destructive). Gated on
-              `showStream` like Read-only: popping out only makes sense once
-              there's a live/reconnecting stream to move into another window;
-              `onPopOut` itself is dock-only (the popped window's own view
-              never renders this component with a handler wired). */}
-          {showStream && onPopOut && (
-            <Button
-              variant="outline"
-              size="xs"
-              className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
-              onClick={onPopOut}
-              aria-label="Pop this session out into its own window"
-            >
-              <ExternalLink className="h-3 w-3" /> Pop out
-            </Button>
+          {readOnly && state.status === "connected" && (
+            <span className="inline-flex items-center gap-1.5 rounded-md border border-violet-500/55 bg-violet-500/10 px-2 py-1 text-[11px] font-bold text-violet-300">
+              <Lock className="h-3 w-3" /> Read-only
+            </span>
           )}
-          {showStream && (
-            <Button
-              variant="outline"
-              size="xs"
-              className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
-              onClick={() => actions.setReadOnly((r) => !r)}
-              aria-pressed={readOnly}
-              aria-label={readOnly ? "Read-only is on — click to allow input" : "Switch to read-only"}
-            >
-              {readOnly ? <Lock className="h-3 w-3" /> : <LockOpen className="h-3 w-3" />}
-              {readOnly ? "Read-only · on" : "Read-only"}
-            </Button>
-          )}
-          {showEnd && (
-            <Button
-              variant="outline"
-              size="xs"
-              className="border-rose-500/45 bg-transparent text-rose-400 hover:bg-rose-500/10"
-              onClick={actions.end}
-              aria-label="End session"
-            >
-              <Power className="h-3 w-3" /> End
-            </Button>
-          )}
-        </span>
-      </div>
-
-      {/* Helper-update nudge (release-gate rework 2a) — non-blocking, dismissible.
-          Missing version (every pre-2a helper) OR older than
-          MINIMUM_RECOMMENDED_HELPER_VERSION shows this; the session itself is
-          never gated on it. */}
-      {showHelperNudge && (
-        <div className="flex items-center gap-2 border-b border-sky-500/30 bg-sky-500/5 px-3 py-1.5 text-[11px] text-sky-300">
-          <Info className="h-3 w-3 shrink-0" />
-          <span className="flex-1">
-            Update your terminal helper — faster and lighter on the relay.{" "}
-            <a
-              href={platform.downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL}
-              className="underline hover:text-sky-200"
-            >
-              Download
-            </a>
+          <span className="hidden font-mono text-xs text-zinc-500 sm:inline">
+            {descriptor.ideaTitle}
+            {pair && <span className="text-zinc-600"> · session {pair.sessionId.slice(0, 8)}</span>}
           </span>
-          <button
-            type="button"
-            className="shrink-0 text-sky-400 hover:text-sky-200"
-            onClick={() => setDismissedHelperNudge(true)}
-            aria-label="Dismiss helper update notice"
-          >
-            <X className="h-3 w-3" />
-          </button>
+          <span className="ml-auto inline-flex items-center gap-1.5">
+            {/* Pop out (D1/D2, design §4 "one new header control, in the old
+                header") — left of Read-only/End, per the design's control
+                cluster ordering (safest → most destructive). Gated on
+                `showStream` like Read-only: popping out only makes sense once
+                there's a live/reconnecting stream to move into another window;
+                `onPopOut` itself is dock-only (the popped window's own view
+                never renders this component with a handler wired). */}
+            {showStream && onPopOut && (
+              <Button
+                variant="outline"
+                size="xs"
+                className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+                onClick={onPopOut}
+                aria-label="Pop this session out into its own window"
+              >
+                <ExternalLink className="h-3 w-3" /> Pop out
+              </Button>
+            )}
+            {showStream && (
+              <Button
+                variant="outline"
+                size="xs"
+                className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+                onClick={() => actions.setReadOnly((r) => !r)}
+                aria-pressed={readOnly}
+                aria-label={readOnly ? "Read-only is on — click to allow input" : "Switch to read-only"}
+              >
+                {readOnly ? <Lock className="h-3 w-3" /> : <LockOpen className="h-3 w-3" />}
+                {readOnly ? "Read-only · on" : "Read-only"}
+              </Button>
+            )}
+            {showEnd && (
+              <Button
+                variant="outline"
+                size="xs"
+                className="border-rose-500/45 bg-transparent text-rose-400 hover:bg-rose-500/10"
+                onClick={actions.end}
+                aria-label="End session"
+              >
+                <Power className="h-3 w-3" /> End
+              </Button>
+            )}
+          </span>
         </div>
-      )}
 
-      {/* Terminal body — the xterm host plus a state overlay. The host stays
-          mounted under every state so scrollback is frozen + readable on end. */}
-      <div className="relative h-[38vh] min-h-[220px]">
-        <div
-          ref={containerRef}
-          className={cn("h-full w-full px-3 py-2", state.status === "disconnected" && "opacity-45")}
-        />
-        {!showStream && (
-          <StateOverlay
-            view={view}
-            state={state}
-            pair={pair}
-            platform={platform}
-            canLaunch={canLaunch}
-            onConnect={() => void actions.connect({ autoLaunch: true })}
-            onRetry={() => void actions.connect({ autoLaunch: true })}
-            onLaunchAgain={actions.beginBrowserLaunch}
-            onCopyBridge={actions.copyBridgeCommand}
-          />
-        )}
-        {state.status === "disconnected" && (
-          <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
-            <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
-            <b>Reconnecting to your session…</b> Your machine may have slept or dropped Wi-Fi. Your agent keeps running locally while we reattach.
-            <button className="ml-2 underline hover:text-amber-200" onClick={actions.reconnectNow}>
-              Reconnect now
+        {/* Helper-update nudge (release-gate rework 2a) — non-blocking, dismissible.
+            Missing version (every pre-2a helper) OR older than
+            MINIMUM_RECOMMENDED_HELPER_VERSION shows this; the session itself is
+            never gated on it. */}
+        {showHelperNudge && (
+          <div className="flex items-center gap-2 border-b border-sky-500/30 bg-sky-500/5 px-3 py-1.5 text-[11px] text-sky-300">
+            <Info className="h-3 w-3 shrink-0" />
+            <span className="flex-1">
+              Update your terminal helper — faster and lighter on the relay.{" "}
+              <a
+                href={platform.downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL}
+                className="underline hover:text-sky-200"
+              >
+                Download
+              </a>
+            </span>
+            <button
+              type="button"
+              className="shrink-0 text-sky-400 hover:text-sky-200"
+              onClick={() => setDismissedHelperNudge(true)}
+              aria-label="Dismiss helper update notice"
+            >
+              <X className="h-3 w-3" />
             </button>
           </div>
         )}
-        {state.status === "connected" && peerDegraded && (
-          <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
-            <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
-            <b>Connection interrupted — reconnecting…</b> Your machine may have slept; we&apos;re holding your session and will resume automatically.
-          </div>
+
+        {/* Terminal body — the xterm host plus a state overlay. The host stays
+            mounted under every state so scrollback is frozen + readable on end. */}
+        <div className="relative h-[38vh] min-h-[220px]">
+          <div
+            ref={containerRef}
+            className={cn("h-full w-full px-3 py-2", state.status === "disconnected" && "opacity-45")}
+          />
+          {!showStream && (
+            <StateOverlay
+              view={view}
+              state={state}
+              pair={pair}
+              platform={platform}
+              canLaunch={canLaunch}
+              onConnect={() => void actions.connect({ autoLaunch: true })}
+              onRetry={() => void actions.connect({ autoLaunch: true })}
+              onLaunchAgain={actions.beginBrowserLaunch}
+              onCopyBridge={actions.copyBridgeCommand}
+            />
+          )}
+          {state.status === "disconnected" && (
+            <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
+              <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
+              <b>Reconnecting to your session…</b> Your machine may have slept or dropped Wi-Fi. Your agent keeps running locally while we reattach.
+              <button className="ml-2 underline hover:text-amber-200" onClick={actions.reconnectNow}>
+                Reconnect now
+              </button>
+            </div>
+          )}
+          {state.status === "connected" && peerDegraded && (
+            <div className="absolute inset-x-0 bottom-0 border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-300">
+              <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
+              <b>Connection interrupted — reconnecting…</b> Your machine may have slept; we&apos;re holding your session and will resume automatically.
+            </div>
+          )}
+        </div>
+
+        {/* Input affordance — read-write bar, or the read-only explanatory note. */}
+        {state.status === "connected" && (
+          inputEnabled ? (
+            <div className="flex items-center gap-2 border-t border-zinc-800 bg-[#141417] px-3 py-2 text-xs text-zinc-500">
+              <span className="font-mono text-emerald-400">›</span>
+              <span>Click the terminal and type to steer the agent. Enter sends.</span>
+            </div>
+          ) : (
+            <div className="border-t border-zinc-800 bg-violet-500/5 px-3 py-2 text-[11px] text-zinc-400">
+              <Lock className="mr-1 inline h-3 w-3 text-violet-300" />
+              <b className="text-violet-300">Read-only is on.</b> You&apos;re watching live; keystrokes are frozen.
+              <button className="ml-2 underline hover:text-zinc-200" onClick={() => actions.setReadOnly(false)}>
+                Allow input
+              </button>
+            </div>
+          )
         )}
       </div>
-
-      {/* Input affordance — read-write bar, or the read-only explanatory note. */}
-      {state.status === "connected" && (
-        inputEnabled ? (
-          <div className="flex items-center gap-2 border-t border-zinc-800 bg-[#141417] px-3 py-2 text-xs text-zinc-500">
-            <span className="font-mono text-emerald-400">›</span>
-            <span>Click the terminal and type to steer the agent. Enter sends.</span>
-          </div>
-        ) : (
-          <div className="border-t border-zinc-800 bg-violet-500/5 px-3 py-2 text-[11px] text-zinc-400">
-            <Lock className="mr-1 inline h-3 w-3 text-violet-300" />
-            <b className="text-violet-300">Read-only is on.</b> You&apos;re watching live; keystrokes are frozen.
-            <button className="ml-2 underline hover:text-zinc-200" onClick={() => actions.setReadOnly(false)}>
-              Allow input
-            </button>
-          </div>
-        )
-      )}
     </div>
   );
 }

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -286,6 +286,16 @@ export interface TerminalSessionActions {
   end: () => void;
   setReadOnly: (value: boolean | ((prev: boolean) => boolean)) => void;
   copyBridgeCommand: () => void;
+  /**
+   * Force a refit + resize-frame send + focus, for a reveal that un-hides
+   * the host WITHOUT `expanded` itself changing — e.g. the caller's own
+   * `poppedOut` prop flipping false on bring-back (fix/terminal-popout-host-
+   * mounted). The container was `display:none` (0-size) the whole time it
+   * was hidden that way, so the `expanded`-keyed resize/focus effects above
+   * never re-fire for it; this is the same recovery those effects already do
+   * on a dock re-expand, just triggered on demand instead of by `expanded`.
+   */
+  refreshView: () => void;
 }
 
 export interface UseTerminalSessionResult {
@@ -1342,6 +1352,17 @@ export function useTerminalSession(
     connect,
   ]);
 
+  // See `refreshView`'s doc on TerminalSessionActions. Mirrors the expand-rAF
+  // resize + expand-focus effects above (next paint, so the container has
+  // already been un-hidden before fit()/focus() land) — just callable
+  // directly rather than gated on `expanded`.
+  const refreshView = useCallback(() => {
+    window.requestAnimationFrame(() => {
+      sendResize();
+      termRef.current?.focus();
+    });
+  }, [sendResize]);
+
   const copyBridgeCommand = useCallback(() => {
     // No bridge token to copy for an attached (not minted) session — see
     // PairInfo.bridgeToken's doc. The legacy-waiting panel that renders this
@@ -1375,6 +1396,7 @@ export function useTerminalSession(
       end: endSession,
       setReadOnly,
       copyBridgeCommand,
+      refreshView,
     },
   };
 }


### PR DESCRIPTION
Fourth and (structurally) last defect on board card 4f9cf03d. Field evidence 2026-08-10: after "Bring back to dock" the dock showed Connected but a black, input-dead terminal — even mid-task, with Claude actively producing output.

**Root cause:** the `poppedOut` branch of `terminal-session-view.tsx` early-returned the placeholder, unmounting the session body including the xterm host div. The Terminal instance survived detached — full buffer intact, healthy socket writing into it invisibly, keyboard unreachable. On bring-back a fresh empty div mounted and nothing re-attached the terminal (the init effect only runs on mount). This violated the component's own rule ("The host stays mounted under every state").

**Fix:** one JSX tree, two faces — the placeholder and the normal body are both always mounted, shown/hidden with the component's existing `hidden`/`aria-hidden` idiom, so the host div's DOM identity survives every pop-out round trip. New `refreshView()` action (refit → resize-sync → focus) fires on the popped-out→back transition so typing works immediately. Bonus: the dock now instantly shows its full pre-pop-out scrollback on bring-back (it was never lost, only orphaned).

**Tests:** new `terminal-session-view.test.tsx` — pins host DOM-node identity across the toggle (fails against the old code), placeholder-visible/host-hidden-but-present, and reveal. Gates: tsc clean · targeted 436/436 · full 2495/2495.

Note: the Vercel Preview check is known-broken on PRs (missing Supabase env) and does not block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)