### PR TITLE
fix(terminal): popped window closes itself after bring-back (card 101bbb2d)

### DIFF
--- a/src/components/board/terminal-popout-view.test.tsx
+++ b/src/components/board/terminal-popout-view.test.tsx
@@ -1,0 +1,124 @@
+// Regression net for card 101bbb2d: the popped-out window used to sit on the
+// calm "Brought back to the dock — you can close this window" screen forever,
+// leaving Nick to close it by hand. It's opened BY SCRIPT (window.open in the
+// dock), so `window.close()` from its own script is browser-permitted; this
+// file pins that TerminalPopoutView actually calls it, on a delay, once
+// `broughtBack` (this window's own 4001 preempted close) is true — and that a
+// browser refusing the close leaves the fallback screen's Close button intact.
+//
+// `useTerminalSession` is mocked out entirely, same idiom as
+// terminal-session-view.test.tsx — this file only cares about
+// TerminalPopoutView's own effect wiring, not xterm/WebSocket internals.
+
+import { useRef } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { UseTerminalSessionResult, TerminalSessionActions } from "./use-terminal-session";
+import { RELAY_CLOSE } from "@/lib/terminal/connection";
+import { BROUGHT_BACK_AUTO_CLOSE_MS } from "@/lib/terminal/popout-channel";
+import type { PopoutPayload } from "@/lib/terminal/popout-channel";
+
+vi.mock("./use-terminal-session", () => ({
+  useTerminalSession: vi.fn(),
+}));
+
+import { useTerminalSession } from "./use-terminal-session";
+import { TerminalPopoutView } from "./terminal-popout-view";
+
+const mockedUseTerminalSession = vi.mocked(useTerminalSession);
+
+const PAYLOAD: PopoutPayload = {
+  sid: "sid-1",
+  browserToken: "tok",
+  relayUrl: "wss://relay.example",
+  ideaId: "idea-1",
+  ideaTitle: "Recipe Saver",
+  label: "Session 1",
+  identity: "Recipe Saver · session sid-1",
+  readOnly: false,
+};
+
+function mockActions(): TerminalSessionActions {
+  return {
+    connect: vi.fn(),
+    beginBrowserLaunch: vi.fn(),
+    launchFromBus: vi.fn(),
+    reconnectNow: vi.fn(),
+    end: vi.fn(),
+    setReadOnly: vi.fn(),
+    copyBridgeCommand: vi.fn(),
+    refreshView: vi.fn(),
+    serializeNow: vi.fn(),
+    restoreBuffer: vi.fn(),
+  };
+}
+
+/** `status: "error"` + `closeCode: RELAY_CLOSE.DUP_BROWSER` is exactly `isPreemptedClose` — the "brought back to the dock" case. */
+function installMockSession(status: "connected" | "error", closeCode: number | null) {
+  mockedUseTerminalSession.mockImplementation((): UseTerminalSessionResult => {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    return {
+      state: { status, sessionId: "sess-1", errorKind: null, endedReason: null, closeCode },
+      launchPhase: "idle",
+      peerDegraded: false,
+      helperVersion: null,
+      pair: { sessionId: "sess-1", bridgeToken: "bridge-tok", browserToken: "browser-tok" },
+      readOnly: false,
+      inputEnabled: true,
+      platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download", downloadUrl: null },
+      paired: true,
+      xtermReady: true,
+      containerRef,
+      actions: mockActions(),
+    };
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("TerminalPopoutView — auto-close on bring-back", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not close the window while merely connected", () => {
+    installMockSession("connected", null);
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+    render(<TerminalPopoutView payload={PAYLOAD} />);
+
+    vi.advanceTimersByTime(BROUGHT_BACK_AUTO_CLOSE_MS * 2);
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows the fallback screen immediately, then calls window.close() after the delay once brought back", () => {
+    installMockSession("error", RELAY_CLOSE.DUP_BROWSER);
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+    render(<TerminalPopoutView payload={PAYLOAD} />);
+
+    // The calm fallback copy is on screen from the first render — it's also
+    // what's visible during the delay, not just what's left if closing fails.
+    expect(screen.getByText("Brought back to the dock")).toBeInTheDocument();
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(BROUGHT_BACK_AUTO_CLOSE_MS);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the fallback screen (and its Close button) intact when the browser refuses the scripted close", () => {
+    installMockSession("error", RELAY_CLOSE.DUP_BROWSER);
+    vi.spyOn(window, "close").mockImplementation(() => {
+      throw new Error("scripts may not close this window");
+    });
+    render(<TerminalPopoutView payload={PAYLOAD} />);
+
+    expect(() => vi.advanceTimersByTime(BROUGHT_BACK_AUTO_CLOSE_MS)).not.toThrow();
+    expect(screen.getByText("Brought back to the dock")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close window" })).toBeInTheDocument();
+  });
+});

--- a/src/components/board/terminal-popout-view.tsx
+++ b/src/components/board/terminal-popout-view.tsx
@@ -26,7 +26,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { resolveDockView, type DockView } from "@/lib/terminal/first-run-flow";
 import type { TerminalConnectionState } from "@/lib/terminal/connection";
-import { isPreemptedClose, type PopoutPayload } from "@/lib/terminal/popout-channel";
+import { isPreemptedClose, startBroughtBackAutoClose, type PopoutPayload } from "@/lib/terminal/popout-channel";
 import { dockStatusMeta, type StatusMeta } from "./terminal-session-view";
 import {
   useTerminalSession,
@@ -134,6 +134,19 @@ export function TerminalPopoutView({ payload, onSessionActions }: TerminalPopout
   // untouched, so every genuine dock error keeps its rose pill everywhere
   // else.
   const meta = broughtBack ? MOVED_TO_DOCK_META : dockStatusMeta(view, state.errorKind);
+
+  // card 101bbb2d: this window was opened BY SCRIPT (the dock's window.open
+  // in openPopoutWindow), so `window.close()` from its OWN script is
+  // browser-permitted — and by the time broughtBack is true, the two-phase
+  // bring-back has already crossed the scrollback buffer, so nothing further
+  // is needed from this window. The BroughtBackOverlay below (and its Close
+  // button) stays exactly as-is as the fallback for a browser that refuses
+  // the scripted close — startBroughtBackAutoClose swallows that refusal
+  // rather than letting it surface as an error.
+  useEffect(() => {
+    if (!broughtBack) return;
+    return startBroughtBackAutoClose({ closeWindow: () => window.close() });
+  }, [broughtBack]);
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/src/lib/terminal/popout-channel.test.ts
+++ b/src/lib/terminal/popout-channel.test.ts
@@ -14,6 +14,8 @@ import {
   createDockPopoutMessageHandler,
   startPopoutClientHandshake,
   startBringBackRequest,
+  startBroughtBackAutoClose,
+  BROUGHT_BACK_AUTO_CLOSE_MS,
   type PopoutPayload,
   type PopoutChannelLike,
   type DockHandshakeState,
@@ -564,6 +566,68 @@ describe("startBringBackRequest", () => {
     vi.advanceTimersByTime(BRING_BACK_REPLY_TIMEOUT_MS);
     expect(onSettle).toHaveBeenCalledTimes(1);
     expect(onSettle).toHaveBeenCalledWith(null);
+  });
+});
+
+describe("startBroughtBackAutoClose", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls closeWindow after BROUGHT_BACK_AUTO_CLOSE_MS", () => {
+    const closeWindow = vi.fn();
+    startBroughtBackAutoClose({ closeWindow });
+
+    vi.advanceTimersByTime(BROUGHT_BACK_AUTO_CLOSE_MS - 1);
+    expect(closeWindow).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(closeWindow).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() prevents closeWindow from ever firing", () => {
+    const closeWindow = vi.fn();
+    const cancel = startBroughtBackAutoClose({ closeWindow });
+    cancel();
+    vi.advanceTimersByTime(BROUGHT_BACK_AUTO_CLOSE_MS * 2);
+    expect(closeWindow).not.toHaveBeenCalled();
+  });
+
+  it("swallows a throwing closeWindow — a browser refusing the scripted close must leave the fallback screen intact, not crash", () => {
+    const closeWindow = vi.fn(() => {
+      throw new Error("scripts may not close this window");
+    });
+    expect(() => {
+      startBroughtBackAutoClose({ closeWindow });
+      vi.advanceTimersByTime(BROUGHT_BACK_AUTO_CLOSE_MS);
+    }).not.toThrow();
+    expect(closeWindow).toHaveBeenCalledTimes(1);
+  });
+
+  it("a throwing closeWindow doesn't leave any dangling timer or unhandled rejection behind — the process stays clean afterwards", () => {
+    const closeWindow = vi.fn(() => {
+      throw new Error("boom");
+    });
+    startBroughtBackAutoClose({ closeWindow });
+    vi.advanceTimersByTime(BROUGHT_BACK_AUTO_CLOSE_MS);
+    expect(closeWindow).toHaveBeenCalledTimes(1);
+
+    // Nothing else was scheduled by the failure — advancing further changes nothing.
+    vi.advanceTimersByTime(BROUGHT_BACK_AUTO_CLOSE_MS * 5);
+    expect(closeWindow).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects a custom delayMs", () => {
+    const closeWindow = vi.fn();
+    startBroughtBackAutoClose({ closeWindow, delayMs: 100 });
+
+    vi.advanceTimersByTime(99);
+    expect(closeWindow).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(closeWindow).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/lib/terminal/popout-channel.ts
+++ b/src/lib/terminal/popout-channel.ts
@@ -656,3 +656,58 @@ export function startBringBackRequest(options: BringBackRequestOptions): () => v
     clearTimeoutFn(timer);
   };
 }
+
+// ── popped-window-side auto-close on bring-back (card 101bbb2d) ────────────
+//
+// The popped window was opened BY SCRIPT — `window.open()` in the dock (see
+// `openPopoutWindow` above) — so `window.close()` from ITS OWN script is
+// browser-permitted (the "scripts may only close windows they opened"
+// restriction). By the time this window sees its own 4001 preempted close
+// (`isPreemptedClose` above), the two-phase bring-back (design's Flow B,
+// `startBringBackRequest`) has already crossed the scrollback buffer BEFORE
+// the dock reattached — nothing further is needed from this window, so it
+// closes itself instead of leaving Nick to close a "you can close this
+// window" tab by hand. `BroughtBackOverlay` (terminal-popout-view.tsx) is
+// kept exactly as-is as the FALLBACK: some browsers refuse a scripted close
+// (e.g. the tab wasn't opened by script from that browser's point of view,
+// or the user has multiple tabs in the window) — `closeWindow` swallows
+// whatever it throws so a refusal never surfaces as an error, it just leaves
+// the calm overlay + its Close button sitting there, which is also what's
+// briefly visible during the delay below either way.
+
+/** How long the popped window waits, once brought back, before closing itself — long enough that the "Brought back to the dock" state is visibly readable for a beat, short enough that it reads as automatic rather than stuck. */
+export const BROUGHT_BACK_AUTO_CLOSE_MS = 600;
+
+/**
+ * Schedules `closeWindow()` after `delayMs` and returns a cancel function.
+ * `closeWindow` is injected (rather than this module calling `window.close()`
+ * directly) for the same reason every other driver in this file injects its
+ * side effect — testable without a real `window`. Never throws: a browser
+ * that refuses the scripted close (or any other failure inside `closeWindow`)
+ * must leave the fallback "Moved to dock" screen intact, not crash the
+ * popped window's render.
+ */
+export function startBroughtBackAutoClose(options: {
+  closeWindow: () => void;
+  delayMs?: number;
+  setTimeoutFn?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimeoutFn?: (id: ReturnType<typeof setTimeout>) => void;
+}): () => void {
+  const {
+    closeWindow,
+    delayMs = BROUGHT_BACK_AUTO_CLOSE_MS,
+    setTimeoutFn = (cb, ms) => setTimeout(cb, ms),
+    clearTimeoutFn = (id) => clearTimeout(id),
+  } = options;
+
+  const timer = setTimeoutFn(() => {
+    try {
+      closeWindow();
+    } catch {
+      /* the browser refused the scripted close — the fallback screen (with
+       * its own Close button) is already on screen; nothing else to do. */
+    }
+  }, delayMs);
+
+  return () => clearTimeoutFn(timer);
+}


### PR DESCRIPTION
Nick's polish request: after "Bring back to dock", the popped window now closes itself ~600ms later (script-opened windows may self-close). The "Moved to dock" screen + Close button remain as the visible beat and as the fallback if a browser refuses the scripted close. Buffer hand-off timing unaffected (it completes before the window ever learns it was brought back).

Tests: +8 (pure driver: delay/cancel/throw-swallowed; component: no close while connected, close fires only after the delay when brought back, throwing close leaves the fallback intact). Gates: tsc clean · targeted 541/541 · full 2546/2546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)