### PR TITLE
feat(terminal): machine identity for Recent-session filtering + simpler Resume copy (card cbe60db5)

### DIFF
--- a/src/app/api/terminal/session/[sid]/route.ts
+++ b/src/app/api/terminal/session/[sid]/route.ts
@@ -1,26 +1,36 @@
 // Terminal session PATCH — multi-session stage 3 (C4: the My-sessions identity
-// line — "machine · cwd · short sid").
+// line — "machine · cwd · short sid"), extended by Nick's sign-off change 2
+// for the bridge-announced machine identity.
 //
-// Best-effort, client-known identity fields ONLY. The browser has no real
-// signal for a machine's display name (no JS API exposes it), so
-// `machine_label` is never set here — only `cwd`, which the dock already
-// resolves client-side to build the launch prompt/deep link (see
-// use-terminal-session.ts → resolveLaunchPromptParts). Called fire-and-forget
-// right after a session mints; a failure here never surfaces to the user (the
-// registry row still exists with cwd left null — an honest omission, not a
-// broken feature).
+// Best-effort, client-known identity fields ONLY: `cwd` (the dock already
+// resolves it client-side to build the launch prompt/deep link — see
+// use-terminal-session.ts → resolveLaunchPromptParts) and, now, `machineLabel`
+// (the bridge's own `os.hostname()`, forwarded via the relay's `bridge-version`
+// control frame — see that same file's bridge-version handling). Both are
+// called fire-and-forget; a failure here never surfaces to the user (the
+// registry row simply keeps whichever field was already there — an honest
+// omission, not a broken feature). `machineLabel` is re-sanitized here with
+// the SAME rules the relay applies before ever forwarding it — never trust the
+// client alone — and is ONLY EVER SET, never cleared: a request with no valid
+// field to write is a silent no-op, not an error.
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
+import { sanitizeMachineLabel } from "../../../../../../terminal/shared/control-frames.mjs";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const BodySchema = z.object({
-  cwd: z.string().trim().min(1).max(1024),
-});
+const BodySchema = z
+  .object({
+    cwd: z.string().trim().min(1).max(1024).optional(),
+    machineLabel: z.string().trim().min(1).max(200).optional(),
+  })
+  .refine((data) => data.cwd !== undefined || data.machineLabel !== undefined, {
+    message: "At least one of cwd or machineLabel is required",
+  });
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ sid: string }> }) {
   try {
@@ -38,9 +48,21 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ sid: s
       return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
     }
 
+    const update: { cwd?: string; machine_label?: string } = {};
+    if (parsed.data.cwd) update.cwd = parsed.data.cwd;
+    if (parsed.data.machineLabel) {
+      const sanitized = sanitizeMachineLabel(parsed.data.machineLabel);
+      if (sanitized) update.machine_label = sanitized;
+    }
+    if (Object.keys(update).length === 0) {
+      // Nothing valid survived sanitization (e.g. a machineLabel-only request
+      // whose value failed the shared gate) — a no-op, not an error.
+      return NextResponse.json({ ok: true });
+    }
+
     const { error } = await supabase
       .from("terminal_sessions")
-      .update({ cwd: parsed.data.cwd })
+      .update(update)
       .eq("sid", sid)
       .eq("user_id", user.id)
       .eq("status", "active");

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -85,6 +85,7 @@ import {
 } from "@/lib/terminal/chooser-data";
 import { decideEntryBehaviour, type EntryDecision } from "@/lib/terminal/entry-decision";
 import { loadSessionSnapshot, readLastTabSid, toReconnectBuffer } from "@/lib/terminal/session-snapshot";
+import { getMachineIdentity } from "@/lib/terminal/machine-identity";
 import {
   type SessionEntry,
   type TabDisplayStatus,
@@ -277,7 +278,14 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   }, [entryDecision]);
 
   const chooserSections: ChooserSections = useMemo(
-    () => deriveChooserSections(registryRows ?? [], ideaId, Date.now(), entrySnapshotInfo?.sid ?? readLastTabSid()),
+    () =>
+      deriveChooserSections(
+        registryRows ?? [],
+        ideaId,
+        Date.now(),
+        entrySnapshotInfo?.sid ?? readLastTabSid(),
+        getMachineIdentity(),
+      ),
     [registryRows, ideaId, entrySnapshotInfo],
   );
   const chooserCounts = useMemo(() => chooserHeaderCounts(chooserSections), [chooserSections]);

