### PR TITLE
feat(terminal): scrollback transfer — history rides the hand-off in both directions (card 35cffc10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-serialize": "^0.14.0",
         "@xterm/xterm": "^6.0.0",
         "ai": "^6.0.86",
         "class-variance-authority": "^0.7.1",
@@ -6704,6 +6705,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -8101,6 +8162,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-serialize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
+      "integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-serialize": "^0.14.0",
     "@xterm/xterm": "^6.0.0",
     "ai": "^6.0.86",
     "class-variance-authority": "^0.7.1",

--- a/src/app/terminal/popout/terminal-popout-client.tsx
+++ b/src/app/terminal/popout/terminal-popout-client.tsx
@@ -21,14 +21,16 @@
 // by itself (see popout-channel.ts's module doc) — it only names the
 // rendezvous channel.
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import {
   popoutChannelName,
+  parsePopoutChannelMessage,
   startPopoutClientHandshake,
   type PopoutPayload,
 } from "@/lib/terminal/popout-channel";
 import { TerminalPopoutView } from "@/components/board/terminal-popout-view";
+import type { TerminalSessionActions } from "@/components/board/use-terminal-session";
 
 // The dock's window.open() target name is `vibecodes-terminal-<nonce>` (see
 // openPopoutWindow in popout-channel.ts) — NOW that the feature string omits
@@ -53,6 +55,20 @@ export function TerminalPopoutClient() {
   const [nonce] = useState<string | null>(() => (typeof window === "undefined" ? null : resolveNonce()));
   const [payload, setPayload] = useState<PopoutPayload | null>(null);
   const [timedOut, setTimedOut] = useState(false);
+  // Scrollback transfer (card 35cffc10): TerminalPopoutView's live session
+  // actions, handed up via onSessionActions the same way terminal-dock.tsx's
+  // TerminalSessionView reports into its parent's actionsMapRef — this
+  // window has no dock chrome to register into, so a single ref is enough.
+  // `null` until the view mounts AND its useTerminalSession instance is
+  // ready, which doubles as the "have we actually attached yet?" signal
+  // below (sendClosed / the bring-back-request reply both read it).
+  const sessionActionsRef = useRef<TerminalSessionActions | null>(null);
+  // Stable identity so TerminalPopoutView's registration effect doesn't churn
+  // on every render of this component (same reasoning as terminal-dock.tsx's
+  // own registerActions).
+  const handleSessionActions = useCallback((actions: TerminalSessionActions | null) => {
+    sessionActionsRef.current = actions;
+  }, []);
 
   useEffect(() => {
     if (!nonce) return;
@@ -74,14 +90,59 @@ export function TerminalPopoutClient() {
     // to (re)send — see createDockPopoutMessageHandler / reduceDockHandshake.
     const stopHandshake = startPopoutClientHandshake({
       channel,
-      onPayload: (p) => setPayload(p),
+      onPayload: (p) => {
+        setPayload(p);
+        // Scrollback transfer, Flow B (design §3): once attached, this same
+        // channel switches roles from "waiting for the hand-off" to
+        // "answering bring-back-request" — safe to reassign onmessage here
+        // because the handshake driver's own handler already latched
+        // `settled = true` (it's the very thing that just called this
+        // callback) and permanently no-ops from now on; nothing double-
+        // handles a later message.
+        channel.onmessage = (ev) => {
+          const message = parsePopoutChannelMessage(ev.data);
+          if (message?.type !== "bring-back-request") return;
+          const buffer = sessionActionsRef.current?.serializeNow();
+          // null = session not attached yet (shouldn't happen once payload
+          // has landed, but never worth a throw) — skip the reply; the
+          // dock's own 500ms timeout covers it (D3's deliberate fallback).
+          if (!buffer) return;
+          try {
+            channel.postMessage({ type: "buffer-reply", buffer });
+          } catch {
+            /* channel already gone — nothing to reply to */
+          }
+        };
+      },
       // On timeout this ALSO posts "closed" on the channel (same module),
       // so a dock that's still listening auto-reattaches instead of being
       // stuck showing "Popped out" forever with nothing on the other end.
       onTimeout: () => setTimedOut(true),
     });
 
+    // Flow C (design §4): closing this window pushes the FULL serialized
+    // scrollback (pre-pop-out history it was handed, plus everything
+    // produced since) immediately before "closed" — BroadcastChannel's
+    // per-sender ordering guarantees the reply lands first. Before this
+    // window has actually attached (`sessionActionsRef.current` still null —
+    // still mid hand-off, or the hand-off never completed), there's nothing
+    // to serialize, so this is exactly today's "closed" alone. Bounded and
+    // never-throws (design E4): a serialize failure — or simply having
+    // nothing to send — falls straight through to "closed" alone rather
+    // than blocking it.
     const sendClosed = () => {
+      try {
+        const buffer = sessionActionsRef.current?.serializeNow();
+        if (buffer) {
+          try {
+            channel.postMessage({ type: "buffer-reply", buffer });
+          } catch {
+            /* channel already gone — still try "closed" below */
+          }
+        }
+      } catch {
+        /* serialize blew up — skip straight to "closed" alone (E4) */
+      }
       try {
         channel.postMessage({ type: "closed" });
       } catch {
@@ -105,7 +166,9 @@ export function TerminalPopoutClient() {
   // Once `payload` is set, the render below returns the live view BEFORE it
   // ever looks at `timedOut` — so a late interval tick racing a just-arrived
   // payload is harmless; there's no need to also clear `timedOut` here.
-  if (payload) return <TerminalPopoutView payload={payload} />;
+  if (payload) {
+    return <TerminalPopoutView payload={payload} onSessionActions={handleSessionActions} />;
+  }
 
   if (!nonce || timedOut) {
     return (

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -67,11 +67,12 @@ import {
   popoutChannelName,
   openPopoutWindow,
   createDockPopoutMessageHandler,
+  startBringBackRequest,
   INITIAL_DOCK_HANDSHAKE_STATE,
-  type DockHandshakeState,
-  type PopoutChannelLike,
+  type DockPopoutEntry,
   type PopoutPayload,
 } from "@/lib/terminal/popout-channel";
+import type { TransferredBuffer } from "@/lib/terminal/scrollback-transfer";
 import {
   type SessionEntry,
   type TabDisplayStatus,
@@ -171,9 +172,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // from the moment "Pop out" is clicked until either "Bring back" or the
   // popped window's own close-signal).
   const [poppedOutKeys, setPoppedOutKeys] = useState<Set<string>>(() => new Set());
-  const popoutChannelsRef = useRef<Map<string, { channel: PopoutChannelLike; handshake: DockHandshakeState }>>(
-    new Map(),
-  );
+  const popoutChannelsRef = useRef<Map<string, DockPopoutEntry>>(new Map());
   // Mirrors so `deliverLaunch` (used by both the launch-bus subscription and
   // "+") can read the CURRENT list/summaries without depending on them — that
   // keeps its identity stable across renders instead of forcing the launch-bus
@@ -273,22 +272,53 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   }, []);
 
   // Reattach the dock's OWN leg for this session (no re-mint — reconnectNow()
-  // reuses the retained sid/browserToken, see use-terminal-session.ts) and
-  // drop the pop-out bookkeeping. The dock's own leg was preempted the moment
-  // the pop-out attached (relay close 4001), so underneath the "Popped out"
-  // placeholder its connection state is stuck in "error" — reconnectNow()
-  // detects that (decideReconnectNow in connection.ts) and resets the state
-  // machine before reopening the socket, rather than silently reattaching into
-  // a state the reducer has no forward edge out of (fix/terminal-bringback-
-  // state-reset). This is what BOTH "Bring back to dock" and the popped
-  // window's close-signal do — the only difference is who triggered it
-  // (design §10b: "two paths, never a race").
-  const bringBackToDock = useCallback(
-    (key: string) => {
+  // reuses the retained sid/browserToken, see use-terminal-session.ts), first
+  // restoring a handed-over buffer into the dock's own (hidden) terminal when
+  // one is available, then dropping the pop-out bookkeeping. The dock's own
+  // leg was preempted the moment the pop-out attached (relay close 4001), so
+  // underneath the "Popped out" placeholder its connection state is stuck in
+  // "error" — reconnectNow() detects that (decideReconnectNow in
+  // connection.ts) and resets the state machine before reopening the socket,
+  // rather than silently reattaching into a state the reducer has no forward
+  // edge out of (fix/terminal-bringback-state-reset).
+  //
+  // Scrollback transfer (card 35cffc10, D1): a non-null `buffer` here is
+  // always a SUPERSET of the dock's own history (Flow A handed the dock's
+  // pre-pop-out buffer to the popped window; it only grew from there) —
+  // wholesale REPLACE via restoreBuffer, never append. `null` (no buffer
+  // ever arrived — deploy skew, a failed serialize, or the hand-off-timeout
+  // "closed" that never carried a payload) leaves the dock's own buffer
+  // untouched, exactly today's pre-this-card behaviour.
+  //
+  // Shared by BOTH reattach paths — the popped window's own close-signal
+  // (Flow C, `onReattach` below) and the button's two-phase request (Flow B,
+  // `bringBackToDock` below) — the only difference between them is HOW the
+  // buffer got decided, never what happens once it has been.
+  const applyBufferAndReattach = useCallback(
+    (key: string, buffer: TransferredBuffer | null) => {
+      if (buffer) actionsMapRef.current.get(key)?.restoreBuffer(buffer);
       actionsMapRef.current.get(key)?.reconnectNow();
       endPopOut(key);
     },
     [endPopOut],
+  );
+
+  // "Bring back to dock" button click (Flow B, design §3): two-phase —
+  // request the popped window's buffer, wait up to 500ms for the reply (or
+  // proceed on timeout with the dock's own buffer, D3) — THEN reconnect and
+  // tear down. No channel entry means Flow C already completed the reattach
+  // moments earlier (the popped window closed on its own, racing this click)
+  // — a no-op (E1).
+  const bringBackToDock = useCallback(
+    (key: string) => {
+      const entry = popoutChannelsRef.current.get(key);
+      if (!entry) return;
+      startBringBackRequest({
+        channel: entry.channel,
+        onSettle: (buffer) => applyBufferAndReattach(key, buffer),
+      });
+    },
+    [applyBufferAndReattach],
   );
 
   const handlePopOut = useCallback(
@@ -329,7 +359,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       // not just the first — as a reason to (re)send the payload.
       const channel = new BroadcastChannel(popoutChannelName(nonce));
       popoutChannelsRef.current.set(key, { channel, handshake: INITIAL_DOCK_HANDSHAKE_STATE });
-      const payload: PopoutPayload = {
+      // Everything but the buffer is static for the lifetime of this
+      // hand-off — the buffer itself is captured FRESH on every send
+      // (including retries) inside getPayload below (design §1/§2's "as
+      // current as possible"), never memoized alongside the rest.
+      const basePayload: Omit<PopoutPayload, "buffer"> = {
         sid: summary.sessionId,
         browserToken: summary.browserToken,
         relayUrl: relayBaseUrl(),
@@ -342,17 +376,23 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       channel.onmessage = createDockPopoutMessageHandler({
         getEntry: () => popoutChannelsRef.current.get(key),
         setEntry: (next) => popoutChannelsRef.current.set(key, next),
-        getPayload: () => payload,
-        // The popped window told us it's closing (D3) — OR its hand-off
-        // timed out and it's telling us to give up on its behalf (see
-        // startPopoutClientHandshake) — either way, reattach automatically.
-        onReattach: () => bringBackToDock(key),
+        getPayload: () => {
+          const buffer = actionsMapRef.current.get(key)?.serializeNow();
+          return buffer ? { ...basePayload, buffer } : basePayload;
+        },
+        // The popped window told us it's closing (D3, Flow C — possibly with
+        // a stashed buffer that arrived just ahead of "closed") — OR its
+        // hand-off timed out and it's telling us to give up on its behalf
+        // (see startPopoutClientHandshake, always with a null buffer) —
+        // either way, apply whatever buffer was stashed (or none) and
+        // reattach automatically.
+        onReattach: (stashedBuffer) => applyBufferAndReattach(key, stashedBuffer),
       });
 
       posthogRef.current?.capture("terminal_popout_used", { origin: entry?.origin ?? "toolbar" });
       setPoppedOutKeys((prev) => new Set(prev).add(key));
     },
-    [ideaId, ideaTitle, ideaSlug, bringBackToDock],
+    [ideaId, ideaTitle, ideaSlug, applyBufferAndReattach],
   );
 
   // ── close / remove a tab ────────────────────────────────────────────────────

--- a/src/components/board/terminal-popout-view.tsx
+++ b/src/components/board/terminal-popout-view.tsx
@@ -20,25 +20,47 @@
 // runs the install-first gate. See use-terminal-session.ts's `attachExisting`
 // doc for why that's safe (same-owner reattach, relay's existing 4001 path).
 
-import { useEffect, useState } from "react";
-import { CircleAlert, Info, Loader2, Lock, LockOpen, Power, Square, Undo2 } from "lucide-react";
+import { useEffect } from "react";
+import { CircleAlert, Loader2, Lock, LockOpen, Power, Square, Undo2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { resolveDockView, type DockView } from "@/lib/terminal/first-run-flow";
 import type { TerminalConnectionState } from "@/lib/terminal/connection";
 import { isPreemptedClose, type PopoutPayload } from "@/lib/terminal/popout-channel";
-import { dockStatusMeta } from "./terminal-session-view";
+import { dockStatusMeta, type StatusMeta } from "./terminal-session-view";
 import {
   useTerminalSession,
   type AttachExistingPair,
+  type TerminalSessionActions,
   type TerminalSessionDescriptor,
 } from "./use-terminal-session";
 
+// Pill fix (card 35cffc10, design §6): "Brought back to the dock" is a
+// deliberate, successful user action — the rose "Error" pill dockStatusMeta
+// would otherwise render for the underlying error/4001 state contradicts the
+// calm overlay sitting right below it. Sky/informational, Undo2 icon —
+// same family as BroughtBackOverlay below (icon + text + colour together,
+// never colour alone, per the existing pill contract).
+const MOVED_TO_DOCK_META: StatusMeta = {
+  label: "Moved to dock",
+  Icon: Undo2,
+  className: "border-sky-500/50 bg-sky-500/10 text-sky-400",
+};
+
 interface TerminalPopoutViewProps {
   payload: PopoutPayload;
+  /**
+   * Scrollback transfer (card 35cffc10): hands this session's live
+   * `TerminalSessionActions` up to TerminalPopoutClient, which needs
+   * `actions.serializeNow()` to answer `bring-back-request` and to push its
+   * own buffer ahead of `closed` on `pagehide` (Flows B/C) — neither of
+   * which this component owns (it has no BroadcastChannel of its own).
+   * Optional so the component stays usable standalone (e.g. in tests).
+   */
+  onSessionActions?: (actions: TerminalSessionActions | null) => void;
 }
 
-export function TerminalPopoutView({ payload }: TerminalPopoutViewProps) {
+export function TerminalPopoutView({ payload, onSessionActions }: TerminalPopoutViewProps) {
   const descriptor: TerminalSessionDescriptor = {
     ideaId: payload.ideaId,
     ideaTitle: payload.ideaTitle,
@@ -47,7 +69,16 @@ export function TerminalPopoutView({ payload }: TerminalPopoutViewProps) {
     // simply never read here.
     ideaGithubUrl: null,
   };
-  const attach: AttachExistingPair = { sessionId: payload.sid, browserToken: payload.browserToken };
+  const attach: AttachExistingPair = {
+    sessionId: payload.sid,
+    browserToken: payload.browserToken,
+    // Scrollback transfer, Flow A (design §2): the dock's serialized buffer
+    // at pop-out, if one rode the payload — restored (by the hook, before
+    // the socket attaches) rather than left for this component to apply
+    // directly. Absent covers deploy skew and "the dock had nothing to
+    // serialize yet".
+    initialBuffer: payload.buffer ?? null,
+  };
 
   const session = useTerminalSession(descriptor, {
     enabled: true,
@@ -63,6 +94,15 @@ export function TerminalPopoutView({ payload }: TerminalPopoutViewProps) {
   });
   const { state, readOnly, inputEnabled, launchPhase, platform, paired, containerRef, actions } = session;
 
+  // Keep the parent's action registry current — same "every render, no deps"
+  // pattern as terminal-session-view.tsx's onRegisterActions, since `actions`
+  // isn't a referentially-stable object as a whole even though its individual
+  // methods are memoized.
+  useEffect(() => {
+    onSessionActions?.(actions);
+  });
+  useEffect(() => () => onSessionActions?.(null), [onSessionActions]);
+
   // Apply the read-only toggle state the dock tab was in at the moment of
   // pop-out (D1's payload) — once, on mount. `actions.setReadOnly` is the
   // hook's own `useState` setter, so it's referentially stable; this is safe
@@ -76,9 +116,7 @@ export function TerminalPopoutView({ payload }: TerminalPopoutViewProps) {
     document.title = `Terminal · ${payload.label}`;
   }, [payload.label]);
 
-  const [noticeDismissed, setNoticeDismissed] = useState(false);
   const view = resolveDockView(state.status, launchPhase, platform.supported, paired);
-  const meta = dockStatusMeta(view, state.errorKind);
   const showStream = state.status === "connected" || state.status === "disconnected";
   const showEnd =
     view === "connected" || view === "disconnected" || view === "connecting" || view === "connecting-returning";
@@ -88,6 +126,14 @@ export function TerminalPopoutView({ payload }: TerminalPopoutViewProps) {
   // dock" (explicit or via this window's own close-signal racing it). Show a
   // calm hand-off message, never the generic "duplicate session" error copy.
   const broughtBack = state.status === "error" && isPreemptedClose(state.closeCode);
+
+  // Pill fix (card 35cffc10, design §6): the underlying status legitimately
+  // stays error/4001 (that's the mechanism) — only the PRESENTATION changes.
+  // When broughtBack, substitute a dedicated informational meta instead of
+  // ever calling dockStatusMeta for this state; dockStatusMeta itself stays
+  // untouched, so every genuine dock error keeps its rose pill everywhere
+  // else.
+  const meta = broughtBack ? MOVED_TO_DOCK_META : dockStatusMeta(view, state.errorKind);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -134,27 +180,6 @@ export function TerminalPopoutView({ payload }: TerminalPopoutViewProps) {
           )}
         </span>
       </div>
-
-      {/* One-time MVP scrollback honesty (D5, AC 17): dismissible, never
-          reappears once closed. Disappears entirely once a future
-          serialize-addon transfer ships real scrollback (design §10a). */}
-      {showStream && !noticeDismissed && (
-        <div
-          role="status"
-          className="flex items-center gap-2 border-b border-sky-500/25 bg-sky-500/[0.07] px-3 py-1.5 text-[11.5px] text-sky-300"
-        >
-          <Info className="h-3.5 w-3.5 flex-none" />
-          Showing output from pop-out onward.
-          <button
-            type="button"
-            className="ml-auto flex-none text-sky-400/70 hover:text-sky-200"
-            aria-label="Dismiss notice"
-            onClick={() => setNoticeDismissed(true)}
-          >
-            ✕
-          </button>
-        </div>
-      )}
 
       <div className="relative min-h-0 flex-1">
         <div

--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -51,6 +51,8 @@ function mockActions(): TerminalSessionActions {
     setReadOnly: vi.fn(),
     copyBridgeCommand: vi.fn(),
     refreshView: vi.fn(),
+    serializeNow: vi.fn(),
+    restoreBuffer: vi.fn(),
   };
 }
 

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -8,26 +8,65 @@
 // connection.test.ts and is NOT re-tested here — this file is about the wiring.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { useTerminalSession, type TerminalSessionDescriptor } from "./use-terminal-session";
 
 vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+// Tracks every mock Terminal instance created — used by the scrollback
+// transfer tests below to inspect reset()/write() calls, the same way
+// `mockSockets` tracks WebSockets. `vi.hoisted` because the mock factory
+// (itself hoisted above this file's other statements) needs a live
+// reference to push into.
+const mockTerminals = vi.hoisted(() => [] as { written: string[]; resetCount: number }[]);
 vi.mock("@xterm/xterm", () => ({
   Terminal: class {
     cols = 80;
     rows = 24;
+    written: string[] = [];
+    resetCount = 0;
+    buffer = { active: { length: 0 } };
+    constructor() {
+      mockTerminals.push(this);
+    }
     onData() {}
     open() {}
-    loadAddon() {}
-    write() {}
+    loadAddon(addon: { activate: (term: unknown) => void }) {
+      addon.activate(this);
+    }
+    write(data: string) {
+      this.written.push(data);
+    }
     clear() {}
+    reset() {
+      this.resetCount += 1;
+    }
     focus() {}
     dispose() {}
   },
 }));
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: class {
+    activate() {}
+    dispose() {}
     fit() {}
+  },
+}));
+// scrollback-transfer.ts's own real serialize/restore logic is unit-tested
+// in its own test file (mocking the addon there, since the addon reaches
+// into a real xterm Terminal's internals). Here it's mocked with a tiny fake
+// so the HOOK WIRING (attachExisting.initialBuffer, serializeNow/restoreBuffer)
+// can be exercised against the plain mock Terminal above without either
+// needing to satisfy the real addon's internals.
+vi.mock("@xterm/addon-serialize", () => ({
+  SerializeAddon: class {
+    private term: { written: string[] } | null = null;
+    activate(term: { written: string[] }) {
+      this.term = term;
+    }
+    dispose() {}
+    serialize() {
+      return (this.term?.written ?? []).join("");
+    }
   },
 }));
 
@@ -97,6 +136,12 @@ function latestSocket(): MockWebSocket {
   return s;
 }
 
+function latestTerminal(): { written: string[]; resetCount: number } {
+  const t = mockTerminals[mockTerminals.length - 1];
+  if (!t) throw new Error("no Terminal was constructed");
+  return t;
+}
+
 const descriptor: TerminalSessionDescriptor = {
   ideaId: "idea-1",
   ideaTitle: "Recipe Saver",
@@ -119,10 +164,25 @@ function mintResponse(overrides: Partial<Record<string, unknown>> = {}) {
 describe("useTerminalSession", () => {
   beforeEach(() => {
     mockSockets = [];
+    mockTerminals.length = 0;
     toastError.mockClear();
     toastSuccess.mockClear();
     vi.stubGlobal("WebSocket", MockWebSocket);
     vi.stubGlobal("fetch", vi.fn(async () => mintResponse()));
+    // jsdom doesn't implement ResizeObserver. Every OTHER test in this file
+    // never actually attaches a DOM node to containerRef (renderHook doesn't
+    // render the consumer's <div ref={containerRef}/> for it), so the hook's
+    // resize-observer effect (gated on `containerRef.current`) never used to
+    // fire — the scrollback transfer tests below are the first to attach a
+    // real container, so they're also the first to reach this code path.
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
   });
 
   afterEach(() => {
@@ -617,6 +677,137 @@ describe("useTerminalSession", () => {
       await flushEffects();
       expect(global.fetch).not.toHaveBeenCalled();
       expect(mockSockets).toHaveLength(1); // exactly the attach's own socket, nothing extra
+    });
+
+    // ── scrollback transfer, Flow A (card 35cffc10) ─────────────────────────
+    //
+    // The xterm-init effect bails out early (`!containerRef.current`) unless
+    // something has attached a real DOM node to `containerRef` — normally the
+    // consumer's `<div ref={containerRef} />`, which `renderHook` never
+    // renders since it exercises the hook in isolation. `mountContainer`
+    // stands in for that JSX by assigning a detached element directly, the
+    // same ref object the hook itself reads at effect-resume time.
+    function mountContainer(result: { current: { containerRef: { current: HTMLDivElement | null } } }) {
+      result.current.containerRef.current = document.createElement("div");
+    }
+
+    it("restores a handed-over initialBuffer into the terminal — reset then marker then data, BEFORE any socket data arrives", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: {
+            sessionId: "sid-popped",
+            browserToken: "popped-browser-token",
+            initialBuffer: { data: "hello from the dock\r\n", truncated: true },
+          },
+        }),
+      );
+      mountContainer(result);
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+
+      const term = latestTerminal();
+      await waitFor(() => expect(term.resetCount).toBe(1));
+      expect(term.written[0]).toContain("older history trimmed during hand-off");
+      expect(term.written[1]).toBe("hello from the dock\r\n");
+    });
+
+    it("falls back to a plain clear() (no reset/write) when no initialBuffer rides the attach — deploy skew / nothing to serialize", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: { sessionId: "sid-popped", browserToken: "popped-browser-token" },
+        }),
+      );
+      mountContainer(result);
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+      await flushEffects();
+
+      const term = latestTerminal();
+      expect(term.resetCount).toBe(0);
+      expect(term.written).toEqual([]);
+    });
+
+    it("restores the buffer even when the terminal mounts AFTER attachToExisting already ran (the pending-buffer race)", async () => {
+      // Reproduces the ordering where the attach effect fires before the
+      // async xterm-init effect has finished mounting the Terminal — the
+      // buffer must not be silently dropped just because termRef was still
+      // null at the moment attachToExisting ran.
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: {
+            sessionId: "sid-popped",
+            browserToken: "popped-browser-token",
+            initialBuffer: { data: "queued before mount\r\n", truncated: false },
+          },
+        }),
+      );
+      mountContainer(result);
+      // No flushEffects() at all yet — attachToExisting may or may not have
+      // already run synchronously; either way the terminal mounts async.
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+      const term = latestTerminal();
+      await waitFor(() => expect(term.written).toContain("queued before mount\r\n"));
+      expect(term.resetCount).toBe(1);
+    });
+  });
+
+  // ── scrollback transfer actions: serializeNow / restoreBuffer ────────────
+
+  describe("scrollback transfer actions", () => {
+    it("serializeNow() returns null before the xterm instance has mounted", () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, { enabled: true, expanded: false, requestExpand }),
+      );
+      // Synchronous — no flush, no container attached — the async xterm-init
+      // effect hasn't (and here, can't yet have) resolved.
+      expect(result.current.actions.serializeNow()).toBeNull();
+    });
+
+    it("serializeNow() returns a buffer once the terminal has mounted", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, { enabled: true, expanded: true, requestExpand }),
+      );
+      result.current.containerRef.current = document.createElement("div");
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+
+      const buffer = result.current.actions.serializeNow();
+      expect(buffer).toEqual({ data: "", truncated: false }); // nothing written yet — honestly empty, not null
+    });
+
+    it("restoreBuffer() writes into the live terminal (reset, marker, data) and is a no-op before mount", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, { enabled: true, expanded: true, requestExpand }),
+      );
+
+      // Before mount: a no-op, never throws.
+      expect(() =>
+        result.current.actions.restoreBuffer({ data: "too early", truncated: false }),
+      ).not.toThrow();
+
+      result.current.containerRef.current = document.createElement("div");
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+      act(() => {
+        result.current.actions.restoreBuffer({ data: "restored content", truncated: false });
+      });
+      const term = latestTerminal();
+      expect(term.resetCount).toBeGreaterThanOrEqual(1);
+      expect(term.written).toContain("restored content");
     });
   });
 });

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -96,6 +96,12 @@ import {
 import { isBrowserPaired, markBrowserPaired, resolveFirstRunEntry } from "@/lib/terminal/paired-flag";
 import { type LaunchPhase, nextLaunchPhaseOnTimeout } from "@/lib/terminal/first-run-flow";
 import { consumeRecentHelperIdleQuit } from "@/lib/terminal/helper-relaunch-signal";
+import {
+  restoreScrollback,
+  serializeScrollback,
+  SCROLLBACK_TRANSFER_CAP_BYTES,
+  type TransferredBuffer,
+} from "@/lib/terminal/scrollback-transfer";
 
 // How long we wait for the helper to attach after firing the deep link before
 // dropping to the calm fallback (~8s, per the approved UX). This is the safety net
@@ -244,6 +250,16 @@ export interface UseTerminalSessionOptions {
 export interface AttachExistingPair {
   sessionId: string;
   browserToken: string;
+  /**
+   * Scrollback transfer (card 35cffc10, Flow A): the dock's serialized
+   * buffer at the moment of pop-out, restored into this window's terminal
+   * AFTER it opens but BEFORE the socket attaches — so handed-over history
+   * sits above the live stream with nothing interleaved. `null`/absent
+   * covers deploy skew (an old dock never sent one) and the case where the
+   * dock had nothing to serialize yet — the terminal just starts empty,
+   * today's pre-this-card behaviour.
+   */
+  initialBuffer?: TransferredBuffer | null;
 }
 
 export interface PairInfo {
@@ -296,6 +312,24 @@ export interface TerminalSessionActions {
    * on a dock re-expand, just triggered on demand instead of by `expanded`.
    */
   refreshView: () => void;
+  /**
+   * Scrollback transfer (card 35cffc10, design §7): serialize THIS
+   * session's live terminal right now, capped at 1 MiB — the dock calls this
+   * fresh inside its pop-out payload builder on every send (including
+   * retries), and the popped window calls it to answer `bring-back-request`
+   * / its own `pagehide`. `null` before the xterm instance has mounted
+   * (nothing to serialize yet) — never throws otherwise
+   * (serializeScrollback's own contract).
+   */
+  serializeNow: () => TransferredBuffer | null;
+  /**
+   * Restore a previously-serialized buffer into THIS session's live
+   * terminal (full reset first — see restoreScrollback's doc). Used by the
+   * dock on both bring-back paths (Flow B's reply, Flow C's stash) to
+   * replace its hidden terminal's history with the popped window's more
+   * complete copy (D1). A no-op if the xterm instance hasn't mounted yet.
+   */
+  restoreBuffer: (buffer: TransferredBuffer) => void;
 }
 
 export interface UseTerminalSessionResult {
@@ -377,6 +411,13 @@ export function useTerminalSession(
   const wsRef = useRef<WebSocket | null>(null);
   const termRef = useRef<XTerm | null>(null);
   const fitRef = useRef<XFitAddon | null>(null);
+  // Scrollback transfer (card 35cffc10): `attachToExisting` can run BEFORE
+  // the async xterm-init effect below has finished mounting the terminal
+  // (attach isn't gated on xtermReady — see attachToExisting's own doc) —
+  // when that happens the buffer it was handed has nowhere to land yet, so
+  // it's stashed here and applied the moment the xterm-init effect sets
+  // `termRef.current`, instead of being silently dropped.
+  const pendingInitialBufferRef = useRef<TransferredBuffer | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const connectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const helperTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -475,6 +516,13 @@ export function useTerminalSession(
 
       termRef.current = term;
       fitRef.current = fit;
+      // A buffer arrived (attachToExisting ran) before the terminal itself
+      // was ready to receive it — apply it now that it is (see
+      // pendingInitialBufferRef's doc).
+      if (pendingInitialBufferRef.current) {
+        restoreScrollback(term, pendingInitialBufferRef.current);
+        pendingInitialBufferRef.current = null;
+      }
       setXtermReady(true);
     })().catch((err) => {
       logger.error("Terminal xterm init failed", { error: err instanceof Error ? err.message : String(err) });
@@ -1169,7 +1217,22 @@ export function useTerminalSession(
       setPair({ sessionId: p.sessionId, browserToken: p.browserToken });
       reconnectDeadlineRef.current = 0;
       reconnectAttemptRef.current = 0;
-      termRef.current?.clear();
+      // Scrollback transfer (card 35cffc10, Flow A): a handed-over buffer
+      // REPLACES the plain clear() below — restoreScrollback does its own
+      // full reset before writing the history, so the two are mutually
+      // exclusive, never both. No buffer (deploy skew, or the dock had
+      // nothing to serialize yet) falls back to today's plain clear().
+      if (p.initialBuffer) {
+        if (termRef.current) {
+          restoreScrollback(termRef.current, p.initialBuffer);
+        } else {
+          // Terminal hasn't mounted yet — the xterm-init effect applies this
+          // the moment it does (pendingInitialBufferRef's doc).
+          pendingInitialBufferRef.current = p.initialBuffer;
+        }
+      } else {
+        termRef.current?.clear();
+      }
       // A newer attach/connect raced this one while it was doing its
       // (synchronous, but still checked for symmetry with connect()) setup —
       // abort before opening a socket that a newer attempt would immediately
@@ -1363,6 +1426,23 @@ export function useTerminalSession(
     });
   }, [sendResize]);
 
+  // Scrollback transfer (card 35cffc10, design §7). See TerminalSessionActions'
+  // doc on both for the full contract — these are thin, stable-identity
+  // wrappers around the pure scrollback-transfer.ts functions, reading
+  // termRef fresh on every call (never a stale-closure risk, same pattern
+  // as sendResize/refreshView above).
+  const serializeNow = useCallback((): TransferredBuffer | null => {
+    const term = termRef.current;
+    if (!term) return null;
+    return serializeScrollback(term, SCROLLBACK_TRANSFER_CAP_BYTES);
+  }, []);
+
+  const restoreBuffer = useCallback((buffer: TransferredBuffer) => {
+    const term = termRef.current;
+    if (!term) return;
+    restoreScrollback(term, buffer);
+  }, []);
+
   const copyBridgeCommand = useCallback(() => {
     // No bridge token to copy for an attached (not minted) session — see
     // PairInfo.bridgeToken's doc. The legacy-waiting panel that renders this
@@ -1397,6 +1477,8 @@ export function useTerminalSession(
       setReadOnly,
       copyBridgeCommand,
       refreshView,
+      serializeNow,
+      restoreBuffer,
     },
   };
 }

--- a/src/lib/terminal/popout-channel.test.ts
+++ b/src/lib/terminal/popout-channel.test.ts
@@ -10,13 +10,17 @@ import {
   hasPopoutHandoffTimedOut,
   POPOUT_HANDOFF_TIMEOUT_MS,
   POPOUT_READY_RETRY_MS,
+  BRING_BACK_REPLY_TIMEOUT_MS,
   createDockPopoutMessageHandler,
   startPopoutClientHandshake,
+  startBringBackRequest,
   type PopoutPayload,
   type PopoutChannelLike,
   type DockHandshakeState,
+  type DockPopoutEntry,
 } from "./popout-channel";
 import { RELAY_CLOSE } from "./connection";
+import type { TransferredBuffer } from "./scrollback-transfer";
 
 const PAYLOAD: PopoutPayload = {
   sid: "sid-123",
@@ -28,6 +32,8 @@ const PAYLOAD: PopoutPayload = {
   identity: "Recipe Saver · session sid-123",
   readOnly: false,
 };
+
+const BUFFER: TransferredBuffer = { data: "some scrollback\r\n", truncated: false };
 
 describe("popoutChannelName", () => {
   it("namespaces the nonce so it can't collide with anything else on the origin", () => {
@@ -122,6 +128,53 @@ describe("parsePopoutChannelMessage", () => {
       expect(parsePopoutChannelMessage(input)).toBeNull();
     },
   );
+
+  // ── scrollback transfer (card 35cffc10) ───────────────────────────────────
+
+  it("deploy-skew: parses a payload with no buffer field at all exactly as before (old sender)", () => {
+    expect(parsePopoutChannelMessage({ type: "payload", payload: PAYLOAD })).toEqual({
+      type: "payload",
+      payload: PAYLOAD,
+    });
+  });
+
+  it("parses a payload carrying a well-formed buffer", () => {
+    const withBuffer = { ...PAYLOAD, buffer: BUFFER };
+    expect(parsePopoutChannelMessage({ type: "payload", payload: withBuffer })).toEqual({
+      type: "payload",
+      payload: withBuffer,
+    });
+  });
+
+  it("a malformed buffer is dropped WITHOUT rejecting the rest of the payload — scrollback never sinks a hand-off", () => {
+    const malformed = { ...PAYLOAD, buffer: { data: "ok", truncated: "not-a-boolean" } };
+    const result = parsePopoutChannelMessage({ type: "payload", payload: malformed });
+    expect(result).toEqual({ type: "payload", payload: PAYLOAD }); // buffer simply absent, credentials intact
+  });
+
+  it.each([null, 42, "nope", [], { data: 5, truncated: false }, { data: "ok" }])(
+    "drops every other shape of malformed buffer %#, credentials still parse",
+    (badBuffer) => {
+      const result = parsePopoutChannelMessage({ type: "payload", payload: { ...PAYLOAD, buffer: badBuffer } });
+      expect(result).toEqual({ type: "payload", payload: PAYLOAD });
+    },
+  );
+
+  it("parses a bring-back-request message", () => {
+    expect(parsePopoutChannelMessage({ type: "bring-back-request" })).toEqual({ type: "bring-back-request" });
+  });
+
+  it("parses a well-formed buffer-reply message", () => {
+    expect(parsePopoutChannelMessage({ type: "buffer-reply", buffer: BUFFER })).toEqual({
+      type: "buffer-reply",
+      buffer: BUFFER,
+    });
+  });
+
+  it("rejects a buffer-reply with a malformed buffer — here the buffer IS the whole message", () => {
+    expect(parsePopoutChannelMessage({ type: "buffer-reply", buffer: { data: "ok" } })).toBeNull();
+    expect(parsePopoutChannelMessage({ type: "buffer-reply" })).toBeNull();
+  });
 });
 
 describe("reduceDockHandshake", () => {
@@ -291,6 +344,72 @@ describe("createDockPopoutMessageHandler", () => {
     expect(() => handler({ data: "not a message" } as unknown as MessageEvent)).not.toThrow();
     expect(channel.posted).toEqual([]);
   });
+
+  // ── Flow C: buffer-reply stashed, applied on the closed that follows ──────
+  // (design §4 — the popped window pushes its buffer unprompted, immediately
+  // before its own "closed", when the user just closes the window rather
+  // than clicking "Bring back".)
+
+  describe("Flow C — buffer-reply then closed", () => {
+    it("stashes buffer-reply without reattaching, then applies it when closed arrives", () => {
+      const channel = makeSpyChannel();
+      let entry: DockPopoutEntry | undefined = { channel, handshake: "payload-sent" };
+      const onReattach = vi.fn();
+      const handler = createDockPopoutMessageHandler({
+        getEntry: () => entry,
+        setEntry: (next) => {
+          entry = next;
+        },
+        getPayload: () => PAYLOAD,
+        onReattach,
+      });
+
+      handler({ data: { type: "buffer-reply", buffer: BUFFER } } as MessageEvent);
+      expect(onReattach).not.toHaveBeenCalled(); // stash only — not a reattach signal by itself
+      expect(entry?.pendingBuffer).toEqual(BUFFER);
+
+      handler({ data: { type: "closed" } } as MessageEvent);
+      expect(onReattach).toHaveBeenCalledTimes(1);
+      expect(onReattach).toHaveBeenCalledWith(BUFFER);
+    });
+
+    it("closed with no prior buffer-reply reattaches with null — today's path (old window, failed serialize, or hand-off timeout)", () => {
+      const channel = makeSpyChannel();
+      let entry: DockPopoutEntry | undefined = { channel, handshake: "payload-sent" };
+      const onReattach = vi.fn();
+      const handler = createDockPopoutMessageHandler({
+        getEntry: () => entry,
+        setEntry: (next) => {
+          entry = next;
+        },
+        getPayload: () => PAYLOAD,
+        onReattach,
+      });
+
+      handler({ data: { type: "closed" } } as MessageEvent);
+      expect(onReattach).toHaveBeenCalledWith(null);
+    });
+
+    it("a malformed buffer-reply is dropped entirely — never stashed, closed still reattaches with null", () => {
+      const channel = makeSpyChannel();
+      let entry: DockPopoutEntry | undefined = { channel, handshake: "payload-sent" };
+      const onReattach = vi.fn();
+      const handler = createDockPopoutMessageHandler({
+        getEntry: () => entry,
+        setEntry: (next) => {
+          entry = next;
+        },
+        getPayload: () => PAYLOAD,
+        onReattach,
+      });
+
+      handler({ data: { type: "buffer-reply", buffer: { data: "ok" } } } as MessageEvent);
+      expect(entry?.pendingBuffer).toBeUndefined();
+
+      handler({ data: { type: "closed" } } as MessageEvent);
+      expect(onReattach).toHaveBeenCalledWith(null);
+    });
+  });
 });
 
 // ── client-side handshake driver, in isolation (fake timers) ───────────────
@@ -351,6 +470,100 @@ describe("startPopoutClientHandshake", () => {
     stop();
     vi.advanceTimersByTime(POPOUT_HANDOFF_TIMEOUT_MS + 1000);
     expect(channel.posted.length).toBe(postedAtStart); // nothing more posted, ever
+  });
+});
+
+// ── dock-side bring-back driver, in isolation (fake timers) — Flow B ───────
+
+describe("startBringBackRequest", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("posts bring-back-request immediately", () => {
+    const channel = makeSpyChannel();
+    startBringBackRequest({ channel, onSettle: vi.fn() });
+    expect(channel.posted).toEqual([{ type: "bring-back-request" }]);
+  });
+
+  it("settles with the buffer the moment a buffer-reply arrives, before the timeout", () => {
+    const channel = makeSpyChannel();
+    const onSettle = vi.fn();
+    startBringBackRequest({ channel, onSettle });
+
+    vi.advanceTimersByTime(BRING_BACK_REPLY_TIMEOUT_MS - 50);
+    channel.onmessage?.({ data: { type: "buffer-reply", buffer: BUFFER } } as MessageEvent);
+
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(onSettle).toHaveBeenCalledWith(BUFFER);
+
+    // The timeout firing afterwards must be a total no-op — settle already happened.
+    vi.advanceTimersByTime(BRING_BACK_REPLY_TIMEOUT_MS * 2);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles with null after the timeout when no reply ever arrives (D3's deliberate fallback)", () => {
+    const channel = makeSpyChannel();
+    const onSettle = vi.fn();
+    startBringBackRequest({ channel, onSettle });
+
+    vi.advanceTimersByTime(BRING_BACK_REPLY_TIMEOUT_MS);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(onSettle).toHaveBeenCalledWith(null);
+  });
+
+  it("ignores a reply that arrives AFTER the timeout already settled — a late reply can never clobber the fallback", () => {
+    const channel = makeSpyChannel();
+    const onSettle = vi.fn();
+    startBringBackRequest({ channel, onSettle });
+
+    vi.advanceTimersByTime(BRING_BACK_REPLY_TIMEOUT_MS);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(onSettle).toHaveBeenCalledWith(null);
+
+    // A stray late buffer-reply (e.g. the popped window was just slow, not
+    // dead) must not fire onSettle a second time.
+    channel.onmessage?.({ data: { type: "buffer-reply", buffer: BUFFER } } as MessageEvent);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores every non-buffer-reply message while waiting", () => {
+    const channel = makeSpyChannel();
+    const onSettle = vi.fn();
+    startBringBackRequest({ channel, onSettle });
+
+    channel.onmessage?.({ data: { type: "ready" } } as MessageEvent);
+    channel.onmessage?.({ data: { type: "closed" } } as MessageEvent);
+    channel.onmessage?.({ data: "garbage" } as unknown as MessageEvent);
+    expect(onSettle).not.toHaveBeenCalled();
+
+    channel.onmessage?.({ data: { type: "buffer-reply", buffer: BUFFER } } as MessageEvent);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(onSettle).toHaveBeenCalledWith(BUFFER);
+  });
+
+  it("cancel() stops the timer and settles nothing — for an ordinary unmount, not a failure", () => {
+    const channel = makeSpyChannel();
+    const onSettle = vi.fn();
+    const cancel = startBringBackRequest({ channel, onSettle });
+    cancel();
+    vi.advanceTimersByTime(BRING_BACK_REPLY_TIMEOUT_MS * 2);
+    expect(onSettle).not.toHaveBeenCalled();
+  });
+
+  it("a postMessage failure (channel already gone) doesn't prevent the timeout fallback from still firing", () => {
+    const channel = makeSpyChannel();
+    channel.postMessage = () => {
+      throw new Error("channel closed");
+    };
+    const onSettle = vi.fn();
+    startBringBackRequest({ channel, onSettle });
+    vi.advanceTimersByTime(BRING_BACK_REPLY_TIMEOUT_MS);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(onSettle).toHaveBeenCalledWith(null);
   });
 });
 

--- a/src/lib/terminal/popout-channel.ts
+++ b/src/lib/terminal/popout-channel.ts
@@ -62,6 +62,21 @@
 // (`reduceDockHandshake`), and every rejection path now warns with its
 // reason instead of dropping silently.
 //
+// SCROLLBACK TRANSFER (card 35cffc10, docs/design-terminal-scrollback-
+// transfer.html): the buffer that rides pop-out and bring-back is carried
+// entirely inside this module's existing message shapes — a `buffer` field
+// added to `payload` (pop-out direction), and two new messages for bring-back
+// (`bring-back-request` / `buffer-reply`). Design §1's decision: a SEPARATE
+// "buffer" message would reintroduce the exact failure class the handshake
+// rework above just eliminated (two coupled messages where either half can
+// be the one that's lost); embedding the buffer in `payload` inherits the
+// idempotent ready/re-send hardening for free. The `buffer` field is always
+// OPTIONAL and leniently parsed — a malformed buffer is dropped (warned) on
+// its own, never sinking the surrounding message; scrollback is never
+// allowed to sink a hand-off. The actual serialize/restore mechanics live in
+// scrollback-transfer.ts (a separate, transport-agnostic module) — this file
+// only carries the resulting `{ data, truncated }` shape across the channel.
+//
 // REWORK ADDENDUM (fix/terminal-popout-open-guard, board task 4f9cf03d): the
 // retried-handshake hardening above was necessary but NOT sufficient — it
 // shipped and the pop-out STILL failed 100% of the time in production,
@@ -80,6 +95,7 @@
 // success.
 
 import { RELAY_CLOSE } from "@/lib/terminal/connection";
+import type { TransferredBuffer } from "@/lib/terminal/scrollback-transfer";
 
 /** Channel names are namespaced so nothing else on the origin could collide. */
 const POPOUT_CHANNEL_PREFIX = "vibecodes:terminal-popout:";
@@ -173,15 +189,60 @@ export interface PopoutPayload {
   /** The identity line shown in both the dock header and the popped window's header. */
   identity: string;
   readOnly: boolean;
+  /**
+   * The dock's serialized scrollback at the moment of send (design §1/§2,
+   * Flow A) — OPTIONAL and captured FRESH on every send (including retries),
+   * never memoized, so a slow handshake still hands over the newest output.
+   * Absent when the sender predates this card (deploy skew, E7) or when
+   * nothing was available to serialize yet (e.g. the dock's own xterm
+   * instance hasn't mounted). A malformed value here is dropped by
+   * `parsePopoutPayload` without rejecting the rest of the payload —
+   * scrollback is never allowed to sink a hand-off.
+   */
+  buffer?: TransferredBuffer;
 }
 
 export type PopoutChannelMessage =
   | { type: "ready" }
   | { type: "payload"; payload: PopoutPayload }
-  | { type: "closed" };
+  | { type: "closed" }
+  /** Dock → popped (Flow B, design §3): "I'm about to reattach — send me your buffer first." No payload of its own. */
+  | { type: "bring-back-request" }
+  /**
+   * Popped → dock: the popped window's full serialized scrollback, either as
+   * the direct reply to `bring-back-request` (Flow B) or pushed unprompted
+   * immediately before `closed` when the window is simply being closed
+   * (Flow C, design §4) — BroadcastChannel's per-sender ordering guarantees
+   * the reply always lands before that `closed`.
+   */
+  | { type: "buffer-reply"; buffer: TransferredBuffer };
 
 function isNonEmptyString(v: unknown): v is string {
   return typeof v === "string" && v.length > 0;
+}
+
+/**
+ * Lenient `TransferredBuffer` parse — `null` (with a console warning giving
+ * the reason) for anything malformed. Used both for `payload.buffer` (where
+ * the caller must NOT let a bad buffer reject the rest of the payload — see
+ * `parsePopoutPayload`) and for `buffer-reply` (where the buffer IS the
+ * entire message, so a bad one drops the whole message, still without ever
+ * throwing).
+ */
+function parseTransferredBuffer(value: unknown): TransferredBuffer | null {
+  if (!value || typeof value !== "object") {
+    console.warn("[terminal-popout] rejected buffer: not an object", value);
+    return null;
+  }
+  const b = value as Record<string, unknown>;
+  if (typeof b.data !== "string" || typeof b.truncated !== "boolean") {
+    console.warn("[terminal-popout] rejected buffer: invalid/missing field(s)", {
+      hasData: typeof b.data === "string",
+      hasTruncated: typeof b.truncated === "boolean",
+    });
+    return null;
+  }
+  return { data: b.data, truncated: b.truncated };
 }
 
 /**
@@ -211,7 +272,7 @@ function parsePopoutPayload(value: unknown): PopoutPayload | null {
     console.warn("[terminal-popout] rejected payload: invalid/missing field(s)", problems);
     return null;
   }
-  return {
+  const result: PopoutPayload = {
     sid: p.sid as string,
     browserToken: p.browserToken as string,
     relayUrl: p.relayUrl as string,
@@ -221,6 +282,16 @@ function parsePopoutPayload(value: unknown): PopoutPayload | null {
     identity: p.identity as string,
     readOnly: p.readOnly as boolean,
   };
+  // Optional and leniently parsed (design §1's decision callout): a
+  // malformed/absent buffer is dropped on its own — the credentials above
+  // still go through either way. `p.buffer === undefined` is the ordinary
+  // "sender predates this card, or had nothing to serialize yet" case and
+  // warns nothing (that's expected, not an error).
+  if (p.buffer !== undefined) {
+    const buffer = parseTransferredBuffer(p.buffer);
+    if (buffer) result.buffer = buffer;
+  }
+  return result;
 }
 
 /**
@@ -235,13 +306,21 @@ export function parsePopoutChannelMessage(data: unknown): PopoutChannelMessage |
     console.warn("[terminal-popout] ignoring channel message: not an object", data);
     return null;
   }
-  const msg = data as { type?: unknown; payload?: unknown };
+  const msg = data as { type?: unknown; payload?: unknown; buffer?: unknown };
   if (msg.type === "ready") return { type: "ready" };
   if (msg.type === "closed") return { type: "closed" };
+  if (msg.type === "bring-back-request") return { type: "bring-back-request" };
   if (msg.type === "payload") {
     // parsePopoutPayload already warns with the specific reason on rejection.
     const payload = parsePopoutPayload(msg.payload);
     return payload ? { type: "payload", payload } : null;
+  }
+  if (msg.type === "buffer-reply") {
+    // Unlike payload.buffer, the buffer IS the whole message here — a
+    // malformed one drops the whole message (parseTransferredBuffer already
+    // warns with the specific reason).
+    const buffer = parseTransferredBuffer(msg.buffer);
+    return buffer ? { type: "buffer-reply", buffer } : null;
   }
   console.warn("[terminal-popout] ignoring channel message: unrecognised type", msg.type);
   return null;
@@ -309,6 +388,21 @@ export interface PopoutChannelLike {
 }
 
 /**
+ * The dock's per-tab pop-out bookkeeping (terminal-dock.tsx's
+ * `popoutChannelsRef` Map value shape) — exported so the caller and this
+ * module agree on it. `pendingBuffer` is Flow C's stash (design §4): the
+ * popped window's unprompted `buffer-reply`, held here until the `closed`
+ * that always follows it (BroadcastChannel's per-sender ordering) actually
+ * applies it. `undefined`/absent means "nothing stashed" — the ordinary case
+ * for every message that isn't part of a Flow C close sequence.
+ */
+export interface DockPopoutEntry {
+  channel: PopoutChannelLike;
+  handshake: DockHandshakeState;
+  pendingBuffer?: TransferredBuffer;
+}
+
+/**
  * Builds the DOCK side's `channel.onmessage` handler — the exact logic
  * terminal-dock.tsx's `handlePopOut` wires up, extracted so it can be driven
  * by a test double instead of a real `BroadcastChannel` + React state. The
@@ -316,12 +410,21 @@ export interface PopoutChannelLike {
  * did a "Bring back" already tear it down?) stays with the CALLER via
  * `getEntry`/`setEntry` — that's terminal-dock.tsx's `popoutChannelsRef` Map,
  * not something this module should own.
+ *
+ * `buffer-reply` (Flow C, design §4) is handled OUTSIDE the pure handshake
+ * reducer below: it's not a handshake-phase transition, just a stash — the
+ * popped window pushes it unprompted, immediately before its own `closed`,
+ * when the user simply closes the window (no "Bring back" click, no
+ * request/reply round trip like Flow B's `startBringBackRequest`). `onReattach`
+ * receives whatever was stashed (or `null` if nothing was — an old popped
+ * window, a failed serialize, or the hand-off-timeout `closed` that never
+ * carried a payload at all) so the caller can restore it before reconnecting.
  */
 export function createDockPopoutMessageHandler(options: {
-  getEntry: () => { channel: PopoutChannelLike; handshake: DockHandshakeState } | undefined;
-  setEntry: (next: { channel: PopoutChannelLike; handshake: DockHandshakeState }) => void;
+  getEntry: () => DockPopoutEntry | undefined;
+  setEntry: (next: DockPopoutEntry) => void;
   getPayload: () => PopoutPayload;
-  onReattach: () => void;
+  onReattach: (stashedBuffer: TransferredBuffer | null) => void;
 }): (ev: MessageEvent) => void {
   const { getEntry, setEntry, getPayload, onReattach } = options;
   return (ev) => {
@@ -329,12 +432,16 @@ export function createDockPopoutMessageHandler(options: {
     if (!message) return; // already warned with a reason
     const current = getEntry();
     if (!current) return; // already torn down (e.g. a racing bring-back)
+    if (message.type === "buffer-reply") {
+      setEntry({ ...current, pendingBuffer: message.buffer });
+      return;
+    }
     const result = reduceDockHandshake(current.handshake, message);
-    setEntry({ channel: current.channel, handshake: result.state });
+    setEntry({ ...current, handshake: result.state });
     if (result.action === "send-payload") {
       current.channel.postMessage({ type: "payload", payload: getPayload() });
     } else if (result.action === "reattach") {
-      onReattach();
+      onReattach(current.pendingBuffer ?? null);
     }
   };
 }
@@ -465,5 +572,87 @@ export function startPopoutClientHandshake(options: PopoutClientHandshakeOptions
   return () => {
     clearIntervalFn(readyTimer);
     clearIntervalFn(pollTimer);
+  };
+}
+
+// ── dock-side bring-back driver (Flow B, design §3) ─────────────────────────
+//
+// The two-phase "Bring back to dock" button click: request the popped
+// window's buffer, wait a bounded amount of time for the reply, then let the
+// caller proceed either way. Mirrors `startPopoutClientHandshake`'s shape —
+// injectable timer/clock, no DOM — so it's unit-tested the same way.
+
+/** D3: 500ms (the midpoint of the design's 400–600ms band) — see the design doc for the full rationale. */
+export const BRING_BACK_REPLY_TIMEOUT_MS = 500;
+
+export interface BringBackRequestOptions {
+  channel: PopoutChannelLike;
+  /**
+   * Called exactly once, with the popped window's buffer on a timely reply,
+   * or `null` on timeout (D3's deliberate fallback: the caller keeps its own
+   * buffer and proceeds — complete history except the popped-out slice,
+   * never a hang).
+   */
+  onSettle: (buffer: TransferredBuffer | null) => void;
+  now?: () => number;
+  setTimeoutFn?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimeoutFn?: (id: ReturnType<typeof setTimeout>) => void;
+  timeoutMs?: number;
+}
+
+/**
+ * The dock's half of Flow B: post `bring-back-request`, then settle exactly
+ * once — either the moment a `buffer-reply` arrives, or after `timeoutMs`
+ * with `null`. A reply that arrives AFTER settling (a late reply racing a
+ * timeout that already fired, or a second call racing a first) is ignored —
+ * `settled` latches permanently the first time either side wins, exactly
+ * like `startPopoutClientHandshake`'s own single-settle guard.
+ *
+ * Deliberately takes over `channel.onmessage` for the duration of the wait
+ * (restored to nothing on settle, same as this module's other drivers) —
+ * the caller owns wiring it back to `createDockPopoutMessageHandler` if the
+ * hand-off fails and the tab stays popped out; on success the whole entry
+ * (channel included) gets torn down anyway (design's `endPopOut`).
+ *
+ * Returns a `cancel()` that settles nothing and just stops the timer — for
+ * an unmount/nonce-change where nothing about the bring-back itself failed.
+ */
+export function startBringBackRequest(options: BringBackRequestOptions): () => void {
+  const {
+    channel,
+    onSettle,
+    setTimeoutFn = (cb, ms) => setTimeout(cb, ms),
+    clearTimeoutFn = (id) => clearTimeout(id),
+    timeoutMs = BRING_BACK_REPLY_TIMEOUT_MS,
+  } = options;
+  let settled = false;
+
+  const finish = (buffer: TransferredBuffer | null) => {
+    if (settled) return;
+    settled = true;
+    clearTimeoutFn(timer);
+    channel.onmessage = null;
+    onSettle(buffer);
+  };
+
+  channel.onmessage = (ev) => {
+    if (settled) return;
+    const message = parsePopoutChannelMessage(ev.data);
+    if (message?.type !== "buffer-reply") return;
+    finish(message.buffer);
+  };
+
+  const timer = setTimeoutFn(() => finish(null), timeoutMs);
+
+  try {
+    channel.postMessage({ type: "bring-back-request" });
+  } catch {
+    /* channel already gone — the timeout above still fires and falls back */
+  }
+
+  return () => {
+    if (settled) return;
+    settled = true;
+    clearTimeoutFn(timer);
   };
 }

--- a/src/lib/terminal/scrollback-transfer.test.ts
+++ b/src/lib/terminal/scrollback-transfer.test.ts
@@ -1,0 +1,257 @@
+// Unit tests for serializeScrollback/restoreScrollback (card 35cffc10).
+//
+// `@xterm/addon-serialize`'s real `SerializeAddon.activate(terminal)` reaches
+// into a real xterm `Terminal`'s internal buffer service — it has nothing to
+// read on a plain stub object and would just throw immediately, which the
+// module's own try/catch would silently swallow into the "internal failure"
+// fallback for EVERY test, defeating the point of testing the cap/truncation
+// logic at all. So this file mocks the addon module itself with a small fake
+// `SerializeAddon` whose `serialize({ scrollback })` returns a deterministic
+// string sized off the STUB terminal's `buffer.active.length` (captured via
+// `activate`, exactly like the real addon would) — enough to drive the
+// halving loop through real, observable inputs without a DOM or a real xterm
+// instance, matching how popout-channel.ts tests a stub channel instead of a
+// real BroadcastChannel.
+//
+// Shared mutable knobs live in `vi.hoisted()` (Vitest's supported way to hand
+// state to a hoisted `vi.mock` factory) so individual tests can drive
+// pathological addon behaviour — always-oversized output, throwing on a
+// given call — without a separate `vi.mock` per test.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const BYTES_PER_LINE = 100;
+const CAP_BYTES = 1_048_576; // mirrors SCROLLBACK_TRANSFER_CAP_BYTES — literal, see note below
+
+const fakeAddonState = vi.hoisted(() => ({
+  forceOversizedBytes: null as number | null,
+  throwOnCallNumber: null as number | null,
+  serializeCallCount: 0,
+  disposeCallCount: 0,
+  loadAddonCallCount: 0,
+}));
+
+vi.mock("@xterm/addon-serialize", () => {
+  class FakeSerializeAddon {
+    private term: { buffer: { active: { length: number } } } | null = null;
+    activate(term: { buffer: { active: { length: number } } }) {
+      this.term = term;
+    }
+    dispose() {
+      fakeAddonState.disposeCallCount += 1;
+    }
+    serialize(options?: { scrollback?: number }): string {
+      fakeAddonState.serializeCallCount += 1;
+      if (
+        fakeAddonState.throwOnCallNumber !== null &&
+        fakeAddonState.serializeCallCount === fakeAddonState.throwOnCallNumber
+      ) {
+        throw new Error("serialize exploded");
+      }
+      if (fakeAddonState.forceOversizedBytes !== null) {
+        return "x".repeat(fakeAddonState.forceOversizedBytes);
+      }
+      const total = this.term?.buffer.active.length ?? 0;
+      const rows = options?.scrollback === undefined ? total : Math.min(options.scrollback, total);
+      return "x".repeat(Math.max(0, rows) * BYTES_PER_LINE);
+    }
+  }
+  return { SerializeAddon: FakeSerializeAddon };
+});
+
+const {
+  serializeScrollback,
+  restoreScrollback,
+  SCROLLBACK_TRANSFER_CAP_BYTES,
+  SCROLLBACK_TRUNCATION_MARKER_TEXT,
+} = await import("./scrollback-transfer");
+
+// The mocked cap must match the real export — pinned once so a future change
+// to the real constant can't silently desync this file's own CAP_BYTES.
+if (CAP_BYTES !== SCROLLBACK_TRANSFER_CAP_BYTES) {
+  throw new Error("test file's CAP_BYTES is out of sync with SCROLLBACK_TRANSFER_CAP_BYTES");
+}
+
+beforeEach(() => {
+  fakeAddonState.forceOversizedBytes = null;
+  fakeAddonState.throwOnCallNumber = null;
+  fakeAddonState.serializeCallCount = 0;
+  fakeAddonState.disposeCallCount = 0;
+  fakeAddonState.loadAddonCallCount = 0;
+});
+
+// A minimal stub satisfying ScrollbackCapableTerminal — records every call so
+// tests can assert both the RESULT and the SEQUENCE of operations (order
+// matters for restoreScrollback's reset-before-write contract).
+function makeStubTerminal(totalLines: number) {
+  const calls: string[] = [];
+  return {
+    calls,
+    // Method-shorthand parameter type (not an arrow-typed property) so this
+    // structurally satisfies ScrollbackCapableTerminal.loadAddon under
+    // strictFunctionTypes — see popout-channel.ts's PopoutChannelLike doc for
+    // the same distinction (method params are bivariant, property-typed
+    // function params are contravariant).
+    loadAddon(addon: { activate(term: unknown): void }) {
+      calls.push("loadAddon");
+      fakeAddonState.loadAddonCallCount += 1;
+      addon.activate(this);
+    },
+    reset() {
+      calls.push("reset");
+    },
+    write(data: string) {
+      calls.push(`write:${data}`);
+    },
+    buffer: { active: { length: totalLines } },
+  };
+}
+
+describe("serializeScrollback", () => {
+  it("returns the full serialize untruncated when it's under the cap", () => {
+    const term = makeStubTerminal(10); // 10 * 100 bytes = 1,000 bytes, well under 1 MiB
+    const result = serializeScrollback(term, SCROLLBACK_TRANSFER_CAP_BYTES);
+    expect(result.truncated).toBe(false);
+    expect(result.data.length).toBe(1000);
+  });
+
+  it("truncates oldest-first by halving scrollback row counts when over the cap", () => {
+    // 20,000 lines * 100 bytes/line = 2,000,000 bytes — over the 1 MiB (1,048,576) cap.
+    const term = makeStubTerminal(20_000);
+    const result = serializeScrollback(term, SCROLLBACK_TRANSFER_CAP_BYTES);
+    expect(result.truncated).toBe(true);
+    expect(new TextEncoder().encode(result.data).length).toBeLessThanOrEqual(SCROLLBACK_TRANSFER_CAP_BYTES);
+    // Halving is whole-row: the result length is always an exact multiple of
+    // one line's byte size, never a byte-offset slice mid-row.
+    expect(result.data.length % BYTES_PER_LINE).toBe(0);
+    // More than one serialize() call proves the halving loop actually ran
+    // (not just a single oversized attempt accepted as-is).
+    expect(fakeAddonState.serializeCallCount).toBeGreaterThan(1);
+  });
+
+  it("respects a custom cap", () => {
+    const term = makeStubTerminal(1000); // 100,000 bytes untruncated
+    const result = serializeScrollback(term, 10_000);
+    expect(result.truncated).toBe(true);
+    expect(new TextEncoder().encode(result.data).length).toBeLessThanOrEqual(10_000);
+  });
+
+  it("the truncation loop is bounded even when the addon NEVER shrinks below the cap", () => {
+    // A pathological addon that always returns an oversized string no matter
+    // how far `scrollback` is halved — this must still terminate (never
+    // hang) rather than loop forever chasing a cap it can't satisfy.
+    fakeAddonState.forceOversizedBytes = SCROLLBACK_TRANSFER_CAP_BYTES * 2;
+    const term = makeStubTerminal(20_000); // ~15 halvings to reach 0
+    const result = serializeScrollback(term, SCROLLBACK_TRANSFER_CAP_BYTES);
+    expect(result.truncated).toBe(true);
+    // Bounded: one initial full serialize + a small, finite number of
+    // halving re-tries (log2(20,000) ≈ 15) — nowhere near hundreds/thousands,
+    // which is what an unbounded or buggy loop would rack up.
+    expect(fakeAddonState.serializeCallCount).toBeGreaterThan(1);
+    expect(fakeAddonState.serializeCallCount).toBeLessThan(50);
+  });
+
+  it("never throws on a hostile terminal stub — loadAddon throws", () => {
+    const term = {
+      loadAddon() {
+        throw new Error("boom");
+      },
+      reset() {},
+      write() {},
+      buffer: { active: { length: 10 } },
+    };
+    const result = serializeScrollback(term);
+    expect(result).toEqual({ data: "", truncated: false });
+  });
+
+  it("never throws on a hostile terminal stub — buffer.active.length is missing/NaN", () => {
+    fakeAddonState.forceOversizedBytes = SCROLLBACK_TRANSFER_CAP_BYTES * 2; // force the halving branch to run
+    const term = makeStubTerminal(Number.NaN);
+    expect(() => serializeScrollback(term)).not.toThrow();
+    const result = serializeScrollback(term);
+    // NaN total lines can't be halved meaningfully — the loop must bail out
+    // (rowCount clamped to 0) rather than compute NaN row counts forever.
+    expect(result.truncated).toBe(true);
+  });
+
+  it("disposes the addon even when serialize() throws mid-truncation, and still returns the safe fallback", () => {
+    fakeAddonState.throwOnCallNumber = 2; // 1st call (full serialize) succeeds oversized, 2nd (first halving) throws
+    fakeAddonState.forceOversizedBytes = SCROLLBACK_TRANSFER_CAP_BYTES * 2;
+    const term = makeStubTerminal(20_000);
+    const result = serializeScrollback(term, SCROLLBACK_TRANSFER_CAP_BYTES);
+    expect(result).toEqual({ data: "", truncated: false });
+    expect(fakeAddonState.disposeCallCount).toBe(1);
+  });
+
+  it("disposes the addon on the ordinary success path too", () => {
+    const term = makeStubTerminal(10);
+    serializeScrollback(term, SCROLLBACK_TRANSFER_CAP_BYTES);
+    expect(fakeAddonState.disposeCallCount).toBe(1);
+  });
+});
+
+describe("restoreScrollback", () => {
+  it("resets BEFORE writing anything — pins the reset-before-write order", () => {
+    const term = makeStubTerminal(0);
+    restoreScrollback(term, { data: "hello", truncated: false });
+    expect(term.calls[0]).toBe("reset");
+    expect(term.calls).toEqual(["reset", "write:hello"]);
+  });
+
+  it("writes the dim truncation marker BEFORE the data, only when truncated", () => {
+    const term = makeStubTerminal(0);
+    restoreScrollback(term, { data: "payload", truncated: true });
+    expect(term.calls).toEqual([
+      "reset",
+      `write:\x1b[2m${SCROLLBACK_TRUNCATION_MARKER_TEXT}\x1b[0m\r\n`,
+      "write:payload",
+    ]);
+  });
+
+  it("never writes the marker when truncated is false", () => {
+    const term = makeStubTerminal(0);
+    restoreScrollback(term, { data: "payload", truncated: false });
+    expect(term.calls.some((c) => c.includes(SCROLLBACK_TRUNCATION_MARKER_TEXT))).toBe(false);
+  });
+
+  it("is a no-op beyond the reset on an empty, non-truncated buffer", () => {
+    const term = makeStubTerminal(0);
+    restoreScrollback(term, { data: "", truncated: false });
+    expect(term.calls).toEqual(["reset"]);
+  });
+
+  it("still writes the marker on an empty but truncated buffer (a pathological cap-of-zero case)", () => {
+    const term = makeStubTerminal(0);
+    restoreScrollback(term, { data: "", truncated: true });
+    expect(term.calls).toEqual(["reset", `write:\x1b[2m${SCROLLBACK_TRUNCATION_MARKER_TEXT}\x1b[0m\r\n`]);
+  });
+
+  it("never throws when reset() itself throws — the marker/data writes never even attempted", () => {
+    const calls: string[] = [];
+    const term = {
+      reset() {
+        calls.push("reset");
+        throw new Error("reset boom");
+      },
+      write(data: string) {
+        calls.push(`write:${data}`);
+      },
+      loadAddon() {},
+      buffer: { active: { length: 0 } },
+    };
+    expect(() => restoreScrollback(term, { data: "x", truncated: true })).not.toThrow();
+    expect(calls).toEqual(["reset"]);
+  });
+
+  it("never throws when write() throws", () => {
+    const term = {
+      reset() {},
+      write() {
+        throw new Error("write boom");
+      },
+      loadAddon() {},
+      buffer: { active: { length: 0 } },
+    };
+    expect(() => restoreScrollback(term, { data: "x", truncated: false })).not.toThrow();
+  });
+});

--- a/src/lib/terminal/scrollback-transfer.ts
+++ b/src/lib/terminal/scrollback-transfer.ts
@@ -1,0 +1,133 @@
+// In-app terminal — scrollback hand-off (card 35cffc10,
+// docs/design-terminal-scrollback-transfer.html §7 "Reusable module
+// boundary"). The two pure functions that turn a live xterm.js terminal's
+// on-screen history into a small, transportable string and back again.
+//
+// Deliberately transport-agnostic: nothing here knows about BroadcastChannel,
+// the pop-out hand-off, or any other caller — see popout-channel.ts for the
+// ONE current caller (both directions: dock → popped at pop-out, popped →
+// dock at bring-back). The reload-reattach card (design §9, out of scope
+// here) reuses these two functions verbatim with a different transport
+// (sessionStorage) and a different trigger; nothing in this module binds to
+// BroadcastChannel-specific concerns.
+//
+// Both functions are pure with respect to everything but the passed
+// terminal, so they unit-test against a stub terminal the same way
+// popout-channel.ts tests against a stub channel — no real xterm/DOM
+// required. `@xterm/addon-serialize`'s own activation reaches into a real
+// Terminal's internals, so the unit tests mock the addon module itself
+// (see scrollback-transfer.test.ts's header doc) rather than trying to run
+// it against a plain stub.
+
+import { SerializeAddon } from "@xterm/addon-serialize";
+
+/** The only shape that crosses any transport (design §7). */
+export interface TransferredBuffer {
+  data: string;
+  truncated: boolean;
+}
+
+/**
+ * Everything serializeScrollback/restoreScrollback need from a live
+ * xterm.js `Terminal` — a real instance satisfies this trivially (every
+ * member is already part of its public API, the same subset
+ * use-terminal-session.ts already calls directly); tests pass a plain
+ * object instead, no DOM or real xterm required.
+ */
+export interface ScrollbackCapableTerminal {
+  loadAddon(addon: SerializeAddon): void;
+  /** Full reset (RIS) — the ONLY xterm operation that actually empties the scrollback buffer; `clear()` only clears the viewport and leaves history behind. */
+  reset(): void;
+  write(data: string): void;
+  readonly buffer: { readonly active: { readonly length: number } };
+}
+
+/** D2: 1 MiB (1,048,576 bytes) of serialized data, per transfer, either direction. */
+export const SCROLLBACK_TRANSFER_CAP_BYTES = 1_048_576;
+
+/** D2's exact marker copy — the em-dash-framed sentence carries the meaning on its own (never colour alone, WCAG 1.4.1); rendered dim via SGR by restoreScrollback. */
+export const SCROLLBACK_TRUNCATION_MARKER_TEXT = "— older history trimmed during hand-off —";
+
+/** Defensive ceiling on halving attempts — a bounded-loop guarantee, not a realistic path: a 5,000-line scrollback (xterm's own cap) resolves under the byte cap in well under this many halvings. */
+const MAX_TRUNCATION_ATTEMPTS = 30;
+
+function byteLength(s: string): number {
+  return new TextEncoder().encode(s).length;
+}
+
+/**
+ * Serializes a terminal's full on-screen history (viewport + scrollback) via
+ * `@xterm/addon-serialize`, capped at `capBytes` (default 1 MiB, D2).
+ *
+ * Truncation is whole-row and oldest-first: a full serialize over the cap is
+ * re-run with a HALVED `scrollback` row count, repeatedly, rather than
+ * slicing the serialized STRING at a byte offset — a byte slice can land
+ * mid-escape-sequence and corrupt every line rendered after the cut (D2,
+ * rejected). The halving starts from the terminal's own current buffer
+ * length so it converges in O(log2(lines)) steps; `MAX_TRUNCATION_ATTEMPTS`
+ * is a defensive bound only, never expected to bind in practice.
+ *
+ * Never throws — any internal failure (a hostile/incomplete terminal stub,
+ * an addon exception, anything) is caught and reported as an honest empty,
+ * non-truncated buffer, exactly like a session with no scrollback to hand
+ * over. Scrollback is never allowed to sink a hand-off (design §1's
+ * "Decision: buffer rides inside payload" callout).
+ */
+export function serializeScrollback(
+  term: ScrollbackCapableTerminal,
+  capBytes: number = SCROLLBACK_TRANSFER_CAP_BYTES,
+): TransferredBuffer {
+  let addon: SerializeAddon | null = null;
+  try {
+    addon = new SerializeAddon();
+    term.loadAddon(addon);
+
+    let data = addon.serialize();
+    if (byteLength(data) <= capBytes) {
+      return { data, truncated: false };
+    }
+
+    // Over cap — halve the scrollback row count, oldest rows dropped first,
+    // until the re-serialized result fits (or we hit the row/attempt floor).
+    const totalLines = term.buffer.active.length;
+    let rowCount = Number.isFinite(totalLines) ? Math.max(0, Math.floor(totalLines)) : 0;
+    let attempts = 0;
+    while (byteLength(data) > capBytes && rowCount > 0 && attempts < MAX_TRUNCATION_ATTEMPTS) {
+      rowCount = Math.floor(rowCount / 2);
+      data = addon.serialize({ scrollback: rowCount });
+      attempts += 1;
+    }
+    return { data, truncated: true };
+  } catch {
+    return { data: "", truncated: false };
+  } finally {
+    try {
+      addon?.dispose();
+    } catch {
+      /* best-effort cleanup only — never overrides the result computed above */
+    }
+  }
+}
+
+/**
+ * Restores a previously-serialized buffer into `term`: a FULL reset first
+ * (`term.reset()`, never `clear()` — see `ScrollbackCapableTerminal.reset`'s
+ * doc), then the dim truncation marker line (only when `buffer.truncated`),
+ * then the data itself. Safe to call with an empty, non-truncated buffer —
+ * a no-op beyond the reset.
+ *
+ * Never throws, mirroring `serializeScrollback`'s contract: a failure here
+ * must never sink a hand-off that otherwise succeeded — the caller (the
+ * pop-out/bring-back wiring) always proceeds to attach/reconnect regardless.
+ */
+export function restoreScrollback(term: ScrollbackCapableTerminal, buffer: TransferredBuffer): void {
+  try {
+    term.reset();
+    if (buffer.truncated) {
+      term.write(`\x1b[2m${SCROLLBACK_TRUNCATION_MARKER_TEXT}\x1b[0m\r\n`);
+    }
+    if (buffer.data) term.write(buffer.data);
+  } catch {
+    /* never throws — a failed restore just leaves the terminal freshly reset */
+  }
+}


### PR DESCRIPTION
Implements the approved design (docs/design-terminal-scrollback-transfer.html). Closes the last visible gap in the pop-out journey: the terminal's contents now travel WITH the session in both directions.

- **Pop-out**: the dock serializes its buffer (new pure `scrollback-transfer.ts`, `@xterm/addon-serialize`, 1 MiB cap with whole-row truncation + dim marker) and embeds it in the existing hand-off payload — the popped window restores it before attaching, so it opens showing full history.
- **Bring-back (button)**: two-phase — dock requests the popped window's buffer (strict superset, including everything produced while popped out), restores it (replace, not append), then reattaches; 500ms timeout falls back to the dock's own retained buffer so a dead window can't hang bring-back.
- **Bring-back (window close)**: pagehide posts the buffer just before the existing "closed" signal; bounded and never-throws.
- **Cosmetic**: the popped window's brought-back state now shows a calm sky "Moved to dock" pill instead of "Error"; the "output from pop-out onward" notice bar is retired.

**Tests**: +60 across the pure modules (cap/truncation bounded-loop, reset-before-write pinned, parser lenience + deploy skew, two-phase driver incl. timeout and late-reply). Gates: tsc clean · targeted 533/533 · full 2538/2538 · eslint clean.

Note: the Vercel Preview check is known-broken on PRs (missing Supabase env) and does not block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)