### PR TITLE
feat(terminal): chooser nudge uses the shared Update now button (card cbe60db5)

### DIFF
--- a/src/components/board/terminal-helper-update-button.tsx
+++ b/src/components/board/terminal-helper-update-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+// In-app terminal — the shared "Update now" button for helper-update nudges
+// (card cbe60db5, rework 4). Extracted so every nudge that offers the same
+// action renders the exact same affordance — Nick's field test on the
+// chooser's nudge: "why didn't you just copy the button rather than add a
+// new type of ux?" The My sessions panel (terminal-my-sessions-panel.tsx)
+// and the session chooser (terminal-session-chooser.tsx) both render this,
+// so they can't drift apart again.
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface HelperUpdateButtonProps {
+  /** My sessions panel: starts the in-app confirm/quiesce/download flow. */
+  onClick?: () => void;
+  /** Chooser (and any caller without the panel's update-flow state): a
+   *  plain link straight to the download, rendered via the Button's
+   *  `asChild` so the markup stays an `<a>` under the hood. */
+  href?: string;
+  className?: string;
+}
+
+export function HelperUpdateButton({ onClick, href, className }: HelperUpdateButtonProps) {
+  const buttonClassName = cn("flex-none bg-sky-500 text-sky-950 hover:bg-sky-400", className);
+  if (href) {
+    return (
+      <Button asChild size="xs" className={buttonClassName}>
+        <a href={href}>Update now</a>
+      </Button>
+    );
+  }
+  return (
+    <Button size="xs" className={buttonClassName} onClick={onClick}>
+      Update now
+    </Button>
+  );
+}

--- a/src/components/board/terminal-my-sessions-panel.tsx
+++ b/src/components/board/terminal-my-sessions-panel.tsx
@@ -25,6 +25,7 @@ import { cn } from "@/lib/utils";
 import { slugifyIdeaTitle } from "@/lib/launch-claude-code";
 import { formatSessionAge, formatSessionIdentity } from "@/lib/terminal/session-registry";
 import { deriveTabLabel } from "./terminal-tabs";
+import { HelperUpdateButton } from "./terminal-helper-update-button";
 import {
   MINIMUM_RECOMMENDED_HELPER_VERSION,
   shouldShowHelperUpdateNudge,
@@ -577,9 +578,7 @@ export function TerminalMySessionsPanel({
         {showHelperNudge && (
           <div className="flex items-center gap-2 border-t border-sky-500/30 bg-sky-500/5 px-3.5 py-1.5 text-[11.5px] text-sky-300">
             <span className="flex-1">{updateNudgeCopy(MINIMUM_RECOMMENDED_HELPER_VERSION)}</span>
-            <Button size="xs" className="flex-none bg-sky-500 text-sky-950 hover:bg-sky-400" onClick={startHelperUpdate}>
-              Update now
-            </Button>
+            <HelperUpdateButton onClick={startHelperUpdate} />
             <button
               type="button"
               className="flex-none text-sky-400 hover:text-sky-200"

--- a/src/components/board/terminal-session-chooser.test.tsx
+++ b/src/components/board/terminal-session-chooser.test.tsx
@@ -331,7 +331,7 @@ describe("TerminalSessionChooser", () => {
     it("shows the nudge, above the sections, when the last-known helper is older than the minimum", () => {
       renderChooser(helperStatus({ version: "0.3.0" }));
       expect(screen.getByText(/A newer terminal helper is available/)).toBeInTheDocument();
-      const link = screen.getByRole("link", { name: "Download" });
+      const link = screen.getByRole("link", { name: "Update now" });
       expect(link).toHaveAttribute("href", "/download/terminal-helper");
     });
 

--- a/src/components/board/terminal-session-chooser.tsx
+++ b/src/components/board/terminal-session-chooser.tsx
@@ -28,6 +28,7 @@ import {
 import { updateNudgeCopy, type HelperStatus } from "@/lib/terminal/helper-row";
 import { MINIMUM_RECOMMENDED_HELPER_VERSION, shouldShowChooserHelperNudge } from "@/lib/terminal/helper-version";
 import { TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
+import { HelperUpdateButton } from "./terminal-helper-update-button";
 
 // F3 (common foundations): the SAME generic warning, visible before every
 // single Reconnect click — never conditional, never sniffed.
@@ -115,12 +116,8 @@ export function TerminalSessionChooser({
       {showHelperNudge && (
         <div className="flex items-center gap-2 border-b border-sky-500/30 bg-sky-500/5 px-3.5 py-1.5 text-[11px] text-sky-300">
           <Info className="h-3 w-3 shrink-0" />
-          <span className="flex-1">
-            {updateNudgeCopy(MINIMUM_RECOMMENDED_HELPER_VERSION)}{" "}
-            <a href={TERMINAL_HELPER_DOWNLOAD_URL} className="underline hover:text-sky-200">
-              Download
-            </a>
-          </span>
+          <span className="flex-1">{updateNudgeCopy(MINIMUM_RECOMMENDED_HELPER_VERSION)}</span>
+          <HelperUpdateButton href={TERMINAL_HELPER_DOWNLOAD_URL} />
           <button
             type="button"
             className="shrink-0 text-sky-400 hover:text-sky-200"


### PR DESCRIPTION
Nick's field-test feedback: the session picker's helper-update notice had a weak underlined "Download" text link while the My sessions panel had a prominent filled "Update now" button — two different affordances for the same action.

The picker now renders the exact same "Update now" button, extracted into a shared component (`HelperUpdateButton`) that both nudges import so they can't visually drift again. The My sessions panel's look and behaviour are unchanged.

Tests updated (link named "Update now" with the correct download href). Full suite 2650/2650, tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)