### PR TITLE
feat(terminal): session entry chooser (Option A) — reload reattach, instant continue, resume (card cbe60db5)

### DIFF
--- a/docs/design-terminal-session-entry-options.html
+++ b/docs/design-terminal-session-entry-options.html
@@ -1,0 +1,581 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Design options — Terminal session entry (reconnect / new / resume)</title>
+<style>
+:root{
+  --bg:#09090b; --panel:#0c0c0e; --panel2:#111114; --panel3:#141417;
+  --border:#27272a; --border2:#3f3f46;
+  --txt:#e4e4e7; --dim:#a1a1aa; --faint:#71717a;
+  --emerald:#34d399; --emerald-bg:rgba(52,211,153,.09); --emerald-bd:rgba(52,211,153,.4);
+  --sky:#38bdf8; --sky-bg:rgba(56,189,248,.09); --sky-bd:rgba(56,189,248,.4);
+  --amber:#fbbf24; --amber-bg:rgba(251,191,36,.09); --amber-bd:rgba(251,191,36,.4);
+  --rose:#fb7185; --rose-bg:rgba(251,113,133,.09); --rose-bd:rgba(251,113,133,.45);
+  --violet:#a78bfa;
+  --mono:ui-monospace,'SF Mono',Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:var(--bg);color:var(--txt);font:14px/1.6 -apple-system,'Segoe UI',Roboto,sans-serif;padding:40px 20px 80px}
+.wrap{max-width:1020px;margin:0 auto}
+h1{font-size:24px;margin-bottom:4px}
+h2{font-size:18px;margin:48px 0 12px;padding-bottom:6px;border-bottom:1px solid var(--border)}
+h3{font-size:14.5px;margin:24px 0 8px}
+h4{font-size:12.5px;margin:18px 0 6px;color:var(--dim);text-transform:uppercase;letter-spacing:.05em}
+p{margin:8px 0;color:var(--dim)}
+strong{color:var(--txt)}
+.sub{color:var(--faint);font-size:13px;margin-bottom:20px}
+.meta{display:flex;gap:8px;flex-wrap:wrap;margin:14px 0 6px}
+.chip{font-size:11px;padding:2px 9px;border-radius:999px;border:1px solid var(--border2);color:var(--dim)}
+.chip.em{border-color:var(--emerald-bd);color:var(--emerald);background:var(--emerald-bg)}
+.chip.rose{border-color:var(--rose-bd);color:var(--rose);background:var(--rose-bg)}
+code{font-family:var(--mono);font-size:12px;background:var(--panel2);border:1px solid var(--border);border-radius:4px;padding:1px 5px;color:var(--txt)}
+.panel{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:16px 18px;margin:12px 0}
+.reject{border-left:3px solid var(--rose)}
+.reject .rtitle{font-size:14px;font-weight:700;color:var(--rose);margin-bottom:6px}
+.found{border-left:3px solid var(--emerald)}
+.veto{border:1px dashed var(--amber-bd);background:var(--amber-bg);border-radius:8px;padding:10px 14px;margin:10px 0;font-size:12.5px;color:var(--amber)}
+.veto b{color:var(--amber)}
+table{width:100%;border-collapse:collapse;margin:12px 0;font-size:12.5px}
+th{text-align:left;padding:7px 10px;color:var(--faint);font-size:11px;text-transform:uppercase;letter-spacing:.05em;border-bottom:1px solid var(--border2);vertical-align:bottom}
+td{padding:8px 10px;border-bottom:1px solid var(--border);color:var(--dim);vertical-align:top}
+td:first-child{color:var(--txt);font-weight:600}
+.tblwrap{overflow-x:auto}
+.copytab td:nth-child(2){font-family:var(--mono);font-size:11.5px;color:var(--txt)}
+.rec td{background:var(--emerald-bg)}
+.pick{color:var(--emerald);font-weight:700}
+/* flows */
+.flow{display:flex;flex-wrap:wrap;align-items:center;gap:6px;margin:10px 0;padding:4px 0}
+.step{background:var(--panel2);border:1px solid var(--border2);border-radius:7px;padding:6px 11px;font-size:12px;color:var(--txt)}
+.step small{display:block;color:var(--faint);font-size:10.5px;max-width:210px}
+.step.sys{border-style:dashed;color:var(--dim)}
+.step.good{border-color:var(--emerald-bd);background:var(--emerald-bg)}
+.step.warn{border-color:var(--amber-bd);background:var(--amber-bg)}
+.step.act{border-color:var(--sky-bd);background:var(--sky-bg)}
+.arr{color:var(--faint);font-size:13px;flex:none}
+/* mockups */
+.mock{background:var(--panel);border:1px solid var(--border2);border-radius:10px;margin:14px 0;overflow:hidden;font-size:13px}
+.mock-cap{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);margin:20px 0 -6px}
+.dockbar{display:flex;align-items:center;gap:10px;background:var(--panel3);padding:7px 12px;font-size:12.5px}
+.dockbar .brand{display:inline-flex;align-items:center;gap:8px;font-weight:700;color:var(--txt)}
+.dockbar .right{margin-left:auto;display:inline-flex;align-items:center;gap:8px}
+.dot{width:8px;height:8px;border-radius:50%;flex:none;display:inline-block}
+.dot.g{background:var(--emerald)} .dot.s{background:var(--sky)} .dot.a{background:var(--amber)} .dot.z{background:var(--faint)} .dot.o{background:transparent;border:1.5px solid var(--sky)}
+.pill{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--border2);border-radius:6px;padding:2px 9px;font-size:11px;font-weight:600;color:var(--dim)}
+.pill.sky{border-color:var(--sky-bd);color:var(--sky);background:var(--sky-bg)}
+.pill.em{border-color:var(--emerald-bd);color:var(--emerald);background:var(--emerald-bg)}
+.pill.zn{color:var(--dim)}
+.btn{display:inline-flex;align-items:center;gap:6px;border-radius:6px;padding:4px 12px;font-size:12px;font-weight:600;border:1px solid var(--border2);color:var(--txt);background:transparent;white-space:nowrap}
+.btn.sky{border-color:var(--sky-bd);color:var(--sky);background:var(--sky-bg)}
+.btn.em{border-color:var(--emerald-bd);color:var(--emerald);background:var(--emerald-bg)}
+.btn.em.solid{background:var(--emerald);color:#052e22;border-color:var(--emerald)}
+.btn.rose{border-color:var(--rose-bd);color:var(--rose)}
+.btn.ghost{border-color:transparent;color:var(--dim)}
+.btn.sm{padding:2px 9px;font-size:11.5px}
+.row{display:flex;align-items:center;gap:10px;padding:10px 14px;border-top:1px solid var(--border)}
+.row .who{min-width:0;flex:1}
+.row .who .t{font-weight:600;color:var(--txt);font-size:13px;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.row .who .t .idea{font-weight:400;color:var(--faint);font-size:11.5px}
+.row .who .m{font-family:var(--mono);font-size:11px;color:var(--faint)}
+.row .age{font-size:11.5px;color:var(--faint);flex:none}
+.sect{padding:6px 14px;font-size:10.5px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;color:var(--faint);background:var(--panel2);border-top:1px solid var(--border)}
+.badge{font-size:10px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;border-radius:4px;padding:1px 6px}
+.badge.here{background:var(--sky-bg);border:1px solid var(--sky-bd);color:var(--sky)}
+.badge.other{background:var(--panel2);border:1px solid var(--border2);color:var(--dim)}
+.badge.was{background:var(--amber-bg);border:1px solid var(--amber-bd);color:var(--amber)}
+.term{background:#0a0a0c;padding:14px 16px;font-family:var(--mono);font-size:12px;color:var(--dim);min-height:48px}
+.note-amber{display:flex;gap:9px;align-items:flex-start;background:var(--amber-bg);border:1px solid var(--amber-bd);border-radius:7px;padding:8px 12px;font-size:12px;color:var(--amber)}
+.caption{font-size:11.5px;color:var(--faint)}
+.tabstrip{display:flex;align-items:stretch;background:var(--panel3);border-bottom:1px solid var(--border)}
+.ttab{display:flex;align-items:center;gap:7px;padding:8px 12px;border-right:1px solid var(--border);border-top:2px solid transparent;font-size:12.5px;color:var(--dim);white-space:nowrap}
+.ttab.on{border-top-color:var(--sky);background:var(--panel);color:var(--txt);font-weight:600}
+.ttab .x{color:var(--faint);font-size:11px;margin-left:2px}
+.ttab .st{font-size:10px;font-weight:700;letter-spacing:.03em;text-transform:uppercase;color:var(--sky)}
+.plus{display:flex;align-items:center;padding:8px 13px;border-left:1px solid var(--border);margin-left:auto;color:var(--dim);font-weight:700}
+.recentrow{display:flex;align-items:center;gap:12px;background:var(--panel2);border-top:1px solid var(--border);padding:6px 14px;font-size:12px;color:var(--dim);flex-wrap:wrap}
+.recentrow .lbl{font-size:10.5px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--faint)}
+.centerpanel{display:flex;flex-direction:column;align-items:center;gap:10px;padding:28px 20px;text-align:center;background:var(--panel)}
+.centerpanel .hl{font-size:14px;font-weight:700;color:var(--txt)}
+.centerpanel .mono{font-family:var(--mono);font-size:11.5px;color:var(--faint)}
+.centerpanel .warn{font-size:11.5px;color:var(--amber);max-width:420px}
+ul.tight{margin:6px 0 6px 20px;color:var(--dim)}
+ul.tight li{margin:4px 0}
+.cols{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+@media(max-width:760px){.cols{grid-template-columns:1fr}}
+.pro h4{color:var(--emerald)} .con h4{color:var(--rose)}
+.opt-h{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap}
+.opt-h .tag{font-size:11px;font-weight:800;letter-spacing:.08em;border-radius:5px;padding:2px 8px}
+.opt-h .tag.a{background:var(--emerald-bg);border:1px solid var(--emerald-bd);color:var(--emerald)}
+.opt-h .tag.b{background:var(--sky-bg);border:1px solid var(--sky-bd);color:var(--sky)}
+.opt-h .tag.c{background:var(--amber-bg);border:1px solid var(--amber-bd);color:var(--amber)}
+.kbd{font-family:var(--mono);font-size:11px;border:1px solid var(--border2);border-bottom-width:2px;border-radius:4px;padding:0 5px;color:var(--dim)}
+.confirmbox{border-left:2px solid var(--emerald);background:var(--emerald-bg);padding:10px 14px;font-size:12.5px;color:var(--dim)}
+.confirmbox b{color:var(--txt)}
+.takeover{font-size:11.5px;color:var(--faint);display:flex;gap:7px;align-items:flex-start}
+.takeover .i{color:var(--amber);flex:none}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Terminal session entry — three options</h1>
+<p class="sub">Rework of card cbe60db5 · reconnect / new / resume — <strong>Nick chooses the direction</strong>; nothing below is decided.</p>
+<div class="meta">
+  <span class="chip rose">REWORK — v1 rejected</span>
+  <span class="chip em">3 options, equal depth</span>
+  <span class="chip">Dock · My sessions · Pop-out</span>
+  <span class="chip">WCAG 2.1 AA · no hover-only · never colour alone</span>
+</div>
+
+<div class="panel reject">
+  <div class="rtitle">Why v1 was rejected — and what every option below fixes</div>
+  <p><strong>1 · It designed for a dock that was already open.</strong> In reality the dock loads <em>collapsed</em>, and expanding it silently mints a brand-new session (the paired auto-connect on expand). The v1 "Reconnect" state was unreachable; every refresh-and-reopen spawned a duplicate — Nick ended up with three.</p>
+  <p><strong>2 · It auto-decided.</strong> Nick, verbatim: <em>"I should be able to decide myself whether I want an existing one, a new one or a resumed one."</em></p>
+  <p><strong>Fixed in all three options:</strong> whenever you have any live or recent session, opening the terminal — via the dock chevron, the toolbar button, or a task launch — <strong>never silently creates and never silently reconnects</strong>. It always lands on a choice with three first-class answers: <strong>Reconnect</strong> · <strong>New session</strong> · <strong>Resume</strong>. The only automatic behaviour anywhere is the optional "instant continue" refresh variant in §2, clearly marked as Nick's to veto.</p>
+</div>
+
+<!-- ============================================================ -->
+<h2>1 · Side-by-side comparison</h2>
+<div class="tblwrap">
+<table>
+  <tr><th style="width:20%"></th><th>A — Chooser panel</th><th>B — My sessions is the front door</th><th>C — Tabs-first</th></tr>
+  <tr><td>Opening the dock shows</td>
+      <td>A session chooser inside the dock body: live sessions, a Recent strip, a prominent "Start new session". Nothing runs until a click.</td>
+      <td>The (upgraded) My sessions panel. The terminal area itself only opens once a session is chosen or created.</td>
+      <td>The tab strip, immediately — one resting "Reconnect" tab per live session, a "+" tab, a slim Recent row beneath.</td></tr>
+  <tr><td>Clicks to reconnect (the common case)</td>
+      <td>2 — open dock, click Reconnect on a row. (1 or 0 with the optional instant-continue variant.)</td>
+      <td>2 — click the header, click Reconnect on a row. (Same variant applies.)</td>
+      <td>2 — open dock, click Reconnect in the pre-selected tab. (Same variant applies.)</td></tr>
+  <tr><td>Clicks to a new session</td>
+      <td>2 — open, "Start new session".</td>
+      <td>2 — header, "New session".</td>
+      <td>2 — open, "+".</td></tr>
+  <tr><td>Live sessions on <em>other</em> boards</td>
+      <td>Listed in the chooser ("on Helper Tools") — reconnect navigates there.</td>
+      <td>Listed natively — the panel is already global.</td>
+      <td><strong>Not in the strip</strong> (tabs are board-scoped) — still needs the My sessions panel.</td></tr>
+  <tr><td>Where Resume lives</td>
+      <td>Recent strip at the bottom of the chooser.</td>
+      <td>Recent section of the panel.</td>
+      <td>Slim Recent row under the tab strip.</td></tr>
+  <tr><td>Discoverability of the three choices</td>
+      <td>Highest — one purpose-built screen shows all three at once.</td>
+      <td>Good, but launching lives inside a management popover next to End/End&nbsp;all.</td>
+      <td>Good for reconnect/new; Resume in a slim row is easy to overlook.</td></tr>
+  <tr><td>Crowding / new chrome</td>
+      <td>One new full-body view; dock header gains counts.</td>
+      <td>Almost none new — header text + three buttons in an existing panel.</td>
+      <td>Strip now renders for a single session too (today it needs 2+), plus a permanent Recent row.</td></tr>
+  <tr><td>Implementation weight</td>
+      <td>Medium — new chooser component; registry fetch on board load; header counts.</td>
+      <td>Low — panel upgrade + header rewire; registry fetch for counts.</td>
+      <td>Medium-high — resting-tab state in the strip machine, single-tab strip exception, Recent row, per-tab reconnect panels.</td></tr>
+  <tr><td>Closeness to today's mental model</td>
+      <td>New screen, familiar parts.</td>
+      <td>Familiar panel, new role.</td>
+      <td>Closest — same tabs, new resting state.</td></tr>
+  <tr class="rec"><td>Recommendation</td>
+      <td class="pick">Preferred — the decision moment is explicit and everything (here / elsewhere / recent / new) is in one glance.</td>
+      <td>Cheapest to build, but launching from an admin popover feels indirect and puts Start next to End.</td>
+      <td>Most familiar, but hides other-board sessions and complicates the strip rules the most.</td></tr>
+</table>
+</div>
+<p class="caption">The recommendation is one reviewer's preference with reasoning — Nick decides.</p>
+
+<!-- ============================================================ -->
+<h2>2 · Common foundations (shared by all three options)</h2>
+<div class="panel found">
+  <p><strong>F1 · The silent auto-mint dies.</strong> Today, expanding the dock auto-connects a paired browser (<code>autoConnectWhenExpanded</code> on the pristine slot). That behaviour survives <em>only</em> in the true empty state: <strong>no live sessions anywhere and no recent ended sessions</strong> → opening the dock launches a new session exactly as today (there is nothing to choose between, and this is explicitly fine). The moment the registry lists any live session or any resumable recent session for this user, every entry point routes to the option's choice surface instead. On board load the dock fetches the registry once (it already fetches for the My sessions badge) to know which world it's in.</p>
+  <p><strong>F2 · Reconnect mechanics.</strong> Reattaching mints a fresh browser token for an owned live session id: <em>no new registry row, exempt from the session cap and the mint rate limit</em> (recovering capacity, not consuming it), but fully authenticated and ownership-checked. Scrollback: while attached, the dock snapshots the buffer to this tab's sessionStorage (pagehide + 20&nbsp;s dirty-flag cadence); on reattach a snapshot restores with the divider <code>— reconnected · earlier output restored —</code>; with no snapshot, a dismissible amber note is pinned above the terminal — never a silently blank screen.</p>
+  <p><strong>F3 · Take-over is always stated, never sniffed.</strong> We don't trust ourselves to know reliably whether another window currently holds the session, so every Reconnect control carries the same generic warning <em>visibly, before the click</em> — the click on Reconnect is the informed confirmation; no second click, no conditional logic: <em>"If this session is open in another window or browser, connecting here takes over — that view stops receiving output."</em></p>
+  <p><strong>F4 · Resume mechanics.</strong> Resume runs <code>claude --continue</code> in the session's recorded project folder, as a <em>new</em> session through the normal capped launch path (the confirm says so). Recent = ended in the last 48&nbsp;h, max 5, one per project folder. <strong>Resume is hidden entirely when the project folder wasn't recorded</strong> — no disabled ghost button. The machine line uses the cautious copy <em>by default</em>: "The conversation lives on the machine that ran it — resume from a browser on that machine.", appending "(recorded as Nick's&nbsp;MacBook)" only when a label exists.</p>
+  <p><strong>F5 · Popped-out window reload (same in all options).</strong> The popped window stashes its session id in its own sessionStorage at hand-off. On reload it shows a one-button Reconnect panel (with the F3 warning) — it never auto-attaches unless the instant-continue variant below is approved, in which case its own &lt;60&nbsp;s snapshot counts as proof. If the mint says the session is gone: "This session has ended. You can close this window — start a new one from the board." + a Close-window button.</p>
+</div>
+
+<div class="veto">
+  <b>Optional variant — "instant continue" on accidental same-tab refresh (Nick's to veto).</b><br>
+  Justification: sessionStorage is per-tab and survives reload; a snapshot for this session id time-stamped under 60&nbsp;seconds ago proves <em>this exact tab</em> held the session moments before. Only in that case, the dock may skip the choice and reattach automatically (restoring scrollback, zero clicks) — the refresher never even notices the reload. Every other case — new tab, restored browser, second machine, stale snapshot — always gets the explicit choice. This is <b>off by default in this document</b>; it ships only if Nick approves it, and it is the <em>only</em> automatic connect anywhere in any option.
+</div>
+
+<p class="caption">Accessibility, all options: every state carries text (never colour alone — dots always sit next to words); all actions are visible buttons (no hover-reveals); choice surfaces are keyboard-traversable lists (<span class="kbd">Tab</span>/<span class="kbd">↑↓</span>, <span class="kbd">Enter</span> activates); focus lands on the first live session's primary action when the surface opens; counts in headers are real text, not badge-only.</p>
+
+<!-- ============================================================ -->
+<h2 id="opt-a">3 · Option A — "Chooser panel"</h2>
+<div class="opt-h"><span class="tag a">OPTION A</span><p>Opening the terminal from anywhere lands on a session chooser <em>inside the dock body</em>. Nothing happens until a click.</p></div>
+
+<h3>Flow walkthrough</h3>
+<div class="flow">
+  <span class="step act">Open terminal<small>chevron, toolbar "In the browser", or task launch</small></span><span class="arr">→</span>
+  <span class="step sys">Sessions exist?<small>registry fetched on board load</small></span><span class="arr">→</span>
+  <span class="step">Chooser fills the dock body<small>live here · live elsewhere · Recent · Start new</small></span><span class="arr">→</span>
+  <span class="step act">One click: Reconnect / Start new / Resume</span><span class="arr">→</span>
+  <span class="step good">Terminal live<small>chooser replaced by the normal terminal; tab strip appears as sessions accumulate</small></span>
+</div>
+<p>Task launches pass their context in: the chooser's "Start new session" row becomes "Start new session for this task — fix-login-bug" (primary, emerald), and if that task already has a live session its row is badged "already running for this task" with Reconnect as the obvious answer — the same dedupe rule as today, made visible instead of automatic.</p>
+
+<p class="mock-cap">Mockup A1 — collapsed dock header (sessions exist)</p>
+<div class="mock">
+  <div class="dockbar">
+    <span class="brand"><span class="dot s" aria-hidden="true"></span>▸_ Terminal</span>
+    <span class="pill sky">2 running here</span>
+    <span class="pill zn">1 on another board</span>
+    <span class="pill zn">2 recent</span>
+    <span class="right">
+      <span class="btn ghost sm">☰ My sessions <span class="pill sky" style="padding:0 6px">3</span></span>
+      <span class="btn sm sky">⌃ Open</span>
+    </span>
+  </div>
+</div>
+<p class="caption">The chevron reads "Open", not "Expand" — it opens the chooser, it never connects. Counts are plain text pills, not colour-only dots.</p>
+
+<p class="mock-cap">Mockup A2 — the chooser (2 live on this board, 1 live on another board, 2 recent)</p>
+<div class="mock">
+  <div class="dockbar">
+    <span class="brand">▸_ Terminal</span>
+    <span class="right"><span class="btn ghost sm">⌄ Collapse</span></span>
+  </div>
+  <div style="padding:12px 14px;border-bottom:1px solid var(--border)">
+    <span class="btn em solid">＋ Start new session</span>
+    <span class="caption" style="margin-left:10px">Runs Claude Code on your machine · counts toward your session limit</span>
+  </div>
+  <div class="sect">Running now — this board · VibeCodes</div>
+  <div class="row">
+    <span class="dot g" aria-hidden="true"></span>
+    <div class="who">
+      <div class="t">fix-login-bug <span class="badge here">this board</span></div>
+      <div class="m">Nick's MacBook · ~/projects/vibecodes · started 3h ago</div>
+      <div class="takeover"><span class="i" aria-hidden="true">⚠</span> If this session is open in another window or browser, connecting here takes over — that view stops receiving output.</div>
+    </div>
+    <span class="btn sky">⇄ Reconnect</span>
+  </div>
+  <div class="row">
+    <span class="dot g" aria-hidden="true"></span>
+    <div class="who">
+      <div class="t">vibecodes · session 4f9a12c8 <span class="badge here">this board</span></div>
+      <div class="m">Nick's MacBook · ~/projects/vibecodes · started 45m ago</div>
+      <div class="takeover"><span class="i" aria-hidden="true">⚠</span> If this session is open in another window or browser, connecting here takes over — that view stops receiving output.</div>
+    </div>
+    <span class="btn sky">⇄ Reconnect</span>
+  </div>
+  <div class="sect">Running now — other boards</div>
+  <div class="row">
+    <span class="dot g" aria-hidden="true"></span>
+    <div class="who">
+      <div class="t">docs-pass <span class="idea">Helper Tools</span> <span class="badge other">other board</span></div>
+      <div class="m">Nick's MacBook · ~/projects/helper · started 1h ago</div>
+    </div>
+    <span class="btn sky">⇄ Open board &amp; reconnect</span>
+  </div>
+  <div class="sect">Recent — ended in the last 48h</div>
+  <div class="row">
+    <span class="dot z" aria-hidden="true"></span>
+    <div class="who">
+      <div class="t">api-cleanup <span class="idea">VibeCodes</span></div>
+      <div class="m">~/projects/vibecodes · ended 2h ago</div>
+    </div>
+    <span class="btn em">↻ Resume</span>
+  </div>
+  <div class="row">
+    <span class="dot z" aria-hidden="true"></span>
+    <div class="who">
+      <div class="t">helper-docs <span class="idea">Helper Tools</span></div>
+      <div class="m">~/projects/helper · ended 1d ago</div>
+    </div>
+    <span class="btn em">↻ Resume</span>
+  </div>
+</div>
+<p class="caption">Clicking Resume swaps the row into the shared inline confirm (F4): new session · counts toward the limit · continues the most recent conversation in that folder · machine-truth line. A recent session whose folder wasn't recorded simply doesn't appear.</p>
+
+<h3>Required cases</h3>
+<ul class="tight">
+  <li><strong>Collapsed header:</strong> mockup A1 — counts for running-here / running-elsewhere / recent; single neutral state dot with text beside it.</li>
+  <li><strong>Toolbar "Launch Claude Code → In the browser":</strong> expands the dock onto the chooser with the task-scoped "Start new session for this task" primary row (above). With no sessions anywhere: launches immediately, as today.</li>
+  <li><strong>Popped-out window reload:</strong> foundations F5 — its own one-button Reconnect panel; no chooser needed, the window already knows which session it is.</li>
+  <li><strong>Accidental same-tab refresh:</strong> dock returns collapsed with the A1 header. Opening shows the chooser with the tab's own last session badged <span class="badge was">was open in this tab</span> and pre-focused, so <span class="kbd">Enter</span> reconnects. With the instant-continue variant approved: that one session reattaches automatically (&lt;60&nbsp;s proof), chooser skipped.</li>
+  <li><strong>Empty state:</strong> unchanged — open → paired auto-connect / setup panel, exactly today's behaviour.</li>
+</ul>
+
+<h3>What changes vs today</h3>
+<ul class="tight">
+  <li>The pristine slot's <code>autoConnectWhenExpanded</code> is gated on "registry empty &amp; no recents" instead of always-on.</li>
+  <li>New chooser view rendered in the dock body when sessions exist; new registry fetch on board load (extends the existing badge fetch).</li>
+  <li>Collapsed bar gains the three count pills; chevron copy "Open/Collapse".</li>
+  <li>Launch-bus payloads route into the chooser instead of straight into <code>deliverLaunch</code>'s mint.</li>
+</ul>
+
+<div class="cols">
+  <div class="panel pro"><h4>Pros</h4>
+    <ul class="tight">
+      <li>The decision moment is a purpose-built screen — all three choices plus other-board sessions visible at once; nothing to recall.</li>
+      <li>Explicit primary action for the newcomer path ("Start new session") — no ambiguity about what the big button does.</li>
+      <li>Task dedupe becomes visible and user-controlled rather than automatic.</li>
+      <li>One consistent surface regardless of entry point (chevron, toolbar, task).</li>
+    </ul>
+  </div>
+  <div class="panel con"><h4>Cons</h4>
+    <ul class="tight">
+      <li>Two clicks to a terminal every time sessions exist (unless the variant is approved).</li>
+      <li>Overlaps the My sessions panel — two surfaces listing sessions must stay consistent (mitigation: both read the same list endpoint).</li>
+      <li>A new full-body dock view to build and test; the heaviest <em>new</em> UI of the three (though not the heaviest overall — see C).</li>
+    </ul>
+  </div>
+</div>
+
+<h3>New copy — Option A</h3>
+<div class="tblwrap">
+<table class="copytab">
+  <tr><th>Where</th><th>String</th></tr>
+  <tr><td>Header pills</td><td>{n} running here · {n} on another board · {n} recent</td></tr>
+  <tr><td>Chevron</td><td>Open / Collapse</td></tr>
+  <tr><td>New-session row</td><td>Start new session</td></tr>
+  <tr><td>New-session row (task launch)</td><td>Start new session for this task — {task title}</td></tr>
+  <tr><td>New-session caption</td><td>Runs Claude Code on your machine · counts toward your session limit</td></tr>
+  <tr><td>Section headers</td><td>Running now — this board · {idea} / Running now — other boards / Recent — ended in the last 48h</td></tr>
+  <tr><td>Other-board reconnect</td><td>Open board &amp; reconnect</td></tr>
+  <tr><td>Task dedupe badge</td><td>already running for this task</td></tr>
+  <tr><td>Refresh badge</td><td>was open in this tab</td></tr>
+</table>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="opt-b">4 · Option B — "My sessions is the front door"</h2>
+<div class="opt-h"><span class="tag b">OPTION B</span><p>The collapsed dock header becomes informative and <em>is</em> the entry point: clicking it opens the existing My sessions panel, upgraded with Reconnect, Resume, and New session. The terminal area only opens once a session is chosen or created.</p></div>
+
+<h3>Flow walkthrough</h3>
+<div class="flow">
+  <span class="step act">Click the dock header<small>"2 sessions running · 2 recent" — or toolbar / task launch</small></span><span class="arr">→</span>
+  <span class="step">My sessions panel opens<small>New session on top · Reconnect on live rows · Resume on recent rows</small></span><span class="arr">→</span>
+  <span class="step act">One click in the panel</span><span class="arr">→</span>
+  <span class="step sys">Panel closes · dock expands<small>other-board rows navigate first</small></span><span class="arr">→</span>
+  <span class="step good">Terminal live</span>
+</div>
+<p>The separate "My sessions" button disappears — the whole header is the trigger, so there is exactly one front door. Task launches open the panel with a context line ("Launching for task: fix-login-bug") and the New session button pre-scoped to that task; a live session for the same task shows Reconnect as its row's first action with the dedupe badge.</p>
+
+<p class="mock-cap">Mockup B1 — informative collapsed header (the whole bar is one button)</p>
+<div class="mock">
+  <div class="dockbar" style="cursor:default">
+    <span class="brand"><span class="dot g" aria-hidden="true"></span>▸_ Terminal — 3 sessions running · 2 recent</span>
+    <span class="right"><span class="caption">Click to choose: reconnect, resume, or start new</span> <span class="btn sm sky">⌃</span></span>
+  </div>
+</div>
+<p class="caption">With no sessions anywhere the bar reads "Terminal" and the chevron opens straight into today's launch/setup — current behaviour, unchanged.</p>
+
+<p class="mock-cap">Mockup B2 — upgraded My sessions panel</p>
+<div class="mock" style="max-width:460px">
+  <div class="dockbar"><span class="brand">My sessions</span><span class="right"><span class="caption">runs on your machines</span></span></div>
+  <div style="padding:10px 14px;border-bottom:1px solid var(--border)">
+    <span class="btn em solid">＋ New session on this board</span>
+  </div>
+  <div class="sect">Running</div>
+  <div class="row">
+    <span class="dot g" aria-hidden="true"></span>
+    <div class="who">
+      <div class="t">fix-login-bug <span class="idea">VibeCodes</span> <span class="badge here">this board</span></div>
+      <div class="m">Nick's MacBook · ~/projects/vibecodes</div>
+    </div>
+    <span class="age">3h</span>
+    <span class="btn sky sm">⇄ Reconnect</span>
+    <span class="btn rose sm">⏻ End</span>
+  </div>
+  <div class="row">
+    <span class="dot g" aria-hidden="true"></span>
+    <div class="who">
+      <div class="t">vibecodes · 4f9a12c8 <span class="idea">VibeCodes</span> <span class="badge here">this board</span></div>
+      <div class="m">Nick's MacBook · ~/projects/vibecodes</div>
+    </div>
+    <span class="age">45m</span>
+    <span class="btn sky sm">⇄ Reconnect</span>
+    <span class="btn rose sm">⏻ End</span>
+  </div>
+  <div class="row">
+    <span class="dot g" aria-hidden="true"></span>
+    <div class="who">
+      <div class="t">docs-pass <span class="idea">Helper Tools</span></div>
+      <div class="m">Nick's MacBook · ~/projects/helper</div>
+    </div>
+    <span class="age">1h</span>
+    <span class="btn sky sm">⇄ Reconnect</span>
+    <span class="btn rose sm">⏻ End</span>
+  </div>
+  <div style="padding:6px 14px 10px" class="takeover"><span class="i" aria-hidden="true">⚠</span> Reconnecting takes over if a session is open in another window or browser — that view stops receiving output.</div>
+  <div class="sect">Recent — ended in the last 48h</div>
+  <div class="row">
+    <span class="dot z" aria-hidden="true"></span>
+    <div class="who"><div class="t">api-cleanup <span class="idea">VibeCodes</span></div><div class="m">~/projects/vibecodes</div></div>
+    <span class="age">ended 2h</span>
+    <span class="btn em sm">↻ Resume</span>
+  </div>
+  <div class="row">
+    <span class="dot z" aria-hidden="true"></span>
+    <div class="who"><div class="t">helper-docs <span class="idea">Helper Tools</span></div><div class="m">~/projects/helper</div></div>
+    <span class="age">ended 1d</span>
+    <span class="btn em sm">↻ Resume</span>
+  </div>
+  <div class="row" style="background:var(--panel2)">
+    <span class="caption">3 running</span>
+    <span class="btn rose sm" style="margin-left:auto">⏻ End all sessions</span>
+  </div>
+</div>
+<p class="caption">The take-over warning is stated once above the list (F3 — visible before any click, applies to every Reconnect). Resume rows swap into the shared inline confirm (F4). End keeps its existing no-confirm behaviour; End all keeps its inline confirm.</p>
+
+<h3>Required cases</h3>
+<ul class="tight">
+  <li><strong>Collapsed header:</strong> mockup B1 — the count line <em>is</em> the affordance; a caption tells first-timers what clicking does (recognition, not recall).</li>
+  <li><strong>Toolbar "Launch Claude Code → In the browser":</strong> opens the same panel, task-scoped New session on top. With no sessions anywhere: launches immediately, as today.</li>
+  <li><strong>Popped-out window reload:</strong> foundations F5 — unchanged by this option.</li>
+  <li><strong>Accidental same-tab refresh:</strong> header shows counts; the panel badges the tab's own last session <span class="badge was">was open in this tab</span> and focuses its Reconnect. Instant-continue variant (if approved): dock reattaches that session directly, panel never opens.</li>
+  <li><strong>Empty state:</strong> unchanged — plain "Terminal" bar, chevron launches/sets up as today.</li>
+</ul>
+
+<h3>What changes vs today</h3>
+<ul class="tight">
+  <li>My sessions panel gains: New session button, Reconnect on live rows, a Recent section with Resume, this-board badges, one shared take-over caption.</li>
+  <li>Collapsed bar rebuilt as a single large trigger with live counts; separate My sessions button removed.</li>
+  <li>Expand is decoupled from connect: the dock body opens only on a panel choice; <code>autoConnectWhenExpanded</code> gated as in F1.</li>
+  <li>Other-board Reconnect navigates with <code>?reconnect=&lt;sid&gt;</code> (an identifier, not a credential — mint still auth + ownership checked).</li>
+</ul>
+
+<div class="cols">
+  <div class="panel pro"><h4>Pros</h4>
+    <ul class="tight">
+      <li>Least new UI — one existing panel upgraded, one list to maintain, global scope for free.</li>
+      <li>The collapsed bar finally tells the truth at a glance ("3 running · 2 recent") even when you don't open anything.</li>
+      <li>One front door for every entry point — no second surface to keep in sync.</li>
+    </ul>
+  </div>
+  <div class="panel con"><h4>Cons</h4>
+    <ul class="tight">
+      <li>Launching happens from a management popover — Start/Reconnect sit in the same rows as destructive End (adjacency risk; mitigated by colour + position + labels, but still the weakest separation of the three).</li>
+      <li>The terminal opens <em>behind</em> a popover — an indirect, slightly admin-flavoured moment for the most common action.</li>
+      <li>Clicking a bar to get a popover (not an expansion) bends the dock's expand/collapse convention.</li>
+      <li>A popover is a cramped home for the task-launch context.</li>
+    </ul>
+  </div>
+</div>
+
+<h3>New copy — Option B</h3>
+<div class="tblwrap">
+<table class="copytab">
+  <tr><th>Where</th><th>String</th></tr>
+  <tr><td>Collapsed bar</td><td>Terminal — {n} sessions running · {n} recent</td></tr>
+  <tr><td>Bar caption</td><td>Click to choose: reconnect, resume, or start new</td></tr>
+  <tr><td>Panel primary</td><td>New session on this board</td></tr>
+  <tr><td>Panel primary (task launch)</td><td>New session for this task — {task title}</td></tr>
+  <tr><td>Shared take-over caption</td><td>Reconnecting takes over if a session is open in another window or browser — that view stops receiving output.</td></tr>
+  <tr><td>Section headers</td><td>Running / Recent — ended in the last 48h</td></tr>
+  <tr><td>Badges</td><td>this board · was open in this tab</td></tr>
+</table>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="opt-c">5 · Option C — "Tabs-first"</h2>
+<div class="opt-h"><span class="tag c">OPTION C</span><p>Opening the dock shows the tab strip immediately — one tab per live session in a resting "Reconnect" state, a "+" tab for new, and a slim Recent row beneath for Resume. Nothing connects until a tab's Reconnect is clicked. Closest to the current multi-tab mental model.</p></div>
+
+<h3>Flow walkthrough</h3>
+<div class="flow">
+  <span class="step act">Open dock<small>chevron / toolbar / task launch</small></span><span class="arr">→</span>
+  <span class="step">Strip renders resting tabs<small>one per live session on this board · ring-dot + "reconnect" text · first tab pre-selected</small></span><span class="arr">→</span>
+  <span class="step">Selected tab's body shows its Reconnect panel<small>identity, age, folder, take-over warning</small></span><span class="arr">→</span>
+  <span class="step act">Click Reconnect (or "+", or Resume in the Recent row)</span><span class="arr">→</span>
+  <span class="step good">That tab goes live<small>others stay resting until clicked</small></span>
+</div>
+<p>Task launches focus the matching resting tab if that task already has a live session (dedupe made visible — it does <em>not</em> connect), otherwise they open a fresh tab whose body shows a "Start session for this task" panel with a single Start button.</p>
+
+<p class="mock-cap">Mockup C1 — expanded dock: resting reconnect tabs + Recent row</p>
+<div class="mock">
+  <div class="dockbar">
+    <span class="brand">▸_ Terminals</span>
+    <span class="pill sky">2 to reconnect</span>
+    <span class="right"><span class="btn ghost sm">☰ My sessions <span class="pill sky" style="padding:0 6px">3</span></span> <span class="btn ghost sm">⌄ Collapse</span></span>
+  </div>
+  <div class="tabstrip" role="tablist">
+    <span class="ttab on"><span class="dot o" aria-hidden="true"></span> fix-login-bug <span class="st">· reconnect</span> <span class="x">✕</span></span>
+    <span class="ttab"><span class="dot o" aria-hidden="true"></span> vibecodes-4f9a <span class="st">· reconnect</span> <span class="x">✕</span></span>
+    <span class="plus" title="New terminal session">＋</span>
+  </div>
+  <div class="centerpanel">
+    <div class="hl">This session is still running on Nick's MacBook</div>
+    <div class="mono">Started 3h ago · ~/projects/vibecodes</div>
+    <div class="warn">⚠ If this session is open in another window or browser, connecting here takes over — that view stops receiving output.</div>
+    <div><span class="btn sky">⇄ Reconnect</span> <span class="btn ghost">⏻ End session</span></div>
+  </div>
+  <div class="recentrow">
+    <span class="lbl">Recent</span>
+    <span>api-cleanup · ended 2h ago</span><span class="btn em sm">↻ Resume</span>
+    <span style="color:var(--border2)">|</span>
+    <span>helper-docs <span class="caption">(Helper Tools)</span> · ended 1d ago</span><span class="btn em sm">↻ Resume</span>
+  </div>
+</div>
+<p class="caption">Resting tabs use a hollow ring dot <em>plus</em> the word "reconnect" in the tab (never colour alone); a live tab keeps today's filled emerald dot. The collapsed header shows the existing chip summary with a new chip: <code>◌ 2 to reconnect</code>. The Recent row hides itself when empty; Resume opens the shared inline confirm (F4) as a small popover anchored to the button.</p>
+
+<h3>Required cases</h3>
+<ul class="tight">
+  <li><strong>Collapsed header:</strong> today's chip summary plus the resting chip — e.g. <code>◌ 2 to reconnect · ● 1 connected</code>; "Terminals" wording unchanged.</li>
+  <li><strong>Toolbar "Launch Claude Code → In the browser":</strong> opens the dock on the strip; task with a live session → focuses its resting tab; otherwise a new tab with a "Start session for this task — fix-login-bug" panel and one Start button. No sessions anywhere: launches immediately, as today.</li>
+  <li><strong>Popped-out window reload:</strong> foundations F5 — unchanged by this option.</li>
+  <li><strong>Accidental same-tab refresh:</strong> the tab this browser tab held is pre-selected in its resting state — reconnect is one click after opening. Instant-continue variant (if approved): that tab auto-connects on open (&lt;60&nbsp;s proof); the others stay resting.</li>
+  <li><strong>Empty state:</strong> unchanged — no strip, no Recent row, today's single-session launch/setup panel.</li>
+  <li><strong>Other-board live sessions:</strong> not in the strip (tabs stay board-scoped). The My sessions button remains the path — its live rows gain Reconnect in this option too, or those sessions would be reachable only by walking to their boards.</li>
+</ul>
+
+<h3>What changes vs today</h3>
+<ul class="tight">
+  <li>New "resting/reconnect" tab state in the strip machine (glyph, aria text, body panel); tabs seeded from the registry on load instead of only from launches.</li>
+  <li>The strip now renders for a <em>single</em> resting session too — today's "no strip until 2+ tabs" rule gets an exception, or a sole session shows the C1 body panel without a strip (recommended: the exception; consistency beats minimalism here).</li>
+  <li>New Recent row chrome under the strip; <code>autoConnectWhenExpanded</code> gated as in F1; My sessions rows gain Reconnect for cross-board reach.</li>
+</ul>
+
+<div class="cols">
+  <div class="panel pro"><h4>Pros</h4>
+    <ul class="tight">
+      <li>Zero new mental model — the tabs Nick already uses, with one new resting state.</li>
+      <li>Reconnect is two clicks with the right tab usually pre-selected; multiple reconnects are naturally per-tab.</li>
+      <li>After connecting, you're already in the exact UI you'll keep using — no surface hand-off.</li>
+    </ul>
+  </div>
+  <div class="panel con"><h4>Cons</h4>
+    <ul class="tight">
+      <li>Board-scoped: other boards' sessions are invisible in the strip — the three-way choice is only complete for this board; cross-board still detours through My sessions.</li>
+      <li>A slim Recent row is the least discoverable Resume home of the three.</li>
+      <li>Resting tabs risk reading as "connected" at a glance (mitigated by ring-dot + the literal word, but the risk is real).</li>
+      <li>Heaviest implementation: strip state machine, single-tab strip exception, Recent row, per-tab reconnect panels, plus the My sessions Reconnect upgrade anyway.</li>
+    </ul>
+  </div>
+</div>
+
+<h3>New copy — Option C</h3>
+<div class="tblwrap">
+<table class="copytab">
+  <tr><th>Where</th><th>String</th></tr>
+  <tr><td>Collapsed chip</td><td>◌ {n} to reconnect</td></tr>
+  <tr><td>Resting tab (aria + visible)</td><td>{label} · reconnect</td></tr>
+  <tr><td>Resting tab body, headline</td><td>This session is still running on {machine label} / …on your machine</td></tr>
+  <tr><td>Resting tab body, sub</td><td>Started {age} ago · {cwd}</td></tr>
+  <tr><td>Recent row label</td><td>Recent · {label} · ended {age} ago</td></tr>
+  <tr><td>Task-launch new tab</td><td>Start session for this task — {task title} → [Start session]</td></tr>
+</table>
+</div>
+
+<!-- ============================================================ -->
+<h2>6 · Shared edge cases (all options)</h2>
+<div class="tblwrap">
+<table>
+  <tr><th style="width:30%">Edge case</th><th>Behaviour</th></tr>
+  <tr><td>Reload during the helper's 60&nbsp;s post-exit linger</td>
+      <td>The registry may still list a session whose Claude process has already exited. The choice surface honestly shows it live; clicking Reconnect mints fine but the attach lands on a dying/dead leg → the standard failure path shows <em>"Couldn't reconnect — the session may have just ended."</em> with Retry, the list refreshes, and the session reappears under Recent (with Resume, if its folder was recorded). No special pre-detection — the copy absorbs the race.</td></tr>
+  <tr><td>Session ends between listing and click</td>
+      <td>The reattach mint returns "gone" → same inline error and list refresh as above. The row/tab is replaced, never left as a dead button. In the popped window this becomes the F5 end-state ("This session has ended…").</td></tr>
+  <tr><td>Two browser tabs both showing the choice surface</td>
+      <td>Both legitimately list the same live session — that's why the take-over warning is unconditional (F3). Whoever clicks first attaches; the second click also succeeds and takes over (the first view gets the existing duplicate-preemption close and shows its normal "connection replaced" state, with its own Reconnect path back). Lists refresh on window focus so counts don't go stale between the two tabs.</td></tr>
+  <tr><td>Cap reached while choosing</td>
+      <td>Only "Start new session" / "+" / Resume are capped (F2/F4) — they fail with the existing cap toast that opens My sessions. Reconnect always works: it is exempt by design.</td></tr>
+</table>
+</div>
+
+<p class="caption" style="margin-top:36px">Deliverable for card cbe60db5 (rework). All mockups are styled divs with realistic data; colours follow the app conventions (emerald = go/new, sky = reconnect/info, amber = caution/honesty notes, rose = destructive). Nothing here ships until Nick picks an option and rules on the instant-continue variant.</p>
+
+</div>
+</body>
+</html>

--- a/src/app/api/terminal/session/list/route.ts
+++ b/src/app/api/terminal/session/list/route.ts
@@ -1,13 +1,21 @@
-// Terminal session LIST — multi-session stage 3 (C3/C4: the "My sessions" panel).
+// Terminal session LIST — multi-session stage 3 (C3/C4: the "My sessions"
+// panel) EXTENDED for the session entry chooser (card cbe60db5, design F1):
+// the chooser needs to know about recently-ended sessions too (its "Recent ·
+// ended in the last 48h" section), not just active ones, so this route now
+// returns BOTH — every active row, plus every row that ended within the last
+// 48h — each carrying `status`/`endedAt` so a caller that only wants
+// "Running" (the My-sessions panel) can filter client-side.
 //
-// GET returns every one of the caller's ACTIVE sessions, across all ideas,
-// newest first — the registry row plus the idea title (a second query; small
-// N per user, not worth a join). RLS scopes this to the caller's own rows
-// regardless; the explicit `.eq("user_id", ...)` keeps the query itself honest.
+// GET returns every one of the caller's active-or-recently-ended sessions,
+// across all ideas, newest-created first — the registry row plus the idea
+// title (a second query; small N per user, not worth a join). RLS scopes
+// this to the caller's own rows regardless; the explicit `.eq("user_id", ...)`
+// keeps the query itself honest.
 
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
+import { RECENT_WINDOW_MS } from "@/lib/terminal/chooser-data";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -22,11 +30,12 @@ export async function GET() {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
 
+    const recentSince = new Date(Date.now() - RECENT_WINDOW_MS).toISOString();
     const { data: rows, error } = await supabase
       .from("terminal_sessions")
-      .select("sid, idea_id, task_id, task_title, machine_label, cwd, created_at")
+      .select("sid, idea_id, task_id, task_title, machine_label, cwd, created_at, status, ended_at")
       .eq("user_id", user.id)
-      .eq("status", "active")
+      .or(`status.eq.active,ended_at.gte.${recentSince}`)
       .order("created_at", { ascending: false });
     if (error) {
       logger.error("Terminal session list failed", { error: error.message });
@@ -49,6 +58,8 @@ export async function GET() {
       machineLabel: row.machine_label,
       cwd: row.cwd,
       createdAt: row.created_at,
+      status: row.status,
+      endedAt: row.ended_at,
     }));
 
     return NextResponse.json({ sessions });

--- a/src/app/api/terminal/session/reattach/route.ts
+++ b/src/app/api/terminal/session/reattach/route.ts
@@ -1,0 +1,122 @@
+// Terminal session REATTACH — session entry chooser + reload-reattach (card
+// cbe60db5, design item 4). A SIBLING to the mint route (POST /api/terminal/
+// session), not a variant of it: this mints a fresh BROWSER-role token for a
+// session id that's ALREADY LIVE — the chooser's Reconnect, instant-continue,
+// and the popped-window reload's own reconnect panel all call this instead
+// of the mint route, because none of them are starting a NEW session.
+//
+// Deliberately exempt from the cap (E1) and the mint rate limit (E2) — F2:
+// "no new registry row, exempt from the session cap and the mint rate limit
+// (recovering capacity, not consuming it)". Auth + ownership mirror the mint
+// route exactly (a member-scoped Supabase client; RLS also enforces
+// user_id-scoping on the read below, same belt-and-braces pattern as every
+// other route in this feature).
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { mintSessionTokens } from "../../../../../../terminal/shared/session-token.mjs";
+import { decideReattach, isSessionExpired } from "@/lib/terminal/session-registry";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  sid: z.string().min(1).max(128),
+});
+
+export async function POST(req: Request) {
+  try {
+    const secret = process.env.TERMINAL_SESSION_SECRET;
+    if (!secret) {
+      logger.error("Terminal session reattach failed: TERMINAL_SESSION_SECRET not configured");
+      return NextResponse.json({ error: "Terminal sessions are not configured" }, { status: 503 });
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const parsed = BodySchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+    const { sid } = parsed.data;
+    const nowMs = Date.now();
+
+    // Reap this user's own expired-but-still-"active" rows first (same R2
+    // mitigation as the mint route) — mirrors that route's reap step so the
+    // registry never drifts further behind just because reattach reads never
+    // triggered it. Best-effort: a failed reap never blocks the decision
+    // below (decideReattach checks expires_at itself either way).
+    const { data: activeRows, error: activeErr } = await supabase
+      .from("terminal_sessions")
+      .select("id, expires_at")
+      .eq("user_id", user.id)
+      .eq("status", "active");
+    if (activeErr) {
+      logger.error("Terminal session reattach: registry read failed", { error: activeErr.message });
+    }
+    const staleIds = (activeRows ?? [])
+      .filter((row) => isSessionExpired(row.expires_at, nowMs))
+      .map((row) => row.id);
+    if (staleIds.length > 0) {
+      const { error: reapErr } = await supabase
+        .from("terminal_sessions")
+        .update({ status: "ended", ended_at: new Date(nowMs).toISOString() })
+        .in("id", staleIds);
+      if (reapErr) {
+        logger.error("Terminal session reattach: reap failed", { error: reapErr.message, count: staleIds.length });
+      }
+    }
+
+    // Ownership: the row must belong to THIS user (RLS also scopes this, but
+    // the explicit filter keeps the query honest regardless of client).
+    const { data: row, error: rowErr } = await supabase
+      .from("terminal_sessions")
+      .select("sid, idea_id, status, expires_at")
+      .eq("sid", sid)
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (rowErr) {
+      logger.error("Terminal session reattach: row lookup failed", { sid, error: rowErr.message });
+      return NextResponse.json({ error: "Couldn't look up that session" }, { status: 500 });
+    }
+
+    const decision = decideReattach(row, nowMs);
+    if (!decision.ok || !row) {
+      const status = !decision.ok && decision.reason !== "not-found" ? 409 : 404;
+      const reason = !decision.ok ? decision.reason : "not-found";
+      const error =
+        reason === "not-found"
+          ? "Session not found"
+          : reason === "ended"
+            ? "This session has ended — start a new one or resume it."
+            : "This session has expired — start a new one.";
+      return NextResponse.json({ error, code: `reattach_${reason}` }, { status });
+    }
+
+    // Mint a fresh BROWSER token for the SAME sid. No registry insert (F2:
+    // not a new session), no cap/rate-limit bookkeeping to touch.
+    const tokens = await mintSessionTokens({ sub: user.id, idea: row.idea_id, sid, secret });
+
+    logger.info("Reattached terminal session (fresh browser token)", { userId: user.id, sid });
+
+    return NextResponse.json({
+      sessionId: tokens.sid,
+      ideaId: tokens.idea,
+      expiresAt: tokens.exp,
+      browserToken: tokens.browser,
+    });
+  } catch (err) {
+    logger.error("Terminal session reattach error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
+  }
+}

--- a/src/app/terminal/popout/terminal-popout-client.tsx
+++ b/src/app/terminal/popout/terminal-popout-client.tsx
@@ -20,15 +20,40 @@
 // could ever actually work. Either way the nonce carries NO session meaning
 // by itself (see popout-channel.ts's module doc) — it only names the
 // rendezvous channel.
+//
+// RELOAD-REATTACH (card cbe60db5, design item 8): a reload of THIS window
+// gets a fresh nonce with no dock listening on it — the handshake above
+// always times out for a reload. `popout-reload-stash.ts` is this window's
+// OWN memory of which session it last held (stashed in its own
+// sessionStorage the moment a hand-off succeeds); on a handshake timeout we
+// check it BEFORE falling to the generic "lost the hand-off" dead end:
+//   - no stash at all → genuinely lost (never attached in this window before,
+//     or the stash was cleared) — the original dead-end copy, unchanged.
+//   - a stash + this window's OWN snapshot for that sid is fresh (<60s) →
+//     instant-continue, exactly like the dock's own reload path: reattach
+//     silently, no button.
+//   - a stash + a stale/absent snapshot → the one-button Reconnect panel
+//     (F3's take-over line applies here too — reconnecting always can take
+//     over another leg).
+//   - the reattach mint itself reports the session gone → the clean "this
+//     session has ended" end state + a Close-window button.
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { AlertTriangle, Loader2, RefreshCw, Square } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { relayBaseUrl } from "@/lib/terminal/connection";
 import {
   popoutChannelName,
   parsePopoutChannelMessage,
   startPopoutClientHandshake,
   type PopoutPayload,
 } from "@/lib/terminal/popout-channel";
+import { loadSessionSnapshot, isSnapshotFresh, toReconnectBuffer } from "@/lib/terminal/session-snapshot";
+import {
+  loadPopoutStash,
+  savePopoutStash,
+  type PopoutStash,
+} from "@/lib/terminal/popout-reload-stash";
 import { TerminalPopoutView } from "@/components/board/terminal-popout-view";
 import type { TerminalSessionActions } from "@/components/board/use-terminal-session";
 
@@ -47,6 +72,39 @@ function resolveNonce(): string | null {
   return name || null;
 }
 
+/** Reattach for a stashed session, rebuilding a full `PopoutPayload` from the stash + the mint response + (if any) this window's own fresh snapshot. */
+async function reattachForStash(
+  stash: PopoutStash,
+): Promise<{ ok: true; payload: PopoutPayload } | { ok: false; gone: boolean }> {
+  try {
+    const res = await fetch("/api/terminal/session/reattach", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sid: stash.sid }),
+    });
+    if (!res.ok) return { ok: false, gone: true };
+    const data = (await res.json()) as { sessionId: string; browserToken: string };
+    const snapshot = loadSessionSnapshot(stash.sid);
+    const buffer = snapshot ? toReconnectBuffer(snapshot) : undefined;
+    return {
+      ok: true,
+      payload: {
+        sid: data.sessionId,
+        browserToken: data.browserToken,
+        relayUrl: relayBaseUrl(),
+        ideaId: stash.ideaId,
+        ideaTitle: stash.ideaTitle,
+        label: stash.label,
+        identity: stash.identity,
+        readOnly: stash.readOnly,
+        buffer,
+      },
+    };
+  } catch {
+    return { ok: false, gone: false };
+  }
+}
+
 export function TerminalPopoutClient() {
   // Read once, at initial render — a derived, render-time fact about this
   // window (its hash/name), not something that needs its own effect+setState
@@ -55,6 +113,12 @@ export function TerminalPopoutClient() {
   const [nonce] = useState<string | null>(() => (typeof window === "undefined" ? null : resolveNonce()));
   const [payload, setPayload] = useState<PopoutPayload | null>(null);
   const [timedOut, setTimedOut] = useState(false);
+  // Reload-reattach (design item 8): a stash found on handshake timeout with
+  // no fresh snapshot to auto-continue — the one-button Reconnect panel.
+  const [reloadStash, setReloadStash] = useState<PopoutStash | null>(null);
+  const [reloadBusy, setReloadBusy] = useState(false);
+  const [reloadError, setReloadError] = useState(false);
+  const [reloadGone, setReloadGone] = useState(false);
   // Scrollback transfer (card 35cffc10): TerminalPopoutView's live session
   // actions, handed up via onSessionActions the same way terminal-dock.tsx's
   // TerminalSessionView reports into its parent's actionsMapRef — this
@@ -69,6 +133,37 @@ export function TerminalPopoutClient() {
   const handleSessionActions = useCallback((actions: TerminalSessionActions | null) => {
     sessionActionsRef.current = actions;
   }, []);
+
+  const attachPayload = useCallback((p: PopoutPayload) => {
+    setPayload(p);
+    savePopoutStash({
+      sid: p.sid,
+      label: p.label,
+      identity: p.identity,
+      readOnly: p.readOnly,
+      ideaId: p.ideaId,
+      ideaTitle: p.ideaTitle,
+    });
+  }, []);
+
+  const handleManualReconnect = useCallback(() => {
+    if (!reloadStash) return;
+    setReloadBusy(true);
+    setReloadError(false);
+    void (async () => {
+      const result = await reattachForStash(reloadStash);
+      setReloadBusy(false);
+      if (result.ok) {
+        setReloadStash(null);
+        attachPayload(result.payload);
+      } else if (result.gone) {
+        setReloadStash(null);
+        setReloadGone(true);
+      } else {
+        setReloadError(true); // network hiccup — stash + button stay, Retry is just clicking again
+      }
+    })();
+  }, [reloadStash, attachPayload]);
 
   useEffect(() => {
     if (!nonce) return;
@@ -91,7 +186,7 @@ export function TerminalPopoutClient() {
     const stopHandshake = startPopoutClientHandshake({
       channel,
       onPayload: (p) => {
-        setPayload(p);
+        attachPayload(p);
         // Scrollback transfer, Flow B (design §3): once attached, this same
         // channel switches roles from "waiting for the hand-off" to
         // "answering bring-back-request" — safe to reassign onmessage here
@@ -114,10 +209,31 @@ export function TerminalPopoutClient() {
           }
         };
       },
-      // On timeout this ALSO posts "closed" on the channel (same module),
-      // so a dock that's still listening auto-reattaches instead of being
-      // stuck showing "Popped out" forever with nothing on the other end.
-      onTimeout: () => setTimedOut(true),
+      // On timeout this ALSO posts "closed" on the channel (same module), so
+      // a dock that's still listening auto-reattaches instead of being stuck
+      // showing "Popped out" forever with nothing on the other end — that
+      // path is unaffected by the reload-reattach recovery below (it's about
+      // THIS window's own next render, not the dock's).
+      onTimeout: () => {
+        const stash = loadPopoutStash();
+        if (!stash) {
+          setTimedOut(true); // genuinely lost — never attached here before
+          return;
+        }
+        const snapshot = loadSessionSnapshot(stash.sid);
+        if (snapshot && isSnapshotFresh(snapshot.savedAt)) {
+          // Instant continue (design's veto note, Nick: yes) — this window's
+          // OWN <60s snapshot is proof enough; reattach silently.
+          void (async () => {
+            const result = await reattachForStash(stash);
+            if (result.ok) attachPayload(result.payload);
+            else if (result.gone) setReloadGone(true);
+            else setReloadStash(stash); // network hiccup — fall back to the manual button
+          })();
+          return;
+        }
+        setReloadStash(stash);
+      },
     });
 
     // Flow C (design §4): closing this window pushes the FULL serialized
@@ -161,13 +277,56 @@ export function TerminalPopoutClient() {
       // never look like the user closing the window. Only the real browser
       // lifecycle events above count as "closed".
     };
-  }, [nonce]);
+  }, [nonce, attachPayload]);
 
   // Once `payload` is set, the render below returns the live view BEFORE it
-  // ever looks at `timedOut` — so a late interval tick racing a just-arrived
-  // payload is harmless; there's no need to also clear `timedOut` here.
+  // ever looks at `timedOut`/reload state — so a late interval tick racing a
+  // just-arrived payload is harmless; there's no need to also clear those
+  // here.
   if (payload) {
     return <TerminalPopoutView payload={payload} onSessionActions={handleSessionActions} />;
+  }
+
+  if (reloadGone) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+        <Square className="h-7 w-7 text-zinc-400" />
+        <div className="text-base font-semibold text-zinc-200">This session has ended</div>
+        <p className="max-w-sm text-[13px] text-zinc-400">
+          You can close this window — start a new one from the board.
+        </p>
+        <Button
+          variant="outline"
+          className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+          onClick={() => window.close()}
+        >
+          Close window
+        </Button>
+      </div>
+    );
+  }
+
+  if (reloadStash) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+        <RefreshCw className={reloadBusy ? "h-7 w-7 animate-spin text-sky-400" : "h-7 w-7 text-sky-400"} />
+        <div className="text-base font-semibold text-sky-400">Reconnect this window</div>
+        <p className="max-w-sm text-[13px] text-zinc-400">{reloadStash.label}</p>
+        <p className="max-w-sm text-[11.5px] text-zinc-500">
+          If this session is open somewhere else, reconnecting here takes it over.
+        </p>
+        <Button
+          className="bg-sky-500 text-sky-950 hover:bg-sky-400"
+          disabled={reloadBusy}
+          onClick={handleManualReconnect}
+        >
+          <RefreshCw className="h-4 w-4" /> Reconnect
+        </Button>
+        {reloadError && (
+          <p className="text-[11.5px] text-rose-400">Couldn&apos;t reconnect — check your connection and try again.</p>
+        )}
+      </div>
+    );
   }
 
   if (!nonce || timedOut) {

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -52,11 +52,13 @@
 // zero new UI anywhere, including the tab strip and "+".
 
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
-import { ChevronUp, ChevronDown, Circle, ListTree, Plus, Terminal as TerminalIcon, X } from "lucide-react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { ChevronUp, ChevronDown, Circle, ListTree, Loader2, Plus, Terminal as TerminalIcon, X } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { logger } from "@/lib/logger";
 import { isTerminalEnabled, relayBaseUrl, type TerminalStatus } from "@/lib/terminal/connection";
 import { subscribeBrowserLaunch, type BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
 import { resolveDockView } from "@/lib/terminal/first-run-flow";
@@ -74,6 +76,16 @@ import {
 } from "@/lib/terminal/popout-channel";
 import type { TransferredBuffer } from "@/lib/terminal/scrollback-transfer";
 import {
+  deriveChooserSections,
+  chooserHeaderCounts,
+  type ChooserSections,
+  type ChooserRegistryRow,
+  type ChooserLiveRow,
+  type ChooserRecentRow,
+} from "@/lib/terminal/chooser-data";
+import { decideEntryBehaviour, type EntryDecision } from "@/lib/terminal/entry-decision";
+import { loadSessionSnapshot, readLastTabSid, toReconnectBuffer } from "@/lib/terminal/session-snapshot";
+import {
   type SessionEntry,
   type TabDisplayStatus,
   type TabTone,
@@ -90,8 +102,9 @@ import {
   dockStatusMeta,
   type SessionSummary,
 } from "./terminal-session-view";
+import { TerminalSessionChooser } from "./terminal-session-chooser";
 import { TerminalMySessionsPanel } from "./terminal-my-sessions-panel";
-import type { TerminalSessionActions, TerminalSessionDescriptor } from "./use-terminal-session";
+import type { AttachExistingPair, TerminalSessionActions, TerminalSessionDescriptor } from "./use-terminal-session";
 
 interface TerminalDockProps {
   ideaId: string;
@@ -143,9 +156,29 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // no dock, no entry point, board unchanged (B9).
   const enabled = isTerminalEnabled();
   const [expanded, setExpanded] = useState(false);
-  const [sessions, setSessions] = useState<SessionEntry[]>(() => [createPristineEntry()]);
-  const [activeKey, setActiveKey] = useState<string>(() => sessions[0].key);
+  // Session entry chooser (card cbe60db5, F1): the dock no longer seeds a
+  // pristine tab unconditionally at page load — whether it does at all (and
+  // whether the chooser renders instead) depends on `entryDecision`, which
+  // needs the registry fetch below FIRST. `sessions` starts genuinely empty;
+  // the seeding effect further down populates it once that decision is known.
+  const [sessions, setSessions] = useState<SessionEntry[]>([]);
+  const [activeKey, setActiveKey] = useState<string>("");
   const [summaries, setSummaries] = useState<Record<string, SessionSummary>>({});
+  // Every one of the caller's active-or-recent (≤48h) sessions across all
+  // ideas — null while the initial fetch is in flight (the "checking your
+  // sessions…" beat: nothing may auto-mint before this is known, F1).
+  const [registryRows, setRegistryRows] = useState<ChooserRegistryRow[] | null>(null);
+  // A task-scoped (or board-level) launch that arrived while the chooser was
+  // showing — carried so "Start new session" / the task-dedupe banner can
+  // act on it once the user actually picks something (F1: nothing mints on
+  // the bus event itself while there's a choice to make).
+  const [pendingLaunch, setPendingLaunch] = useState<BrowserLaunchPayload | null>(null);
+  // Disables every chooser action while a click's async work (reattach mint,
+  // resume launch) is in flight — never a silent double-submit.
+  const [chooserBusy, setChooserBusy] = useState(false);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   // Tab close arms an inline confirm on a LIVE session (OQ1) — the second click
   // on the SAME tab's × (or a second Delete keypress) actually ends it. Ended
   // tabs close instantly, no confirm.
@@ -181,6 +214,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   const summariesRef = useRef(summaries);
   const posthog = usePostHog();
   const posthogRef = useRef(posthog);
+  // Session entry chooser (card cbe60db5): mirrors `entryDecision` (declared
+  // below, after the registry fetch) for the same reason as the refs above —
+  // `deliverLaunch` needs a synchronous, always-current read without being a
+  // dependency that would force the launch-bus effect to resubscribe.
+  const entryDecisionRef = useRef<EntryDecision | null>(null);
   // Refs must only be WRITTEN outside render (react-hooks/refs) — sync them in
   // an effect, which always commits before any later event handler can read
   // them, so `deliverLaunch` (called only from event handlers / the launch-bus
@@ -190,6 +228,59 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     summariesRef.current = summaries;
     posthogRef.current = posthog;
   }, [sessions, summaries, posthog]);
+
+  // ── session entry chooser (card cbe60db5) — registry fetch + entry decision ──
+  //
+  // F1: "On board load the dock fetches the registry once (it already
+  // fetches for the My sessions badge)". `refreshRegistry` is also reused
+  // after a failed reattach (the row may have just gone stale) and by the
+  // `?reconnect=` handler below.
+  const refreshRegistry = useCallback(async () => {
+    try {
+      const res = await fetch("/api/terminal/session/list");
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const body = (await res.json()) as { sessions: ChooserRegistryRow[] };
+      setRegistryRows(body.sessions);
+    } catch (err) {
+      logger.error("Terminal registry fetch failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Fail OPEN (matches the mint route's own R2 read-error posture): never
+      // let a transient registry read wedge the dock in "checking…" forever.
+      // A never-loaded dock falls back to today's empty-launch behaviour; an
+      // already-loaded dock just keeps its last known rows.
+      setRegistryRows((prev) => prev ?? []);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    void refreshRegistry();
+  }, [enabled, refreshRegistry]);
+
+  // This tab's own snapshot info (session-snapshot.ts) — read once; a tab
+  // doesn't gain a NEW "last sid" mid-session except by attaching another
+  // session itself, at which point the chooser is long since resolved.
+  const [entrySnapshotInfo] = useState(() => {
+    const sid = readLastTabSid();
+    if (!sid) return null;
+    const snap = loadSessionSnapshot(sid);
+    return snap ? { sid, savedAt: snap.savedAt } : null;
+  });
+
+  const entryDecision: EntryDecision | null = useMemo(() => {
+    if (registryRows === null) return null; // still loading
+    return decideEntryBehaviour(registryRows, entrySnapshotInfo, Date.now());
+  }, [registryRows, entrySnapshotInfo]);
+  useEffect(() => {
+    entryDecisionRef.current = entryDecision;
+  }, [entryDecision]);
+
+  const chooserSections: ChooserSections = useMemo(
+    () => deriveChooserSections(registryRows ?? [], ideaId, Date.now(), entrySnapshotInfo?.sid ?? readLastTabSid()),
+    [registryRows, ideaId, entrySnapshotInfo],
+  );
+  const chooserCounts = useMemo(() => chooserHeaderCounts(chooserSections), [chooserSections]);
 
   // Close every open pop-out hand-off channel if the dock itself unmounts
   // (board navigation away) — the popped windows keep running independently
@@ -457,7 +548,12 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   const cancelClose = useCallback(() => setConfirmingKey(null), []);
 
   // ── launch routing (B7/B10) + the pristine-slot reuse for the FIRST launch ──
-  const deliverLaunch = useCallback((payload: BrowserLaunchPayload | null) => {
+  // Renamed from the pre-chooser `deliverLaunch` — this is the ACTUAL mint
+  // path (today's unchanged mint/dedupe/pristine-reuse behaviour), now
+  // reached either directly (F1's empty-launch state — nothing to choose
+  // between) or via the chooser's "Start new session" (see `deliverLaunch`
+  // below, which decides which of the two applies).
+  const mintAndDeliver = useCallback((payload: BrowserLaunchPayload | null) => {
     const currentSessions = sessionsRef.current;
     const currentSummaries = summariesRef.current;
     const candidates: DedupeCandidate[] = currentSessions.map((s) => ({
@@ -474,14 +570,16 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     }
 
     setExpanded(true);
-    const pristineKey = findPristineSlot(currentSessions.map((s) => ({ key: s.key, launchSeq: s.launchSeq })));
+    const pristineKey = findPristineSlot(
+      currentSessions.map((s) => ({ key: s.key, launchSeq: s.launchSeq, hasAttach: !!s.attach })),
+    );
     if (pristineKey) {
       setSessions((prev) =>
         prev.map((s) =>
           s.key === pristineKey
             ? {
                 ...s,
-                origin: payload?.taskId ? "task" : "toolbar",
+                origin: payload?.resume ? "resume" : payload?.taskId ? "task" : "toolbar",
                 taskId: payload?.taskId,
                 taskTitle: payload?.taskTitle,
                 launchSeq: s.launchSeq + 1,
@@ -496,7 +594,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
 
     const entry: SessionEntry = {
       key: freshSessionKey(),
-      origin: payload?.taskId ? "task" : "toolbar",
+      origin: payload?.resume ? "resume" : payload?.taskId ? "task" : "toolbar",
       taskId: payload?.taskId,
       taskTitle: payload?.taskTitle,
       createdAt: Date.now(),
@@ -510,6 +608,25 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     // same as P1, and isn't a "multi-session" event).
     posthogRef.current?.capture("terminal_tab_opened", { origin: entry.origin });
   }, []);
+
+  // Session entry chooser (card cbe60db5, F1): the actual entry point every
+  // launch source (toolbar bus event, task-launch bus event, "+") calls.
+  // Routes into the chooser instead of minting whenever the chooser is still
+  // the dock's resting state for THIS pageview (no local tabs yet AND the
+  // registry says there's something to choose between) — once any tab
+  // exists, the chooser has already resolved and every launch after that is
+  // `mintAndDeliver`'s unchanged behaviour.
+  const deliverLaunch = useCallback(
+    (payload: BrowserLaunchPayload | null) => {
+      if (sessionsRef.current.length === 0 && entryDecisionRef.current?.kind === "chooser") {
+        setExpanded(true);
+        setPendingLaunch(payload);
+        return;
+      }
+      mintAndDeliver(payload);
+    },
+    [mintAndDeliver],
+  );
 
   // The "In the browser" menu item (board toolbar) and task-card menus fire the
   // launch bus; forward every event to the routing decision above. Called
@@ -526,6 +643,150 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     // this always mints a genuinely new, board-level tab (B7).
     deliverLaunch(null);
   }, [deliverLaunch]);
+
+  // ── reattach (chooser Reconnect, instant-continue, ?reconnect=<sid>) ───────
+  // Sibling to `mintAndDeliver`: mints NOTHING new (F2 — the reattach route
+  // is exempt from the cap/rate-limit) and reuses the pristine-slot rule
+  // (`findPristineSlot`) so, in the rare case an attach entry is the dock's
+  // sole existing tab and ANOTHER reattach is requested, it doesn't leak a
+  // stray idle slot either. `focus` controls whether the dock expands to
+  // show the result immediately (an explicit chooser/My-sessions click) or
+  // stays collapsed (instant-continue — attach quietly, reopening feels
+  // instant, design's veto-note wording: "the refresher never even notices
+  // the reload").
+  const performReattach = useCallback(async (sid: string, opts: { focus: boolean }) => {
+    setChooserBusy(true);
+    try {
+      const res = await fetch("/api/terminal/session/reattach", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sid }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(body?.error || "Couldn't reconnect — the session may have just ended.", {
+          action: { label: "Retry", onClick: () => void performReattach(sid, opts) },
+        });
+        void refreshRegistry(); // the row may have just ended/expired — let the chooser reflect that
+        return;
+      }
+      const data = (await res.json()) as { sessionId: string; browserToken: string };
+      const snapshot = loadSessionSnapshot(sid);
+      const initialBuffer = snapshot ? toReconnectBuffer(snapshot) : null;
+      const attach: AttachExistingPair = { sessionId: data.sessionId, browserToken: data.browserToken, initialBuffer };
+
+      const currentSessions = sessionsRef.current;
+      const pristineKey = findPristineSlot(
+        currentSessions.map((s) => ({ key: s.key, launchSeq: s.launchSeq, hasAttach: !!s.attach })),
+      );
+      const entry: SessionEntry = {
+        key: pristineKey ?? freshSessionKey(),
+        origin: "reconnect",
+        taskId: undefined,
+        taskTitle: undefined,
+        createdAt: Date.now(),
+        launchSeq: 0,
+        launchPayload: null,
+        attach,
+        showReconnectedNoHistoryNote: !initialBuffer,
+      };
+      setSessions((prev) => (pristineKey ? prev.map((s) => (s.key === pristineKey ? entry : s)) : [...prev, entry]));
+      setActiveKey(entry.key);
+      if (opts.focus) setExpanded(true);
+      posthogRef.current?.capture("terminal_session_reconnected", { instant: !opts.focus });
+    } catch (err) {
+      logger.error("Terminal reattach failed", { sid, error: err instanceof Error ? err.message : String(err) });
+      toast.error("Couldn't reconnect — check your connection and try again.");
+    } finally {
+      setChooserBusy(false);
+    }
+  }, [refreshRegistry]);
+
+  // F1's empty-launch state ("today's open→launch behaviour remains") and
+  // the instant-continue variant (design's veto note, Nick: yes) are both
+  // driven off `entryDecision` the moment it resolves — neither waits for
+  // the user to open the dock. Guarded on `sessions.length === 0` so this
+  // only ever seeds/attaches ONCE per pageview; every launch after that is
+  // real user action.
+  const instantContinueTriggeredRef = useRef(false);
+  useEffect(() => {
+    if (!entryDecision || sessions.length > 0) return;
+    if (entryDecision.kind === "empty-launch") {
+      const fresh = createPristineEntry();
+      setSessions([fresh]);
+      setActiveKey(fresh.key);
+    } else if (entryDecision.kind === "instant-continue" && !instantContinueTriggeredRef.current) {
+      instantContinueTriggeredRef.current = true;
+      void performReattach(entryDecision.sid, { focus: false });
+    }
+    // "chooser": nothing to seed — the chooser renders in the body below.
+  }, [entryDecision, sessions.length, performReattach]);
+
+  // ── other-board Reconnect (`?reconnect=<sid>`, design item 2) ──────────────
+  // "Open board & reconnect" navigates here with the target sid on the URL;
+  // once the registry confirms it, reattach immediately (no second chooser —
+  // the click on the OTHER board's chooser was already the informed
+  // confirmation, F3) and strip the param without a server round-trip (same
+  // recipe as kit-applied-toast.tsx — this board route is force-dynamic).
+  const reconnectParam = searchParams.get("reconnect");
+  const reconnectHandledRef = useRef(false);
+  useEffect(() => {
+    if (!reconnectParam || reconnectHandledRef.current || registryRows === null) return;
+    reconnectHandledRef.current = true;
+    const params = new URLSearchParams(window.location.search);
+    params.delete("reconnect");
+    const qs = params.toString();
+    window.history.replaceState(null, "", `${pathname}${qs ? `?${qs}` : ""}`);
+    void performReattach(reconnectParam, { focus: true });
+  }, [reconnectParam, registryRows, pathname, performReattach]);
+
+  // ── chooser action handlers ─────────────────────────────────────────────────
+  const handleChooserStartNew = useCallback(() => {
+    const payload = pendingLaunch;
+    setPendingLaunch(null);
+    mintAndDeliver(payload);
+  }, [pendingLaunch, mintAndDeliver]);
+
+  const handleChooserReconnectHere = useCallback(
+    (row: ChooserLiveRow) => {
+      setPendingLaunch(null);
+      void performReattach(row.sid, { focus: true });
+    },
+    [performReattach],
+  );
+
+  const handleChooserOpenBoardAndReconnect = useCallback(
+    (row: ChooserLiveRow) => {
+      router.push(`/ideas/${row.ideaId}/board?reconnect=${encodeURIComponent(row.sid)}`);
+    },
+    [router],
+  );
+
+  const handleChooserResume = useCallback(
+    (row: ChooserRecentRow) => {
+      setPendingLaunch(null);
+      // F4's Resume: the EXISTING (capped) launch flow, carrying `resume` +
+      // the ended row's own recorded folder instead of a bootstrap prompt —
+      // see BrowserLaunchPayload's doc and use-terminal-session.ts's
+      // fireLaunchDeepLink, which fires `claude --continue` there.
+      mintAndDeliver({ resume: true, cwd: row.cwd, taskId: row.taskId ?? undefined, taskTitle: row.taskTitle ?? undefined });
+    },
+    [mintAndDeliver],
+  );
+
+  // My sessions panel Reconnect (design item 9) — the SAME reattach flow;
+  // "this board" attaches in place, any other board navigates + reconnects.
+  const handleMySessionsReconnect = useCallback(
+    (sid: string, targetIdeaId: string) => {
+      setMySessionsOpen(false);
+      if (targetIdeaId === ideaId) {
+        void performReattach(sid, { focus: true });
+      } else {
+        router.push(`/ideas/${targetIdeaId}/board?reconnect=${encodeURIComponent(sid)}`);
+      }
+    },
+    [ideaId, performReattach, router],
+  );
 
   const handleTabKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>, index: number, key: string) => {
@@ -562,6 +823,13 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   const multi = sessions.length > 1;
   const activeIsPoppedOut = poppedOutKeys.has(activeKey);
   const soleIsPoppedOut = !multi && !!sessions[0] && poppedOutKeys.has(sessions[0].key);
+  // Session entry chooser (card cbe60db5): the dock's resting state for this
+  // pageview — no local tab yet, and the registry says there's something to
+  // choose between (mockup A1's collapsed header + A2's chooser body).
+  const showingChooser = sessions.length === 0 && entryDecision?.kind === "chooser";
+  const pendingTask = pendingLaunch?.taskId
+    ? { taskId: pendingLaunch.taskId, taskTitle: pendingLaunch.taskTitle ?? "" }
+    : null;
 
   // Substitute "popped-out" for any tab the dock knows it popped — its real
   // status is usually mid-preemption at this exact moment and would
@@ -585,7 +853,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       {/* Collapsed dock bar — always visible */}
       <div className="flex items-center gap-2.5 px-3 py-1.5">
         <span className="inline-flex items-center gap-2 text-xs font-semibold">
-          {!multi && (
+          {!multi && sessions.length > 0 && (
             <Circle
               className={cn("h-2.5 w-2.5 fill-current", activeIsPoppedOut ? "text-violet-400" : dotClass(activeStatus))}
             />
@@ -599,7 +867,30 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
           )}
         </span>
         <span className="ml-auto inline-flex items-center gap-1.5">
-          {multi &&
+          {/* Mockup A1: header count pills, only while the chooser is the
+              resting state — real text, never badge-only (a11y, design §2). */}
+          {showingChooser && registryRows === null && (
+            <span className="inline-flex items-center gap-1 text-[11px] text-zinc-500">
+              <Loader2 className="h-3 w-3 animate-spin" /> Checking your sessions…
+            </span>
+          )}
+          {showingChooser && chooserCounts.here > 0 && (
+            <span className="rounded-md border border-sky-500/50 bg-sky-500/10 px-2 py-0.5 text-[11px] font-semibold text-sky-300">
+              {chooserCounts.here} running here
+            </span>
+          )}
+          {showingChooser && chooserCounts.elsewhere > 0 && (
+            <span className="rounded-md border border-zinc-600 bg-zinc-800/60 px-2 py-0.5 text-[11px] font-semibold text-zinc-400">
+              {chooserCounts.elsewhere} on another board
+            </span>
+          )}
+          {showingChooser && chooserCounts.recent > 0 && (
+            <span className="rounded-md border border-zinc-600 bg-zinc-800/60 px-2 py-0.5 text-[11px] font-semibold text-zinc-400">
+              {chooserCounts.recent} recent
+            </span>
+          )}
+          {sessions.length > 0 &&
+            multi &&
             statusChips.map((chip) => (
               <span
                 key={chip.label}
@@ -617,12 +908,12 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
                 {chip.label}
               </span>
             ))}
-          {!multi && soleIsPoppedOut && (
+          {sessions.length > 0 && !multi && soleIsPoppedOut && (
             <span className="inline-flex items-center gap-1.5 rounded-md border border-violet-500/50 bg-violet-500/10 px-2 py-0.5 text-[11px] font-semibold text-violet-300">
               <span aria-hidden="true">⧉</span> Popped out
             </span>
           )}
-          {!multi && !soleIsPoppedOut && (
+          {sessions.length > 0 && !multi && !soleIsPoppedOut && (
             <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-semibold", singleMeta.className)}>
               <singleMeta.Icon className={cn("h-3 w-3", singleMeta.spin && "animate-spin")} />
               {singleMeta.label}
@@ -633,6 +924,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
           open={mySessionsOpen}
           onOpenChange={setMySessionsOpen}
           onCountChange={setMySessionsCount}
+          onReconnect={handleMySessionsReconnect}
         >
           <Button
             variant="ghost"
@@ -655,11 +947,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
           size="xs"
           className="text-zinc-300 hover:text-zinc-100"
           onClick={() => setExpanded((e) => !e)}
-          aria-label={expanded ? "Collapse terminal panel" : "Expand terminal panel"}
+          aria-label={expanded ? "Collapse terminal panel" : showingChooser ? "Open terminal sessions" : "Expand terminal panel"}
           aria-expanded={expanded}
         >
           {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronUp className="h-3.5 w-3.5" />}
-          <span className="hidden sm:inline">{expanded ? "Collapse" : "Expand"}</span>
+          <span className="hidden sm:inline">{expanded ? "Collapse" : showingChooser ? "Open" : "Expand"}</span>
         </Button>
       </div>
 
@@ -667,6 +959,24 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
           instance and its scrollback survive collapse/expand and live bytes are
           never lost. */}
       <div className={cn("border-t border-zinc-800 bg-[#0c0c0e]", !expanded && "hidden")}>
+        {sessions.length === 0 && registryRows === null && (
+          <div className="flex items-center justify-center gap-2 px-4 py-10 text-[12.5px] text-zinc-500">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Checking your sessions…
+          </div>
+        )}
+
+        {showingChooser && (
+          <TerminalSessionChooser
+            sections={chooserSections}
+            pendingTask={pendingTask}
+            busy={chooserBusy}
+            onReconnectHere={handleChooserReconnectHere}
+            onOpenBoardAndReconnect={handleChooserOpenBoardAndReconnect}
+            onResume={handleChooserResume}
+            onStartNew={handleChooserStartNew}
+          />
+        )}
+
         {multi && (
           <div role="tablist" aria-label="Terminal sessions" className="flex items-stretch border-b border-zinc-800 bg-[#141417]">
             {/* Tabs shrink then scroll; "+" (below) stays pinned OUTSIDE this
@@ -780,7 +1090,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
             isActive={entry.key === activeKey}
             expanded={expanded && entry.key === activeKey}
             onRequestExpand={requestExpand}
-            autoConnectWhenExpanded={entry.launchSeq === 0}
+            autoConnectWhenExpanded={entry.launchSeq === 0 && !entry.attach}
             onReportSummary={reportSummary}
             onRegisterActions={registerActions}
             onAnnounce={announce}

--- a/src/components/board/terminal-my-sessions-panel.tsx
+++ b/src/components/board/terminal-my-sessions-panel.tsx
@@ -10,9 +10,9 @@
 //
 // Fetch-on-open + refresh-after-action (no realtime, per the stage brief).
 
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { usePostHog } from "posthog-js/react";
-import { Loader2, Power, Terminal as TerminalIcon, X } from "lucide-react";
+import { Loader2, Power, RefreshCw, Terminal as TerminalIcon, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -69,6 +69,11 @@ interface ListedSession {
   machineLabel: string | null;
   cwd: string | null;
   createdAt: string;
+  /** Session entry chooser (card cbe60db5): the list route now also returns
+   *  recently-ended rows (for the chooser) — this panel still shows only
+   *  "Running", so it filters on this field client-side (see `running` below). */
+  status: "active" | "ended";
+  endedAt: string | null;
 }
 
 type LoadState = "idle" | "loading" | "ready" | "error";
@@ -89,11 +94,20 @@ function helperChipClassName(kind: HelperChipKind): string {
 }
 
 interface TerminalMySessionsPanelProps {
-  /** Fires whenever the panel's session count is known/changes, so the dock's badge stays in sync. */
+  /** Fires whenever the panel's RUNNING session count is known/changes, so the dock's badge stays in sync. */
   onCountChange?: (count: number) => void;
   /** Imperative open control — the cap-refusal toast's action opens this panel (design §7b). */
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /**
+   * Session entry chooser (card cbe60db5, design item 9): "live rows gain
+   * Reconnect wired to the same flow (the panel already reaches the dock)".
+   * Called with a running row's sid + ideaId; the dock decides whether that's
+   * an in-place reattach (this board) or a navigate-and-reconnect (another
+   * board). Omitted → no Reconnect button (keeps the panel usable standalone,
+   * e.g. in tests).
+   */
+  onReconnect?: (sid: string, ideaId: string) => void;
   children: ReactNode;
 }
 
@@ -101,6 +115,7 @@ export function TerminalMySessionsPanel({
   onCountChange,
   open,
   onOpenChange,
+  onReconnect,
   children,
 }: TerminalMySessionsPanelProps) {
   const [loadState, setLoadState] = useState<LoadState>("idle");
@@ -109,6 +124,10 @@ export function TerminalMySessionsPanel({
   const [confirmingEndAll, setConfirmingEndAll] = useState(false);
   const [endingAll, setEndingAll] = useState(false);
   const posthog = usePostHog();
+  // The panel still shows only "Running" (the chooser is the front door for
+  // Recent/Resume now — design item 9) — the list route returns recently-
+  // ended rows too (for the chooser), so this filters them back out.
+  const running = useMemo(() => sessions.filter((s) => s.status === "active"), [sessions]);
 
   // ── Helper row state (card cc74a067) ────────────────────────────────────────
   const [helperStatus, setHelperStatus] = useState<HelperStatus | null>(null);
@@ -139,11 +158,12 @@ export function TerminalMySessionsPanel({
       if (!sessionsRes.ok) throw new Error(`Failed to load sessions (${sessionsRes.status})`);
       const body = (await sessionsRes.json()) as { sessions: ListedSession[] };
       setSessions(body.sessions);
-      onCountChange?.(body.sessions.length);
+      const runningCount = body.sessions.filter((s) => s.status === "active").length;
+      onCountChange?.(runningCount);
 
       if (helperRes.ok) {
         const nextStatus = (await helperRes.json()) as HelperStatus;
-        const nextChip = deriveHelperChip(nextStatus, body.sessions.length);
+        const nextChip = deriveHelperChip(nextStatus, runningCount);
         const prevKind = prevHelperChipKindRef.current;
         if (prevKind === "winding-down" && nextChip?.kind === "not-running") {
           if (suppressIdleQuitSignalRef.current) suppressIdleQuitSignalRef.current = false;
@@ -196,7 +216,7 @@ export function TerminalMySessionsPanel({
 
   const endAll = useCallback(async () => {
     setEndingAll(true);
-    posthog?.capture("terminal_end_all_used", { count: sessions.length });
+    posthog?.capture("terminal_end_all_used", { count: running.length });
     try {
       await fetch("/api/terminal/session/end", {
         method: "POST",
@@ -210,7 +230,7 @@ export function TerminalMySessionsPanel({
       setConfirmingEndAll(false);
       void load();
     }
-  }, [load, posthog, sessions.length]);
+  }, [load, posthog, running.length]);
 
   // ── Helper row actions (card cc74a067) ──────────────────────────────────────
   const stopHelper = useCallback(async () => {
@@ -270,8 +290,8 @@ export function TerminalMySessionsPanel({
   }, [setAlwaysOnRemote]);
 
   const startHelperUpdate = useCallback(() => {
-    setUpdateFlow(updateFlowReducer(INITIAL_UPDATE_FLOW_STATE, { type: "update-clicked", sessionCount: sessions.length }));
-  }, [sessions.length]);
+    setUpdateFlow(updateFlowReducer(INITIAL_UPDATE_FLOW_STATE, { type: "update-clicked", sessionCount: running.length }));
+  }, [running.length]);
 
   // Drive the "quiescing" phase: end any live sessions first (only reached via
   // "confirming" when sessions existed), send the quiesce command, then poll
@@ -282,7 +302,7 @@ export function TerminalMySessionsPanel({
     if (updateFlow.phase !== "quiescing") return;
     let cancelled = false;
     suppressIdleQuitSignalRef.current = true; // an update-triggered quiesce is not an idle-quit
-    const hadSessions = sessions.length > 0;
+    const hadSessions = running.length > 0;
     (async () => {
       if (hadSessions) {
         try {
@@ -332,7 +352,7 @@ export function TerminalMySessionsPanel({
     return () => {
       cancelled = true;
     };
-  }, [updateFlow.phase, sessions.length]);
+  }, [updateFlow.phase, running.length]);
 
   // Either outcome of quiescing starts the download (design: the whole point
   // is drag-to-Applications always succeeds because nothing is running by
@@ -344,7 +364,7 @@ export function TerminalMySessionsPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [updateFlow.phase]);
 
-  const helperChip: HelperChip | null = deriveHelperChip(helperStatus, sessions.length);
+  const helperChip: HelperChip | null = deriveHelperChip(helperStatus, running.length);
   const showHelperNudge =
     updateFlow.phase === "idle" &&
     !dismissedHelperNudge &&
@@ -374,7 +394,7 @@ export function TerminalMySessionsPanel({
           </div>
         )}
 
-        {loadState === "ready" && sessions.length === 0 && (
+        {loadState === "ready" && running.length === 0 && (
           <div className="flex flex-col items-center gap-1 px-4 py-8 text-center">
             <TerminalIcon className="h-5 w-5 text-zinc-600" />
             <p className="text-[13px] font-semibold text-zinc-300">No terminals running.</p>
@@ -384,9 +404,15 @@ export function TerminalMySessionsPanel({
           </div>
         )}
 
-        {loadState === "ready" && sessions.length > 0 && (
+        {loadState === "ready" && running.length > 0 && onReconnect && (
+          <div className="border-t border-zinc-800 px-3.5 py-1.5 text-[11px] text-zinc-500">
+            Reconnecting takes over if a session is open in another window or browser — that view stops receiving
+            output.
+          </div>
+        )}
+        {loadState === "ready" && running.length > 0 && (
           <ul className="max-h-80 overflow-y-auto">
-            {sessions.map((s) => {
+            {running.map((s) => {
               const ideaSlug = slugifyIdeaTitle(s.ideaTitle ?? "");
               const label = deriveTabLabel({
                 taskTitle: s.taskTitle,
@@ -413,6 +439,18 @@ export function TerminalMySessionsPanel({
                     <div className="truncate font-mono text-[11px] text-zinc-500">{identity}</div>
                   </div>
                   <span className="flex-none text-[11.5px] text-zinc-500">{formatSessionAge(s.createdAt)}</span>
+                  {onReconnect && (
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      className="flex-none border-sky-500/45 bg-transparent text-sky-400 hover:bg-sky-500/10"
+                      disabled={ending}
+                      onClick={() => onReconnect(s.sid, s.ideaId)}
+                      aria-label={`Reconnect: ${label}`}
+                    >
+                      <RefreshCw className="h-3 w-3" /> Reconnect
+                    </Button>
+                  )}
                   <Button
                     variant="outline"
                     size="xs"
@@ -429,7 +467,7 @@ export function TerminalMySessionsPanel({
           </ul>
         )}
 
-        {loadState === "ready" && sessions.length > 0 && (
+        {loadState === "ready" && running.length > 0 && (
           <div
             className={cn(
               "flex items-center gap-2.5 border-t border-zinc-800 px-3.5 py-2.5",
@@ -439,7 +477,7 @@ export function TerminalMySessionsPanel({
             {confirmingEndAll ? (
               <>
                 <div className="min-w-0 flex-1">
-                  <div className="text-[12.5px] font-bold text-rose-400">End all {sessions.length} sessions?</div>
+                  <div className="text-[12.5px] font-bold text-rose-400">End all {running.length} sessions?</div>
                   <div className="text-[11px] text-zinc-500">
                     Claude stops on your machine in every one. Unpushed worktree changes stay on disk.
                   </div>
@@ -458,7 +496,7 @@ export function TerminalMySessionsPanel({
               </>
             ) : (
               <>
-                <span className="text-[11.5px] text-zinc-500">{sessions.length} sessions</span>
+                <span className="text-[11.5px] text-zinc-500">{running.length} sessions</span>
                 <Button
                   variant="outline"
                   size="xs"
@@ -519,7 +557,7 @@ export function TerminalMySessionsPanel({
         {confirmingStopHelper && (
           <div className="border-t border-l-2 border-l-rose-500 bg-rose-500/5 px-3.5 py-2.5">
             <div className="text-[12.5px] font-bold text-rose-400">{STOP_CONFIRM_HEADING}</div>
-            <div className="text-[11px] text-zinc-500">{stopConfirmBody(sessions.length)}</div>
+            <div className="text-[11px] text-zinc-500">{stopConfirmBody(running.length)}</div>
             <div className="mt-2 flex items-center justify-end gap-2">
               <Button variant="ghost" size="xs" onClick={() => setConfirmingStopHelper(false)} disabled={stoppingHelper}>
                 Cancel

--- a/src/components/board/terminal-session-chooser.test.tsx
+++ b/src/components/board/terminal-session-chooser.test.tsx
@@ -1,0 +1,240 @@
+// Session entry chooser component tests (card cbe60db5, Option A) — render
+// each section from a plain `ChooserSections` fixture (deriveChooserSections
+// itself is covered by chooser-data.test.ts) and prove the click contract:
+// Start new / Reconnect / Open board & reconnect / Resume's inline confirm.
+
+import { afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { TerminalSessionChooser } from "./terminal-session-chooser";
+import type { ChooserSections } from "@/lib/terminal/chooser-data";
+
+afterEach(cleanup);
+
+const EMPTY: ChooserSections = { liveHere: [], liveElsewhere: [], recent: [] };
+
+function sections(overrides: Partial<ChooserSections>): ChooserSections {
+  return { ...EMPTY, ...overrides };
+}
+
+describe("TerminalSessionChooser", () => {
+  it("renders the Start new session button and fires onStartNew", () => {
+    const onStartNew = vi.fn();
+    render(
+      <TerminalSessionChooser
+        sections={EMPTY}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={onStartNew}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /start new session/i }));
+    expect(onStartNew).toHaveBeenCalledOnce();
+  });
+
+  it("shows the task-scoped Start label when a pendingTask is supplied", () => {
+    render(
+      <TerminalSessionChooser
+        sections={EMPTY}
+        pendingTask={{ taskId: "t1", taskTitle: "Fix login bug" }}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Start new session for this task — Fix login bug/)).toBeInTheDocument();
+  });
+
+  it("renders a 'Running now — this board' row and fires onReconnectHere", () => {
+    const onReconnectHere = vi.fn();
+    const row = {
+      sid: "sid-here",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      machineLabel: "Nick's MacBook",
+      cwd: "~/projects/vibecodes",
+      createdAt: new Date().toISOString(),
+      wasOpenInThisTab: false,
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ liveHere: [row] })}
+        onReconnectHere={onReconnectHere}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Running now — this board")).toBeInTheDocument();
+    expect(screen.getByText(/If this session is open somewhere else/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Reconnect" }));
+    expect(onReconnectHere).toHaveBeenCalledWith(row);
+  });
+
+  it("renders a 'Running now — other boards' row and fires onOpenBoardAndReconnect", () => {
+    const onOpenBoardAndReconnect = vi.fn();
+    const row = {
+      sid: "sid-elsewhere",
+      ideaId: "idea-2",
+      ideaTitle: "Helper Tools",
+      taskId: null,
+      taskTitle: null,
+      machineLabel: null,
+      cwd: "~/projects/helper",
+      createdAt: new Date().toISOString(),
+      wasOpenInThisTab: false,
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ liveElsewhere: [row] })}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={onOpenBoardAndReconnect}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Open board & reconnect/ }));
+    expect(onOpenBoardAndReconnect).toHaveBeenCalledWith(row);
+  });
+
+  it("badges a 'was open in this tab' row", () => {
+    const row = {
+      sid: "sid-here",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      machineLabel: null,
+      cwd: "~/projects/vibecodes",
+      createdAt: new Date().toISOString(),
+      wasOpenInThisTab: true,
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ liveHere: [row] })}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("was open in this tab")).toBeInTheDocument();
+  });
+
+  it("shows the task dedupe badge + Reconnect-first when a live session matches pendingTask", () => {
+    const onReconnectHere = vi.fn();
+    const row = {
+      sid: "sid-task",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: "t1",
+      taskTitle: "Fix login bug",
+      machineLabel: null,
+      cwd: "~/projects/vibecodes",
+      createdAt: new Date().toISOString(),
+      wasOpenInThisTab: false,
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ liveHere: [row] })}
+        pendingTask={{ taskId: "t1", taskTitle: "Fix login bug" }}
+        onReconnectHere={onReconnectHere}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("already running for this task")).toBeInTheDocument();
+    // Two Reconnect buttons render (dedupe banner + the row itself) — click the first.
+    const reconnectButtons = screen.getAllByRole("button", { name: "Reconnect" });
+    fireEvent.click(reconnectButtons[0]);
+    expect(onReconnectHere).toHaveBeenCalledWith(row);
+  });
+
+  it("Recent row: clicking Resume opens the inline confirm, not the launch itself", () => {
+    const onResume = vi.fn();
+    const row = {
+      sid: "sid-recent",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      cwd: "~/projects/vibecodes",
+      machineLabel: "Nick's MacBook",
+      endedAt: new Date().toISOString(),
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ recent: [row] })}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={onResume}
+        onStartNew={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    expect(onResume).not.toHaveBeenCalled(); // confirm first, no launch yet
+    expect(screen.getByText(/This starts a/)).toBeInTheDocument();
+    expect(screen.getByText(/recorded as Nick's MacBook/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByText(/This starts a/)).not.toBeInTheDocument();
+  });
+
+  it("Recent row: confirming Resume calls onResume with the row", () => {
+    const onResume = vi.fn();
+    const row = {
+      sid: "sid-recent",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      cwd: "~/projects/vibecodes",
+      machineLabel: null,
+      endedAt: new Date().toISOString(),
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ recent: [row] })}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={onResume}
+        onStartNew={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    expect(screen.getByText(/The conversation lives on the machine that ran it/)).toBeInTheDocument();
+    const confirmButtons = screen.getAllByRole("button", { name: "Resume" });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+    expect(onResume).toHaveBeenCalledWith(row);
+  });
+
+  it("disables every action while busy", () => {
+    const row = {
+      sid: "sid-here",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      machineLabel: null,
+      cwd: "~/projects/vibecodes",
+      createdAt: new Date().toISOString(),
+      wasOpenInThisTab: false,
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ liveHere: [row] })}
+        busy
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /start new session/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Reconnect" })).toBeDisabled();
+  });
+});

--- a/src/components/board/terminal-session-chooser.tsx
+++ b/src/components/board/terminal-session-chooser.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+// In-app terminal — the session entry chooser (card cbe60db5, Option A,
+// docs/design-terminal-session-entry-options.html §3). Renders INSIDE the
+// dock body whenever `decideEntryBehaviour` (entry-decision.ts) says
+// "chooser" — i.e. the user has any live session anywhere, or any recent
+// (≤48h, recorded-folder) ended one. Nothing here mints or connects anything
+// until a click (F1's whole point): "Start new session" is the only action
+// that mints; every Reconnect attaches an already-minted session; every
+// Resume launches a normal (capped) NEW session with `claude --continue`.
+//
+// Pure data derivation (dedupe, 48h window, task-match) lives in
+// chooser-data.ts — this component only renders `ChooserSections` and wires
+// clicks to the callbacks the dock supplies.
+
+import { useEffect, useRef, useState } from "react";
+import { RefreshCw, Terminal as TerminalIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { formatSessionAge } from "@/lib/terminal/session-registry";
+import { newSessionTooltip } from "@/lib/terminal/session-cap";
+import {
+  findLiveSessionForTask,
+  type ChooserSections,
+  type ChooserLiveRow,
+  type ChooserRecentRow,
+} from "@/lib/terminal/chooser-data";
+
+// F3 (common foundations): the SAME generic warning, visible before every
+// single Reconnect click — never conditional, never sniffed.
+const TAKEOVER_LINE =
+  "If this session is open somewhere else, reconnecting here takes it over.";
+
+export interface TerminalSessionChooserProps {
+  sections: ChooserSections;
+  /** A task-scoped launch awaiting a decision (toolbar/task-menu bus event carrying a task identity), or null for a board-level open. */
+  pendingTask?: { taskId: string; taskTitle: string } | null;
+  /** Disables every action while a click's async work (reattach mint / resume launch) is in flight. */
+  busy?: boolean;
+  /** Reconnect a LIVE session on THIS board — attaches in place, no navigation. */
+  onReconnectHere: (row: ChooserLiveRow) => void;
+  /** Reconnect a LIVE session on ANOTHER board — navigates there with `?reconnect=<sid>`. */
+  onOpenBoardAndReconnect: (row: ChooserLiveRow) => void;
+  /** Resume a RECENT (ended) session — confirmed inline first (F4). */
+  onResume: (row: ChooserRecentRow) => void;
+  /** "Start new session" — the only action that mints (capped, rate-limited, exactly today's mint path). */
+  onStartNew: () => void;
+  cap?: number;
+}
+
+export function TerminalSessionChooser({
+  sections,
+  pendingTask = null,
+  busy = false,
+  onReconnectHere,
+  onOpenBoardAndReconnect,
+  onResume,
+  onStartNew,
+  cap,
+}: TerminalSessionChooserProps) {
+  const [confirmingResumeSid, setConfirmingResumeSid] = useState<string | null>(null);
+  const firstFocusRef = useRef<HTMLButtonElement | null>(null);
+
+  // Focus the first row's primary action when the chooser opens (design:
+  // "focus lands on the first live session's primary action when the choice
+  // surface opens"); a row badged "was open in this tab" takes priority so
+  // Enter reconnects it immediately.
+  useEffect(() => {
+    firstFocusRef.current?.focus();
+    // Only on mount — re-focusing on every prop change would steal focus
+    // back from whatever the user is doing (e.g. mid-confirm on Resume).
+  }, []);
+
+  const taskMatch = pendingTask ? findLiveSessionForTask(sections, pendingTask.taskId) : null;
+  const wasOpenSid =
+    sections.liveHere.find((r) => r.wasOpenInThisTab)?.sid ??
+    sections.liveElsewhere.find((r) => r.wasOpenInThisTab)?.sid ??
+    null;
+
+  const startNewLabel = pendingTask
+    ? `Start new session for this task — ${pendingTask.taskTitle}`
+    : "Start new session";
+
+  return (
+    <div className="max-h-[60vh] overflow-y-auto" data-testid="terminal-session-chooser">
+      {taskMatch && (
+        <div className="flex items-center gap-2.5 border-b border-sky-500/25 bg-sky-500/5 px-3.5 py-2.5">
+          <div className="min-w-0 flex-1">
+            <div className="text-[12.5px] font-semibold text-sky-300">already running for this task</div>
+            <div className="truncate text-[11.5px] text-zinc-500">{taskMatch.taskTitle}</div>
+          </div>
+          <Button
+            ref={firstFocusRef}
+            size="xs"
+            className="flex-none bg-sky-500 text-sky-950 hover:bg-sky-400"
+            disabled={busy}
+            onClick={() =>
+              (sections.liveHere.some((r) => r.sid === taskMatch.sid) ? onReconnectHere : onOpenBoardAndReconnect)(
+                taskMatch,
+              )
+            }
+          >
+            <RefreshCw className="h-3 w-3" /> Reconnect
+          </Button>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2.5 border-b border-zinc-800 px-3.5 py-3">
+        <Button
+          ref={taskMatch ? undefined : firstFocusRef}
+          className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400"
+          disabled={busy}
+          onClick={onStartNew}
+        >
+          <TerminalIcon className="h-4 w-4" /> {startNewLabel}
+        </Button>
+        <span className="text-[11.5px] text-zinc-500">{newSessionTooltip(cap).replace(/^New terminal — /, "")}</span>
+      </div>
+
+      {sections.liveHere.length > 0 && (
+        <ChooserSection label="Running now — this board">
+          {sections.liveHere.map((row) => (
+            <LiveRow
+              key={row.sid}
+              row={row}
+              busy={busy}
+              badge={row.wasOpenInThisTab ? "was open in this tab" : null}
+              buttonLabel="Reconnect"
+              autoFocusRef={!taskMatch && row.sid === wasOpenSid ? firstFocusRef : undefined}
+              onClick={() => onReconnectHere(row)}
+            />
+          ))}
+        </ChooserSection>
+      )}
+
+      {sections.liveElsewhere.length > 0 && (
+        <ChooserSection label="Running now — other boards">
+          {sections.liveElsewhere.map((row) => (
+            <LiveRow
+              key={row.sid}
+              row={row}
+              busy={busy}
+              badge={row.wasOpenInThisTab ? "was open in this tab" : null}
+              buttonLabel="Open board & reconnect"
+              autoFocusRef={!taskMatch && sections.liveHere.length === 0 && row.sid === wasOpenSid ? firstFocusRef : undefined}
+              onClick={() => onOpenBoardAndReconnect(row)}
+            />
+          ))}
+        </ChooserSection>
+      )}
+
+      {sections.recent.length > 0 && (
+        <ChooserSection label="Recent — ended in the last 48h">
+          {sections.recent.map((row) => (
+            <RecentRow
+              key={row.sid}
+              row={row}
+              busy={busy}
+              confirming={confirmingResumeSid === row.sid}
+              onRequestConfirm={() => setConfirmingResumeSid(row.sid)}
+              onCancelConfirm={() => setConfirmingResumeSid(null)}
+              onConfirm={() => {
+                setConfirmingResumeSid(null);
+                onResume(row);
+              }}
+            />
+          ))}
+        </ChooserSection>
+      )}
+    </div>
+  );
+}
+
+function ChooserSection({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="border-t border-zinc-800 bg-[#111114] px-3.5 py-1.5 text-[10.5px] font-bold uppercase tracking-wide text-zinc-500">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function LiveRow({
+  row,
+  busy,
+  badge,
+  buttonLabel,
+  autoFocusRef,
+  onClick,
+}: {
+  row: ChooserLiveRow;
+  busy: boolean;
+  badge: string | null;
+  buttonLabel: string;
+  autoFocusRef?: React.RefObject<HTMLButtonElement | null>;
+  onClick: () => void;
+}) {
+  const label = row.taskTitle?.trim() || row.ideaTitle || row.sid.slice(0, 8);
+  const identity = [row.machineLabel, row.cwd].filter(Boolean).join(" · ") || `session ${row.sid.slice(0, 8)}`;
+  return (
+    <div className="flex items-start gap-2.5 border-t border-zinc-800 px-3.5 py-2.5">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-1.5 text-[13px] font-semibold text-zinc-100">
+          <span className="truncate">{label}</span>
+          {row.ideaTitle && <span className="text-[11px] font-normal text-zinc-500">{row.ideaTitle}</span>}
+          {badge && (
+            <span className="rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-bold uppercase text-amber-300">
+              {badge}
+            </span>
+          )}
+        </div>
+        <div className="truncate font-mono text-[11px] text-zinc-500">
+          {identity} · started {formatSessionAge(row.createdAt)} ago
+        </div>
+        <div className="mt-1 text-[11px] text-zinc-500">{TAKEOVER_LINE}</div>
+      </div>
+      <Button
+        ref={autoFocusRef}
+        size="xs"
+        className="flex-none bg-sky-500 text-sky-950 hover:bg-sky-400"
+        disabled={busy}
+        onClick={onClick}
+      >
+        <RefreshCw className="h-3 w-3" /> {buttonLabel}
+      </Button>
+    </div>
+  );
+}
+
+function machineLine(machineLabel: string | null): string {
+  const base = "The conversation lives on the machine that ran it — resume from a browser on that machine.";
+  return machineLabel ? `${base} (recorded as ${machineLabel})` : base;
+}
+
+function RecentRow({
+  row,
+  busy,
+  confirming,
+  onRequestConfirm,
+  onCancelConfirm,
+  onConfirm,
+}: {
+  row: ChooserRecentRow;
+  busy: boolean;
+  confirming: boolean;
+  onRequestConfirm: () => void;
+  onCancelConfirm: () => void;
+  onConfirm: () => void;
+}) {
+  const label = row.taskTitle?.trim() || row.ideaTitle || row.sid.slice(0, 8);
+  return (
+    <div className={cn("border-t border-zinc-800 px-3.5 py-2.5", confirming && "bg-emerald-500/5")}>
+      <div className="flex items-start gap-2.5">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5 text-[13px] font-semibold text-zinc-100">
+            <span className="truncate">{label}</span>
+            {row.ideaTitle && <span className="text-[11px] font-normal text-zinc-500">{row.ideaTitle}</span>}
+          </div>
+          <div className="truncate font-mono text-[11px] text-zinc-500">
+            {row.cwd} · ended {formatSessionAge(row.endedAt)} ago
+          </div>
+        </div>
+        {!confirming && (
+          <Button
+            size="xs"
+            className="flex-none bg-emerald-500 text-emerald-950 hover:bg-emerald-400"
+            disabled={busy}
+            onClick={onRequestConfirm}
+          >
+            Resume
+          </Button>
+        )}
+      </div>
+      {confirming && (
+        <div className="mt-2 border-l-2 border-emerald-500 pl-2.5 text-[11.5px] text-zinc-400">
+          <p>
+            This starts a <b className="text-zinc-200">new session</b> (counts toward your limit) that continues the
+            most recent conversation in <span className="font-mono text-zinc-300">{row.cwd}</span>.
+          </p>
+          <p className="mt-1">{machineLine(row.machineLabel)}</p>
+          <div className="mt-2 flex items-center justify-end gap-2">
+            <Button variant="ghost" size="xs" onClick={onCancelConfirm} disabled={busy}>
+              Cancel
+            </Button>
+            <Button
+              size="xs"
+              className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400"
+              disabled={busy}
+              onClick={onConfirm}
+            >
+              Resume
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -162,6 +162,11 @@ export function TerminalSessionView({
     taskId: entry.taskId,
     taskTitle: entry.taskTitle,
     onCapExceeded,
+    // Session entry chooser (card cbe60db5): a Reconnect/instant-continue
+    // entry carries a ready-minted `attach` pair instead of a launch to
+    // deliver — the hook's own attach-once-per-sid effect handles it below,
+    // independent of `launchSeq`/`launchPayload` (see SessionEntry's doc).
+    attachExisting: entry.attach ?? null,
   });
   const {
     state,
@@ -181,6 +186,9 @@ export function TerminalSessionView({
   // thing that satisfies "dismissible", and a fresh tab/reload re-evaluating the
   // gate is exactly the desired behaviour (still-stale helper, nudge again).
   const [dismissedHelperNudge, setDismissedHelperNudge] = useState(false);
+  // Common foundations F2: a reconnect/instant-continue entry with no fresh
+  // snapshot to restore — the dismissible "history isn't shown here" note.
+  const [dismissedReconnectNote, setDismissedReconnectNote] = useState(false);
 
   // Deliver this entry's launch exactly once per `launchSeq` bump (B7/B10): a
   // real bus payload goes through `launchFromBus` (carries the resolved
@@ -398,6 +406,26 @@ export function TerminalSessionView({
               className="shrink-0 text-sky-400 hover:text-sky-200"
               onClick={() => setDismissedHelperNudge(true)}
               aria-label="Dismiss helper update notice"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        )}
+
+        {/* Session entry chooser — reconnect with no snapshot to restore
+            (common foundations F2): never a silently blank screen. Shown
+            once there's a stream to sit above; dismissible, per-session. */}
+        {showStream && entry.showReconnectedNoHistoryNote && !dismissedReconnectNote && (
+          <div className="flex items-center gap-2 border-b border-amber-500/30 bg-amber-500/5 px-3 py-1.5 text-[11px] text-amber-300">
+            <Info className="h-3 w-3 shrink-0" />
+            <span className="flex-1">
+              History from before you reconnected isn&apos;t shown here — it&apos;s still in Claude&apos;s context.
+            </span>
+            <button
+              type="button"
+              className="shrink-0 text-amber-400 hover:text-amber-200"
+              onClick={() => setDismissedReconnectNote(true)}
+              aria-label="Dismiss reconnect notice"
             >
               <X className="h-3 w-3" />
             </button>

--- a/src/components/board/terminal-tabs.test.ts
+++ b/src/components/board/terminal-tabs.test.ts
@@ -128,6 +128,11 @@ describe("findPristineSlot (first-launch reuse)", () => {
     ];
     expect(findPristineSlot(sessions)).toBeNull();
   });
+
+  it("never reuses a chooser-attach entry, even at launchSeq 0 (card cbe60db5)", () => {
+    const sessions: PristineCandidate[] = [{ key: "s1", launchSeq: 0, hasAttach: true }];
+    expect(findPristineSlot(sessions)).toBeNull();
+  });
 });
 
 describe("decideTaskLaunch (B10)", () => {

--- a/src/components/board/terminal-tabs.ts
+++ b/src/components/board/terminal-tabs.ts
@@ -20,6 +20,7 @@
 
 import type { TerminalStatus } from "@/lib/terminal/connection";
 import type { BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
+import type { AttachExistingPair } from "./use-terminal-session";
 
 /**
  * One tab = one `useTerminalSession` instance, mounted by a dedicated
@@ -35,12 +36,32 @@ import type { BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
  */
 export interface SessionEntry {
   key: string;
-  origin: "toolbar" | "task";
+  origin: "toolbar" | "task" | "reconnect" | "resume";
   taskId?: string;
   taskTitle?: string;
   createdAt: number;
   launchSeq: number;
   launchPayload: BrowserLaunchPayload | null;
+  /**
+   * Session entry chooser (card cbe60db5): set for a Reconnect / instant-
+   * continue entry — this tab attaches directly to an ALREADY-MINTED session
+   * (no mint, no launch-bus delivery, no install-first gate) via
+   * `useTerminalSession`'s own `attachExisting` option (see
+   * terminal-session-view.tsx). Always paired with `launchSeq: 0` and
+   * `launchPayload: null` (there is nothing to "deliver" — the hook's own
+   * attach-once-per-sid effect does the work) — but is NOT a reusable
+   * "pristine" slot in the auto-connect sense, so `findPristineSlot` and the
+   * dock's `autoConnectWhenExpanded` gate both exclude any entry with this
+   * set (see the `hasAttach` field on `PristineCandidate`).
+   */
+  attach?: AttachExistingPair | null;
+  /**
+   * Common foundations F2: this is a reconnect/instant-continue entry whose
+   * `attach.initialBuffer` came back null (no fresh snapshot to restore) —
+   * render the dismissible amber note ("History from before you reconnected
+   * isn't shown here…") instead of a silently blank terminal.
+   */
+  showReconnectedNoHistoryNote?: boolean;
 }
 
 // ── shared tone vocabulary (drives both the per-tab glyph and the collapsed
@@ -139,23 +160,32 @@ export function deriveTabLabel(input: TabLabelInput): string {
 export interface PristineCandidate {
   key: string;
   launchSeq: number;
+  /**
+   * Session entry chooser (card cbe60db5): true for a Reconnect / instant-
+   * continue entry (`SessionEntry.attach` set). Such an entry has
+   * `launchSeq === 0` too (nothing was ever "delivered" to it) but is NOT a
+   * reusable pristine slot — it's already attached to a specific live
+   * session, so a later fresh launch must open a genuinely new tab rather
+   * than overwrite it.
+   */
+  hasAttach?: boolean;
 }
 
 /**
  * The dock always keeps at least one `useTerminalSession` instance mounted from
  * page load (matching P1's single always-mounted hook — see the `SessionEntry`
  * doc above). That entry is "pristine" — never yet handed a launch — for exactly
- * as long as it's the ONLY entry and its `launchSeq` is still 0. The very FIRST
- * launch on a board reuses it in place (bump its `launchSeq`, attach the
- * payload) instead of minting a second, redundant idle instance; every launch
- * after that opens a genuinely new tab (B7). Returns the reusable entry's key,
- * or null when there's nothing to reuse (a second+ launch, or the single entry
- * has already been used).
+ * as long as it's the ONLY entry, its `launchSeq` is still 0, AND it isn't a
+ * chooser-attach entry (`hasAttach`). The very FIRST launch on a board reuses it
+ * in place (bump its `launchSeq`, attach the payload) instead of minting a
+ * second, redundant idle instance; every launch after that opens a genuinely
+ * new tab (B7). Returns the reusable entry's key, or null when there's nothing
+ * to reuse (a second+ launch, an already-used entry, or a chooser-attach entry).
  */
 export function findPristineSlot(sessions: PristineCandidate[]): string | null {
   if (sessions.length !== 1) return null;
   const [only] = sessions;
-  return only.launchSeq === 0 ? only.key : null;
+  return only.launchSeq === 0 && !only.hasAttach ? only.key : null;
 }
 
 // ── B10: dedupe a task-scoped launch against existing tabs ─────────────────

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -102,6 +102,12 @@ import {
   SCROLLBACK_TRANSFER_CAP_BYTES,
   type TransferredBuffer,
 } from "@/lib/terminal/scrollback-transfer";
+import {
+  saveSessionSnapshot,
+  clearSessionSnapshot,
+  rememberLastTabSid,
+  SNAPSHOT_SAVE_INTERVAL_MS,
+} from "@/lib/terminal/session-snapshot";
 
 // How long we wait for the helper to attach after firing the deep link before
 // dropping to the calm fallback (~8s, per the approved UX). This is the safety net
@@ -441,6 +447,12 @@ export function useTerminalSession(
   const degradeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pairRef = useRef<PairInfo | null>(null);
   const scheduleReconnectRef = useRef<() => void>(() => {});
+  // Reload-reattach instant-continue (card cbe60db5, design item 5): true
+  // once output has arrived since the last snapshot save — the periodic
+  // snapshot effect below only writes to sessionStorage when this is set, so
+  // a quiet connected session doesn't re-serialize+re-write an unchanged
+  // buffer every 20s. Cleared the instant a snapshot is taken.
+  const snapshotDirtyRef = useRef(false);
   // Silent-link watchdog bookkeeping (fix/terminal-dock-heartbeat).
   // `lastInboundAtRef` is stamped on EVERY inbound frame (PTY bytes, control
   // frames, hb-acks); `hbArmedRef` is a PER-SOCKET latch set on the socket's first
@@ -730,14 +742,104 @@ export function useTerminalSession(
   // Firefox may still surface a milder prompt) — the ~8s timeout below is the real
   // safety net, and the authoritative success signal is the first byte from the
   // bridge (ws.onmessage), which proves the helper actually opened AND attached.
+  // Fire `link` via the hidden-iframe (falling back to a direct assign) and
+  // arm the ~8s helper-open timeout — the tail every launch variant shares,
+  // whether it built a bootstrap prompt or a bare resume link. Returns false
+  // when even the fallback assign threw, so the caller can set the honest
+  // "helper-timeout" phase itself (its own log fields differ per variant, so
+  // logging stays with the caller).
+  const openLaunchLinkAndArmTimeout = useCallback(
+    (link: string): boolean => {
+      setLaunchPhase("opening");
+      removeLaunchIframe();
+      try {
+        const frame = document.createElement("iframe");
+        frame.setAttribute("aria-hidden", "true");
+        frame.style.display = "none";
+        frame.src = link;
+        document.body.appendChild(frame);
+        launchIframeRef.current = frame;
+      } catch {
+        // Iframe path unavailable — fall back to a direct assign.
+        try {
+          window.location.assign(link);
+        } catch {
+          return false;
+        }
+      }
+
+      // If the helper doesn't stream within ~8s, drop to the calm fallback (never an
+      // infinite spinner — criterion #8).
+      clearHelperTimer();
+      helperTimerRef.current = setTimeout(() => {
+        removeLaunchIframe();
+        setLaunchPhase(nextLaunchPhaseOnTimeout);
+      }, HELPER_OPEN_TIMEOUT_MS);
+      return true;
+    },
+    [clearHelperTimer, removeLaunchIframe],
+  );
+
   const fireLaunchDeepLink = useCallback(
     (sessionId: string, bridgeToken: string, helperToken?: string) => {
+      // Session entry chooser — Resume (card cbe60db5, design item 7/F4): a
+      // resume launch carries no bootstrap prompt at all — a minimal link
+      // with `resume: true` + the ended session's recorded `cwd`, so the
+      // local bridge runs `claude --continue` there instead of building a
+      // prompt (see terminal/bridge/src/index.js). Checked FIRST so the
+      // normal essentials/budgeting path below never runs for a resume.
+      const carriedForResume = promptPartsRef.current;
+      if (carriedForResume?.resume) {
+        const cwd = carriedForResume.cwd;
+        if (!cwd) {
+          // Should never happen — the chooser only offers Resume for a row
+          // with a recorded folder (F4) — but stay honest rather than fire a
+          // directory-less --continue.
+          logger.error("Terminal resume launch missing cwd — refusing to fire");
+          toast.error("Couldn't resume — no folder was recorded for that session");
+          setLaunchPhase("helper-timeout");
+          return;
+        }
+        let link: string;
+        try {
+          link = buildLaunchDeepLink({
+            relay: relayBaseUrl(),
+            session: sessionId,
+            token: bridgeToken,
+            helperToken,
+            cwd,
+            resume: true,
+          });
+        } catch (err) {
+          logger.error("Terminal resume deep-link build failed", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+          setLaunchPhase("helper-timeout");
+          return;
+        }
+        logger.info("Terminal firing resume deep link", {
+          sessionId,
+          url: redactDeepLinkToken(link).replace(/([?&]cwd=)[^&]*/g, "$1***"),
+          urlChars: link.length,
+        });
+        if (!openLaunchLinkAndArmTimeout(link)) setLaunchPhase("helper-timeout");
+        return;
+      }
+
       let link: string;
       let urlChars = 0;
       let hasCwd = false;
       let droppedCwd = false;
       try {
         const { essentials, cwd } = resolveLaunchPromptParts();
+        if (!essentials) {
+          // Only reachable for a resume-shaped payload that somehow bypassed
+          // the branch above — defensive, never expected in practice (see
+          // BrowserLaunchPayload's doc: essentials is optional ONLY for resume).
+          logger.error("Terminal deep-link build failed", { reason: "missing_essentials" });
+          setLaunchPhase("helper-timeout");
+          return;
+        }
         hasCwd = !!cwd;
         // Budget the prompt against the vibecodes:// URL ceiling via
         // buildBoundedDeepLink (FIX A, QA BUG A) — the SAME shared helper the
@@ -794,35 +896,9 @@ export function useTerminalSession(
         hasCwd,
         droppedCwd,
       });
-      setLaunchPhase("opening");
-
-      removeLaunchIframe();
-      try {
-        const frame = document.createElement("iframe");
-        frame.setAttribute("aria-hidden", "true");
-        frame.style.display = "none";
-        frame.src = link;
-        document.body.appendChild(frame);
-        launchIframeRef.current = frame;
-      } catch {
-        // Iframe path unavailable — fall back to a direct assign.
-        try {
-          window.location.assign(link);
-        } catch {
-          setLaunchPhase("helper-timeout");
-          return;
-        }
-      }
-
-      // If the helper doesn't stream within ~8s, drop to the calm fallback (never an
-      // infinite spinner — criterion #8).
-      clearHelperTimer();
-      helperTimerRef.current = setTimeout(() => {
-        removeLaunchIframe();
-        setLaunchPhase(nextLaunchPhaseOnTimeout);
-      }, HELPER_OPEN_TIMEOUT_MS);
+      if (!openLaunchLinkAndArmTimeout(link)) setLaunchPhase("helper-timeout");
     },
-    [clearHelperTimer, removeLaunchIframe, resolveLaunchPromptParts],
+    [resolveLaunchPromptParts, openLaunchLinkAndArmTimeout],
   );
 
   const teardownSocket = useCallback(() => {
@@ -955,6 +1031,10 @@ export function useTerminalSession(
         }
         dispatch({ type: "data" });
         termRef.current?.write(new Uint8Array(ev.data as ArrayBuffer));
+        // Reload-reattach instant-continue (design item 5): mark the buffer
+        // dirty so the periodic snapshot effect below has something new to
+        // save next tick.
+        snapshotDirtyRef.current = true;
       };
       ws.onerror = () => {
         logger.warn("Terminal relay socket error", { sessionId });
@@ -1075,6 +1155,52 @@ export function useTerminalSession(
       window.removeEventListener("offline", check);
     };
   }, [enabled, state.status, declareLinkSilent]);
+
+  // ── reload-reattach instant-continue (card cbe60db5, design item 5) ────────
+  // Mirror this session's live scrollback into THIS TAB's own sessionStorage
+  // while connected: every SNAPSHOT_SAVE_INTERVAL_MS (20s) if output arrived
+  // since the last save (snapshotDirtyRef), and unconditionally on pagehide
+  // (a refresh/close is exactly the moment a fresh snapshot matters most —
+  // worth the write even if nothing changed since the last tick). A same-tab
+  // reload within SNAPSHOT_FRESHNESS_MS (60s) then lets the dock's
+  // `decideEntryBehaviour` skip the chooser and reattach automatically,
+  // restoring this buffer with the "reconnected" divider (design's veto
+  // note — Nick: yes).
+  const doSnapshotNow = useCallback(() => {
+    const sid = pairRef.current?.sessionId;
+    const term = termRef.current;
+    if (!sid || !term || !snapshotDirtyRef.current) return;
+    const buffer = serializeScrollback(term, SCROLLBACK_TRANSFER_CAP_BYTES);
+    saveSessionSnapshot(sid, buffer);
+    snapshotDirtyRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || state.status !== "connected") return;
+    const interval = setInterval(doSnapshotNow, SNAPSHOT_SAVE_INTERVAL_MS);
+    window.addEventListener("pagehide", doSnapshotNow);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("pagehide", doSnapshotNow);
+    };
+  }, [enabled, state.status, doSnapshotNow]);
+
+  // Remember this tab's own sid the moment a pair is established (mint,
+  // attach-existing, or a fresh-attach-reset reconnect) — independent of the
+  // snapshot's own freshness, this is the chooser's "was open in this tab"
+  // badge (session-snapshot.ts's `rememberLastTabSid`).
+  useEffect(() => {
+    if (pair?.sessionId) rememberLastTabSid(pair.sessionId);
+  }, [pair?.sessionId]);
+
+  // Clear this session's snapshot on any terminal end (user End, idle,
+  // max-duration, or a reconnect-grace exhaustion) — a later reload must
+  // never restore a dead session's output as if it were still live.
+  useEffect(() => {
+    if (state.status !== "session-ended") return;
+    const sid = pairRef.current?.sessionId;
+    if (sid) clearSessionSnapshot(sid);
+  }, [state.status]);
 
   // ── connect (browser leg) ───────────────────────────────────────────────────
   // `autoLaunch` = the same-machine path: after minting, fire the vibecodes:// deep

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import {
+  RECENT_WINDOW_MS,
+  RECENT_MAX,
+  deriveChooserSections,
+  chooserHeaderCounts,
+  findLiveSessionForTask,
+  type ChooserRegistryRow,
+} from "./chooser-data";
+
+const NOW = Date.parse("2026-07-20T12:00:00.000Z");
+const IDEA_A = "idea-a";
+const IDEA_B = "idea-b";
+
+function row(overrides: Partial<ChooserRegistryRow> & { sid: string }): ChooserRegistryRow {
+  return {
+    ideaId: IDEA_A,
+    ideaTitle: "VibeCodes",
+    taskId: null,
+    taskTitle: null,
+    machineLabel: null,
+    cwd: null,
+    createdAt: new Date(NOW - 60_000).toISOString(),
+    status: "active",
+    endedAt: null,
+    ...overrides,
+  };
+}
+
+describe("deriveChooserSections", () => {
+  it("splits live rows into here vs. elsewhere by the current idea id", () => {
+    const rows = [
+      row({ sid: "live-here", ideaId: IDEA_A, status: "active" }),
+      row({ sid: "live-elsewhere", ideaId: IDEA_B, status: "active" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(sections.liveHere.map((r) => r.sid)).toEqual(["live-here"]);
+    expect(sections.liveElsewhere.map((r) => r.sid)).toEqual(["live-elsewhere"]);
+  });
+
+  it("includes a recently-ended row (with a recorded cwd) in Recent", () => {
+    const rows = [
+      row({
+        sid: "ended-1",
+        status: "ended",
+        cwd: "~/projects/recipe-saver",
+        endedAt: new Date(NOW - 2 * 60 * 60 * 1000).toISOString(),
+      }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(sections.recent).toHaveLength(1);
+    expect(sections.recent[0].sid).toBe("ended-1");
+    expect(sections.recent[0].cwd).toBe("~/projects/recipe-saver");
+  });
+
+  it("hides an ended row with no recorded folder — no ghost Resume (F4)", () => {
+    const rows = [
+      row({ sid: "no-cwd", status: "ended", cwd: null, endedAt: new Date(NOW - 60_000).toISOString() }),
+      row({ sid: "blank-cwd", status: "ended", cwd: "   ", endedAt: new Date(NOW - 60_000).toISOString() }),
+    ];
+    expect(deriveChooserSections(rows, IDEA_A, NOW).recent).toEqual([]);
+  });
+
+  it("excludes an ended row past the 48h window, includes one just inside it", () => {
+    const rows = [
+      row({
+        sid: "just-inside",
+        status: "ended",
+        cwd: "~/projects/a",
+        endedAt: new Date(NOW - RECENT_WINDOW_MS + 1000).toISOString(),
+      }),
+      row({
+        sid: "just-outside",
+        status: "ended",
+        cwd: "~/projects/b",
+        endedAt: new Date(NOW - RECENT_WINDOW_MS - 1000).toISOString(),
+      }),
+    ];
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent.map((r) => r.sid);
+    expect(recent).toContain("just-inside");
+    expect(recent).not.toContain("just-outside");
+  });
+
+  it("dedupes recent rows one-per-cwd, keeping the most recently ended", () => {
+    const rows = [
+      row({
+        sid: "older",
+        status: "ended",
+        cwd: "~/projects/dupe",
+        endedAt: new Date(NOW - 3 * 60 * 60 * 1000).toISOString(),
+      }),
+      row({
+        sid: "newer",
+        status: "ended",
+        cwd: "~/projects/dupe",
+        endedAt: new Date(NOW - 1 * 60 * 60 * 1000).toISOString(),
+      }),
+    ];
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+    expect(recent).toHaveLength(1);
+    expect(recent[0].sid).toBe("newer");
+  });
+
+  it("caps Recent at RECENT_MAX, newest first", () => {
+    const rows = Array.from({ length: RECENT_MAX + 3 }, (_, i) =>
+      row({
+        sid: `ended-${i}`,
+        status: "ended",
+        cwd: `~/projects/proj-${i}`,
+        endedAt: new Date(NOW - i * 60_000).toISOString(),
+      }),
+    );
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+    expect(recent).toHaveLength(RECENT_MAX);
+    expect(recent[0].sid).toBe("ended-0"); // newest (smallest offset) first
+  });
+
+  it("badges the row matching lastTabSid as wasOpenInThisTab, regardless of freshness", () => {
+    const rows = [row({ sid: "live-here", ideaId: IDEA_A, status: "active" })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW, "live-here");
+    expect(sections.liveHere[0].wasOpenInThisTab).toBe(true);
+  });
+
+  it("does not badge rows that don't match lastTabSid", () => {
+    const rows = [row({ sid: "live-here", ideaId: IDEA_A, status: "active" })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW, "some-other-sid");
+    expect(sections.liveHere[0].wasOpenInThisTab).toBe(false);
+  });
+});
+
+describe("chooserHeaderCounts", () => {
+  it("counts each section", () => {
+    const sections = deriveChooserSections(
+      [
+        row({ sid: "a", ideaId: IDEA_A, status: "active" }),
+        row({ sid: "b", ideaId: IDEA_B, status: "active" }),
+        row({ sid: "c", status: "ended", cwd: "~/x", endedAt: new Date(NOW - 60_000).toISOString() }),
+      ],
+      IDEA_A,
+      NOW,
+    );
+    expect(chooserHeaderCounts(sections)).toEqual({ here: 1, elsewhere: 1, recent: 1 });
+  });
+});
+
+describe("findLiveSessionForTask", () => {
+  it("returns null for a board-level launch (no taskId)", () => {
+    const sections = deriveChooserSections([], IDEA_A, NOW);
+    expect(findLiveSessionForTask(sections, undefined)).toBeNull();
+    expect(findLiveSessionForTask(sections, null)).toBeNull();
+  });
+
+  it("finds a live 'here' row over an 'elsewhere' one for the same task", () => {
+    const rows = [
+      row({ sid: "here", ideaId: IDEA_A, status: "active", taskId: "task-1" }),
+      row({ sid: "elsewhere", ideaId: IDEA_B, status: "active", taskId: "task-1" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(findLiveSessionForTask(sections, "task-1")?.sid).toBe("here");
+  });
+
+  it("falls back to an elsewhere row when there is no here match", () => {
+    const rows = [row({ sid: "elsewhere", ideaId: IDEA_B, status: "active", taskId: "task-1" })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(findLiveSessionForTask(sections, "task-1")?.sid).toBe("elsewhere");
+  });
+
+  it("returns null when no live row matches the task", () => {
+    const rows = [row({ sid: "other-task", ideaId: IDEA_A, status: "active", taskId: "task-2" })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(findLiveSessionForTask(sections, "task-1")).toBeNull();
+  });
+});

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -1,0 +1,163 @@
+// Session entry chooser (card cbe60db5, Option A) — PURE derivation of the
+// chooser's three sections from the registry's raw rows, so the component
+// itself never has to reason about dedupe/48h/null-cwd rules.
+//
+// The registry list route (GET /api/terminal/session/list) returns every one
+// of the caller's rows that's either still ACTIVE or ENDED within the last
+// 48h (extended for this card — see that route's doc) — this module turns
+// that flat list into "Running now · this board", "Running now · other
+// boards", and "Recent · ended in the last 48h", applying the design's exact
+// rules (docs/design-terminal-session-entry-options.html §3):
+//   - Recent = ended ≤48h ago, max 5, ONE per project folder (`cwd`), rows
+//     with a null `cwd` hidden entirely (F4: "Resume is hidden entirely when
+//     the project folder wasn't recorded — no disabled ghost button").
+//   - Live sessions split by whether they belong to the board currently open
+//     (`currentIdeaId`) or another one.
+
+export const RECENT_WINDOW_MS = 48 * 60 * 60 * 1000;
+export const RECENT_MAX = 5;
+
+/** One row as the (extended) list route returns it — active or recently-ended. */
+export interface ChooserRegistryRow {
+  sid: string;
+  ideaId: string;
+  ideaTitle: string | null;
+  taskId: string | null;
+  taskTitle: string | null;
+  machineLabel: string | null;
+  cwd: string | null;
+  createdAt: string;
+  status: "active" | "ended";
+  endedAt: string | null;
+}
+
+export interface ChooserLiveRow {
+  sid: string;
+  ideaId: string;
+  ideaTitle: string | null;
+  taskId: string | null;
+  taskTitle: string | null;
+  machineLabel: string | null;
+  cwd: string | null;
+  createdAt: string;
+  /** Design badge: this row is the sid this browser TAB last attached, even past the instant-continue freshness window. */
+  wasOpenInThisTab: boolean;
+}
+
+export interface ChooserRecentRow {
+  sid: string;
+  ideaId: string;
+  ideaTitle: string | null;
+  taskId: string | null;
+  taskTitle: string | null;
+  /** Never null/empty — rows without a recorded folder never reach this list (F4). */
+  cwd: string;
+  machineLabel: string | null;
+  endedAt: string;
+}
+
+export interface ChooserSections {
+  liveHere: ChooserLiveRow[];
+  liveElsewhere: ChooserLiveRow[];
+  recent: ChooserRecentRow[];
+}
+
+function withinRecentWindow(endedAt: string, nowMs: number): boolean {
+  const t = Date.parse(endedAt);
+  if (Number.isNaN(t)) return false;
+  const age = nowMs - t;
+  return age >= 0 && age <= RECENT_WINDOW_MS;
+}
+
+/**
+ * Split the registry's raw rows into the chooser's three sections (design
+ * §3). `lastTabSid` (optional — this tab's own remembered sid, see
+ * session-snapshot.ts's `readLastTabSid`) badges the matching LIVE row
+ * `wasOpenInThisTab`, independent of snapshot freshness — a stale snapshot
+ * still deserves the "was open in this tab" hint even once instant-continue
+ * itself no longer applies.
+ */
+export function deriveChooserSections(
+  rows: ChooserRegistryRow[],
+  currentIdeaId: string,
+  nowMs: number = Date.now(),
+  lastTabSid: string | null = null,
+): ChooserSections {
+  const toLiveRow = (r: ChooserRegistryRow): ChooserLiveRow => ({
+    sid: r.sid,
+    ideaId: r.ideaId,
+    ideaTitle: r.ideaTitle,
+    taskId: r.taskId,
+    taskTitle: r.taskTitle,
+    machineLabel: r.machineLabel,
+    cwd: r.cwd,
+    createdAt: r.createdAt,
+    wasOpenInThisTab: !!lastTabSid && r.sid === lastTabSid,
+  });
+
+  const live = rows.filter((r) => r.status === "active");
+  const liveHere = live.filter((r) => r.ideaId === currentIdeaId).map(toLiveRow);
+  const liveElsewhere = live.filter((r) => r.ideaId !== currentIdeaId).map(toLiveRow);
+
+  const recentCandidates = rows
+    .filter((r): r is ChooserRegistryRow & { cwd: string; endedAt: string } => {
+      if (r.status !== "ended") return false;
+      if (!r.cwd || !r.cwd.trim()) return false; // F4: no recorded folder → never shown
+      if (!r.endedAt) return false;
+      return withinRecentWindow(r.endedAt, nowMs);
+    })
+    .sort((a, b) => Date.parse(b.endedAt) - Date.parse(a.endedAt)); // newest-ended first
+
+  const seenCwd = new Set<string>();
+  const recent: ChooserRecentRow[] = [];
+  for (const r of recentCandidates) {
+    const cwd = r.cwd.trim();
+    if (seenCwd.has(cwd)) continue; // one per project folder
+    seenCwd.add(cwd);
+    recent.push({
+      sid: r.sid,
+      ideaId: r.ideaId,
+      ideaTitle: r.ideaTitle,
+      taskId: r.taskId,
+      taskTitle: r.taskTitle,
+      cwd,
+      machineLabel: r.machineLabel,
+      endedAt: r.endedAt,
+    });
+    if (recent.length >= RECENT_MAX) break;
+  }
+
+  return { liveHere, liveElsewhere, recent };
+}
+
+/** Header pill counts ("2 running here · 1 on another board · 2 recent") — a thin, testable view over the sections. */
+export function chooserHeaderCounts(sections: ChooserSections): {
+  here: number;
+  elsewhere: number;
+  recent: number;
+} {
+  return {
+    here: sections.liveHere.length,
+    elsewhere: sections.liveElsewhere.length,
+    recent: sections.recent.length,
+  };
+}
+
+/**
+ * A task-scoped launch (task menu / task card) that already has a LIVE
+ * session anywhere gets that row surfaced first with the "already running
+ * for this task" dedupe badge (design: "made visible instead of automatic").
+ * `here` rows take priority over `elsewhere` — reconnecting on THIS board is
+ * the more direct action when both somehow exist.
+ */
+export function findLiveSessionForTask(
+  sections: ChooserSections,
+  taskId: string | null | undefined,
+): ChooserLiveRow | null {
+  if (!taskId) return null;
+  return (
+    sections.liveHere.find((r) => r.taskId === taskId) ??
+    sections.liveElsewhere.find((r) => r.taskId === taskId) ??
+    null
+  );
+}

--- a/src/lib/terminal/deep-link.test.ts
+++ b/src/lib/terminal/deep-link.test.ts
@@ -81,6 +81,27 @@ describe("buildLaunchDeepLink with a helperToken (card cc74a067)", () => {
   });
 });
 
+describe("buildLaunchDeepLink with resume (card cbe60db5)", () => {
+  it("includes resume=1, positioned before prompt, and round-trips", () => {
+    const withResume = { ...SAMPLE, resume: true };
+    const url = buildLaunchDeepLink(withResume);
+    expect(url).toContain("resume=1");
+    expect(parseLaunchDeepLink(url)).toEqual(withResume);
+  });
+
+  it("omits resume entirely when false/absent — no version-skew risk for an old bridge", () => {
+    const url = buildLaunchDeepLink(SAMPLE);
+    expect(url).not.toContain("resume=");
+    const falseUrl = buildLaunchDeepLink({ ...SAMPLE, resume: false });
+    expect(falseUrl).not.toContain("resume=");
+  });
+
+  it("resume rides before prompt, mirroring helperToken's position", () => {
+    const url = buildLaunchDeepLink({ ...SAMPLE, resume: true, prompt: "ignored on a real resume link" });
+    expect(url.indexOf("resume=")).toBeLessThan(url.indexOf("prompt="));
+  });
+});
+
 describe("redactDeepLinkToken", () => {
   it("replaces the token value with *** and never leaks the secret", () => {
     const url = buildLaunchDeepLink(SAMPLE);

--- a/src/lib/terminal/deep-link.ts
+++ b/src/lib/terminal/deep-link.ts
@@ -53,16 +53,32 @@ export interface LaunchDeepLinkParams {
    * redactDeepLinkToken (it can contain user task/idea content).
    */
   prompt?: string;
+  /**
+   * Session entry chooser — Resume (card cbe60db5, design item 7/F4): when
+   * true, the bridge spawns `claude --continue` in `cwd` instead of
+   * `claude "<prompt>"`. `prompt` is ignored (and normally absent) on a
+   * resume link.
+   */
+  resume?: boolean;
 }
 
 /**
  * Build a `vibecodes://launch?relay=…&session=…&token=…[&helperToken=…]
- * [&cwd=…][&prompt=…]` deep link. Throws when a required field is missing so
- * a malformed link is never fired. `prompt` is always the LAST param so the
- * base-link length (and therefore the prompt budget) is stable — `helperToken`
- * is inserted before it, alongside the other credentials.
+ * [&cwd=…][&resume=1][&prompt=…]` deep link. Throws when a required field is
+ * missing so a malformed link is never fired. `prompt` is always the LAST
+ * param so the base-link length (and therefore the prompt budget) is stable —
+ * `helperToken`/`resume` are inserted before it, alongside the other
+ * credentials.
  */
-export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt }: LaunchDeepLinkParams): string {
+export function buildLaunchDeepLink({
+  relay,
+  session,
+  token,
+  helperToken,
+  cwd,
+  prompt,
+  resume,
+}: LaunchDeepLinkParams): string {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
   }
@@ -73,6 +89,7 @@ export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, p
   ];
   if (helperToken) parts.push(`helperToken=${encodeURIComponent(helperToken)}`);
   if (cwd) parts.push(`cwd=${encodeURIComponent(cwd)}`);
+  if (resume) parts.push(`resume=1`);
   if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
 }

--- a/src/lib/terminal/entry-decision.test.ts
+++ b/src/lib/terminal/entry-decision.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { decideEntryBehaviour, type EntryRegistryRow } from "./entry-decision";
+import { SNAPSHOT_FRESHNESS_MS } from "./session-snapshot";
+import { RECENT_WINDOW_MS } from "./chooser-data";
+
+const NOW = Date.parse("2026-07-20T12:00:00.000Z");
+
+function row(overrides: Partial<EntryRegistryRow> & { sid: string }): EntryRegistryRow {
+  return { status: "active", cwd: null, endedAt: null, ...overrides };
+}
+
+describe("decideEntryBehaviour", () => {
+  it("empty-launch when there is nothing live or recent anywhere", () => {
+    expect(decideEntryBehaviour([], null, NOW)).toEqual({ kind: "empty-launch" });
+  });
+
+  it("chooser when a live session exists, with no snapshot", () => {
+    const rows = [row({ sid: "live-1", status: "active" })];
+    expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "chooser" });
+  });
+
+  it("chooser when only a recent (≤48h, recorded-folder) ended session exists", () => {
+    const rows = [row({ sid: "ended-1", status: "ended", cwd: "~/projects/a", endedAt: new Date(NOW - 60_000).toISOString() })];
+    expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "chooser" });
+  });
+
+  it("empty-launch when the only ended row has no recorded folder", () => {
+    const rows = [row({ sid: "ended-1", status: "ended", cwd: null, endedAt: new Date(NOW - 60_000).toISOString() })];
+    expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "empty-launch" });
+  });
+
+  it("empty-launch when the only ended row is past the 48h window", () => {
+    const rows = [
+      row({
+        sid: "ended-1",
+        status: "ended",
+        cwd: "~/projects/a",
+        endedAt: new Date(NOW - RECENT_WINDOW_MS - 1000).toISOString(),
+      }),
+    ];
+    expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "empty-launch" });
+  });
+
+  it("instant-continue when a fresh snapshot's sid is a live, owned row", () => {
+    const rows = [row({ sid: "live-1", status: "active" })];
+    const snapshotInfo = { sid: "live-1", savedAt: NOW - 5000 };
+    expect(decideEntryBehaviour(rows, snapshotInfo, NOW)).toEqual({ kind: "instant-continue", sid: "live-1" });
+  });
+
+  it("falls back to chooser when the snapshot is stale, even if the row is live", () => {
+    const rows = [row({ sid: "live-1", status: "active" })];
+    const snapshotInfo = { sid: "live-1", savedAt: NOW - SNAPSHOT_FRESHNESS_MS - 1 };
+    expect(decideEntryBehaviour(rows, snapshotInfo, NOW)).toEqual({ kind: "chooser" });
+  });
+
+  it("falls back to chooser when the fresh snapshot's sid is not a live row (ended/foreign/gone)", () => {
+    const rows = [row({ sid: "live-1", status: "active" })];
+    const snapshotInfo = { sid: "some-other-sid", savedAt: NOW - 5000 };
+    expect(decideEntryBehaviour(rows, snapshotInfo, NOW)).toEqual({ kind: "chooser" });
+  });
+
+  it("falls back to chooser when the fresh snapshot's sid row exists but has since ended", () => {
+    const rows = [row({ sid: "live-1", status: "ended", cwd: "~/projects/a", endedAt: new Date(NOW - 60_000).toISOString() })];
+    const snapshotInfo = { sid: "live-1", savedAt: NOW - 5000 };
+    expect(decideEntryBehaviour(rows, snapshotInfo, NOW)).toEqual({ kind: "chooser" });
+  });
+
+  it("empty-launch when there is a snapshot but no rows at all", () => {
+    const snapshotInfo = { sid: "live-1", savedAt: NOW - 5000 };
+    expect(decideEntryBehaviour([], snapshotInfo, NOW)).toEqual({ kind: "empty-launch" });
+  });
+});

--- a/src/lib/terminal/entry-decision.ts
+++ b/src/lib/terminal/entry-decision.ts
@@ -1,0 +1,70 @@
+// Session entry chooser + reload-reattach (card cbe60db5) — the top-level
+// PURE decision every terminal entry point (dock chevron, board toolbar "In
+// the browser", a task-launch bus event) routes through before it's allowed
+// to mint or attach anything (design's Common Foundations F1 + the instant-
+// continue variant).
+//
+// Exactly one of three outcomes, in this priority order:
+//   1. instant-continue — a fresh (<60s) snapshot for a sid that IS a live,
+//      owned session in the registry → reattach it immediately, no click.
+//   2. chooser           — any other live session, or any recent (≤48h,
+//      recorded-folder) ended session exists → render the chooser, mint
+//      nothing until a click.
+//   3. empty-launch      — nothing live or recent anywhere → today's
+//      unchanged open→launch behaviour (F1: "there is nothing to choose
+//      between, and this is explicitly fine").
+
+import { RECENT_WINDOW_MS } from "./chooser-data";
+import { isSnapshotFresh } from "./session-snapshot";
+
+/** The minimal per-row shape this decision needs — a subset of ChooserRegistryRow. */
+export interface EntryRegistryRow {
+  sid: string;
+  status: "active" | "ended";
+  cwd: string | null;
+  endedAt: string | null;
+}
+
+export interface EntrySnapshotInfo {
+  sid: string;
+  savedAt: number;
+}
+
+export type EntryDecision =
+  | { kind: "instant-continue"; sid: string }
+  | { kind: "chooser" }
+  | { kind: "empty-launch" };
+
+function isRecentEnded(row: EntryRegistryRow, nowMs: number): boolean {
+  if (row.status !== "ended") return false;
+  if (!row.cwd || !row.cwd.trim()) return false;
+  if (!row.endedAt) return false;
+  const t = Date.parse(row.endedAt);
+  if (Number.isNaN(t)) return false;
+  const age = nowMs - t;
+  return age >= 0 && age <= RECENT_WINDOW_MS;
+}
+
+/**
+ * `rows` — every one of the caller's registry rows (active + recently-ended,
+ * exactly what the extended list route returns; see chooser-data.ts for the
+ * shared 48h/cwd rules this mirrors). `snapshotInfo` — this tab's own
+ * `vc:term:snap:<sid>` metadata, if any (see session-snapshot.ts); `null`
+ * when nothing was ever saved in this tab.
+ */
+export function decideEntryBehaviour(
+  rows: EntryRegistryRow[],
+  snapshotInfo: EntrySnapshotInfo | null,
+  nowMs: number = Date.now(),
+): EntryDecision {
+  if (snapshotInfo && isSnapshotFresh(snapshotInfo.savedAt, nowMs)) {
+    const row = rows.find((r) => r.sid === snapshotInfo.sid && r.status === "active");
+    if (row) return { kind: "instant-continue", sid: snapshotInfo.sid };
+  }
+
+  const hasLive = rows.some((r) => r.status === "active");
+  const hasRecent = rows.some((r) => isRecentEnded(r, nowMs));
+  if (hasLive || hasRecent) return { kind: "chooser" };
+
+  return { kind: "empty-launch" };
+}

--- a/src/lib/terminal/helper-version.ts
+++ b/src/lib/terminal/helper-version.ts
@@ -20,7 +20,7 @@
  *  checklist. 0.3.0 (card cc74a067) is the first release with the helper
  *  lifecycle rework — quit-when-idle, crash log-and-exit, and the "Keep
  *  helper ready" opt-in. */
-export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.0";
+export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.1";
 
 export type HelperVersionParts = readonly [number, number, number];
 

--- a/src/lib/terminal/launch-mode.test.ts
+++ b/src/lib/terminal/launch-mode.test.ts
@@ -45,7 +45,7 @@ describe("launch bus payload (bootstrap-prompt transport)", () => {
       cwd: "/Users/me/projects/my-idea",
     };
     requestBrowserLaunch(payload);
-    expect(handler.mock.calls[0][0]?.essentials.protocol).toBe("WORKTREE_PROTOCOL");
+    expect(handler.mock.calls[0][0]?.essentials?.protocol).toBe("WORKTREE_PROTOCOL");
     unsubscribe();
   });
 

--- a/src/lib/terminal/launch-mode.ts
+++ b/src/lib/terminal/launch-mode.ts
@@ -60,15 +60,34 @@ const LAUNCH_EVENT = "vibecodes:terminal-browser-launch";
  * identically (never overflow, never a half-truncated protocol fragment).
  */
 export interface BrowserLaunchPayload {
-  essentials: CompactPromptEssentials;
+  /**
+   * Optional ONLY for a `resume` payload (see below) — a `--continue` launch
+   * carries no bootstrap prompt at all, so there is nothing to build
+   * essentials for. Every other payload always sets this.
+   */
+  essentials?: CompactPromptEssentials;
   /**
    * The working directory the launch should open in — resolved by the button
    * with the SAME rule the claude-cli:// path uses (resolveLaunchCwd over the
    * pinned/effective path), so a pinned or recorded existing-mode folder is
    * honoured in the browser too. Omitted when the state carries no cwd
    * (repo-backed, or a brand-new ~/projects/<slug> the agent creates).
+   *
+   * REQUIRED when `resume` is true — a resumed session always runs in a
+   * SPECIFIC recorded folder (the ended session's own `cwd`), never the
+   * board's default target.
    */
   cwd?: string;
+  /**
+   * Session entry chooser — Resume (card cbe60db5, design item 7, F4): this
+   * launch is a chooser "Resume" pick, not a fresh bootstrap. The dock skips
+   * building/sending a prompt entirely and fires the deep link with the
+   * `resume` flag instead, so the local bridge runs `claude --continue` in
+   * `cwd` (the ended session's recorded folder) rather than spawning a new
+   * bootstrap conversation. Always paired with `cwd`; `essentials` is not
+   * read for a resume payload.
+   */
+  resume?: boolean;
   /**
    * Multi-session stage 2 (B10 dedupe, B3 tab labels): the task this launch was
    * scoped to, when it came from a task card ("task-icon" / "task-menu-item"

--- a/src/lib/terminal/popout-reload-stash.test.ts
+++ b/src/lib/terminal/popout-reload-stash.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePopoutStash,
+  savePopoutStash,
+  loadPopoutStash,
+  clearPopoutStash,
+  type PopoutStash,
+} from "./popout-reload-stash";
+
+class FakeStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+const STASH: PopoutStash = {
+  sid: "sid-1",
+  label: "fix-login-bug",
+  identity: "Nick's MacBook · session sid-1",
+  readOnly: false,
+  ideaId: "idea-1",
+  ideaTitle: "VibeCodes",
+};
+
+describe("parsePopoutStash", () => {
+  it("parses a valid stash", () => {
+    expect(parsePopoutStash(JSON.stringify(STASH))).toEqual(STASH);
+  });
+
+  it("returns null for null/empty/malformed/incomplete input", () => {
+    expect(parsePopoutStash(null)).toBeNull();
+    expect(parsePopoutStash(undefined)).toBeNull();
+    expect(parsePopoutStash("")).toBeNull();
+    expect(parsePopoutStash("not json")).toBeNull();
+    expect(parsePopoutStash(JSON.stringify({ sid: "sid-1" }))).toBeNull();
+  });
+});
+
+describe("savePopoutStash / loadPopoutStash / clearPopoutStash", () => {
+  it("round-trips", () => {
+    const storage = new FakeStorage();
+    savePopoutStash(STASH, storage);
+    expect(loadPopoutStash(storage)).toEqual(STASH);
+  });
+
+  it("loading with nothing saved returns null", () => {
+    expect(loadPopoutStash(new FakeStorage())).toBeNull();
+  });
+
+  it("a later save overwrites the earlier one (one flat key)", () => {
+    const storage = new FakeStorage();
+    savePopoutStash(STASH, storage);
+    const next = { ...STASH, sid: "sid-2" };
+    savePopoutStash(next, storage);
+    expect(loadPopoutStash(storage)).toEqual(next);
+  });
+
+  it("clear removes the stash", () => {
+    const storage = new FakeStorage();
+    savePopoutStash(STASH, storage);
+    clearPopoutStash(storage);
+    expect(loadPopoutStash(storage)).toBeNull();
+  });
+
+  it("null storage is a silent no-op everywhere", () => {
+    expect(() => savePopoutStash(STASH, null)).not.toThrow();
+    expect(loadPopoutStash(null)).toBeNull();
+    expect(() => clearPopoutStash(null)).not.toThrow();
+  });
+});

--- a/src/lib/terminal/popout-reload-stash.ts
+++ b/src/lib/terminal/popout-reload-stash.ts
@@ -1,0 +1,92 @@
+// Session entry chooser + reload-reattach (card cbe60db5, design item 8) —
+// the POPPED WINDOW's own memory of which session it holds, stashed in ITS
+// OWN sessionStorage at successful hand-off. A popped window that gets
+// reloaded (accidental Cmd+R, a crash-recovery restore) starts a FRESH
+// handshake with a nonce that no longer means anything to a dock that's
+// still listening for the OLD one — see terminal-popout-client.tsx's doc for
+// the two outcomes: if the originating dock tab is still open and still
+// listening on that (stable, window.name-persisted) channel name, the
+// existing retried-handshake protocol just re-delivers the payload as
+// normal; if it's gone (closed, navigated away), the handshake times out
+// with a "stale nonce" and THIS stash is what lets the popped window recover
+// on its own via the reattach route, instead of the generic "lost the
+// hand-off, close and re-pop" dead end.
+//
+// Deliberately its own tiny module (mirrors session-snapshot.ts's shape) so
+// the storage plumbing is unit-tested without a real popped window.
+
+/** One flat key — a popped window holds exactly one session for its lifetime. */
+const STASH_KEY = "vc:pop:sid";
+
+export interface PopoutStash {
+  sid: string;
+  label: string;
+  identity: string;
+  readOnly: boolean;
+  ideaId: string;
+  /** Not in the design's literal field list but required by TerminalPopoutView's
+   *  descriptor/document-title — carried alongside the rest rather than re-fetched. */
+  ideaTitle: string;
+}
+
+function defaultStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** Pure parse — malformed/foreign JSON (or a missing field) parses to `null`, never throws. */
+export function parsePopoutStash(raw: string | null | undefined): PopoutStash | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as PopoutStash).sid === "string" &&
+      typeof (parsed as PopoutStash).label === "string" &&
+      typeof (parsed as PopoutStash).identity === "string" &&
+      typeof (parsed as PopoutStash).readOnly === "boolean" &&
+      typeof (parsed as PopoutStash).ideaId === "string" &&
+      typeof (parsed as PopoutStash).ideaTitle === "string"
+    ) {
+      return parsed as PopoutStash;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Save this window's hand-off stash — best-effort, never throws. */
+export function savePopoutStash(stash: PopoutStash, storage: Storage | null = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    storage.setItem(STASH_KEY, JSON.stringify(stash));
+  } catch {
+    /* best-effort only — a failed stash just means a stale-nonce reload falls
+     * back to the generic "lost the hand-off" state instead of recovering */
+  }
+}
+
+/** Load this window's stash, or `null` when absent/unparseable/unavailable. Never throws. */
+export function loadPopoutStash(storage: Storage | null = defaultStorage()): PopoutStash | null {
+  if (!storage) return null;
+  try {
+    return parsePopoutStash(storage.getItem(STASH_KEY));
+  } catch {
+    return null;
+  }
+}
+
+/** Clear the stash — best-effort, never throws. */
+export function clearPopoutStash(storage: Storage | null = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(STASH_KEY);
+  } catch {
+    /* best-effort only */
+  }
+}

--- a/src/lib/terminal/session-registry.test.ts
+++ b/src/lib/terminal/session-registry.test.ts
@@ -7,6 +7,7 @@ import {
   rateLimitWindowStart,
   decideCap,
   decideRateLimit,
+  decideReattach,
   formatSessionAge,
   formatSessionIdentity,
 } from "./session-registry";
@@ -112,5 +113,40 @@ describe("formatSessionIdentity", () => {
     expect(formatSessionIdentity({ machineLabel: "Nick's MacBook Pro", cwd: null, sid: "a3f9beef" })).toBe(
       "Nick's MacBook Pro · a3f9beef",
     );
+  });
+});
+
+describe("decideReattach", () => {
+  it("refuses when no row is found for this sid + user (foreign, deleted, or never existed)", () => {
+    expect(decideReattach(null, NOW)).toEqual({ ok: false, reason: "not-found" });
+  });
+
+  it("refuses an already-ended row", () => {
+    const future = new Date(NOW + 60_000).toISOString();
+    expect(decideReattach({ status: "ended", expires_at: future }, NOW)).toEqual({
+      ok: false,
+      reason: "ended",
+    });
+  });
+
+  it("refuses an active row past its expiry", () => {
+    const past = new Date(NOW - 1).toISOString();
+    expect(decideReattach({ status: "active", expires_at: past }, NOW)).toEqual({
+      ok: false,
+      reason: "expired",
+    });
+  });
+
+  it("allows an active, unexpired row", () => {
+    const future = new Date(NOW + 60_000).toISOString();
+    expect(decideReattach({ status: "active", expires_at: future }, NOW)).toEqual({ ok: true });
+  });
+
+  it("checks status before expiry — an ended-but-still-unexpired row is still refused as ended", () => {
+    const future = new Date(NOW + 60_000).toISOString();
+    expect(decideReattach({ status: "ended", expires_at: future }, NOW)).toEqual({
+      ok: false,
+      reason: "ended",
+    });
   });
 });

--- a/src/lib/terminal/session-registry.ts
+++ b/src/lib/terminal/session-registry.ts
@@ -66,6 +66,30 @@ export function decideRateLimit(recentCount: number, limit: number): RateLimitDe
   return { ok: true };
 }
 
+export type ReattachDecision =
+  | { ok: true }
+  | { ok: false; reason: "not-found" | "ended" | "expired" };
+
+/**
+ * Session entry chooser + reload-reattach (card cbe60db5): the reattach mint
+ * route's OWN decision — separate from `decideCap`/`decideRateLimit` because a
+ * reattach is exempt from both (F2: "no new registry row, exempt from the
+ * session cap and the mint rate limit"). Ownership itself is enforced by the
+ * caller's `.eq("user_id", ...)` read (RLS-scoped too) — a `row` reaching this
+ * function already belongs to the caller; `null` here means "no row for this
+ * sid + this user", which reads identically to "not found" whether the sid
+ * never existed, belongs to someone else, or was deleted.
+ */
+export function decideReattach(
+  row: { status: "active" | "ended"; expires_at: string } | null,
+  nowMs: number = Date.now(),
+): ReattachDecision {
+  if (!row) return { ok: false, reason: "not-found" };
+  if (row.status !== "active") return { ok: false, reason: "ended" };
+  if (isSessionExpired(row.expires_at, nowMs)) return { ok: false, reason: "expired" };
+  return { ok: true };
+}
+
 /**
  * Compact "age" string for the My-sessions list (design §9: "12m", "41m",
  * "2h", "3h 50m"). Minutes below 60; hours + minutes above, dropping the

--- a/src/lib/terminal/session-snapshot.test.ts
+++ b/src/lib/terminal/session-snapshot.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import {
+  SNAPSHOT_KEY_PREFIX,
+  SNAPSHOT_FRESHNESS_MS,
+  RECONNECT_DIVIDER_TEXT,
+  snapshotKey,
+  isSnapshotFresh,
+  serializeSnapshot,
+  parseSnapshot,
+  saveSessionSnapshot,
+  loadSessionSnapshot,
+  clearSessionSnapshot,
+  rememberLastTabSid,
+  readLastTabSid,
+  toReconnectBuffer,
+} from "./session-snapshot";
+import type { TransferredBuffer } from "./scrollback-transfer";
+
+const NOW = Date.parse("2026-07-20T12:00:00.000Z");
+const BUFFER: TransferredBuffer = { data: "hello\r\n", truncated: false };
+
+/** A minimal in-memory `Storage` stub — no jsdom/browser required. */
+class FakeStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+/** Throws quota errors on `setItem` until `allowAfter` further writes have been attempted. */
+class QuotaLimitedStorage extends FakeStorage {
+  constructor(private allowAfter: number) {
+    super();
+  }
+  setItem(key: string, value: string): void {
+    if (this.allowAfter > 0) {
+      this.allowAfter -= 1;
+      const err = new Error("QuotaExceededError");
+      err.name = "QuotaExceededError";
+      throw err;
+    }
+    super.setItem(key, value);
+  }
+}
+
+describe("snapshotKey", () => {
+  it("namespaces under the shared prefix", () => {
+    expect(snapshotKey("abc123")).toBe(`${SNAPSHOT_KEY_PREFIX}abc123`);
+  });
+});
+
+describe("isSnapshotFresh", () => {
+  it("is fresh just under the 60s boundary", () => {
+    expect(isSnapshotFresh(NOW - (SNAPSHOT_FRESHNESS_MS - 1), NOW)).toBe(true);
+  });
+
+  it("is stale exactly at and beyond the boundary", () => {
+    expect(isSnapshotFresh(NOW - SNAPSHOT_FRESHNESS_MS, NOW)).toBe(false);
+    expect(isSnapshotFresh(NOW - SNAPSHOT_FRESHNESS_MS - 1000, NOW)).toBe(false);
+  });
+
+  it("rejects a clock-skewed future savedAt rather than treating it as fresh", () => {
+    expect(isSnapshotFresh(NOW + 5000, NOW)).toBe(false);
+  });
+});
+
+describe("serializeSnapshot / parseSnapshot", () => {
+  it("round-trips", () => {
+    const raw = serializeSnapshot(BUFFER, NOW);
+    expect(parseSnapshot(raw)).toEqual({ data: BUFFER.data, truncated: BUFFER.truncated, savedAt: NOW });
+  });
+
+  it("parses null/empty/malformed input to null, never throws", () => {
+    expect(parseSnapshot(null)).toBeNull();
+    expect(parseSnapshot(undefined)).toBeNull();
+    expect(parseSnapshot("")).toBeNull();
+    expect(parseSnapshot("not json")).toBeNull();
+    expect(parseSnapshot("{}")).toBeNull();
+    expect(parseSnapshot(JSON.stringify({ data: "x" }))).toBeNull();
+  });
+});
+
+describe("saveSessionSnapshot / loadSessionSnapshot / clearSessionSnapshot", () => {
+  it("saves and loads a snapshot for a sid", () => {
+    const storage = new FakeStorage();
+    saveSessionSnapshot("sid-1", BUFFER, NOW, storage);
+    expect(loadSessionSnapshot("sid-1", storage)).toEqual({
+      data: BUFFER.data,
+      truncated: BUFFER.truncated,
+      savedAt: NOW,
+    });
+  });
+
+  it("loading an absent sid returns null", () => {
+    const storage = new FakeStorage();
+    expect(loadSessionSnapshot("nope", storage)).toBeNull();
+  });
+
+  it("clear removes exactly that sid's snapshot", () => {
+    const storage = new FakeStorage();
+    saveSessionSnapshot("sid-1", BUFFER, NOW, storage);
+    saveSessionSnapshot("sid-2", BUFFER, NOW, storage);
+    clearSessionSnapshot("sid-1", storage);
+    expect(loadSessionSnapshot("sid-1", storage)).toBeNull();
+    expect(loadSessionSnapshot("sid-2", storage)).not.toBeNull();
+  });
+
+  it("a null storage (SSR / unavailable) is a silent no-op, never throws", () => {
+    expect(() => saveSessionSnapshot("sid-1", BUFFER, NOW, null)).not.toThrow();
+    expect(loadSessionSnapshot("sid-1", null)).toBeNull();
+    expect(() => clearSessionSnapshot("sid-1", null)).not.toThrow();
+  });
+
+  it("quota-safe: evicts its own oldest snapshot and retries once", () => {
+    // Only the SUT's write for "sid-new" throws (once) — everything else
+    // (the pre-seeded older snapshot, the eviction's removeItem, the retry)
+    // behaves like plain storage.
+    const combined = new (class extends FakeStorage {
+      private thrown = false;
+      setItem(key: string, value: string): void {
+        if (!this.thrown && key === snapshotKey("sid-new")) {
+          this.thrown = true;
+          const err = new Error("QuotaExceededError");
+          err.name = "QuotaExceededError";
+          throw err;
+        }
+        super.setItem(key, value);
+      }
+    })();
+    combined.setItem(snapshotKey("sid-old"), serializeSnapshot(BUFFER, NOW - 10_000));
+    saveSessionSnapshot("sid-new", BUFFER, NOW, combined);
+    expect(loadSessionSnapshot("sid-old", combined)).toBeNull(); // evicted
+    expect(loadSessionSnapshot("sid-new", combined)).not.toBeNull(); // retry succeeded
+  });
+
+  it("quota-safe: gives up silently when there is nothing of its own to evict", () => {
+    const storage = new QuotaLimitedStorage(Infinity); // every write throws forever
+    expect(() => saveSessionSnapshot("sid-1", BUFFER, NOW, storage)).not.toThrow();
+    expect(loadSessionSnapshot("sid-1", storage)).toBeNull();
+  });
+
+  it("eviction never touches a key outside the snapshot prefix", () => {
+    const combined = new (class extends FakeStorage {
+      private thrown = false;
+      setItem(key: string, value: string): void {
+        if (!this.thrown && key === snapshotKey("sid-new")) {
+          this.thrown = true;
+          const err = new Error("QuotaExceededError");
+          err.name = "QuotaExceededError";
+          throw err;
+        }
+        super.setItem(key, value);
+      }
+    })();
+    combined.setItem("some-other-feature-key", "keep-me");
+    saveSessionSnapshot("sid-new", BUFFER, NOW, combined);
+    // Nothing of ours to evict, so the retry still fails — but the foreign key survives either way.
+    expect(combined.getItem("some-other-feature-key")).toBe("keep-me");
+  });
+});
+
+describe("rememberLastTabSid / readLastTabSid", () => {
+  it("round-trips", () => {
+    const storage = new FakeStorage();
+    expect(readLastTabSid(storage)).toBeNull();
+    rememberLastTabSid("sid-1", storage);
+    expect(readLastTabSid(storage)).toBe("sid-1");
+    rememberLastTabSid("sid-2", storage);
+    expect(readLastTabSid(storage)).toBe("sid-2");
+  });
+
+  it("null storage is a silent no-op", () => {
+    expect(() => rememberLastTabSid("sid-1", null)).not.toThrow();
+    expect(readLastTabSid(null)).toBeNull();
+  });
+});
+
+describe("toReconnectBuffer", () => {
+  it("prefixes the reconnect divider onto the snapshot's data", () => {
+    const buffer = toReconnectBuffer({ data: "hello\r\n", truncated: false, savedAt: NOW });
+    expect(buffer.data).toBe(`\x1b[2m${RECONNECT_DIVIDER_TEXT}\x1b[0m\r\nhello\r\n`);
+    expect(buffer.truncated).toBe(false);
+  });
+
+  it("preserves the truncated flag so restoreScrollback still adds its own marker", () => {
+    const buffer = toReconnectBuffer({ data: "x", truncated: true, savedAt: NOW });
+    expect(buffer.truncated).toBe(true);
+  });
+});

--- a/src/lib/terminal/session-snapshot.ts
+++ b/src/lib/terminal/session-snapshot.ts
@@ -1,0 +1,230 @@
+// Session entry chooser + reload-reattach (card cbe60db5) — the "instant
+// continue" snapshot layer (design doc's optional variant, § veto note,
+// Nick: yes). A live session periodically mirrors its scrollback into THIS
+// TAB's own `sessionStorage` under `vc:term:snap:<sid>`; on a same-tab reload
+// within `SNAPSHOT_FRESHNESS_MS` (60s), the dock treats that as proof the tab
+// held the session moments before and reattaches automatically — no chooser,
+// no click (see entry-decision.ts's `decideEntryBehaviour`).
+//
+// `sessionStorage` is per-tab and survives a reload but not a new tab/window
+// — exactly the "this exact tab, moments ago" signal the design calls for.
+// Deliberately NOT a re-implementation of scrollback-transfer.ts's
+// serialize/restore mechanics (that module stays transport-agnostic, per its
+// own doc comment) — this module is only the STORAGE half: turning a
+// `TransferredBuffer` into a timestamped, size-capped `sessionStorage` entry
+// and back.
+//
+// Quota-safe (design: "quota-safe: catch → evict own oldest → retry once →
+// skip"): a `sessionStorage` write can throw `QuotaExceededError` (Safari in
+// particular has a low per-origin cap). On failure this module evicts its OWN
+// oldest snapshot (never another feature's keys — only `vc:term:snap:*`),
+// retries once, and silently gives up beyond that — a failed snapshot must
+// never surface to the user or block the terminal itself.
+
+import type { TransferredBuffer } from "./scrollback-transfer";
+
+/** Every snapshot this module writes lives under this prefix — the ONLY keys eviction is allowed to touch. */
+export const SNAPSHOT_KEY_PREFIX = "vc:term:snap:";
+
+/** "Fresh" per the design's instant-continue variant: under 60s old. */
+export const SNAPSHOT_FRESHNESS_MS = 60_000;
+
+/** How often a connected session re-snapshots while output keeps arriving (design item 5). */
+export const SNAPSHOT_SAVE_INTERVAL_MS = 20_000;
+
+export interface StoredSnapshot {
+  data: string;
+  truncated: boolean;
+  /** Epoch ms the snapshot was written — the freshness check's input. */
+  savedAt: number;
+}
+
+/** The `sessionStorage` key for one session id's snapshot. */
+export function snapshotKey(sid: string): string {
+  return `${SNAPSHOT_KEY_PREFIX}${sid}`;
+}
+
+/** Pure freshness check — never negative-clock-skew "fresh" (savedAt in the future fails too). */
+export function isSnapshotFresh(
+  savedAt: number,
+  nowMs: number = Date.now(),
+  freshnessMs: number = SNAPSHOT_FRESHNESS_MS,
+): boolean {
+  const age = nowMs - savedAt;
+  return age >= 0 && age < freshnessMs;
+}
+
+/** Pure serialize — the exact string written to storage, so tests don't need real `sessionStorage`. */
+export function serializeSnapshot(buffer: TransferredBuffer, savedAt: number): string {
+  return JSON.stringify({ data: buffer.data, truncated: buffer.truncated, savedAt } satisfies StoredSnapshot);
+}
+
+/** Pure parse — malformed/foreign JSON (or a missing field) parses to `null`, never throws. */
+export function parseSnapshot(raw: string | null | undefined): StoredSnapshot | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as StoredSnapshot).data === "string" &&
+      typeof (parsed as StoredSnapshot).truncated === "boolean" &&
+      typeof (parsed as StoredSnapshot).savedAt === "number"
+    ) {
+      return parsed as StoredSnapshot;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** `window.sessionStorage`, or `null` when unavailable (SSR, privacy mode, disabled storage) — never throws. */
+function defaultStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Evicts THIS module's own oldest snapshot (by `savedAt`, ignoring
+ * `excludeKey` — the write that's currently failing) to make room. Returns
+ * whether an eviction happened, so the caller knows whether a retry is worth
+ * attempting. Never touches a key outside `SNAPSHOT_KEY_PREFIX`.
+ */
+function evictOldestSnapshot(storage: Storage, excludeKey: string): boolean {
+  let oldestKey: string | null = null;
+  let oldestSavedAt = Infinity;
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (!key || key === excludeKey || !key.startsWith(SNAPSHOT_KEY_PREFIX)) continue;
+    const parsed = parseSnapshot(storage.getItem(key));
+    const savedAt = parsed?.savedAt ?? -Infinity; // an unparseable entry is evicted first
+    if (savedAt < oldestSavedAt) {
+      oldestSavedAt = savedAt;
+      oldestKey = key;
+    }
+  }
+  if (!oldestKey) return false;
+  try {
+    storage.removeItem(oldestKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Save a session's scrollback snapshot to THIS tab's `sessionStorage`.
+ * Quota-safe per the module doc: on a write failure, evict our own oldest
+ * snapshot and retry once; a second failure is a silent no-op (never blocks
+ * or surfaces to the user — a missing snapshot just means the next reload
+ * shows the chooser/amber note instead of instant-continue, never a crash).
+ */
+export function saveSessionSnapshot(
+  sid: string,
+  buffer: TransferredBuffer,
+  nowMs: number = Date.now(),
+  storage: Storage | null = defaultStorage(),
+): void {
+  if (!storage) return;
+  const key = snapshotKey(sid);
+  const raw = serializeSnapshot(buffer, nowMs);
+  try {
+    storage.setItem(key, raw);
+    return;
+  } catch {
+    /* quota (or another storage error) — fall through to eviction below */
+  }
+  if (evictOldestSnapshot(storage, key)) {
+    try {
+      storage.setItem(key, raw);
+    } catch {
+      /* still over quota after evicting one — skip, never throw */
+    }
+  }
+}
+
+/** Load a session's snapshot, or `null` when absent/unparseable/storage unavailable. Never throws. */
+export function loadSessionSnapshot(
+  sid: string,
+  storage: Storage | null = defaultStorage(),
+): StoredSnapshot | null {
+  if (!storage) return null;
+  try {
+    return parseSnapshot(storage.getItem(snapshotKey(sid)));
+  } catch {
+    return null;
+  }
+}
+
+/** Clear a session's snapshot — called on a clean end so a later reload never restores a dead session's output. */
+export function clearSessionSnapshot(sid: string, storage: Storage | null = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(snapshotKey(sid));
+  } catch {
+    /* best-effort only */
+  }
+}
+
+// ── the "reconnected" divider (design: instant-continue + chooser Reconnect) ─
+//
+// Common foundations F2: "on reattach a snapshot restores with the divider
+// `— reconnected · earlier output restored —`". `restoreScrollback`
+// (scrollback-transfer.ts) already prepends its OWN dim marker line when
+// `buffer.truncated` — that marker means something different (older history
+// TRIMMED during a hand-off) and stays untouched; this is a distinct divider
+// for a distinct moment (a whole PRIOR snapshot restored after a reload), so
+// it's composed into the `data` here rather than added as a second field
+// scrollback-transfer.ts would have to know about.
+
+/** The design's exact divider text. */
+export const RECONNECT_DIVIDER_TEXT = "— reconnected · earlier output restored —";
+
+/**
+ * Turn a stored snapshot into a `TransferredBuffer` ready for
+ * `restoreScrollback`, with the reconnect divider prefixed (dim SGR + CRLF,
+ * matching scrollback-transfer.ts's own truncation-marker styling). If the
+ * snapshot was itself truncated, `restoreScrollback` still adds ITS marker
+ * first (older-history-trimmed), then this divider, then the data — both
+ * are honest about what happened and neither hides the other.
+ */
+export function toReconnectBuffer(snapshot: StoredSnapshot): TransferredBuffer {
+  return {
+    data: `\x1b[2m${RECONNECT_DIVIDER_TEXT}\x1b[0m\r\n${snapshot.data}`,
+    truncated: snapshot.truncated,
+  };
+}
+
+// ── "was open in this tab" (design: instant-continue's fallback badge) ─────
+//
+// A SEPARATE, un-timestamped memory of the last session id this tab ever
+// attached — kept even once the snapshot itself goes stale, so a reload well
+// past the 60s instant-continue window can still badge that row "was open in
+// this tab" and pre-focus it (Enter reconnects) instead of leaving the
+// chooser with no hint which session was this tab's own.
+
+const LAST_TAB_SID_KEY = "vc:term:last-sid";
+
+/** Remember this tab's most recently attached session id (best-effort, never throws). */
+export function rememberLastTabSid(sid: string, storage: Storage | null = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    storage.setItem(LAST_TAB_SID_KEY, sid);
+  } catch {
+    /* best-effort only */
+  }
+}
+
+/** This tab's last-known session id, or `null` if never set/unavailable. */
+export function readLastTabSid(storage: Storage | null = defaultStorage()): string | null {
+  if (!storage) return null;
+  try {
+    return storage.getItem(LAST_TAB_SID_KEY);
+  } catch {
+    return null;
+  }
+}

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -128,7 +128,13 @@ if (!isRelayHostAllowed(RELAY, { allowLoopback: ALLOW_LOOPBACK_RELAY })) {
 }
 const SESSION = launched?.session || args.session || process.env.SESSION_ID || `dev-${Math.random().toString(36).slice(2, 10)}`;
 const TOKEN = launched?.token || args.token || process.env.BRIDGE_TOKEN || "";
-const CMD = args.cmd || process.env.BRIDGE_CMD || "claude";
+// Session entry chooser — Resume (card cbe60db5, design item 7/F4): a
+// `resume=1` launch runs `claude --continue` instead of the default `claude`,
+// continuing the most recent conversation in CWD rather than bootstrapping a
+// new one. An explicit `--cmd`/`BRIDGE_CMD` override still wins (dev/test
+// convenience), same precedence as every other launched field here.
+const RESUME = !!launched?.resume;
+const CMD = args.cmd || process.env.BRIDGE_CMD || (RESUME ? "claude --continue" : "claude");
 const CWD = launched?.cwd || args.cwd || process.env.BRIDGE_CWD || process.cwd();
 // The URL-carried bootstrap prompt (deep-link launches only). INERT DATA with two
 // hard rules (see docs/terminal-bootstrap-prompt-ux.html + the shared deep-link
@@ -140,7 +146,10 @@ const CWD = launched?.cwd || args.cwd || process.env.BRIDGE_CWD || process.cwd()
 //      until the relay confirms the owner-bound token with the `attached`
 //      control frame (accept-then-close rejections make ws.onopen meaningless
 //      as an auth signal). No frame in time → exit WITHOUT spawning anything.
-const PROMPT = launched?.prompt || "";
+// A resume launch never carries a prompt (nothing to bootstrap) — RESUME
+// forces it empty even if a caller somehow sent both, so `--continue` is
+// never followed by a stray argv element.
+const PROMPT = RESUME ? "" : launched?.prompt || "";
 // ── helper-version announcement (release-gate rework 2a) ─────────────────────
 // Read the RUNNING helper's own version so the relay/dock can nudge stale
 // installs to update. Priority: BRIDGE_HELPER_VERSION (set by the packaged

--- a/terminal/helper/package-lock.json
+++ b/terminal/helper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibecodes-terminal-helper",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8"

--- a/terminal/helper/package.json
+++ b/terminal/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "macOS helper app: registers the vibecodes:// URL scheme and runs the terminal bridge (node-pty PTY -> relay) on launch. A thin, installable, signable wrapper around terminal/bridge (no logic duplication).",
   "author": "VibeCodes",

--- a/terminal/shared/deep-link.mjs
+++ b/terminal/shared/deep-link.mjs
@@ -26,6 +26,14 @@
 //             DATA: the bridge passes it as ONE argv element (never through
 //             shellSplit / a shell) and only spawns AFTER the relay has accepted
 //             the owner-bound token (R1 — see bridge/src/index.js).
+//   resume  — session entry chooser (card cbe60db5, design item 7/F4): when
+//             `"1"`, the bridge spawns `claude --continue` in `cwd` instead of
+//             `claude "<prompt>"` — the chooser's Resume action, continuing the
+//             most recent conversation in that folder rather than bootstrapping
+//             a new one. `prompt` is ignored (and normally absent) on a resume
+//             link. An old bridge that doesn't recognise `resume` simply never
+//             sees the param (it's omitted unless truthy) — no version-skew
+//             risk in either direction.
 //
 // `token` and `helperToken` are secrets and `prompt` is user content. NEVER log
 // a raw link — use redactDeepLinkToken first (it elides all three). `prompt` is
@@ -51,10 +59,10 @@ export const LAUNCH_HOST = "launch";
  * (and therefore the app-side prompt budget) is stable. Throws when a required
  * field is missing so a malformed link is never fired.
  *
- * @param {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string }} params
+ * @param {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean }} params
  * @returns {string}
  */
-export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt } = {}) {
+export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt, resume } = {}) {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
   }
@@ -65,6 +73,7 @@ export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, p
   ];
   if (helperToken) parts.push(`helperToken=${encodeURIComponent(helperToken)}`);
   if (cwd) parts.push(`cwd=${encodeURIComponent(cwd)}`);
+  if (resume) parts.push(`resume=1`);
   if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
 }
@@ -79,7 +88,7 @@ export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, p
  * param existed (version-skew safe both ways).
  *
  * @param {unknown} url
- * @returns {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string } | null}
+ * @returns {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean } | null}
  */
 export function parseLaunchDeepLink(url) {
   if (typeof url !== "string" || url.length === 0) return null;
@@ -101,11 +110,13 @@ export function parseLaunchDeepLink(url) {
   const helperToken = parsed.searchParams.get("helperToken") || undefined;
   const cwd = parsed.searchParams.get("cwd") || undefined;
   const prompt = parsed.searchParams.get("prompt") || undefined;
+  const resume = parsed.searchParams.get("resume") === "1" || undefined;
   if (!relay || !session || !token) return null;
 
   const out = { relay, session, token };
   if (helperToken) out.helperToken = helperToken;
   if (cwd) out.cwd = cwd;
+  if (resume) out.resume = true;
   if (prompt) out.prompt = prompt;
   return out;
 }


### PR DESCRIPTION
Implements Nick's chosen design (Option A + instant continue) from docs/design-terminal-session-entry-options.html, after the first design was rejected at the human gate and reworked into three options.

**The core fix:** opening the terminal never silently mints a session when any live/recent session exists. Every entry point (dock chevron, toolbar launch, task launch) routes through an entry decision:
- **Instant continue** — same-tab refresh with a <60s scrollback snapshot reattaches the same session silently, history restored with a divider (the ONLY automatic connect).
- **Chooser** — otherwise: Running here (Reconnect) · Running elsewhere (Open board & reconnect via cleaned `?reconnect=<sid>`) · Recent ≤48h (Resume → new capped session running `claude --continue` in the recorded folder) · prominent Start new session. Unconditional take-over line before every Reconnect.
- **Empty state** — unchanged (open → launch).

Plus: reattach mint route (fresh browser token for an owned live sid — cap/rate exempt, ownership-checked, reap-first); sessionStorage snapshot layer (pagehide + 20s dirty cadence, quota-safe); popped-window reload reattach via sid stash; My sessions Reconnect.

**Bridge change (flagged):** 13 lines — `resume=1` in the deep link makes the bridge spawn `claude --continue`. Helper 0.3.1 bumped in this PR; the notarized build is being published to `terminal-helper-v0.3.1` before this merges (old helpers degrade gracefully: Resume becomes a plain fresh launch in the right folder).

**Tests:** 65 new/extended. Gates: tsc clean · targeted 606/606 · full 2611/2611 · eslint 0/0.

Note: the Vercel Preview check is known-broken on PRs (missing Supabase env) and does not block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)