### PR TITLE
feat(terminal): surface the helper-update nudge in the session chooser (card cbe60db5)

### DIFF
--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -86,6 +86,7 @@ import {
 import { decideEntryBehaviour, type EntryDecision } from "@/lib/terminal/entry-decision";
 import { loadSessionSnapshot, readLastTabSid, toReconnectBuffer } from "@/lib/terminal/session-snapshot";
 import { getMachineIdentity } from "@/lib/terminal/machine-identity";
+import { fetchHelperStatus, type HelperStatus } from "@/lib/terminal/helper-row";
 import {
   type SessionEntry,
   type TabDisplayStatus,
@@ -169,6 +170,13 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // ideas — null while the initial fetch is in flight (the "checking your
   // sessions…" beat: nothing may auto-mint before this is known, F1).
   const [registryRows, setRegistryRows] = useState<ChooserRegistryRow[] | null>(null);
+  // Chooser helper-update nudge (card cbe60db5, rework 3): the caller's own
+  // last-known helper status, fetched once alongside the registry — same
+  // `/api/terminal/helper/status` response the My sessions panel polls
+  // on-open. Best-effort only: a failed fetch leaves this `null`, which the
+  // chooser's own predicate treats as "nothing to nudge about", never an
+  // error state.
+  const [helperStatus, setHelperStatus] = useState<HelperStatus | null>(null);
   // A task-scoped (or board-level) launch that arrived while the chooser was
   // showing — carried so "Start new session" / the task-dedupe banner can
   // act on it once the user actually picks something (F1: nothing mints on
@@ -258,6 +266,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     if (!enabled) return;
     void refreshRegistry();
   }, [enabled, refreshRegistry]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    void fetchHelperStatus().then(setHelperStatus);
+  }, [enabled]);
 
   // This tab's own snapshot info (session-snapshot.ts) — read once; a tab
   // doesn't gain a NEW "last sid" mid-session except by attaching another
@@ -982,6 +995,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
             onOpenBoardAndReconnect={handleChooserOpenBoardAndReconnect}
             onResume={handleChooserResume}
             onStartNew={handleChooserStartNew}
+            helperStatus={helperStatus}
           />
         )}
 