--- a/src/components/board/terminal-session-chooser.test.tsx
+++ b/src/components/board/terminal-session-chooser.test.tsx
@@ -178,13 +178,12 @@ describe("TerminalSessionChooser", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Resume" }));
     expect(onResume).not.toHaveBeenCalled(); // confirm first, no launch yet
-    expect(screen.getByText(/This starts a/)).toBeInTheDocument();
-    expect(screen.getByText(/recorded as Nick's MacBook/)).toBeInTheDocument();
+    expect(screen.getByText(/Starts a new terminal that picks up your last conversation in/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(screen.queryByText(/This starts a/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Starts a new terminal/)).not.toBeInTheDocument();
   });
 
-  it("Recent row: confirming Resume calls onResume with the row", () => {
+  it("Recent row: confirming Resume calls onResume with the row, and never shows the removed machine-warning line", () => {
     const onResume = vi.fn();
     const row = {
       sid: "sid-recent",
@@ -206,10 +205,69 @@ describe("TerminalSessionChooser", () => {
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: "Resume" }));
-    expect(screen.getByText(/The conversation lives on the machine that ran it/)).toBeInTheDocument();
+    expect(screen.queryByText(/The conversation lives on the machine that ran it/)).not.toBeInTheDocument();
     const confirmButtons = screen.getAllByRole("button", { name: "Resume" });
     fireEvent.click(confirmButtons[confirmButtons.length - 1]);
     expect(onResume).toHaveBeenCalledWith(row);
+  });
+
+  function liveRow(sid: string) {
+    return {
+      sid,
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      machineLabel: null,
+      cwd: "~/projects/vibecodes",
+      createdAt: new Date().toISOString(),
+      wasOpenInThisTab: false,
+    };
+  }
+
+  const recentRow = {
+    sid: "sid-recent",
+    ideaId: "idea-1",
+    ideaTitle: "VibeCodes",
+    taskId: null,
+    taskTitle: null,
+    cwd: "~/projects/vibecodes",
+    machineLabel: null,
+    endedAt: new Date().toISOString(),
+  };
+
+  it("Recent row: hides the limit line when comfortably under the session cap", () => {
+    render(
+      <TerminalSessionChooser
+        sections={sections({ recent: [recentRow], liveHere: [liveRow("live-1")] })}
+        cap={5}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    expect(screen.queryByText(/You're using/)).not.toBeInTheDocument();
+  });
+
+  it("Recent row: shows the limit line when near the session cap", () => {
+    render(
+      <TerminalSessionChooser
+        sections={sections({
+          recent: [recentRow],
+          liveHere: [liveRow("live-1"), liveRow("live-2")],
+          liveElsewhere: [liveRow("live-3"), liveRow("live-4")],
+        })}
+        cap={5}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    expect(screen.getByText("You're using 4 of your 5 terminals.")).toBeInTheDocument();
   });
 
   it("disables every action while busy", () => {

--- a/src/components/board/terminal-session-chooser.tsx
+++ b/src/components/board/terminal-session-chooser.tsx
@@ -18,7 +18,7 @@ import { RefreshCw, Terminal as TerminalIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { formatSessionAge } from "@/lib/terminal/session-registry";
-import { newSessionTooltip } from "@/lib/terminal/session-cap";
+import { newSessionTooltip, getTerminalSessionCap, isNearSessionCap, terminalLimitLine } from "@/lib/terminal/session-cap";
 import {
   findLiveSessionForTask,
   type ChooserSections,
@@ -76,6 +76,14 @@ export function TerminalSessionChooser({
     sections.liveHere.find((r) => r.wasOpenInThisTab)?.sid ??
     sections.liveElsewhere.find((r) => r.wasOpenInThisTab)?.sid ??
     null;
+
+  // Resume confirm's honesty limit line (Nick's sign-off change 1): shown only
+  // when the user is close enough to the cap that resuming matters — the live
+  // count is every session this browser already knows about across BOTH live
+  // sections (the cap itself is per-user, not per-board).
+  const resolvedCap = cap ?? getTerminalSessionCap();
+  const liveCount = sections.liveHere.length + sections.liveElsewhere.length;
+  const limitLine = isNearSessionCap(liveCount, resolvedCap) ? terminalLimitLine(liveCount, resolvedCap) : null;
 
   const startNewLabel = pendingTask
     ? `Start new session for this task — ${pendingTask.taskTitle}`
@@ -157,6 +165,7 @@ export function TerminalSessionChooser({
               row={row}
               busy={busy}
               confirming={confirmingResumeSid === row.sid}
+              limitLine={limitLine}
               onRequestConfirm={() => setConfirmingResumeSid(row.sid)}
               onCancelConfirm={() => setConfirmingResumeSid(null)}
               onConfirm={() => {
@@ -229,15 +238,11 @@ function LiveRow({
   );
 }
 
-function machineLine(machineLabel: string | null): string {
-  const base = "The conversation lives on the machine that ran it — resume from a browser on that machine.";
-  return machineLabel ? `${base} (recorded as ${machineLabel})` : base;
-}
-
 function RecentRow({
   row,
   busy,
   confirming,
+  limitLine,
   onRequestConfirm,
   onCancelConfirm,
   onConfirm,
@@ -245,6 +250,8 @@ function RecentRow({
   row: ChooserRecentRow;
   busy: boolean;
   confirming: boolean;
+  /** Resume confirm's honesty limit line (Nick's sign-off change 1) — null unless the user is near the cap. */
+  limitLine: string | null;
   onRequestConfirm: () => void;
   onCancelConfirm: () => void;
   onConfirm: () => void;
@@ -276,10 +283,10 @@ function RecentRow({
       {confirming && (
         <div className="mt-2 border-l-2 border-emerald-500 pl-2.5 text-[11.5px] text-zinc-400">
           <p>
-            This starts a <b className="text-zinc-200">new session</b> (counts toward your limit) that continues the
-            most recent conversation in <span className="font-mono text-zinc-300">{row.cwd}</span>.
+            Starts a new terminal that picks up your last conversation in{" "}
+            <span className="font-mono text-zinc-300">{row.cwd}</span>.
           </p>
-          <p className="mt-1">{machineLine(row.machineLabel)}</p>
+          {limitLine && <p className="mt-1">{limitLine}</p>}
           <div className="mt-2 flex items-center justify-end gap-2">
             <Button variant="ghost" size="xs" onClick={onCancelConfirm} disabled={busy}>
               Cancel

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -69,6 +69,7 @@ import {
   isPeerReattachedFrame,
   mapCloseCode,
   parseBridgeVersionFrame,
+  parseBridgeVersionHost,
   relayBaseUrl,
   shouldDeclareLinkSilent,
   terminalReducer,
@@ -94,6 +95,7 @@ import {
   resolveTerminalPlatform,
 } from "@/lib/terminal/platform";
 import { isBrowserPaired, markBrowserPaired, resolveFirstRunEntry } from "@/lib/terminal/paired-flag";
+import { setMachineIdentity } from "@/lib/terminal/machine-identity";
 import { type LaunchPhase, nextLaunchPhaseOnTimeout } from "@/lib/terminal/first-run-flow";
 import { consumeRecentHelperIdleQuit } from "@/lib/terminal/helper-relaunch-signal";
 import {
@@ -461,6 +463,11 @@ export function useTerminalSession(
   // openBrowserLeg when a fresh socket is opened.
   const lastInboundAtRef = useRef(0);
   const hbArmedRef = useRef(false);
+  // Machine identity (Nick's sign-off change 2): once-per-session guard so a
+  // bridge that re-announces the SAME host on every attach (grace-window
+  // reconnect, etc.) doesn't re-fire the identity PATCH each time — keyed by
+  // sessionId so a genuinely NEW session (a fresh mint) always fires again.
+  const machineIdentityAnnouncedSidRef = useRef<string | null>(null);
   // The compact bootstrap prompt ESSENTIALS (BUG5 follow-through, 4th rework
   // cycle) the LAST launch-bus event carried — i.e. what the launch button
   // resolved. Hook-initiated launches with no bus payload (paired auto-connect
@@ -985,6 +992,24 @@ export function useTerminalSession(
             // regresses a known-good value to "unknown").
             const v = parseBridgeVersionFrame(ev.data);
             if (v) setHelperVersion(v);
+            // Machine identity (Nick's sign-off change 2): the SAME frame
+            // optionally carries the bridge's hostname. Recorded once per
+            // session (see machineIdentityAnnouncedSidRef's doc) — (1) as this
+            // browser's own remembered identity (machine-identity.ts, read by
+            // the chooser's Recent filter), and (2) a best-effort PATCH onto
+            // the registry row so OTHER browsers can filter against it too.
+            // Never awaited/blocking — an old bridge that omits `host` simply
+            // never triggers this (parses to null, nothing to record).
+            const host = parseBridgeVersionHost(ev.data);
+            if (host && machineIdentityAnnouncedSidRef.current !== sessionId) {
+              machineIdentityAnnouncedSidRef.current = sessionId;
+              setMachineIdentity(host);
+              void fetch(`/api/terminal/session/${encodeURIComponent(sessionId)}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ machineLabel: host }),
+              }).catch(() => {});
+            }
             return;
           }
           if (isPeerDegradedFrame(ev.data)) {

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -126,6 +126,52 @@ describe("deriveChooserSections", () => {
     const sections = deriveChooserSections(rows, IDEA_A, NOW, "some-other-sid");
     expect(sections.liveHere[0].wasOpenInThisTab).toBe(false);
   });
+
+  // Machine identity (Nick's sign-off change 2): Recent-section filtering
+  // against this browser's own recorded machine identity.
+  describe("machine identity filtering (Recent section only)", () => {
+    function endedRow(overrides: Partial<ChooserRegistryRow> & { sid: string }): ChooserRegistryRow {
+      return row({
+        status: "ended",
+        cwd: `~/projects/${overrides.sid}`,
+        endedAt: new Date(NOW - 60_000).toISOString(),
+        ...overrides,
+      });
+    }
+
+    it("shows a Recent row whose machineLabel matches the stored identity", () => {
+      const rows = [endedRow({ sid: "match", machineLabel: "Nicks-MacBook-Pro" })];
+      const recent = deriveChooserSections(rows, IDEA_A, NOW, null, "Nicks-MacBook-Pro").recent;
+      expect(recent.map((r) => r.sid)).toEqual(["match"]);
+    });
+
+    it("hides a Recent row whose machineLabel differs from the stored identity", () => {
+      const rows = [endedRow({ sid: "mismatch", machineLabel: "Nicks-Mac-Studio" })];
+      const recent = deriveChooserSections(rows, IDEA_A, NOW, null, "Nicks-MacBook-Pro").recent;
+      expect(recent).toEqual([]);
+    });
+
+    it("shows a Recent row with a null machineLabel even when an identity is stored", () => {
+      const rows = [endedRow({ sid: "no-label", machineLabel: null })];
+      const recent = deriveChooserSections(rows, IDEA_A, NOW, null, "Nicks-MacBook-Pro").recent;
+      expect(recent.map((r) => r.sid)).toEqual(["no-label"]);
+    });
+
+    it("shows every Recent row when no identity is stored, regardless of machineLabel", () => {
+      const rows = [
+        endedRow({ sid: "labeled", machineLabel: "Nicks-Mac-Studio" }),
+        endedRow({ sid: "unlabeled", machineLabel: null }),
+      ];
+      const recent = deriveChooserSections(rows, IDEA_A, NOW, null, null).recent;
+      expect(recent.map((r) => r.sid).sort()).toEqual(["labeled", "unlabeled"]);
+    });
+
+    it("never filters live sections, even on a machine mismatch", () => {
+      const rows = [row({ sid: "live-mismatch", ideaId: IDEA_A, status: "active", machineLabel: "Nicks-Mac-Studio" })];
+      const sections = deriveChooserSections(rows, IDEA_A, NOW, null, "Nicks-MacBook-Pro");
+      expect(sections.liveHere.map((r) => r.sid)).toEqual(["live-mismatch"]);
+    });
+  });
 });
 
 describe("chooserHeaderCounts", () => {

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -13,6 +13,18 @@
 //     the project folder wasn't recorded — no disabled ghost button").
 //   - Live sessions split by whether they belong to the board currently open
 //     (`currentIdeaId`) or another one.
+//
+// MACHINE IDENTITY (Nick's sign-off change 2 — "hide conversations that
+// aren't on the machine that you're running vibecodes on"): Recent rows also
+// get filtered against `storedMachineLabel` (this browser's own recorded
+// identity — see machine-identity.ts). A row is hidden ONLY when BOTH sides
+// are known and disagree (`row.machineLabel` set AND differs from the stored
+// one) — a row with no recorded machine label stays visible (honest
+// omission, not assumed foreign), and when this browser has never recorded
+// an identity at all, nothing is filtered (F4-style: never a silently empty
+// section over data we simply don't have an opinion on yet). "Running now"
+// sections are NEVER filtered — a live session is unambiguously reachable
+// regardless of which machine it's on.
 
 export const RECENT_WINDOW_MS = 48 * 60 * 60 * 1000;
 export const RECENT_MAX = 5;
@@ -75,13 +87,17 @@ function withinRecentWindow(endedAt: string, nowMs: number): boolean {
  * session-snapshot.ts's `readLastTabSid`) badges the matching LIVE row
  * `wasOpenInThisTab`, independent of snapshot freshness — a stale snapshot
  * still deserves the "was open in this tab" hint even once instant-continue
- * itself no longer applies.
+ * itself no longer applies. `storedMachineLabel` (this browser's own recorded
+ * machine identity, see machine-identity.ts) filters the Recent section per
+ * this module's MACHINE IDENTITY header comment — omit/pass null to show
+ * every recent row unfiltered (the pre-this-card behaviour).
  */
 export function deriveChooserSections(
   rows: ChooserRegistryRow[],
   currentIdeaId: string,
   nowMs: number = Date.now(),
   lastTabSid: string | null = null,
+  storedMachineLabel: string | null = null,
 ): ChooserSections {
   const toLiveRow = (r: ChooserRegistryRow): ChooserLiveRow => ({
     sid: r.sid,
@@ -104,7 +120,11 @@ export function deriveChooserSections(
       if (r.status !== "ended") return false;
       if (!r.cwd || !r.cwd.trim()) return false; // F4: no recorded folder → never shown
       if (!r.endedAt) return false;
-      return withinRecentWindow(r.endedAt, nowMs);
+      if (!withinRecentWindow(r.endedAt, nowMs)) return false;
+      // Machine identity: hide only when BOTH sides are known and disagree —
+      // see this module's header comment.
+      if (storedMachineLabel && r.machineLabel && r.machineLabel !== storedMachineLabel) return false;
+      return true;
     })
     .sort((a, b) => Date.parse(b.endedAt) - Date.parse(a.endedAt)); // newest-ended first
 

--- a/src/lib/terminal/connection.test.ts
+++ b/src/lib/terminal/connection.test.ts
@@ -14,6 +14,7 @@ import {
   isHeartbeatAckFrame,
   isBridgeVersionFrame,
   parseBridgeVersionFrame,
+  parseBridgeVersionHost,
   shouldDeclareLinkSilent,
   buildRelayUrl,
   encodeResizeMessage,
@@ -442,6 +443,35 @@ describe("silent-link watchdog (fix/terminal-dock-heartbeat)", () => {
     expect(parseBridgeVersionFrame('{"t":"bridge-version","v":123}')).toBeNull();
     expect(parseBridgeVersionFrame('{"t":"bridge-version"}')).toBeNull();
     expect(parseBridgeVersionFrame('{"t":"bridge-version"' /* truncated */)).toBeNull();
+  });
+
+  // Machine identity (Nick's sign-off change 2): the SAME frame gains an
+  // optional `host` field — pin byte-for-byte against the real shared encoder,
+  // same as the version field above.
+  it("detects the shared bridge-version frame's host field byte-for-byte", () => {
+    const frame = encodeSharedBridgeVersionFrame("0.3.2", "Nicks-MacBook-Pro");
+    expect(isBridgeVersionFrame(frame)).toBe(true);
+    expect(parseBridgeVersionFrame(frame)).toBe("0.3.2");
+    expect(parseBridgeVersionHost(frame)).toBe("Nicks-MacBook-Pro");
+  });
+
+  it("parseBridgeVersionHost returns null when `host` is absent (old bridge — graceful degrade)", () => {
+    const frame = encodeSharedBridgeVersionFrame("0.3.2");
+    expect(parseBridgeVersionHost(frame)).toBeNull();
+    expect(parseBridgeVersionFrame(frame)).toBe("0.3.2"); // version still parses fine
+  });
+
+  it("parseBridgeVersionHost returns null for a non-string `host` or malformed JSON", () => {
+    expect(parseBridgeVersionHost('{"t":"bridge-version","v":"0.3.2","host":42}')).toBeNull();
+    expect(parseBridgeVersionHost('{"t":"bridge-version"}')).toBeNull();
+    expect(parseBridgeVersionHost('{"t":"bridge-version"' /* truncated */)).toBeNull();
+  });
+
+  it("a frame carrying only `host` (no version) still parses the host", () => {
+    const frame = encodeSharedBridgeVersionFrame(undefined, "Nicks-MacBook-Pro");
+    expect(isBridgeVersionFrame(frame)).toBe(true);
+    expect(parseBridgeVersionFrame(frame)).toBeNull();
+    expect(parseBridgeVersionHost(frame)).toBe("Nicks-MacBook-Pro");
   });
 
   it("shouldDeclareLinkSilent: exactly the threshold is NOT yet dead; strictly beyond is", () => {

--- a/src/lib/terminal/connection.ts
+++ b/src/lib/terminal/connection.ts
@@ -403,8 +403,13 @@ export function relayBaseUrl(): string {
 // drift is pinned by connection.test.ts, which imports the real encoders and checks
 // these detectors agree byte-for-byte.
 
+// 160 (not the original 64) is sized to fit the bridge-version frame's worst
+// case — `v` (semver) plus a full 80-char `host` (sanitizeMachineLabel's own
+// cap, terminal/shared/control-frames.mjs) plus JSON overhead — while staying
+// a trivially bounded size for every other (much shorter) control frame that
+// shares this same gate. Kept in lockstep with the .mjs's own isControlFrame.
 function isControlFrame(text: string, tag: string): boolean {
-  if (text.length === 0 || text.length > 64) return false;
+  if (text.length === 0 || text.length > 160) return false;
   try {
     const msg = JSON.parse(text) as unknown;
     return !!msg && typeof msg === "object" && (msg as { t?: unknown }).t === tag;
@@ -501,6 +506,29 @@ export function parseBridgeVersionFrame(text: string): string | null {
   try {
     const msg = JSON.parse(text) as { v?: unknown };
     return typeof msg.v === "string" ? msg.v : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── machine identity (Nick's sign-off change 2) ───────────────────────────────
+//
+// The SAME bridge-version frame gains an optional `host` field carrying the
+// bridge's machine identity (terminal/shared/control-frames.mjs's
+// MACHINE IDENTITY header comment has the full picture). Extracted here rather
+// than folded into parseBridgeVersionFrame so a frame carrying only ONE of the
+// two fields still yields a clean result for whichever one it's missing,
+// instead of the caller having to re-parse the JSON itself.
+
+/** Extract the announced HOST from a bridge-version control frame, or null for
+ *  anything absent/malformed (a non-string `host`, bad JSON, wrong tag) — an
+ *  OLD bridge never sends `host` at all, which parses identically to "unknown"
+ *  here (the same graceful-degrade shape as a missing `v`). */
+export function parseBridgeVersionHost(text: string): string | null {
+  if (!isControlFrame(text, "bridge-version")) return null;
+  try {
+    const msg = JSON.parse(text) as { host?: unknown };
+    return typeof msg.host === "string" ? msg.host : null;
   } catch {
     return null;
   }

--- a/src/lib/terminal/helper-version.ts
+++ b/src/lib/terminal/helper-version.ts
@@ -19,8 +19,9 @@
  *  that file's header comment and docs/release-process.md for the release
  *  checklist. 0.3.0 (card cc74a067) is the first release with the helper
  *  lifecycle rework — quit-when-idle, crash log-and-exit, and the "Keep
- *  helper ready" opt-in. */
-export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.1";
+ *  helper ready" opt-in. 0.3.2 (card cbe60db5, sign-off change 2) adds the
+ *  bridge's machine-identity (hostname) announcement. */
+export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.2";
 
 export type HelperVersionParts = readonly [number, number, number];
 

--- a/src/lib/terminal/machine-identity.test.ts
+++ b/src/lib/terminal/machine-identity.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  MACHINE_IDENTITY_KEY,
+  getMachineIdentity,
+  setMachineIdentity,
+  clearMachineIdentity,
+} from "./machine-identity";
+
+describe("machine identity — localStorage round-trip", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("is null before anything is recorded", () => {
+    expect(getMachineIdentity()).toBeNull();
+  });
+
+  it("sets + reads the identity under the versioned key", () => {
+    setMachineIdentity("Nicks-MacBook-Pro");
+    expect(getMachineIdentity()).toBe("Nicks-MacBook-Pro");
+    expect(window.localStorage.getItem(MACHINE_IDENTITY_KEY)).toBe("Nicks-MacBook-Pro");
+  });
+
+  it("a later set overwrites the previous value", () => {
+    setMachineIdentity("Nicks-MacBook-Pro");
+    setMachineIdentity("Nicks-Mac-Studio");
+    expect(getMachineIdentity()).toBe("Nicks-Mac-Studio");
+  });
+
+  it("clearMachineIdentity resets it", () => {
+    setMachineIdentity("Nicks-MacBook-Pro");
+    clearMachineIdentity();
+    expect(getMachineIdentity()).toBeNull();
+  });
+});

--- a/src/lib/terminal/machine-identity.ts
+++ b/src/lib/terminal/machine-identity.ts
@@ -1,0 +1,51 @@
+// In-app terminal — this browser's recorded MACHINE identity (Nick's sign-off
+// change 2: "hide conversations that aren't on the machine that you're
+// running vibecodes on"). Set the first time a bridge announces its hostname
+// (the `bridge-version` frame's optional `host` field — see
+// use-terminal-session.ts and terminal/shared/control-frames.mjs); read by
+// chooser-data.ts to filter the session entry chooser's Recent section down
+// to sessions that ended on THIS machine. A never-set (null) identity always
+// shows everything — an honest "we don't know yet" default, never a broken
+// feature.
+//
+// Pure localStorage helpers, unit-tested against jsdom's real localStorage
+// (the same pattern as paired-flag.ts) — no React involved.
+
+/** localStorage key holding this browser's recorded machine identity. */
+export const MACHINE_IDENTITY_KEY = "vc:term:machine";
+
+/** This browser's recorded machine identity, or null if never set / storage unavailable. SSR-safe. */
+export function getMachineIdentity(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(MACHINE_IDENTITY_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Record this browser's machine identity. Only ever called to SET a freshly
+ * announced host — no product flow ever calls this to clear one (an
+ * intermittent bridge that fails to announce on some connection must not
+ * erase a previously known identity). SSR-safe, best-effort: a full/disabled
+ * store just means the chooser's filter never activates, never a thrown error.
+ */
+export function setMachineIdentity(label: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(MACHINE_IDENTITY_KEY, label);
+  } catch {
+    // Storage disabled/full — worst case Recent stays unfiltered.
+  }
+}
+
+/** Clear the recorded identity (test/reset use only — no product flow calls this today). SSR-safe. */
+export function clearMachineIdentity(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(MACHINE_IDENTITY_KEY);
+  } catch {
+    // Nothing to do — storage unavailable.
+  }
+}

--- a/src/lib/terminal/session-cap.test.ts
+++ b/src/lib/terminal/session-cap.test.ts
@@ -14,6 +14,8 @@ import {
   RATE_LIMIT_CODE,
   DAILY_RELAY_BUDGET_CODE,
   DAILY_RELAY_BUDGET_MESSAGE,
+  isNearSessionCap,
+  terminalLimitLine,
 } from "./session-cap";
 
 describe("getTerminalSessionCap", () => {
@@ -142,5 +144,42 @@ describe("daily-relay-budget copy stays distinct (MITIGATION 3 — account-wide 
 
   it("is never misclassified as a cap refusal", () => {
     expect(isCapRefusalMessage(DAILY_RELAY_BUDGET_MESSAGE)).toBe(false);
+  });
+});
+
+describe("isNearSessionCap — Resume confirm's honesty limit line (sign-off change 1)", () => {
+  it("is false when comfortably under the cap", () => {
+    expect(isNearSessionCap(1, 5)).toBe(false);
+    expect(isNearSessionCap(2, 5)).toBe(false);
+    expect(isNearSessionCap(3, 5)).toBe(false);
+  });
+
+  it("is true once the live count is within one of the cap", () => {
+    expect(isNearSessionCap(4, 5)).toBe(true); // one more session hits the cap
+  });
+
+  it("is true at and beyond the cap", () => {
+    expect(isNearSessionCap(5, 5)).toBe(true);
+    expect(isNearSessionCap(6, 5)).toBe(true);
+  });
+
+  it("is true at a cap of 1 (any live session is already the last slot)", () => {
+    expect(isNearSessionCap(0, 1)).toBe(true);
+  });
+
+  it("defaults cap to getTerminalSessionCap()", () => {
+    expect(isNearSessionCap(4)).toBe(true); // default cap is 5
+    expect(isNearSessionCap(2)).toBe(false);
+  });
+});
+
+describe("terminalLimitLine", () => {
+  it("templates the live count and cap, never a hardcoded number", () => {
+    expect(terminalLimitLine(4, 5)).toBe("You're using 4 of your 5 terminals.");
+    expect(terminalLimitLine(3, 3)).toBe("You're using 3 of your 3 terminals.");
+  });
+
+  it("defaults cap to getTerminalSessionCap()", () => {
+    expect(terminalLimitLine(4)).toBe("You're using 4 of your 5 terminals.");
   });
 });

--- a/src/lib/terminal/session-cap.ts
+++ b/src/lib/terminal/session-cap.ts
@@ -98,6 +98,24 @@ export function capReachedToastCopy(cap: number = getTerminalSessionCap()): {
   };
 }
 
+// ── Resume confirm's honesty limit line (Nick's sign-off change 1) ─────────
+//
+// The chooser's Resume inline confirm shows a one-line "you're close to the
+// limit" hint ONLY when the user is near the cap — never on every Resume
+// (that would be noise for the common case of 1 of 5 running). "Near" means
+// the live count already accounts for all but one remaining slot, i.e. one
+// more session (this Resume) would either hit or exceed the cap.
+
+/** Pure predicate: is `liveCount` close enough to `cap` that Resume should warn? */
+export function isNearSessionCap(liveCount: number, cap: number = getTerminalSessionCap()): boolean {
+  return liveCount >= cap - 1;
+}
+
+/** The Resume confirm's honesty limit line, templated from config (never a hardcoded number). */
+export function terminalLimitLine(liveCount: number, cap: number = getTerminalSessionCap()): string {
+  return `You're using ${liveCount} of your ${cap} terminals.`;
+}
+
 // ── stage 3: server-side refusal bodies (mint route) ────────────────────────
 //
 // The mint route returns a distinct `code` per refusal reason so the client

--- a/src/lib/terminal/session-registry.ts
+++ b/src/lib/terminal/session-registry.ts
@@ -107,11 +107,13 @@ export function formatSessionAge(createdAt: string, nowMs: number = Date.now()):
 
 /**
  * The My-sessions identity line (design §9: "machine · cwd · short sid,
- * whatever's non-null"). `machine_label` is never actually populated today
- * (no browser API can read it — see the PATCH route's doc comment), but the
- * shape stays ready for whenever a real signal exists; `cwd` is set
- * best-effort post-connect. The short sid is always present so a row is never
- * a blank line.
+ * whatever's non-null"). `machine_label` is populated best-effort once the
+ * bridge announces its hostname over the relay (Nick's sign-off change 2 —
+ * see use-terminal-session.ts's bridge-version handling and the PATCH route's
+ * doc comment); `cwd` is set best-effort post-connect. Either can still be
+ * null (an old bridge that never announces a host, or a PATCH that hasn't
+ * landed yet) — the short sid is always present so a row is never a blank
+ * line.
  */
 export function formatSessionIdentity(input: {
   machineLabel?: string | null;

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -40,7 +40,7 @@ import { createRequire } from "node:module";
 import WebSocket from "ws";
 import { parseControlMessage } from "./framing.js";
 import { createOutputBatcher } from "./output-batcher.js";
-import { sanitizeHelperVersion } from "../../shared/control-frames.mjs";
+import { sanitizeHelperVersion, sanitizeMachineLabel } from "../../shared/control-frames.mjs";
 import { parseLaunchDeepLink, redactDeepLinkToken } from "../../shared/deep-link.mjs";
 import { isRelayHostAllowed } from "../../shared/relay-allowlist.mjs";
 import {
@@ -171,6 +171,18 @@ function resolveHelperVersion() {
   }
 }
 const HELPER_VERSION = resolveHelperVersion();
+
+// ── machine identity announcement (Nick's sign-off change 2) ─────────────────
+// This machine's hostname, sanitized with the SAME rules the relay applies to
+// `helperVersion` (bounded, defensive re-validation on every hop — see
+// terminal/shared/control-frames.mjs's `sanitizeMachineLabel`). Sent alongside
+// `helperVersion` on the SAME relay connect URL so the browser dock can learn
+// (and remember) which physical machine a session ran on, and later hide
+// Recent rows recorded on a DIFFERENT machine (chooser-data.ts). `null` for an
+// unreadable/absurd hostname is an honest omission, never a crash — the relay
+// simply has nothing to forward, identical to an old bridge that never sends
+// this param at all.
+const HOST = sanitizeMachineLabel(os.hostname());
 
 const MAX_SECONDS = Number(args["max-seconds"] || process.env.BRIDGE_MAX_SECONDS || 28800);
 const CONNECT_TIMEOUT_MS = Number(args["connect-timeout-ms"] || 30000);
@@ -510,7 +522,8 @@ async function main() {
   const url =
     `${RELAY.replace(/\/$/, "")}/?session=${encodeURIComponent(SESSION)}` +
     `&role=bridge&token=${encodeURIComponent(TOKEN)}` +
-    (HELPER_VERSION ? `&helperVersion=${encodeURIComponent(HELPER_VERSION)}` : "");
+    (HELPER_VERSION ? `&helperVersion=${encodeURIComponent(HELPER_VERSION)}` : "") +
+    (HOST ? `&host=${encodeURIComponent(HOST)}` : "");
   const redactedUrl = url.replace(/token=[^&]*/, "token=***");
 
   // The absolute max-duration cap is armed ONCE and spans reconnects (a link drop

--- a/terminal/helper/package-lock.json
+++ b/terminal/helper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibecodes-terminal-helper",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "devDependencies": {
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8"

--- a/terminal/helper/package.json
+++ b/terminal/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "description": "macOS helper app: registers the vibecodes:// URL scheme and runs the terminal bridge (node-pty PTY -> relay) on launch. A thin, installable, signable wrapper around terminal/bridge (no logic duplication).",
   "author": "VibeCodes",

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -582,33 +582,48 @@ export class TerminalRelay {
       }
     }
 
-    // 5b) HELPER-VERSION ANNOUNCEMENT (release-gate rework 2a). Ordering-independent
-    //     both ways:
-    //       - bridge attaches with a (sanitized) `helperVersion` query param → store
-    //         it durably (attach-ordering independent: outlives this one socket) and,
-    //         if a browser leg is ALREADY live, tell it now.
-    //       - browser attaches → if a bridge version is already on file (the bridge
+    // 5b) HELPER-VERSION + MACHINE-IDENTITY ANNOUNCEMENT (release-gate rework 2a,
+    //     extended by Nick's sign-off change 2 to also carry the bridge's
+    //     hostname). Ordering-independent both ways, and the two fields are
+    //     independent of each other (either alone is a valid update):
+    //       - bridge attaches with a (sanitized) `helperVersion` and/or `host`
+    //         query param → store whichever is present durably (attach-ordering
+    //         independent: outlives this one socket) and, if a browser leg is
+    //         ALREADY live, tell it the CURRENT combined state (freshest of both
+    //         fields, not just what arrived on this one attach — a bridge that
+    //         only re-sends `host` this time must not regress an already-known
+    //         version to "unknown", and vice versa).
+    //       - browser attaches → if anything is already on file (the bridge
     //         attached first, or this is a reattach), tell THIS leg immediately.
-    //     A missing/malformed param is a no-op either way (old bridge, or nothing to
-    //     report yet) — never overwrites a previously-stored version with nothing.
+    //     A missing/malformed param is a no-op either way (old bridge, or nothing
+    //     to report yet) — never overwrites a previously-stored value with nothing.
     if (role === "bridge") {
       const helperVersion = sanitizeHelperVersion(url.searchParams.get("helperVersion"));
-      if (helperVersion) {
-        await this.state.storage.put("bridgeHelperVersion", helperVersion);
+      const bridgeHost = sanitizeMachineLabel(url.searchParams.get("host"));
+      if (helperVersion) await this.state.storage.put("bridgeHelperVersion", helperVersion);
+      if (bridgeHost) await this.state.storage.put("bridgeHost", bridgeHost);
+      if (helperVersion || bridgeHost) {
         const browserPeer = this.findPeer("bridge");
         if (browserPeer) {
+          const [storedVersion, storedHost] = await Promise.all([
+            this.state.storage.get("bridgeHelperVersion"),
+            this.state.storage.get("bridgeHost"),
+          ]);
           try {
-            browserPeer.send(encodeBridgeVersionFrame(helperVersion));
+            browserPeer.send(encodeBridgeVersionFrame(storedVersion, storedHost));
           } catch (e) {
             this.log("bridge-version forward failed", { session, err: String(e) });
           }
         }
       }
     } else if (role === "browser") {
-      const bridgeHelperVersion = await this.state.storage.get("bridgeHelperVersion");
-      if (bridgeHelperVersion) {
+      const [bridgeHelperVersion, bridgeHost] = await Promise.all([
+        this.state.storage.get("bridgeHelperVersion"),
+        this.state.storage.get("bridgeHost"),
+      ]);
+      if (bridgeHelperVersion || bridgeHost) {
         try {
-          server.send(encodeBridgeVersionFrame(bridgeHelperVersion));
+          server.send(encodeBridgeVersionFrame(bridgeHelperVersion, bridgeHost));
         } catch (e) {
           this.log("bridge-version send failed", { session, err: String(e) });
         }
@@ -917,6 +932,7 @@ export class TerminalRelay {
       "lastActivityAt",
       "graceDeadline",
       "bridgeHelperVersion",
+      "bridgeHost",
     ]);
     await this.state.storage.deleteAlarm();
     // MITIGATION 1: invalidate the per-wake soft caches so a LATER attach to

--- a/terminal/shared/control-frames.mjs
+++ b/terminal/shared/control-frames.mjs
@@ -64,6 +64,19 @@
 //     relay simply has nothing to forward), and a dock that predates this frame
 //     ignores an unknown `t` tag exactly like it already does for any other one.
 //
+// MACHINE IDENTITY (Nick's sign-off change 2 — "hide conversations that aren't on
+// the machine that you're running vibecodes on") extends this SAME frame with an
+// optional `host` field: `{"t":"bridge-version","v":"x.y.z","host":"Nicks-MBP"}`.
+// The bridge announces `os.hostname()` (sanitized with `sanitizeMachineLabel`
+// below — same query-param path as `helperVersion`, see terminal/bridge/src/
+// index.js) alongside its version; the relay stores it durably as `bridgeHost`
+// (mirroring `bridgeHelperVersion`) and replays it to a late-attaching browser
+// leg exactly like the version. Extending the existing frame (rather than adding
+// a new one) keeps this skew-safe the same way: an OLD bridge never sends `host`
+// at all (the relay has nothing to forward, `host` is simply absent), and a dock
+// that predates this field ignores the unknown key. `host` is OPTIONAL even on a
+// frame that also carries `v` — either field alone is a valid, useful frame.
+//
 // HELPER LIFECYCLE (card cc74a067) adds three more control frames, all scoped to
 // the NEW `helper` leg (terminal/helper/main.js's persistent control connection —
 // see session-token.mjs's "helper" role) — never sent on a bridge/browser leg:
@@ -99,9 +112,13 @@ export const HELPER_GOODBYE_REASONS = Object.freeze([
 /** The closed set of commands the web app may forward to a helper leg. */
 export const HELPER_COMMANDS = Object.freeze(["stop", "quiesce", "set-always-on"]);
 
-/** Detect any control TEXT frame with a given `t` tag. Cheap + strict + bounded. */
+/** Detect any control TEXT frame with a given `t` tag. Cheap + strict + bounded.
+ *  160 (not the original 64) is sized to fit the bridge-version frame's worst
+ *  case — `v` (semver) plus a full 80-char `host` (sanitizeMachineLabel's own
+ *  cap) plus JSON overhead — while staying a trivially bounded, DoS-safe size
+ *  for every other (much shorter) control frame that shares this same gate. */
 function isControlFrame(text, tag) {
-  if (typeof text !== "string" || text.length === 0 || text.length > 64) return false;
+  if (typeof text !== "string" || text.length === 0 || text.length > 160) return false;
   try {
     const msg = JSON.parse(text);
     return !!msg && typeof msg === "object" && msg.t === tag;
@@ -171,9 +188,20 @@ export function isHeartbeatAckFrame(text) {
  *  something the dock's gating logic can't parse. */
 const SEMVER_RE = /^\d+\.\d+\.\d+$/;
 
-/** TEXT frame the relay sends the BROWSER leg announcing the bridge's helper version. */
-export function encodeBridgeVersionFrame(version) {
-  return JSON.stringify({ t: "bridge-version", v: version });
+/**
+ * TEXT frame the relay sends the BROWSER leg announcing the bridge's helper
+ * version and/or machine identity. `host` is optional (omitted whenever falsy)
+ * so a call site that only knows one of the two fields still emits a valid,
+ * minimal frame — see this module's MACHINE IDENTITY header comment.
+ * @param {string | null | undefined} version
+ * @param {string | null | undefined} [host]
+ * @returns {string}
+ */
+export function encodeBridgeVersionFrame(version, host) {
+  const msg = { t: "bridge-version" };
+  if (version) msg.v = version;
+  if (host) msg.host = host;
+  return JSON.stringify(msg);
 }
 
 /** @param {unknown} text @returns {boolean} */
@@ -193,6 +221,27 @@ export function parseBridgeVersionFrame(text) {
   try {
     const msg = JSON.parse(text);
     return typeof msg.v === "string" && SEMVER_RE.test(msg.v) ? msg.v : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract + validate the HOST carried by a bridge-version frame (Nick's
+ * sign-off change 2 — per-session machine identity). Returns null for
+ * anything absent/malformed — an OLD bridge never sends `host` at all, which
+ * parses identically to "unknown" here (the same graceful-degrade shape as a
+ * missing `v`). Re-validated with `sanitizeMachineLabel` even though the relay
+ * already sanitized it before forwarding — defense in depth, never trust the
+ * wire twice-removed from the source.
+ * @param {unknown} text
+ * @returns {string | null}
+ */
+export function parseBridgeVersionHost(text) {
+  if (!isBridgeVersionFrame(text)) return null;
+  try {
+    const msg = JSON.parse(text);
+    return typeof msg.host === "string" ? sanitizeMachineLabel(msg.host) : null;
   } catch {
     return null;
   }

--- a/terminal/test/control-frames.test.mjs
+++ b/terminal/test/control-frames.test.mjs
@@ -22,6 +22,7 @@ import {
   encodeBridgeVersionFrame,
   isBridgeVersionFrame,
   parseBridgeVersionFrame,
+  parseBridgeVersionHost,
   sanitizeHelperVersion,
   sanitizeMachineLabel,
   encodeHelperCommandFrame,
@@ -106,6 +107,52 @@ test("parseBridgeVersionFrame rejects a malformed/hostile `v` even inside a well
   assert.equal(parseBridgeVersionFrame(JSON.stringify({ t: "bridge-version", v: 123 })), null);
   assert.equal(parseBridgeVersionFrame("not json"), null);
   assert.equal(parseBridgeVersionFrame(null), null);
+});
+
+// ── machine identity (Nick's sign-off change 2 — the SAME frame's `host` field) ──
+
+test("bridge-version frame's `host` field encode ⇄ detect ⇄ parse round-trips alongside `v`", () => {
+  const frame = encodeBridgeVersionFrame("0.3.2", "Nicks-MacBook-Pro");
+  assert.equal(isBridgeVersionFrame(frame), true);
+  assert.equal(parseBridgeVersionFrame(frame), "0.3.2");
+  assert.equal(parseBridgeVersionHost(frame), "Nicks-MacBook-Pro");
+});
+
+test("a frame with no `host` (old bridge) parses host as null — the version still parses fine", () => {
+  const frame = encodeBridgeVersionFrame("0.3.2");
+  assert.equal(parseBridgeVersionHost(frame), null);
+  assert.equal(parseBridgeVersionFrame(frame), "0.3.2");
+});
+
+test("a frame carrying only `host` (no version) is still a valid, parseable frame", () => {
+  const frame = encodeBridgeVersionFrame(undefined, "Nicks-MacBook-Pro");
+  assert.equal(isBridgeVersionFrame(frame), true);
+  assert.equal(parseBridgeVersionFrame(frame), null);
+  assert.equal(parseBridgeVersionHost(frame), "Nicks-MacBook-Pro");
+});
+
+test("parseBridgeVersionHost rejects a malformed/hostile `host` even inside a well-formed frame", () => {
+  assert.equal(parseBridgeVersionHost(JSON.stringify({ t: "bridge-version", v: "0.3.2", host: 42 })), null);
+  assert.equal(parseBridgeVersionHost(JSON.stringify({ t: "bridge-version" })), null);
+  assert.equal(parseBridgeVersionHost("not json"), null);
+  assert.equal(parseBridgeVersionHost(null), null);
+});
+
+test("parseBridgeVersionHost re-sanitizes (trims + bounds) even a well-formed `host`", () => {
+  assert.equal(
+    parseBridgeVersionHost(JSON.stringify({ t: "bridge-version", host: " Nicks-MacBook-Pro " })),
+    "Nicks-MacBook-Pro",
+  );
+  assert.equal(
+    parseBridgeVersionHost(JSON.stringify({ t: "bridge-version", host: "" })),
+    null,
+  );
+});
+
+test("a bridge-version frame carrying a full-length host stays within the control-frame length bound", () => {
+  const frame = encodeBridgeVersionFrame("999.999.999", "x".repeat(80));
+  assert.equal(isBridgeVersionFrame(frame), true);
+  assert.equal(parseBridgeVersionHost(frame), "x".repeat(80));
 });
 
 test("sanitizeHelperVersion accepts only strict x.y.z", () => {

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -378,6 +378,7 @@ export function startStandinRelay(opts = {}) {
         maxTimer: null,
         graceTimer: null,
         bridgeHelperVersion: null,
+        bridgeHost: null,
       });
     }
     const legs = sessions.get(session);
@@ -415,21 +416,27 @@ export function startStandinRelay(opts = {}) {
       try { ws.send(encodeAttachedFrame()); } catch { /* leg already gone */ }
     }
 
-    // HELPER-VERSION ANNOUNCEMENT (release-gate rework 2a) — mirrors the Cloudflare
-    // DO's fetch() step 5b: ordering-independent both ways. A bridge attaching with
-    // a sanitized `helperVersion` stores it on the session and forwards it to an
-    // already-live browser leg; a browser attaching (before or after the bridge)
-    // gets whatever version is already on file, if any.
+    // HELPER-VERSION + MACHINE-IDENTITY ANNOUNCEMENT (release-gate rework 2a,
+    // extended by Nick's sign-off change 2) — mirrors the Cloudflare DO's fetch()
+    // step 5b: ordering-independent both ways, and the two fields are independent
+    // of each other. A bridge attaching with a sanitized `helperVersion` and/or
+    // `host` stores whichever is present on the session and forwards the CURRENT
+    // combined state to an already-live browser leg; a browser attaching (before
+    // or after the bridge) gets whatever's already on file, if any.
     if (role === "bridge") {
       const helperVersion = sanitizeHelperVersion(url.searchParams.get("helperVersion"));
-      if (helperVersion) {
-        legs.bridgeHelperVersion = helperVersion;
-        if (legs.browser && legs.browser.readyState === legs.browser.OPEN) {
-          try { legs.browser.send(encodeBridgeVersionFrame(helperVersion)); } catch { /* closing */ }
-        }
+      const host = sanitizeMachineLabel(url.searchParams.get("host"));
+      if (helperVersion) legs.bridgeHelperVersion = helperVersion;
+      if (host) legs.bridgeHost = host;
+      if ((helperVersion || host) && legs.browser && legs.browser.readyState === legs.browser.OPEN) {
+        try {
+          legs.browser.send(encodeBridgeVersionFrame(legs.bridgeHelperVersion, legs.bridgeHost));
+        } catch { /* closing */ }
       }
-    } else if (role === "browser" && legs.bridgeHelperVersion) {
-      try { ws.send(encodeBridgeVersionFrame(legs.bridgeHelperVersion)); } catch { /* leg already gone */ }
+    } else if (role === "browser" && (legs.bridgeHelperVersion || legs.bridgeHost)) {
+      try {
+        ws.send(encodeBridgeVersionFrame(legs.bridgeHelperVersion, legs.bridgeHost));
+      } catch { /* leg already gone */ }
     }
 
     // GRACE-WINDOW REATTACH reconciliation: if this session was being HELD for a


### PR DESCRIPTION
Nick's two Final Sign-off change requests on the session-entry card:

## 1. Resume confirm copy
The inline confirm now says one plain sentence — "Starts a new terminal that picks up your last conversation in {folder}." The machine-warning line is removed. A session-limit line ("You're using N of your X terminals.") appears only when the user is within one session of the cap.

## 2. Machine identity — record + filter
- The bridge announces the Mac's hostname (sanitized, length-capped) alongside its helper version in the existing announcement frame; the relay stores it and replays it to late-attaching browsers.
- The dock records the announced host once per session: as this browser's machine identity (localStorage `vc:term:machine`) and onto the session's registry row (`machine_label`, via the extended cwd PATCH route — server-side sanitized, set-only).
- The chooser's **Recent** section hides rows recorded on a different machine. Null-label rows stay visible, a browser with no stored identity shows everything, and **Running now** sections are never filtered.

Requires helper **0.3.2** (release published before this deploys; `MINIMUM_RECOMMENDED_HELPER_VERSION` bumped). Old helpers degrade gracefully: no hostname → nothing filtered, exactly today's behaviour.

## Tests
+~28 across 6 files: frame host round-trip/lenience (shared .mjs + TS mirror byte-pinned), machine-identity storage, chooser filter rules, near-cap boundary, chooser copy assertions. Gates: tsc clean · full web 2633/2633 · relay 38/38 · shared 27/27 · terminal integration 122/122 · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)