--- a/src/components/board/terminal-my-sessions-panel.tsx
+++ b/src/components/board/terminal-my-sessions-panel.tsx
@@ -38,6 +38,7 @@ import {
   HELPER_ROW_STOP_TOAST,
   STOP_CONFIRM_HEADING,
   deriveHelperChip,
+  fetchHelperStatus,
   formatHelperEventAge,
   shouldShowStopButton,
   stopButtonLabel,
@@ -151,9 +152,9 @@ export function TerminalMySessionsPanel({
   const load = useCallback(async () => {
     setLoadState((s) => (s === "idle" ? "loading" : s));
     try {
-      const [sessionsRes, helperRes] = await Promise.all([
+      const [sessionsRes, nextStatus] = await Promise.all([
         fetch("/api/terminal/session/list"),
-        fetch("/api/terminal/helper/status"),
+        fetchHelperStatus(),
       ]);
       if (!sessionsRes.ok) throw new Error(`Failed to load sessions (${sessionsRes.status})`);
       const body = (await sessionsRes.json()) as { sessions: ListedSession[] };
@@ -161,8 +162,7 @@ export function TerminalMySessionsPanel({
       const runningCount = body.sessions.filter((s) => s.status === "active").length;
       onCountChange?.(runningCount);
 
-      if (helperRes.ok) {
-        const nextStatus = (await helperRes.json()) as HelperStatus;
+      if (nextStatus) {
         const nextChip = deriveHelperChip(nextStatus, runningCount);
         const prevKind = prevHelperChipKindRef.current;
         if (prevKind === "winding-down" && nextChip?.kind === "not-running") {

--- a/src/components/board/terminal-session-chooser.test.tsx
+++ b/src/components/board/terminal-session-chooser.test.tsx
@@ -8,6 +8,8 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { TerminalSessionChooser } from "./terminal-session-chooser";
 import type { ChooserSections } from "@/lib/terminal/chooser-data";
+import { MINIMUM_RECOMMENDED_HELPER_VERSION } from "@/lib/terminal/helper-version";
+import type { HelperStatus } from "@/lib/terminal/helper-row";
 
 afterEach(cleanup);
 
@@ -294,5 +296,72 @@ describe("TerminalSessionChooser", () => {
     );
     expect(screen.getByRole("button", { name: /start new session/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Reconnect" })).toBeDisabled();
+  });
+
+  describe("helper-update nudge (card cbe60db5, rework 3)", () => {
+    // The dock owns the actual `/api/terminal/helper/status` fetch and hands
+    // the chooser its result as a prop (see terminal-dock.tsx) — this
+    // component only renders off that prop, so these tests supply it
+    // directly rather than mocking fetch.
+    function helperStatus(overrides: Partial<HelperStatus> = {}): HelperStatus {
+      return {
+        connected: true,
+        version: null,
+        machineLabel: null,
+        alwaysOn: false,
+        stoppedUnexpectedly: false,
+        lastEventAt: null,
+        ...overrides,
+      };
+    }
+
+    function renderChooser(status: HelperStatus | null) {
+      return render(
+        <TerminalSessionChooser
+          sections={EMPTY}
+          onReconnectHere={vi.fn()}
+          onOpenBoardAndReconnect={vi.fn()}
+          onResume={vi.fn()}
+          onStartNew={vi.fn()}
+          helperStatus={status}
+        />,
+      );
+    }
+
+    it("shows the nudge, above the sections, when the last-known helper is older than the minimum", () => {
+      renderChooser(helperStatus({ version: "0.3.0" }));
+      expect(screen.getByText(/A newer terminal helper is available/)).toBeInTheDocument();
+      const link = screen.getByRole("link", { name: "Download" });
+      expect(link).toHaveAttribute("href", "/download/terminal-helper");
+    });
+
+    it("hides the nudge when the last-known helper is already current", () => {
+      renderChooser(helperStatus({ version: MINIMUM_RECOMMENDED_HELPER_VERSION }));
+      expect(screen.queryByText(/A newer terminal helper is available/)).not.toBeInTheDocument();
+    });
+
+    it("hides the nudge when the last-known helper is newer than the minimum", () => {
+      renderChooser(helperStatus({ version: "9.9.9" }));
+      expect(screen.queryByText(/A newer terminal helper is available/)).not.toBeInTheDocument();
+    });
+
+    it("hides the nudge when no helper version has ever been recorded (fresh account)", () => {
+      renderChooser(helperStatus({ version: null }));
+      expect(screen.queryByText(/A newer terminal helper is available/)).not.toBeInTheDocument();
+    });
+
+    it("hides the nudge, silently, while the status is still loading or the fetch failed", () => {
+      renderChooser(null);
+      expect(screen.queryByText(/A newer terminal helper is available/)).not.toBeInTheDocument();
+      // The chooser itself never errors out — its own content still renders.
+      expect(screen.getByRole("button", { name: /start new session/i })).toBeInTheDocument();
+    });
+
+    it("dismissing the nudge (X) hides it", () => {
+      renderChooser(helperStatus({ version: "0.1.0" }));
+      expect(screen.getByText(/A newer terminal helper is available/)).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Dismiss helper update notice" }));
+      expect(screen.queryByText(/A newer terminal helper is available/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/board/terminal-session-chooser.tsx
+++ b/src/components/board/terminal-session-chooser.tsx
@@ -14,7 +14,7 @@
 // clicks to the callbacks the dock supplies.
 
 import { useEffect, useRef, useState } from "react";
-import { RefreshCw, Terminal as TerminalIcon } from "lucide-react";
+import { Info, RefreshCw, Terminal as TerminalIcon, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { formatSessionAge } from "@/lib/terminal/session-registry";
@@ -25,6 +25,9 @@ import {
   type ChooserLiveRow,
   type ChooserRecentRow,
 } from "@/lib/terminal/chooser-data";
+import { updateNudgeCopy, type HelperStatus } from "@/lib/terminal/helper-row";
+import { MINIMUM_RECOMMENDED_HELPER_VERSION, shouldShowChooserHelperNudge } from "@/lib/terminal/helper-version";
+import { TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
 
 // F3 (common foundations): the SAME generic warning, visible before every
 // single Reconnect click — never conditional, never sniffed.
@@ -46,6 +49,17 @@ export interface TerminalSessionChooserProps {
   /** "Start new session" — the only action that mints (capped, rate-limited, exactly today's mint path). */
   onStartNew: () => void;
   cap?: number;
+  /**
+   * The caller's own last-known helper status (card cbe60db5, rework 3 —
+   * Nick's field test: "I click Open and there's no indication I need to
+   * update the helper"). The dock owns the fetch — the SAME
+   * `/api/terminal/helper/status` response the My sessions panel polls
+   * on-open (see terminal-my-sessions-panel.tsx's `load()`) — and passes the
+   * result down, so this stays a pure render component like the rest of the
+   * chooser; `undefined`/`null` (still loading, or the fetch failed) simply
+   * renders no nudge, never an error state.
+   */
+  helperStatus?: HelperStatus | null;
 }
 
 export function TerminalSessionChooser({
@@ -57,9 +71,16 @@ export function TerminalSessionChooser({
   onResume,
   onStartNew,
   cap,
+  helperStatus = null,
 }: TerminalSessionChooserProps) {
   const [confirmingResumeSid, setConfirmingResumeSid] = useState<string | null>(null);
   const firstFocusRef = useRef<HTMLButtonElement | null>(null);
+
+  // Helper-update nudge (card cbe60db5, rework 3): dismissed for the rest of
+  // the browser session only — component-local state, not persisted, same
+  // mechanism as `dismissedHelperNudge` in terminal-session-view.tsx.
+  const [dismissedHelperNudge, setDismissedHelperNudge] = useState(false);
+  const showHelperNudge = !dismissedHelperNudge && shouldShowChooserHelperNudge(helperStatus?.version);
 
   // Focus the first row's primary action when the chooser opens (design:
   // "focus lands on the first live session's primary action when the choice
@@ -91,6 +112,26 @@ export function TerminalSessionChooser({
 
   return (
     <div className="max-h-[60vh] overflow-y-auto" data-testid="terminal-session-chooser">
+      {showHelperNudge && (
+        <div className="flex items-center gap-2 border-b border-sky-500/30 bg-sky-500/5 px-3.5 py-1.5 text-[11px] text-sky-300">
+          <Info className="h-3 w-3 shrink-0" />
+          <span className="flex-1">
+            {updateNudgeCopy(MINIMUM_RECOMMENDED_HELPER_VERSION)}{" "}
+            <a href={TERMINAL_HELPER_DOWNLOAD_URL} className="underline hover:text-sky-200">
+              Download
+            </a>
+          </span>
+          <button
+            type="button"
+            className="shrink-0 text-sky-400 hover:text-sky-200"
+            onClick={() => setDismissedHelperNudge(true)}
+            aria-label="Dismiss helper update notice"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      )}
+
       {taskMatch && (
         <div className="flex items-center gap-2.5 border-b border-sky-500/25 bg-sky-500/5 px-3.5 py-2.5">
           <div className="min-w-0 flex-1">

--- a/src/lib/terminal/helper-row.test.ts
+++ b/src/lib/terminal/helper-row.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   deriveHelperChip,
+  fetchHelperStatus,
   shouldShowStopButton,
   stopButtonLabel,
   stopConfirmBody,
@@ -90,6 +91,45 @@ describe("copy strings", () => {
 
   it("updateNudgeCopy interpolates the reported version", () => {
     expect(updateNudgeCopy("0.3.0")).toBe("A newer terminal helper is available (v0.3.0).");
+  });
+});
+
+describe("fetchHelperStatus", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves the parsed status on a 2xx response", async () => {
+    const body = status({ connected: true, version: "0.3.2" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => body }),
+    );
+    await expect(fetchHelperStatus()).resolves.toEqual(body);
+    expect(fetch).toHaveBeenCalledWith("/api/terminal/helper/status");
+  });
+
+  it("resolves null on a non-2xx response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    await expect(fetchHelperStatus()).resolves.toBeNull();
+  });
+
+  it("resolves null when the fetch itself throws (network error / relay unreachable)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    await expect(fetchHelperStatus()).resolves.toBeNull();
+  });
+
+  it("resolves null when the response body isn't valid JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw new SyntaxError("Unexpected token");
+        },
+      }),
+    );
+    await expect(fetchHelperStatus()).resolves.toBeNull();
   });
 });
 

--- a/src/lib/terminal/helper-row.ts
+++ b/src/lib/terminal/helper-row.ts
@@ -22,6 +22,25 @@ export interface HelperStatus {
   lastEventAt: number | null;
 }
 
+/**
+ * Shared fetch for the caller's own helper status (`GET
+ * /api/terminal/helper/status` — see that route's header comment). Both the
+ * My sessions panel and the session chooser (card cbe60db5, rework 3) need
+ * "the last-known helper version", so the fetch + failure handling lives
+ * here once instead of being duplicated. ANY failure — network error,
+ * non-2xx, unparseable body — resolves to `null`; every caller treats a
+ * failed check as best-effort/silent, never a confirmed "not running".
+ */
+export async function fetchHelperStatus(): Promise<HelperStatus | null> {
+  try {
+    const res = await fetch("/api/terminal/helper/status");
+    if (!res.ok) return null;
+    return (await res.json()) as HelperStatus;
+  } catch {
+    return null;
+  }
+}
+
 export type HelperChipKind = "running" | "winding-down" | "not-running" | "stopped-unexpectedly";
 
 export interface HelperChip {

--- a/src/lib/terminal/helper-version.test.ts
+++ b/src/lib/terminal/helper-version.test.ts
@@ -4,6 +4,7 @@ import {
   parseHelperVersion,
   compareHelperVersions,
   shouldShowHelperUpdateNudge,
+  shouldShowChooserHelperNudge,
 } from "./helper-version";
 
 describe("parseHelperVersion", () => {
@@ -86,5 +87,44 @@ describe("shouldShowHelperUpdateNudge", () => {
   it("fails open (never nudges) if the configured minimum is itself malformed", () => {
     expect(shouldShowHelperUpdateNudge("0.1.0", "not-a-version")).toBe(false);
     expect(shouldShowHelperUpdateNudge(null, "not-a-version")).toBe(false);
+  });
+});
+
+describe("shouldShowChooserHelperNudge", () => {
+  const min = "0.2.0";
+
+  it("nudges when the version is older than the minimum", () => {
+    expect(shouldShowChooserHelperNudge("0.1.0", min)).toBe(true);
+    expect(shouldShowChooserHelperNudge("0.1.99", min)).toBe(true);
+  });
+
+  it("does not nudge when the version equals the minimum", () => {
+    expect(shouldShowChooserHelperNudge("0.2.0", min)).toBe(false);
+  });
+
+  it("does not nudge when the version is newer than the minimum", () => {
+    expect(shouldShowChooserHelperNudge("0.2.1", min)).toBe(false);
+    expect(shouldShowChooserHelperNudge("1.0.0", min)).toBe(false);
+  });
+
+  it("does NOT nudge on a missing/unknown version — unlike shouldShowHelperUpdateNudge, a fresh account with no recorded helper is not provably stale", () => {
+    expect(shouldShowChooserHelperNudge(null, min)).toBe(false);
+    expect(shouldShowChooserHelperNudge(undefined, min)).toBe(false);
+    expect(shouldShowChooserHelperNudge("", min)).toBe(false);
+  });
+
+  it("does not nudge on a malformed version", () => {
+    expect(shouldShowChooserHelperNudge("not-a-version", min)).toBe(false);
+    expect(shouldShowChooserHelperNudge("0.2", min)).toBe(false);
+    expect(shouldShowChooserHelperNudge("v0.2.0", min)).toBe(false);
+  });
+
+  it("uses MINIMUM_RECOMMENDED_HELPER_VERSION as the default threshold", () => {
+    expect(shouldShowChooserHelperNudge(MINIMUM_RECOMMENDED_HELPER_VERSION)).toBe(false);
+    expect(shouldShowChooserHelperNudge(null)).toBe(false);
+  });
+
+  it("fails open (never nudges) if the configured minimum is itself malformed", () => {
+    expect(shouldShowChooserHelperNudge("0.1.0", "not-a-version")).toBe(false);
   });
 });

--- a/src/lib/terminal/helper-version.ts
+++ b/src/lib/terminal/helper-version.ts
@@ -70,3 +70,26 @@ export function shouldShowHelperUpdateNudge(
   if (!reported) return true;
   return compareHelperVersions(reported, min) < 0;
 }
+
+/**
+ * Chooser-specific variant (card cbe60db5, rework 3 — Nick's field test: "I
+ * click Open and there's no indication I need to update"). The chooser is now
+ * the front door for EVERY entry, including a fresh account that has never
+ * connected a helper at all — for that account "no version recorded" just
+ * means "no data yet", not "an old helper". That's the opposite assumption
+ * from `shouldShowHelperUpdateNudge` above, which is only ever evaluated once
+ * a session/helper connection already exists (where a missing version safely
+ * implies a pre-2a install and SHOULD nudge). This variant only nudges when a
+ * version WAS reported and is provably older than the minimum — missing or
+ * malformed data stays silent rather than assuming the worst.
+ */
+export function shouldShowChooserHelperNudge(
+  reportedVersion: string | null | undefined,
+  minVersion: string = MINIMUM_RECOMMENDED_HELPER_VERSION,
+): boolean {
+  const min = parseHelperVersion(minVersion);
+  if (!min) return false;
+  const reported = parseHelperVersion(reportedVersion);
+  if (!reported) return false;
+  return compareHelperVersions(reported, min) < 0;
+}


### PR DESCRIPTION
Nick's field-test change request: opening the terminal showed the new session picker with no indication a newer helper was available — the update nudge only existed inside a running session and in the My sessions panel.

The picker now shows the same dismissible "update your terminal helper" line (same copy, same download link, same styling) at the top whenever the last-known helper version is behind the recommended one. Fresh accounts that have never connected a helper see nothing — no data is not an old install. Fetch failures stay silent; the nudge never blocks the picker.

Web-only — no helper or relay change. The My sessions panel now shares the same status-fetch helper (a malformed response no longer errors the whole panel).

Tests: predicate boundaries (older/equal/newer/missing/malformed), fetch failure modes, and chooser component coverage (shown/hidden/dismiss/link). Full suite 2650/2650, tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)