### PR TITLE
feat(terminal): exact-conversation Resume via minted session IDs + dock persistence (card cbe60db5)

### DIFF
--- a/src/app/api/terminal/session/[sid]/route.ts
+++ b/src/app/api/terminal/session/[sid]/route.ts
@@ -1,24 +1,30 @@
 // Terminal session PATCH — multi-session stage 3 (C4: the My-sessions identity
 // line — "machine · cwd · short sid"), extended by Nick's sign-off change 2
-// for the bridge-announced machine identity.
+// for the bridge-announced machine identity, and rework 5 (exact-conversation
+// Resume) for the bridge-announced claude conversation id.
 //
 // Best-effort, client-known identity fields ONLY: `cwd` (the dock already
 // resolves it client-side to build the launch prompt/deep link — see
-// use-terminal-session.ts → resolveLaunchPromptParts) and, now, `machineLabel`
-// (the bridge's own `os.hostname()`, forwarded via the relay's `bridge-version`
-// control frame — see that same file's bridge-version handling). Both are
-// called fire-and-forget; a failure here never surfaces to the user (the
-// registry row simply keeps whichever field was already there — an honest
-// omission, not a broken feature). `machineLabel` is re-sanitized here with
-// the SAME rules the relay applies before ever forwarding it — never trust the
-// client alone — and is ONLY EVER SET, never cleared: a request with no valid
-// field to write is a silent no-op, not an error.
+// use-terminal-session.ts → resolveLaunchPromptParts), `machineLabel` (the
+// bridge's own `os.hostname()`), and `claudeSessionId` (the id of the claude
+// conversation the bridge just spawned/resumed) — the latter two both
+// forwarded via the relay's `bridge-version` control frame (see that same
+// file's bridge-version handling). All three are called fire-and-forget; a
+// failure here never surfaces to the user (the registry row simply keeps
+// whichever field was already there — an honest omission, not a broken
+// feature). `machineLabel`/`claudeSessionId` are re-sanitized here with the
+// SAME rules the relay applies before ever forwarding them — never trust the
+// client alone — and are ONLY EVER SET, never cleared: a request with no
+// valid field to write is a silent no-op, not an error.
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
-import { sanitizeMachineLabel } from "../../../../../../terminal/shared/control-frames.mjs";
+import {
+  sanitizeMachineLabel,
+  sanitizeConversationId,
+} from "../../../../../../terminal/shared/control-frames.mjs";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -27,10 +33,12 @@ const BodySchema = z
   .object({
     cwd: z.string().trim().min(1).max(1024).optional(),
     machineLabel: z.string().trim().min(1).max(200).optional(),
+    claudeSessionId: z.string().trim().min(1).max(64).optional(),
   })
-  .refine((data) => data.cwd !== undefined || data.machineLabel !== undefined, {
-    message: "At least one of cwd or machineLabel is required",
-  });
+  .refine(
+    (data) => data.cwd !== undefined || data.machineLabel !== undefined || data.claudeSessionId !== undefined,
+    { message: "At least one of cwd, machineLabel or claudeSessionId is required" },
+  );
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ sid: string }> }) {
   try {
@@ -48,11 +56,15 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ sid: s
       return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
     }
 
-    const update: { cwd?: string; machine_label?: string } = {};
+    const update: { cwd?: string; machine_label?: string; claude_session_id?: string } = {};
     if (parsed.data.cwd) update.cwd = parsed.data.cwd;
     if (parsed.data.machineLabel) {
       const sanitized = sanitizeMachineLabel(parsed.data.machineLabel);
       if (sanitized) update.machine_label = sanitized;
+    }
+    if (parsed.data.claudeSessionId) {
+      const sanitized = sanitizeConversationId(parsed.data.claudeSessionId);
+      if (sanitized) update.claude_session_id = sanitized;
     }
     if (Object.keys(update).length === 0) {
       // Nothing valid survived sanitization (e.g. a machineLabel-only request

--- a/src/app/api/terminal/session/list/route.ts
+++ b/src/app/api/terminal/session/list/route.ts
@@ -10,7 +10,10 @@
 // across all ideas, newest-created first — the registry row plus the idea
 // title (a second query; small N per user, not worth a join). RLS scopes
 // this to the caller's own rows regardless; the explicit `.eq("user_id", ...)`
-// keeps the query itself honest.
+// keeps the query itself honest. `claudeSessionId` (rework 5, card cbe60db5)
+// is the exact-conversation Resume field — chooser-data.ts consumes it to
+// decide whether a Recent row can offer an exact `--resume <id>` or falls
+// back to the legacy `--continue`.
 
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
@@ -33,7 +36,7 @@ export async function GET() {
     const recentSince = new Date(Date.now() - RECENT_WINDOW_MS).toISOString();
     const { data: rows, error } = await supabase
       .from("terminal_sessions")
-      .select("sid, idea_id, task_id, task_title, machine_label, cwd, created_at, status, ended_at")
+      .select("sid, idea_id, task_id, task_title, machine_label, cwd, claude_session_id, created_at, status, ended_at")
       .eq("user_id", user.id)
       .or(`status.eq.active,ended_at.gte.${recentSince}`)
       .order("created_at", { ascending: false });
@@ -57,6 +60,7 @@ export async function GET() {
       taskTitle: row.task_title,
       machineLabel: row.machine_label,
       cwd: row.cwd,
+      claudeSessionId: row.claude_session_id,
       createdAt: row.created_at,
       status: row.status,
       endedAt: row.ended_at,

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -85,6 +85,7 @@ import {
 } from "@/lib/terminal/chooser-data";
 import { decideEntryBehaviour, type EntryDecision } from "@/lib/terminal/entry-decision";
 import { loadSessionSnapshot, readLastTabSid, toReconnectBuffer } from "@/lib/terminal/session-snapshot";
+import { readDockOpen, writeDockOpen } from "@/lib/terminal/dock-open-persistence";
 import { getMachineIdentity } from "@/lib/terminal/machine-identity";
 import { fetchHelperStatus, type HelperStatus } from "@/lib/terminal/helper-row";
 import {
@@ -157,6 +158,12 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // Defence-in-depth: also gated at the page mount. When off, render nothing —
   // no dock, no entry point, board unchanged (B9).
   const enabled = isTerminalEnabled();
+  // Dock-open persistence (rework 5, card cbe60db5 — Nick's field test: "fix
+  // the terminal panel staying open as well"). Initial paint stays collapsed
+  // (SSR-safe, matches every other install-first input use-terminal-session.ts
+  // corrects on mount) — the effect below flips it open right after mount if
+  // this tab last left it expanded, so the entry-decision (instant-continue
+  // or chooser) still runs exactly as if the reload never happened.
   const [expanded, setExpanded] = useState(false);
   // Session entry chooser (card cbe60db5, F1): the dock no longer seeds a
   // pristine tab unconditionally at page load — whether it does at all (and
@@ -237,6 +244,22 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     summariesRef.current = summaries;
     posthogRef.current = posthog;
   }, [sessions, summaries, posthog]);
+
+  // ── dock-open persistence (rework 5, card cbe60db5) ─────────────────────────
+  // Correct the collapsed initial paint on mount if this tab last left the
+  // dock expanded (mirrors the platform/paired install-first corrections in
+  // use-terminal-session.ts — SSR paints collapsed, a mount effect flips it
+  // open). Then persist every subsequent change, whatever caused it (a user
+  // click, or any of the programmatic setExpanded(true) calls throughout this
+  // file) — so the NEXT refresh keeps reflecting reality.
+  useEffect(() => {
+    if (readDockOpen()) setExpanded(true);
+    // Mount-only correction (empty deps, intentional) — re-running this on
+    // every render would fight the user's own collapse.
+  }, []);
+  useEffect(() => {
+    writeDockOpen(expanded);
+  }, [expanded]);
 
   // ── session entry chooser (card cbe60db5) — registry fetch + entry decision ──
   //
@@ -600,7 +623,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
           s.key === pristineKey
             ? {
                 ...s,
-                origin: payload?.resume ? "resume" : payload?.taskId ? "task" : "toolbar",
+                origin: payload?.resume || payload?.resumeId ? "resume" : payload?.taskId ? "task" : "toolbar",
                 taskId: payload?.taskId,
                 taskTitle: payload?.taskTitle,
                 launchSeq: s.launchSeq + 1,
@@ -615,7 +638,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
 
     const entry: SessionEntry = {
       key: freshSessionKey(),
-      origin: payload?.resume ? "resume" : payload?.taskId ? "task" : "toolbar",
+      origin: payload?.resume || payload?.resumeId ? "resume" : payload?.taskId ? "task" : "toolbar",
       taskId: payload?.taskId,
       taskTitle: payload?.taskTitle,
       createdAt: Date.now(),
@@ -786,11 +809,21 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   const handleChooserResume = useCallback(
     (row: ChooserRecentRow) => {
       setPendingLaunch(null);
-      // F4's Resume: the EXISTING (capped) launch flow, carrying `resume` +
-      // the ended row's own recorded folder instead of a bootstrap prompt —
-      // see BrowserLaunchPayload's doc and use-terminal-session.ts's
-      // fireLaunchDeepLink, which fires `claude --continue` there.
-      mintAndDeliver({ resume: true, cwd: row.cwd, taskId: row.taskId ?? undefined, taskTitle: row.taskTitle ?? undefined });
+      // F4's Resume: the EXISTING (capped) launch flow, carrying the ended
+      // row's own recorded folder instead of a bootstrap prompt — see
+      // BrowserLaunchPayload's doc and use-terminal-session.ts's
+      // fireLaunchDeepLink. A row with a tracked `claudeSessionId` (rework 5,
+      // exact-conversation Resume) fires `claude --resume <id>` — the exact
+      // conversation the row described, never whatever else has run in that
+      // folder since; a row without one falls back to the legacy
+      // `claude --continue`.
+      mintAndDeliver({
+        resume: row.claudeSessionId ? undefined : true,
+        resumeId: row.claudeSessionId ?? undefined,
+        cwd: row.cwd,
+        taskId: row.taskId ?? undefined,
+        taskTitle: row.taskTitle ?? undefined,
+      });
     },
     [mintAndDeliver],
   );

--- a/src/components/board/terminal-session-chooser.test.tsx
+++ b/src/components/board/terminal-session-chooser.test.tsx
@@ -167,6 +167,7 @@ describe("TerminalSessionChooser", () => {
       taskTitle: null,
       cwd: "~/projects/vibecodes",
       machineLabel: "Nick's MacBook",
+      claudeSessionId: null,
       endedAt: new Date().toISOString(),
     };
     render(
@@ -180,9 +181,38 @@ describe("TerminalSessionChooser", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Resume" }));
     expect(onResume).not.toHaveBeenCalled(); // confirm first, no launch yet
-    expect(screen.getByText(/Starts a new terminal that picks up your last conversation in/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Starts a new terminal that picks up the most recent conversation in/),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.queryByText(/Starts a new terminal/)).not.toBeInTheDocument();
+  });
+
+  it("Recent row with a tracked claudeSessionId: the confirm copy promises the EXACT conversation (rework 5)", () => {
+    const onResume = vi.fn();
+    const row = {
+      sid: "sid-recent-exact",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      cwd: "~/projects/vibecodes",
+      machineLabel: null,
+      claudeSessionId: "99999999-8888-7777-6666-555555555555",
+      endedAt: new Date().toISOString(),
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ recent: [row] })}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={onResume}
+        onStartNew={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    expect(screen.getByText(/Continues this exact conversation in/)).toBeInTheDocument();
+    expect(screen.queryByText(/most recent conversation/)).not.toBeInTheDocument();
   });
 
   it("Recent row: confirming Resume calls onResume with the row, and never shows the removed machine-warning line", () => {
@@ -195,6 +225,7 @@ describe("TerminalSessionChooser", () => {
       taskTitle: null,
       cwd: "~/projects/vibecodes",
       machineLabel: null,
+      claudeSessionId: null,
       endedAt: new Date().toISOString(),
     };
     render(
@@ -235,6 +266,7 @@ describe("TerminalSessionChooser", () => {
     taskTitle: null,
     cwd: "~/projects/vibecodes",
     machineLabel: null,
+    claudeSessionId: null,
     endedAt: new Date().toISOString(),
   };
 

--- a/src/components/board/terminal-session-chooser.tsx
+++ b/src/components/board/terminal-session-chooser.tsx
@@ -321,8 +321,17 @@ function RecentRow({
       {confirming && (
         <div className="mt-2 border-l-2 border-emerald-500 pl-2.5 text-[11.5px] text-zinc-400">
           <p>
-            Starts a new terminal that picks up your last conversation in{" "}
-            <span className="font-mono text-zinc-300">{row.cwd}</span>.
+            {row.claudeSessionId ? (
+              <>
+                Continues this exact conversation in{" "}
+                <span className="font-mono text-zinc-300">{row.cwd}</span>.
+              </>
+            ) : (
+              <>
+                Starts a new terminal that picks up the most recent conversation in{" "}
+                <span className="font-mono text-zinc-300">{row.cwd}</span>.
+              </>
+            )}
           </p>
           {limitLine && <p className="mt-1">{limitLine}</p>}
           <div className="mt-2 flex items-center justify-end gap-2">

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -275,6 +275,54 @@ describe("useTerminalSession", () => {
     expect(result.current.helperVersion).toBeNull();
   });
 
+  it("PATCHes the announced conv id onto the registry row, once per session (exact-conversation Resume, rework 5)", async () => {
+    const { result } = setup();
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+    act(() => latestSocket().simulateOpen());
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockClear();
+
+    const conv = "99999999-8888-7777-6666-555555555555";
+    act(() => {
+      latestSocket().onmessage?.({ data: JSON.stringify({ t: "bridge-version", conv }) });
+    });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/terminal/session/sid-abc123",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ claudeSessionId: conv }),
+        }),
+      );
+    });
+
+    // Re-announcing the SAME id on a later frame (e.g. a grace-window
+    // reconnect) must not re-fire the PATCH — once-per-session, mirroring
+    // the machine-identity guard.
+    fetchMock.mockClear();
+    act(() => {
+      latestSocket().onmessage?.({ data: JSON.stringify({ t: "bridge-version", conv }) });
+    });
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/terminal/session/sid-abc123", expect.anything());
+  });
+
+  it("does not PATCH a malformed conv id (non-UUID) — never forwarded to the registry", async () => {
+    const { result } = setup();
+    await act(async () => {
+      await result.current.actions.connect({ autoLaunch: false });
+    });
+    act(() => latestSocket().simulateOpen());
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockClear();
+
+    act(() => {
+      latestSocket().onmessage?.({ data: JSON.stringify({ t: "bridge-version", conv: "not-a-uuid" }) });
+    });
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/terminal/session/sid-abc123", expect.anything());
+  });
+
   it("read-only gates inputEnabled while connected, independent of status", async () => {
     const { result } = setup();
     await act(async () => {

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -70,6 +70,7 @@ import {
   mapCloseCode,
   parseBridgeVersionFrame,
   parseBridgeVersionHost,
+  parseBridgeVersionConv,
   relayBaseUrl,
   shouldDeclareLinkSilent,
   terminalReducer,
@@ -468,6 +469,12 @@ export function useTerminalSession(
   // reconnect, etc.) doesn't re-fire the identity PATCH each time — keyed by
   // sessionId so a genuinely NEW session (a fresh mint) always fires again.
   const machineIdentityAnnouncedSidRef = useRef<string | null>(null);
+  // Exact-conversation Resume (rework 5, card cbe60db5): the SAME once-per-
+  // session pattern for the claude conversation id the bridge announces
+  // (relay `bridge-version` frame's `conv` field) — keyed by sessionId so a
+  // fresh mint always re-fires, but a grace-window reconnect re-announcing
+  // the SAME id doesn't re-PATCH on every reattach.
+  const convIdAnnouncedSidRef = useRef<string | null>(null);
   // The compact bootstrap prompt ESSENTIALS (BUG5 follow-through, 4th rework
   // cycle) the LAST launch-bus event carried — i.e. what the launch button
   // resolved. Hook-initiated launches with no bus payload (paired auto-connect
@@ -791,17 +798,19 @@ export function useTerminalSession(
     (sessionId: string, bridgeToken: string, helperToken?: string) => {
       // Session entry chooser — Resume (card cbe60db5, design item 7/F4): a
       // resume launch carries no bootstrap prompt at all — a minimal link
-      // with `resume: true` + the ended session's recorded `cwd`, so the
-      // local bridge runs `claude --continue` there instead of building a
-      // prompt (see terminal/bridge/src/index.js). Checked FIRST so the
-      // normal essentials/budgeting path below never runs for a resume.
+      // with `resumeId` (exact-conversation, rework 5) or the legacy
+      // `resume: true` + the ended session's recorded `cwd`, so the local
+      // bridge runs `claude --resume <id>` or `claude --continue` there
+      // instead of building a prompt (see terminal/bridge/src/index.js).
+      // Checked FIRST so the normal essentials/budgeting path below never
+      // runs for a resume.
       const carriedForResume = promptPartsRef.current;
-      if (carriedForResume?.resume) {
+      if (carriedForResume?.resume || carriedForResume?.resumeId) {
         const cwd = carriedForResume.cwd;
         if (!cwd) {
           // Should never happen — the chooser only offers Resume for a row
           // with a recorded folder (F4) — but stay honest rather than fire a
-          // directory-less --continue.
+          // directory-less resume.
           logger.error("Terminal resume launch missing cwd — refusing to fire");
           toast.error("Couldn't resume — no folder was recorded for that session");
           setLaunchPhase("helper-timeout");
@@ -815,7 +824,8 @@ export function useTerminalSession(
             token: bridgeToken,
             helperToken,
             cwd,
-            resume: true,
+            resume: carriedForResume.resumeId ? undefined : true,
+            resumeId: carriedForResume.resumeId,
           });
         } catch (err) {
           logger.error("Terminal resume deep-link build failed", {
@@ -826,6 +836,7 @@ export function useTerminalSession(
         }
         logger.info("Terminal firing resume deep link", {
           sessionId,
+          exact: !!carriedForResume.resumeId,
           url: redactDeepLinkToken(link).replace(/([?&]cwd=)[^&]*/g, "$1***"),
           urlChars: link.length,
         });
@@ -1008,6 +1019,22 @@ export function useTerminalSession(
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ machineLabel: host }),
+              }).catch(() => {});
+            }
+            // Exact-conversation Resume (rework 5): the SAME frame optionally
+            // carries the id of the claude conversation this bridge just
+            // spawned/resumed. Best-effort PATCH onto the registry row (same
+            // once-per-session guard as machine identity above) so a FUTURE
+            // Resume of this row can pass `--resume <id>` instead of falling
+            // back to `--continue` — never awaited/blocking, and an old
+            // bridge that omits `conv` simply never triggers this.
+            const conv = parseBridgeVersionConv(ev.data);
+            if (conv && convIdAnnouncedSidRef.current !== sessionId) {
+              convIdAnnouncedSidRef.current = sessionId;
+              void fetch(`/api/terminal/session/${encodeURIComponent(sessionId)}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ claudeSessionId: conv }),
               }).catch(() => {});
             }
             return;

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -20,6 +20,7 @@ function row(overrides: Partial<ChooserRegistryRow> & { sid: string }): ChooserR
     taskTitle: null,
     machineLabel: null,
     cwd: null,
+    claudeSessionId: null,
     createdAt: new Date(NOW - 60_000).toISOString(),
     status: "active",
     endedAt: null,
@@ -99,6 +100,92 @@ describe("deriveChooserSections", () => {
     const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
     expect(recent).toHaveLength(1);
     expect(recent[0].sid).toBe("newer");
+  });
+
+  // Root-cause hardening (rework 5, card cbe60db5 — Nick's field test: a
+  // Recent row was labelled "ended 8h 54m ago" when a newer conversation for
+  // the same folder had ended minutes earlier). The dedupe above already
+  // sorts by `endedAt` DESC before keeping one row per folder — these two
+  // tests lock that in against regressions the task explicitly called out:
+  // wrong INPUT ORDERING, and reading the wrong timestamp field.
+  it("keeps the newest-ended row per folder regardless of the INPUT array's order (not first-seen)", () => {
+    // The newer row is listed FIRST here — a naive "keep first-seen" dedupe
+    // would already pass by accident. Flip the order so only a real
+    // endedAt-based sort (not input order) can produce the right answer.
+    const rows = [
+      row({
+        sid: "newer",
+        status: "ended",
+        cwd: "~/projects/dupe",
+        endedAt: new Date(NOW - 1 * 60 * 60 * 1000).toISOString(),
+      }),
+      row({
+        sid: "older",
+        status: "ended",
+        cwd: "~/projects/dupe",
+        endedAt: new Date(NOW - 3 * 60 * 60 * 1000).toISOString(),
+      }),
+    ];
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+    expect(recent).toHaveLength(1);
+    expect(recent[0].sid).toBe("newer");
+  });
+
+  it("orders Recent by endedAt across DIFFERENT folders too, not by createdAt or input order", () => {
+    // Each row's createdAt/input-position is the OPPOSITE of its endedAt
+    // recency, so only a correct endedAt-desc sort produces b, a, c.
+    const rows = [
+      row({
+        sid: "a",
+        status: "ended",
+        cwd: "~/projects/a",
+        createdAt: new Date(NOW - 10 * 60 * 60 * 1000).toISOString(),
+        endedAt: new Date(NOW - 5 * 60 * 1000).toISOString(), // 5m ago — 2nd newest
+      }),
+      row({
+        sid: "b",
+        status: "ended",
+        cwd: "~/projects/b",
+        createdAt: new Date(NOW - 1 * 60 * 60 * 1000).toISOString(),
+        endedAt: new Date(NOW - 1 * 60 * 1000).toISOString(), // 1m ago — newest
+      }),
+      row({
+        sid: "c",
+        status: "ended",
+        cwd: "~/projects/c",
+        createdAt: new Date(NOW - 20 * 60 * 60 * 1000).toISOString(),
+        endedAt: new Date(NOW - 30 * 60 * 1000).toISOString(), // 30m ago — oldest
+      }),
+    ];
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+    expect(recent.map((r) => r.sid)).toEqual(["b", "a", "c"]);
+  });
+
+  it("Recent rows carry endedAt from the `ended_at` field, never createdAt — a stale label never masks a truly-recent end", () => {
+    const staleCreatedAt = new Date(NOW - 30 * 60 * 60 * 1000).toISOString(); // 30h ago
+    const freshEndedAt = new Date(NOW - 5 * 60 * 1000).toISOString(); // 5m ago
+    const rows = [
+      row({ sid: "x", status: "ended", cwd: "~/projects/x", createdAt: staleCreatedAt, endedAt: freshEndedAt }),
+    ];
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+    expect(recent[0].endedAt).toBe(freshEndedAt);
+    expect(recent[0].endedAt).not.toBe(staleCreatedAt);
+  });
+
+  it("carries claudeSessionId through to the Recent row (exact-conversation Resume, rework 5)", () => {
+    const rows = [
+      row({
+        sid: "tracked",
+        status: "ended",
+        cwd: "~/projects/tracked",
+        endedAt: new Date(NOW - 60_000).toISOString(),
+        claudeSessionId: "99999999-8888-7777-6666-555555555555",
+      }),
+      row({ sid: "untracked", status: "ended", cwd: "~/projects/untracked", endedAt: new Date(NOW - 60_000).toISOString() }),
+    ];
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+    expect(recent.find((r) => r.sid === "tracked")?.claudeSessionId).toBe("99999999-8888-7777-6666-555555555555");
+    expect(recent.find((r) => r.sid === "untracked")?.claudeSessionId).toBeNull();
   });
 
   it("caps Recent at RECENT_MAX, newest first", () => {

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -38,6 +38,14 @@ export interface ChooserRegistryRow {
   taskTitle: string | null;
   machineLabel: string | null;
   cwd: string | null;
+  /**
+   * Exact-conversation Resume (rework 5, card cbe60db5): the id of the claude
+   * conversation this session's bridge spawned/resumed, once announced —
+   * null before the bridge attaches, or forever for a bridge too old to
+   * announce one. Only meaningful on an ENDED row (a live row is reconnected
+   * to, never "resumed" — see `findLiveSessionForTask`/the live sections).
+   */
+  claudeSessionId: string | null;
   createdAt: string;
   status: "active" | "ended";
   endedAt: string | null;
@@ -65,6 +73,8 @@ export interface ChooserRecentRow {
   /** Never null/empty — rows without a recorded folder never reach this list (F4). */
   cwd: string;
   machineLabel: string | null;
+  /** Exact-conversation Resume (rework 5) — see ChooserRegistryRow's doc. Null → the chooser falls back to the legacy `--continue` resume. */
+  claudeSessionId: string | null;
   endedAt: string;
 }
 
@@ -142,6 +152,7 @@ export function deriveChooserSections(
       taskTitle: r.taskTitle,
       cwd,
       machineLabel: r.machineLabel,
+      claudeSessionId: r.claudeSessionId,
       endedAt: r.endedAt,
     });
     if (recent.length >= RECENT_MAX) break;

--- a/src/lib/terminal/connection.test.ts
+++ b/src/lib/terminal/connection.test.ts
@@ -15,6 +15,7 @@ import {
   isBridgeVersionFrame,
   parseBridgeVersionFrame,
   parseBridgeVersionHost,
+  parseBridgeVersionConv,
   shouldDeclareLinkSilent,
   buildRelayUrl,
   encodeResizeMessage,
@@ -472,6 +473,47 @@ describe("silent-link watchdog (fix/terminal-dock-heartbeat)", () => {
     expect(isBridgeVersionFrame(frame)).toBe(true);
     expect(parseBridgeVersionFrame(frame)).toBeNull();
     expect(parseBridgeVersionHost(frame)).toBe("Nicks-MacBook-Pro");
+  });
+
+  // Exact-conversation resume (rework 5, card cbe60db5): the SAME frame gains
+  // an optional `conv` field — pin byte-for-byte against the real shared
+  // encoder, same as version/host above.
+  const CONV_ID = "99999999-8888-7777-6666-555555555555";
+
+  it("detects the shared bridge-version frame's conv field byte-for-byte", () => {
+    const frame = encodeSharedBridgeVersionFrame("0.3.3", "Nicks-MacBook-Pro", CONV_ID);
+    expect(isBridgeVersionFrame(frame)).toBe(true);
+    expect(parseBridgeVersionFrame(frame)).toBe("0.3.3");
+    expect(parseBridgeVersionHost(frame)).toBe("Nicks-MacBook-Pro");
+    expect(parseBridgeVersionConv(frame)).toBe(CONV_ID);
+  });
+
+  it("parseBridgeVersionConv returns null when `conv` is absent (old bridge — graceful degrade)", () => {
+    const frame = encodeSharedBridgeVersionFrame("0.3.3");
+    expect(parseBridgeVersionConv(frame)).toBeNull();
+    expect(parseBridgeVersionFrame(frame)).toBe("0.3.3"); // version still parses fine
+  });
+
+  it("parseBridgeVersionConv rejects a non-UUID/non-string `conv` or malformed JSON", () => {
+    expect(parseBridgeVersionConv(`{"t":"bridge-version","conv":"not-a-uuid"}`)).toBeNull();
+    expect(parseBridgeVersionConv('{"t":"bridge-version","conv":42}')).toBeNull();
+    expect(parseBridgeVersionConv('{"t":"bridge-version"}')).toBeNull();
+    expect(parseBridgeVersionConv('{"t":"bridge-version"' /* truncated */)).toBeNull();
+  });
+
+  it("a frame carrying only `conv` (no version/host) still parses the conv", () => {
+    const frame = encodeSharedBridgeVersionFrame(undefined, undefined, CONV_ID);
+    expect(isBridgeVersionFrame(frame)).toBe(true);
+    expect(parseBridgeVersionFrame(frame)).toBeNull();
+    expect(parseBridgeVersionHost(frame)).toBeNull();
+    expect(parseBridgeVersionConv(frame)).toBe(CONV_ID);
+  });
+
+  it("a frame carrying a full-length version + host + conv stays within the control-frame length bound", () => {
+    const frame = encodeSharedBridgeVersionFrame("999.999.999", "x".repeat(80), CONV_ID);
+    expect(isBridgeVersionFrame(frame)).toBe(true);
+    expect(parseBridgeVersionHost(frame)).toBe("x".repeat(80));
+    expect(parseBridgeVersionConv(frame)).toBe(CONV_ID);
   });
 
   it("shouldDeclareLinkSilent: exactly the threshold is NOT yet dead; strictly beyond is", () => {

--- a/src/lib/terminal/connection.ts
+++ b/src/lib/terminal/connection.ts
@@ -403,13 +403,15 @@ export function relayBaseUrl(): string {
 // drift is pinned by connection.test.ts, which imports the real encoders and checks
 // these detectors agree byte-for-byte.
 
-// 160 (not the original 64) is sized to fit the bridge-version frame's worst
-// case — `v` (semver) plus a full 80-char `host` (sanitizeMachineLabel's own
-// cap, terminal/shared/control-frames.mjs) plus JSON overhead — while staying
-// a trivially bounded size for every other (much shorter) control frame that
-// shares this same gate. Kept in lockstep with the .mjs's own isControlFrame.
+// 200 (not the original 64, bumped from 160 for the `conv` field) is sized to
+// fit the bridge-version frame's worst case — `v` (semver) plus a full
+// 80-char `host` (sanitizeMachineLabel's own cap) plus a 36-char `conv` UUID
+// (exact-conversation Resume, rework 5) plus JSON overhead (176 bytes
+// measured, terminal/shared/control-frames.mjs) — while staying a trivially
+// bounded size for every other (much shorter) control frame that shares this
+// same gate. Kept in lockstep with the .mjs's own isControlFrame.
 function isControlFrame(text: string, tag: string): boolean {
-  if (text.length === 0 || text.length > 160) return false;
+  if (text.length === 0 || text.length > 200) return false;
   try {
     const msg = JSON.parse(text) as unknown;
     return !!msg && typeof msg === "object" && (msg as { t?: unknown }).t === tag;
@@ -529,6 +531,37 @@ export function parseBridgeVersionHost(text: string): string | null {
   try {
     const msg = JSON.parse(text) as { host?: unknown };
     return typeof msg.host === "string" ? msg.host : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── exact-conversation resume (rework 5, card cbe60db5) ───────────────────────
+//
+// The SAME bridge-version frame gains an optional `conv` field carrying the id
+// of the claude conversation the bridge just spawned/resumed (terminal/shared/
+// control-frames.mjs's EXACT-CONVERSATION RESUME header comment has the full
+// picture). Extracted here rather than folded into parseBridgeVersionFrame for
+// the same reason parseBridgeVersionHost is separate: a frame carrying only
+// SOME of the three fields still yields a clean result for whichever ones are
+// present.
+
+/** Strict UUID shape — mirrors control-frames.mjs's `sanitizeConversationId`.
+ *  Duplicated (not imported) for the same reason RELAY_CLOSE/isControlFrame
+ *  are: that module is plain .mjs outside the app's TS build graph. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Extract + validate the claude conversation id from a bridge-version control
+ *  frame, or null for anything absent/malformed/hostile (a non-string/non-UUID
+ *  `conv`, bad JSON, wrong tag) — an OLD bridge never sends `conv` at all,
+ *  which parses identically to "unknown" here. */
+export function parseBridgeVersionConv(text: string): string | null {
+  if (!isControlFrame(text, "bridge-version")) return null;
+  try {
+    const msg = JSON.parse(text) as { conv?: unknown };
+    if (typeof msg.conv !== "string") return null;
+    const trimmed = msg.conv.trim();
+    return UUID_RE.test(trimmed) ? trimmed.toLowerCase() : null;
   } catch {
     return null;
   }

--- a/src/lib/terminal/deep-link.test.ts
+++ b/src/lib/terminal/deep-link.test.ts
@@ -102,6 +102,43 @@ describe("buildLaunchDeepLink with resume (card cbe60db5)", () => {
   });
 });
 
+describe("buildLaunchDeepLink with resumeId (rework 5, exact-conversation resume)", () => {
+  const RESUME_ID = "99999999-8888-7777-6666-555555555555";
+
+  it("includes resume_id, positioned before prompt, and round-trips", () => {
+    const withResumeId = { ...SAMPLE, resumeId: RESUME_ID };
+    const url = buildLaunchDeepLink(withResumeId);
+    expect(url).toContain(`resume_id=${RESUME_ID}`);
+    expect(parseLaunchDeepLink(url)).toEqual(withResumeId);
+  });
+
+  it("omits resume_id entirely when absent — no version-skew risk for an old bridge", () => {
+    const url = buildLaunchDeepLink(SAMPLE);
+    expect(url).not.toContain("resume_id=");
+  });
+
+  it("resume_id rides before prompt, mirroring resume's position", () => {
+    const url = buildLaunchDeepLink({ ...SAMPLE, resumeId: RESUME_ID, prompt: "ignored on a real resume link" });
+    expect(url.indexOf("resume_id=")).toBeLessThan(url.indexOf("prompt="));
+  });
+
+  it("wins over the legacy resume flag when both are somehow set — only resume_id is fired", () => {
+    const url = buildLaunchDeepLink({ ...SAMPLE, resume: true, resumeId: RESUME_ID });
+    expect(url).toContain(`resume_id=${RESUME_ID}`);
+    expect(url).not.toContain("resume=1");
+    const parsed = parseLaunchDeepLink(url);
+    expect(parsed?.resumeId).toBe(RESUME_ID);
+    expect(parsed).not.toHaveProperty("resume");
+  });
+
+  it("a malformed resume_id on the wire is rejected by the shared parser, never forwarded", () => {
+    const url = `${LAUNCH_SCHEME}://${LAUNCH_HOST}?relay=${encodeURIComponent(SAMPLE.relay)}&session=${SAMPLE.session}&token=${encodeURIComponent(SAMPLE.token)}&resume_id=not-a-uuid`;
+    const parsed = parseLaunchDeepLink(url);
+    expect(parsed).not.toBeNull();
+    expect(parsed).not.toHaveProperty("resumeId");
+  });
+});
+
 describe("redactDeepLinkToken", () => {
   it("replaces the token value with *** and never leaks the secret", () => {
     const url = buildLaunchDeepLink(SAMPLE);

--- a/src/lib/terminal/deep-link.ts
+++ b/src/lib/terminal/deep-link.ts
@@ -54,12 +54,25 @@ export interface LaunchDeepLinkParams {
    */
   prompt?: string;
   /**
-   * Session entry chooser — Resume (card cbe60db5, design item 7/F4): when
-   * true, the bridge spawns `claude --continue` in `cwd` instead of
-   * `claude "<prompt>"`. `prompt` is ignored (and normally absent) on a
-   * resume link.
+   * Session entry chooser — Resume (card cbe60db5, design item 7/F4), LEGACY
+   * path for a row with no tracked conversation id: when true, the bridge
+   * spawns `claude --continue` in `cwd` instead of `claude "<prompt>"` —
+   * continuing whatever's most recent ON DISK in that folder, not
+   * necessarily the row the user clicked. `prompt` is ignored (and normally
+   * absent) on a resume link. Superseded by `resumeId` when present — see
+   * that field's doc.
    */
   resume?: boolean;
+  /**
+   * EXACT-CONVERSATION Resume (rework 5, card cbe60db5 — the proper fix for
+   * Nick's field test: a `resume` link resumed the wrong conversation
+   * because `--continue` doesn't know which row was clicked). A validated
+   * UUID naming the SPECIFIC claude conversation to resume
+   * (`terminal_sessions.claude_session_id`) — the bridge runs
+   * `claude --resume <id>` instead of `--continue`. Wins over `resume` when
+   * both are somehow set (see buildLaunchDeepLink).
+   */
+  resumeId?: string;
 }
 
 /**
@@ -78,6 +91,7 @@ export function buildLaunchDeepLink({
   cwd,
   prompt,
   resume,
+  resumeId,
 }: LaunchDeepLinkParams): string {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
@@ -89,7 +103,13 @@ export function buildLaunchDeepLink({
   ];
   if (helperToken) parts.push(`helperToken=${encodeURIComponent(helperToken)}`);
   if (cwd) parts.push(`cwd=${encodeURIComponent(cwd)}`);
-  if (resume) parts.push(`resume=1`);
+  // resumeId (exact-conversation) wins over the legacy resume=1 flag — mirrors
+  // terminal/shared/deep-link.mjs's precedence exactly (drift-tested).
+  if (resumeId) {
+    parts.push(`resume_id=${encodeURIComponent(resumeId)}`);
+  } else if (resume) {
+    parts.push(`resume=1`);
+  }
   if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
 }

--- a/src/lib/terminal/dock-open-persistence.test.ts
+++ b/src/lib/terminal/dock-open-persistence.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { DOCK_OPEN_KEY, writeDockOpen, readDockOpen } from "./dock-open-persistence";
+
+/** A minimal in-memory `Storage` stub — no jsdom/browser required. Mirrors session-snapshot.test.ts's own fixture. */
+class FakeStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+/** Always throws — simulates quota exceeded / disabled storage / privacy mode. */
+class ThrowingStorage extends FakeStorage {
+  setItem(): never {
+    const err = new Error("QuotaExceededError");
+    err.name = "QuotaExceededError";
+    throw err;
+  }
+  getItem(): never {
+    throw new Error("SecurityError");
+  }
+  removeItem(): never {
+    throw new Error("QuotaExceededError");
+  }
+}
+
+describe("readDockOpen", () => {
+  it("defaults to false (collapsed) when nothing was ever written", () => {
+    expect(readDockOpen(new FakeStorage())).toBe(false);
+  });
+
+  it("returns true once writeDockOpen(true) has run", () => {
+    const storage = new FakeStorage();
+    writeDockOpen(true, storage);
+    expect(readDockOpen(storage)).toBe(true);
+  });
+
+  it("returns false when storage is null (SSR)", () => {
+    expect(readDockOpen(null)).toBe(false);
+  });
+
+  it("returns false, never throws, when storage.getItem throws", () => {
+    expect(readDockOpen(new ThrowingStorage())).toBe(false);
+  });
+
+  it("ignores a foreign/garbage value under the key — only the exact '1' marker counts", () => {
+    const storage = new FakeStorage();
+    storage.setItem(DOCK_OPEN_KEY, "true");
+    expect(readDockOpen(storage)).toBe(false);
+  });
+});
+
+describe("writeDockOpen", () => {
+  it("writes the exact '1' marker for expanded", () => {
+    const storage = new FakeStorage();
+    writeDockOpen(true, storage);
+    expect(storage.getItem(DOCK_OPEN_KEY)).toBe("1");
+  });
+
+  it("removes the key entirely for collapsed — not a '0' value", () => {
+    const storage = new FakeStorage();
+    writeDockOpen(true, storage);
+    writeDockOpen(false, storage);
+    expect(storage.getItem(DOCK_OPEN_KEY)).toBeNull();
+  });
+
+  it("collapsing a tab that never opened the dock is a harmless no-op", () => {
+    const storage = new FakeStorage();
+    writeDockOpen(false, storage);
+    expect(readDockOpen(storage)).toBe(false);
+  });
+
+  it("is a silent no-op when storage is null (SSR)", () => {
+    expect(() => writeDockOpen(true, null)).not.toThrow();
+  });
+
+  it("quota-safe: a throwing setItem never propagates", () => {
+    expect(() => writeDockOpen(true, new ThrowingStorage())).not.toThrow();
+  });
+
+  it("quota-safe: a throwing removeItem never propagates", () => {
+    expect(() => writeDockOpen(false, new ThrowingStorage())).not.toThrow();
+  });
+
+  it("round-trips true then false then true across independent calls", () => {
+    const storage = new FakeStorage();
+    writeDockOpen(true, storage);
+    expect(readDockOpen(storage)).toBe(true);
+    writeDockOpen(false, storage);
+    expect(readDockOpen(storage)).toBe(false);
+    writeDockOpen(true, storage);
+    expect(readDockOpen(storage)).toBe(true);
+  });
+});

--- a/src/lib/terminal/dock-open-persistence.ts
+++ b/src/lib/terminal/dock-open-persistence.ts
@@ -1,0 +1,59 @@
+// Terminal dock — expanded/collapsed persistence across a same-tab refresh
+// (rework 5, card cbe60db5 — Nick's field test: "fix the terminal panel
+// staying open as well"). A page reload used to always reset the dock's
+// chrome state to collapsed, regardless of whether the user had it open —
+// silently hiding the session entry chooser / instant-continue reattach
+// (entry-decision.ts) behind a closed bar until the user noticed and clicked
+// it back open.
+//
+// `sessionStorage` is per-tab and survives a reload but not a new tab/window
+// — exactly the "this tab, as I left it" signal wanted here, and the same
+// storage session-snapshot.ts's `vc:term:last-sid` uses. This module mirrors
+// that file's quota-safe, NEVER-THROW contract for a single boolean flag: a
+// failed write just means the next reload collapses (today's pre-this-card
+// behaviour), never a crash or a surfaced error.
+
+/** The `sessionStorage` key this module owns. */
+export const DOCK_OPEN_KEY = "vc:term:dock-open";
+
+/** `window.sessionStorage`, or `null` when unavailable (SSR, privacy mode, disabled storage) — never throws. */
+function defaultStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the dock's current expanded/collapsed state for this tab.
+ * Best-effort: a `sessionStorage` write can throw (quota, privacy mode,
+ * disabled storage) — caught and silently dropped, never surfaced to the
+ * user or the terminal itself. Collapsed is stored as an absent key (not
+ * `"0"`) so a tab that never opened the dock reads exactly like one that
+ * explicitly closed it — both are honestly "start collapsed".
+ */
+export function writeDockOpen(expanded: boolean, storage: Storage | null = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    if (expanded) storage.setItem(DOCK_OPEN_KEY, "1");
+    else storage.removeItem(DOCK_OPEN_KEY);
+  } catch {
+    /* best-effort only — a failed write just means the next reload collapses */
+  }
+}
+
+/**
+ * Was the dock expanded the last time this tab wrote its state? Defaults to
+ * `false` — SSR-safe (matches the collapsed initial paint every other
+ * install-first input in use-terminal-session.ts uses) and the honest answer
+ * when storage is unavailable or throws.
+ */
+export function readDockOpen(storage: Storage | null = defaultStorage()): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(DOCK_OPEN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/terminal/helper-version.ts
+++ b/src/lib/terminal/helper-version.ts
@@ -20,8 +20,10 @@
  *  checklist. 0.3.0 (card cc74a067) is the first release with the helper
  *  lifecycle rework — quit-when-idle, crash log-and-exit, and the "Keep
  *  helper ready" opt-in. 0.3.2 (card cbe60db5, sign-off change 2) adds the
- *  bridge's machine-identity (hostname) announcement. */
-export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.2";
+ *  bridge's machine-identity (hostname) announcement. 0.3.3 (rework 5,
+ *  exact-conversation Resume) adds the bridge's own conversation-id minting
+ *  (`--session-id`/`--resume`) and its announcement alongside version/host. */
+export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.3";
 
 export type HelperVersionParts = readonly [number, number, number];
 

--- a/src/lib/terminal/launch-mode.ts
+++ b/src/lib/terminal/launch-mode.ts
@@ -79,15 +79,27 @@ export interface BrowserLaunchPayload {
    */
   cwd?: string;
   /**
-   * Session entry chooser — Resume (card cbe60db5, design item 7, F4): this
-   * launch is a chooser "Resume" pick, not a fresh bootstrap. The dock skips
-   * building/sending a prompt entirely and fires the deep link with the
-   * `resume` flag instead, so the local bridge runs `claude --continue` in
-   * `cwd` (the ended session's recorded folder) rather than spawning a new
-   * bootstrap conversation. Always paired with `cwd`; `essentials` is not
-   * read for a resume payload.
+   * Session entry chooser — Resume (card cbe60db5, design item 7, F4), LEGACY
+   * path for a row with no tracked conversation id: this launch is a chooser
+   * "Resume" pick, not a fresh bootstrap. The dock skips building/sending a
+   * prompt entirely and fires the deep link with the `resume` flag instead,
+   * so the local bridge runs `claude --continue` in `cwd` (the ended
+   * session's recorded folder) rather than spawning a new bootstrap
+   * conversation. Always paired with `cwd`; `essentials` is not read for a
+   * resume payload. Superseded by `resumeId` when present.
    */
   resume?: boolean;
+  /**
+   * EXACT-CONVERSATION Resume (rework 5, card cbe60db5 — the proper fix): the
+   * SPECIFIC claude conversation id to resume
+   * (`terminal_sessions.claude_session_id`, tracked from the row the user
+   * clicked). When set, the dock fires the deep link with `resumeId` instead
+   * of `resume`, so the local bridge runs `claude --resume <id>` — the
+   * resumed content is always exactly the row the user clicked, never
+   * whatever else has run in that folder since. Always paired with `cwd`,
+   * same as `resume`.
+   */
+  resumeId?: string;
   /**
    * Multi-session stage 2 (B10 dedupe, B3 tab labels): the task this launch was
    * scoped to, when it came from a task card ("task-icon" / "task-menu-item"

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2777,6 +2777,7 @@ export type Database = {
         task_title: string | null;
         machine_label: string | null;
         cwd: string | null;
+        claude_session_id: string | null;
         status: "active" | "ended";
         created_at: string;
         ended_at: string | null;
@@ -2791,6 +2792,7 @@ export type Database = {
         task_title?: string | null;
         machine_label?: string | null;
         cwd?: string | null;
+        claude_session_id?: string | null;
         status?: "active" | "ended";
         created_at?: string;
         ended_at?: string | null;
@@ -2805,6 +2807,7 @@ export type Database = {
         task_title?: string | null;
         machine_label?: string | null;
         cwd?: string | null;
+        claude_session_id?: string | null;
         status?: "active" | "ended";
         created_at?: string;
         ended_at?: string | null;

--- a/supabase/migrations/00157_terminal_sessions_claude_session_id.sql
+++ b/supabase/migrations/00157_terminal_sessions_claude_session_id.sql
@@ -1,0 +1,25 @@
+-- Exact-conversation Resume (rework 5, card cbe60db5) — Nick's field test:
+-- a Resume click on a Recent row resumed a DIFFERENT conversation than the
+-- one the row described. Root cause: `claude --continue` resumes whatever's
+-- most recent ON DISK in a folder, decoupled from which registry row/session
+-- was actually clicked. The fix is to track the SPECIFIC claude conversation
+-- id per row (minted by the bridge itself at spawn time via
+-- `claude --session-id <uuid>`, or handed a tracked id to resume via
+-- `claude --resume <uuid>`) and resume by that id instead of by folder.
+--
+-- Nullable, best-effort — mirrors `machine_label`'s own column (added in the
+-- original 00141_terminal_sessions.sql CREATE TABLE, not a later ALTER): it
+-- is populated ONLY once the bridge announces the id it spawned/resumed with
+-- (relay `bridge-version` control frame's new `conv` field →
+-- PATCH /api/terminal/session/[sid]), so a row can legitimately have no
+-- value yet (before the bridge attaches) or forever (a bridge too old to
+-- announce one). Absence is an honest "unknown", exactly like machine_label,
+-- never treated as an error.
+--
+-- No RLS changes needed: terminal_sessions' existing owner-only policies
+-- (00141) already cover every column on the row, including this new one —
+-- there is nothing column-specific to grant/restrict here (unlike
+-- 00151/00152's users-table column-level lockdown, which existed because
+-- `authenticated` had broader-than-owner table-level access to that table).
+alter table public.terminal_sessions
+  add column claude_session_id uuid null;

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -35,12 +35,18 @@
 import os from "node:os";
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import WebSocket from "ws";
 import { parseControlMessage } from "./framing.js";
 import { createOutputBatcher } from "./output-batcher.js";
-import { sanitizeHelperVersion, sanitizeMachineLabel } from "../../shared/control-frames.mjs";
+import { resolveClaudeLaunch } from "./resume-cmd.js";
+import {
+  sanitizeHelperVersion,
+  sanitizeMachineLabel,
+  sanitizeConversationId,
+} from "../../shared/control-frames.mjs";
 import { parseLaunchDeepLink, redactDeepLinkToken } from "../../shared/deep-link.mjs";
 import { isRelayHostAllowed } from "../../shared/relay-allowlist.mjs";
 import {
@@ -128,13 +134,30 @@ if (!isRelayHostAllowed(RELAY, { allowLoopback: ALLOW_LOOPBACK_RELAY })) {
 }
 const SESSION = launched?.session || args.session || process.env.SESSION_ID || `dev-${Math.random().toString(36).slice(2, 10)}`;
 const TOKEN = launched?.token || args.token || process.env.BRIDGE_TOKEN || "";
-// Session entry chooser — Resume (card cbe60db5, design item 7/F4): a
-// `resume=1` launch runs `claude --continue` instead of the default `claude`,
-// continuing the most recent conversation in CWD rather than bootstrapping a
-// new one. An explicit `--cmd`/`BRIDGE_CMD` override still wins (dev/test
-// convenience), same precedence as every other launched field here.
+// Session entry chooser — Resume (card cbe60db5, design item 7/F4), LEGACY
+// path: a `resume=1` launch (no tracked conversation id) runs
+// `claude --continue`, continuing whatever's most recent ON DISK in CWD —
+// not necessarily the row the user clicked. See RESUME_ID below for the
+// EXACT-CONVERSATION path (rework 5) every row minted after this feature
+// carries instead.
 const RESUME = !!launched?.resume;
-const CMD = args.cmd || process.env.BRIDGE_CMD || (RESUME ? "claude --continue" : "claude");
+// Exact-conversation Resume (rework 5, card cbe60db5 — Nick's field test: a
+// Resume click landed on the wrong conversation because `--continue` doesn't
+// know which row was clicked). A validated UUID from a `resume_id=` deep
+// link (already UUID-checked by parseLaunchDeepLink; re-checked here as
+// defense in depth — same posture as HOST/sanitizeMachineLabel above) names
+// the SPECIFIC claude conversation to resume.
+const RESUME_ID = sanitizeConversationId(launched?.resumeId);
+// An explicit `--cmd`/`BRIDGE_CMD` override always wins (dev/test
+// convenience) — see resolveClaudeLaunch's doc for the full launch-shape
+// priority order and the empirical finding behind CONV.
+const explicitCmd = args.cmd || process.env.BRIDGE_CMD || null;
+const { cmd: CMD, conv: CONV } = resolveClaudeLaunch({
+  explicitCmd,
+  resumeId: RESUME_ID,
+  resume: RESUME,
+  mintId: () => crypto.randomUUID(),
+});
 const CWD = launched?.cwd || args.cwd || process.env.BRIDGE_CWD || process.cwd();
 // The URL-carried bootstrap prompt (deep-link launches only). INERT DATA with two
 // hard rules (see docs/terminal-bootstrap-prompt-ux.html + the shared deep-link
@@ -146,10 +169,11 @@ const CWD = launched?.cwd || args.cwd || process.env.BRIDGE_CWD || process.cwd()
 //      until the relay confirms the owner-bound token with the `attached`
 //      control frame (accept-then-close rejections make ws.onopen meaningless
 //      as an auth signal). No frame in time → exit WITHOUT spawning anything.
-// A resume launch never carries a prompt (nothing to bootstrap) — RESUME
-// forces it empty even if a caller somehow sent both, so `--continue` is
-// never followed by a stray argv element.
-const PROMPT = RESUME ? "" : launched?.prompt || "";
+// A resume launch (legacy `--continue` OR exact-conversation `--resume`)
+// never carries a prompt (nothing to bootstrap) — forced empty even if a
+// caller somehow sent both, so the resumed command is never followed by a
+// stray argv element.
+const PROMPT = RESUME || RESUME_ID ? "" : launched?.prompt || "";
 // ── helper-version announcement (release-gate rework 2a) ─────────────────────
 // Read the RUNNING helper's own version so the relay/dock can nudge stale
 // installs to update. Priority: BRIDGE_HELPER_VERSION (set by the packaged
@@ -523,7 +547,14 @@ async function main() {
     `${RELAY.replace(/\/$/, "")}/?session=${encodeURIComponent(SESSION)}` +
     `&role=bridge&token=${encodeURIComponent(TOKEN)}` +
     (HELPER_VERSION ? `&helperVersion=${encodeURIComponent(HELPER_VERSION)}` : "") +
-    (HOST ? `&host=${encodeURIComponent(HOST)}` : "");
+    (HOST ? `&host=${encodeURIComponent(HOST)}` : "") +
+    // Exact-conversation Resume (rework 5): announce the id of the claude
+    // conversation this launch just spawned/resumed, alongside
+    // helperVersion/host — same query-param path, same skew-safe shape (see
+    // terminal/shared/control-frames.mjs's EXACT-CONVERSATION RESUME header
+    // comment). Absent for an explicit --cmd override or a legacy --continue
+    // launch (CONV is null there — nothing honest to announce).
+    (CONV ? `&conv=${encodeURIComponent(CONV)}` : "");
   const redactedUrl = url.replace(/token=[^&]*/, "token=***");
 
   // The absolute max-duration cap is armed ONCE and spans reconnects (a link drop

--- a/terminal/bridge/src/resume-cmd.js
+++ b/terminal/bridge/src/resume-cmd.js
@@ -1,0 +1,51 @@
+// Exact-conversation Resume (rework 5, card cbe60db5) — the pure decision of
+// WHAT COMMAND to spawn and WHICH conversation id (if any) to announce
+// upstream. Extracted out of the top-level launch-argv wiring in index.js so
+// this branching is unit-testable without a real PTY/relay/claude binary.
+//
+// Nick's field test: a Resume click resumed a DIFFERENT, more-recent
+// conversation than the one the clicked row described — because `claude
+// --continue` only ever continues whatever's most recent ON DISK in a
+// folder, decoupled from which row/session the click meant. The fix is to
+// track the SPECIFIC claude conversation id per row and resume by id.
+//
+// EMPIRICAL FINDING (tested on this machine, see the implementation report):
+// `claude --resume <id>` keeps appending to the SAME `<id>.jsonl` transcript
+// file forever — it never forks to a new id. That means the id a session is
+// FIRST minted under (via `--session-id <id>`, brand-new sessions) is the
+// SAME id every future `--resume <id>` needs — no directory-watching, no
+// race with claude's own file creation, and no need to mint a NEW id on
+// every resume.
+//
+// Four launch shapes, in priority order:
+//   1. `explicitCmd` (an explicit --cmd/BRIDGE_CMD override — dev/test
+//      convenience) — never touched, no id minted or injected anywhere.
+//      `conv` is null: this bridge has no idea what the overriding command
+//      will actually run.
+//   2. `resumeId` (a validated UUID — the row carries a tracked
+//      `claude_session_id`) — `claude --resume <id>`, and `conv` is that
+//      SAME id (per the empirical finding above).
+//   3. `resume` (legacy — a row minted before this feature, no tracked id) —
+//      `claude --continue`, today's best-effort behaviour. `conv` is null:
+//      `--continue` doesn't accept (or report) a specific id, so there is
+//      nothing honest to announce.
+//   4. Neither — a brand-new session. `mintId()` mints the id (the bridge
+//      itself, not the app — no directory-watching/race) and it's passed via
+//      `--session-id`, so the very first mint is exact-resumable too.
+//
+// `resumeId` and `resume` are mutually exclusive on a real deep link (see
+// terminal/shared/deep-link.mjs's build/parse precedence) — if a caller
+// somehow sets both, `resumeId` wins here too, for the same reason: it is
+// the verified-safe, exact path.
+
+/**
+ * @param {{ explicitCmd?: string | null, resumeId?: string | null, resume?: boolean, mintId: () => string }} opts
+ * @returns {{ cmd: string, conv: string | null }}
+ */
+export function resolveClaudeLaunch({ explicitCmd, resumeId, resume, mintId }) {
+  if (explicitCmd) return { cmd: explicitCmd, conv: null };
+  if (resumeId) return { cmd: `claude --resume ${resumeId}`, conv: resumeId };
+  if (resume) return { cmd: "claude --continue", conv: null };
+  const conv = mintId();
+  return { cmd: `claude --session-id ${conv}`, conv };
+}

--- a/terminal/bridge/src/resume-cmd.test.js
+++ b/terminal/bridge/src/resume-cmd.test.js
@@ -1,0 +1,61 @@
+// Unit tests for the exact-conversation Resume launch decision (rework 5).
+// Run: cd terminal/bridge && node --test   (or: npm test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveClaudeLaunch } from "./resume-cmd.js";
+
+const MINTED = "11111111-2222-3333-4444-555555555555";
+const RESUME_ID = "99999999-8888-7777-6666-555555555555";
+
+test("an explicit --cmd/BRIDGE_CMD override is never touched — no id minted or injected", () => {
+  let minted = false;
+  const result = resolveClaudeLaunch({
+    explicitCmd: "bash",
+    resumeId: RESUME_ID, // even if somehow also present, explicitCmd wins
+    resume: true,
+    mintId: () => {
+      minted = true;
+      return MINTED;
+    },
+  });
+  assert.deepEqual(result, { cmd: "bash", conv: null });
+  assert.equal(minted, false, "mintId must never be called on the explicit-cmd path");
+});
+
+test("a resumeId spawns `claude --resume <id>` and announces that SAME id", () => {
+  const result = resolveClaudeLaunch({ resumeId: RESUME_ID, resume: false, mintId: () => MINTED });
+  assert.deepEqual(result, { cmd: `claude --resume ${RESUME_ID}`, conv: RESUME_ID });
+});
+
+test("resumeId wins over the legacy resume flag when both are somehow set", () => {
+  const result = resolveClaudeLaunch({ resumeId: RESUME_ID, resume: true, mintId: () => MINTED });
+  assert.equal(result.cmd, `claude --resume ${RESUME_ID}`);
+  assert.equal(result.conv, RESUME_ID);
+});
+
+test("the legacy resume flag (no tracked id) spawns `claude --continue` and announces nothing", () => {
+  let minted = false;
+  const result = resolveClaudeLaunch({
+    resume: true,
+    mintId: () => {
+      minted = true;
+      return MINTED;
+    },
+  });
+  assert.deepEqual(result, { cmd: "claude --continue", conv: null });
+  assert.equal(minted, false, "mintId must never be called on the legacy --continue path");
+});
+
+test("a brand-new session mints an id and spawns `claude --session-id <id>`", () => {
+  const result = resolveClaudeLaunch({ mintId: () => MINTED });
+  assert.deepEqual(result, { cmd: `claude --session-id ${MINTED}`, conv: MINTED });
+});
+
+test("falsy resumeId/resume (undefined, empty string, false) all fall through to the mint path", () => {
+  for (const resumeId of [undefined, null, ""]) {
+    for (const resume of [undefined, false]) {
+      const result = resolveClaudeLaunch({ resumeId, resume, mintId: () => MINTED });
+      assert.deepEqual(result, { cmd: `claude --session-id ${MINTED}`, conv: MINTED });
+    }
+  }
+});

--- a/terminal/helper/package-lock.json
+++ b/terminal/helper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibecodes-terminal-helper",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "devDependencies": {
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8"

--- a/terminal/helper/package.json
+++ b/terminal/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "description": "macOS helper app: registers the vibecodes:// URL scheme and runs the terminal bridge (node-pty PTY -> relay) on launch. A thin, installable, signable wrapper around terminal/bridge (no logic duplication).",
   "author": "VibeCodes",

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -54,6 +54,7 @@ import {
   encodeBridgeVersionFrame,
   sanitizeHelperVersion,
   sanitizeMachineLabel,
+  sanitizeConversationId,
   encodeHelperCommandFrame,
   isGoodbyeFrame,
   parseGoodbyeReason,
@@ -582,17 +583,19 @@ export class TerminalRelay {
       }
     }
 
-    // 5b) HELPER-VERSION + MACHINE-IDENTITY ANNOUNCEMENT (release-gate rework 2a,
-    //     extended by Nick's sign-off change 2 to also carry the bridge's
-    //     hostname). Ordering-independent both ways, and the two fields are
-    //     independent of each other (either alone is a valid update):
-    //       - bridge attaches with a (sanitized) `helperVersion` and/or `host`
+    // 5b) HELPER-VERSION + MACHINE-IDENTITY + CONVERSATION-ID ANNOUNCEMENT
+    //     (release-gate rework 2a, extended by Nick's sign-off change 2 for the
+    //     bridge's hostname, and rework 5's exact-conversation Resume for the
+    //     claude conversation id). Ordering-independent both ways, and all
+    //     three fields are independent of each other (any one alone is a
+    //     valid update):
+    //       - bridge attaches with a (sanitized) `helperVersion`/`host`/`conv`
     //         query param → store whichever is present durably (attach-ordering
     //         independent: outlives this one socket) and, if a browser leg is
-    //         ALREADY live, tell it the CURRENT combined state (freshest of both
-    //         fields, not just what arrived on this one attach — a bridge that
-    //         only re-sends `host` this time must not regress an already-known
-    //         version to "unknown", and vice versa).
+    //         ALREADY live, tell it the CURRENT combined state (freshest of all
+    //         three fields, not just what arrived on this one attach — a bridge
+    //         that only re-sends `host` this time must not regress an
+    //         already-known version/conv to "unknown", and vice versa).
     //       - browser attaches → if anything is already on file (the bridge
     //         attached first, or this is a reattach), tell THIS leg immediately.
     //     A missing/malformed param is a no-op either way (old bridge, or nothing
@@ -600,30 +603,39 @@ export class TerminalRelay {
     if (role === "bridge") {
       const helperVersion = sanitizeHelperVersion(url.searchParams.get("helperVersion"));
       const bridgeHost = sanitizeMachineLabel(url.searchParams.get("host"));
+      // Exact-conversation Resume (rework 5): the id of the claude
+      // conversation this bridge just spawned/resumed — same store-durably +
+      // forward-current-combined-state treatment as helperVersion/host (see
+      // this block's own header comment and control-frames.mjs's
+      // EXACT-CONVERSATION RESUME doc).
+      const bridgeConv = sanitizeConversationId(url.searchParams.get("conv"));
       if (helperVersion) await this.state.storage.put("bridgeHelperVersion", helperVersion);
       if (bridgeHost) await this.state.storage.put("bridgeHost", bridgeHost);
-      if (helperVersion || bridgeHost) {
+      if (bridgeConv) await this.state.storage.put("bridgeConv", bridgeConv);
+      if (helperVersion || bridgeHost || bridgeConv) {
         const browserPeer = this.findPeer("bridge");
         if (browserPeer) {
-          const [storedVersion, storedHost] = await Promise.all([
+          const [storedVersion, storedHost, storedConv] = await Promise.all([
             this.state.storage.get("bridgeHelperVersion"),
             this.state.storage.get("bridgeHost"),
+            this.state.storage.get("bridgeConv"),
           ]);
           try {
-            browserPeer.send(encodeBridgeVersionFrame(storedVersion, storedHost));
+            browserPeer.send(encodeBridgeVersionFrame(storedVersion, storedHost, storedConv));
           } catch (e) {
             this.log("bridge-version forward failed", { session, err: String(e) });
           }
         }
       }
     } else if (role === "browser") {
-      const [bridgeHelperVersion, bridgeHost] = await Promise.all([
+      const [bridgeHelperVersion, bridgeHost, bridgeConv] = await Promise.all([
         this.state.storage.get("bridgeHelperVersion"),
         this.state.storage.get("bridgeHost"),
+        this.state.storage.get("bridgeConv"),
       ]);
-      if (bridgeHelperVersion || bridgeHost) {
+      if (bridgeHelperVersion || bridgeHost || bridgeConv) {
         try {
-          server.send(encodeBridgeVersionFrame(bridgeHelperVersion, bridgeHost));
+          server.send(encodeBridgeVersionFrame(bridgeHelperVersion, bridgeHost, bridgeConv));
         } catch (e) {
           this.log("bridge-version send failed", { session, err: String(e) });
         }
@@ -933,6 +945,7 @@ export class TerminalRelay {
       "graceDeadline",
       "bridgeHelperVersion",
       "bridgeHost",
+      "bridgeConv",
     ]);
     await this.state.storage.deleteAlarm();
     // MITIGATION 1: invalidate the per-wake soft caches so a LATER attach to

--- a/terminal/shared/control-frames.mjs
+++ b/terminal/shared/control-frames.mjs
@@ -99,6 +99,21 @@
 //     has a current answer without waking the helper.
 // All three are skew-safe the same way as every frame above: an old relay/helper
 // that doesn't know a tag treats it as an unknown control frame and ignores it.
+//
+// EXACT-CONVERSATION RESUME (rework 5, card cbe60db5 — Nick's field test: a
+// Resume click resumed the wrong conversation because `claude --continue`
+// only ever continues whatever's most recent ON DISK in a folder, not the
+// specific chooser row clicked) extends the SAME bridge-version frame with a
+// third optional field: `{"t":"bridge-version","v":"x.y.z","host":"…","conv":
+// "<uuid>"}`. `conv` is the id of the CLAUDE CONVERSATION the bridge just
+// spawned or resumed — minted by the bridge itself via `--session-id <uuid>`
+// for a brand-new session, or the `--resume <uuid>` id it was handed for a
+// tracked one (terminal/bridge/src/index.js's resolveClaudeLaunch). Verified
+// empirically: `claude --resume <id>` keeps appending to the SAME <id>.jsonl
+// transcript forever (never forks to a new id), so the id announced here is
+// exactly the id every future Resume of this row needs to reach the same
+// conversation. Same skew-safe shape as `v`/`host`: optional, independently
+// present, ignored by anything that predates it.
 
 /** The closed set of reasons a helper's goodbye frame may carry (design §2 table). */
 export const HELPER_GOODBYE_REASONS = Object.freeze([
@@ -113,12 +128,14 @@ export const HELPER_GOODBYE_REASONS = Object.freeze([
 export const HELPER_COMMANDS = Object.freeze(["stop", "quiesce", "set-always-on"]);
 
 /** Detect any control TEXT frame with a given `t` tag. Cheap + strict + bounded.
- *  160 (not the original 64) is sized to fit the bridge-version frame's worst
- *  case — `v` (semver) plus a full 80-char `host` (sanitizeMachineLabel's own
- *  cap) plus JSON overhead — while staying a trivially bounded, DoS-safe size
- *  for every other (much shorter) control frame that shares this same gate. */
+ *  200 (not the original 64, bumped from 160 for the `conv` field) is sized to
+ *  fit the bridge-version frame's worst case — `v` (semver) plus a full
+ *  80-char `host` (sanitizeMachineLabel's own cap) plus a 36-char `conv` UUID
+ *  plus JSON overhead (176 bytes measured) — while staying a trivially
+ *  bounded, DoS-safe size for every other (much shorter) control frame that
+ *  shares this same gate. */
 function isControlFrame(text, tag) {
-  if (typeof text !== "string" || text.length === 0 || text.length > 160) return false;
+  if (typeof text !== "string" || text.length === 0 || text.length > 200) return false;
   try {
     const msg = JSON.parse(text);
     return !!msg && typeof msg === "object" && msg.t === tag;
@@ -190,17 +207,21 @@ const SEMVER_RE = /^\d+\.\d+\.\d+$/;
 
 /**
  * TEXT frame the relay sends the BROWSER leg announcing the bridge's helper
- * version and/or machine identity. `host` is optional (omitted whenever falsy)
- * so a call site that only knows one of the two fields still emits a valid,
- * minimal frame — see this module's MACHINE IDENTITY header comment.
+ * version, machine identity, and/or the id of the claude conversation it just
+ * spawned/resumed (exact-conversation Resume, rework 5). Every field is
+ * optional (omitted whenever falsy) so a call site that only knows a subset
+ * still emits a valid, minimal frame — see this module's MACHINE IDENTITY and
+ * EXACT-CONVERSATION RESUME header comments.
  * @param {string | null | undefined} version
  * @param {string | null | undefined} [host]
+ * @param {string | null | undefined} [conv]
  * @returns {string}
  */
-export function encodeBridgeVersionFrame(version, host) {
+export function encodeBridgeVersionFrame(version, host, conv) {
   const msg = { t: "bridge-version" };
   if (version) msg.v = version;
   if (host) msg.host = host;
+  if (conv) msg.conv = conv;
   return JSON.stringify(msg);
 }
 
@@ -248,6 +269,27 @@ export function parseBridgeVersionHost(text) {
 }
 
 /**
+ * Extract + validate the claude conversation id carried by a bridge-version
+ * frame (exact-conversation Resume, rework 5). Returns null for anything
+ * absent/malformed — an OLD bridge never sends `conv` at all, which parses
+ * identically to "unknown" here (the same graceful-degrade shape as a missing
+ * `v`/`host`). Re-validated with `sanitizeConversationId` even though the
+ * relay already sanitized it before forwarding — defense in depth, never
+ * trust the wire twice-removed from the source.
+ * @param {unknown} text
+ * @returns {string | null}
+ */
+export function parseBridgeVersionConv(text) {
+  if (!isBridgeVersionFrame(text)) return null;
+  try {
+    const msg = JSON.parse(text);
+    return typeof msg.conv === "string" ? sanitizeConversationId(msg.conv) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Validate a raw `helperVersion` value (e.g. straight off a URL query param)
  * before it's ever stored/forwarded — the ONE gate the relay applies so a
  * hostile/malformed bridge can't smuggle arbitrary text into a control frame
@@ -275,6 +317,29 @@ export function sanitizeMachineLabel(raw) {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return null;
   return trimmed.slice(0, 80);
+}
+
+/** Strict UUID shape (any version/variant — `crypto.randomUUID()`'s own shape,
+ *  and whatever `claude --session-id`/`--resume` accept). Mirrors the format
+ *  the `claude` CLI itself requires ("must be a valid UUID"). */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Validate a raw claude-conversation-id value (exact-conversation Resume,
+ * rework 5 — e.g. a `conv`/`resume_id` query param, or a `claude_session_id`
+ * DB column value) before it's stored/forwarded/spawned-with. A strict UUID
+ * gate: this value is later interpolated into a shell-split bridge CMD
+ * string (`claude --resume <id>`/`claude --session-id <id>`), so anything
+ * that isn't exactly a UUID is rejected outright rather than sanitized —
+ * there is no safe partial value here, unlike the free-form machine label.
+ * Lower-cased so a case-varying but otherwise valid id always compares equal.
+ * @param {unknown} raw
+ * @returns {string | null}
+ */
+export function sanitizeConversationId(raw) {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return UUID_RE.test(trimmed) ? trimmed.toLowerCase() : null;
 }
 
 // ── helper-command frame (web -> relay -> helper leg) ─────────────────────────

--- a/terminal/shared/deep-link.mjs
+++ b/terminal/shared/deep-link.mjs
@@ -26,14 +26,30 @@
 //             DATA: the bridge passes it as ONE argv element (never through
 //             shellSplit / a shell) and only spawns AFTER the relay has accepted
 //             the owner-bound token (R1 — see bridge/src/index.js).
-//   resume  — session entry chooser (card cbe60db5, design item 7/F4): when
+//   resume  — session entry chooser (card cbe60db5, design item 7/F4), LEGACY
+//             path for a Recent row with no tracked conversation id: when
 //             `"1"`, the bridge spawns `claude --continue` in `cwd` instead of
-//             `claude "<prompt>"` — the chooser's Resume action, continuing the
-//             most recent conversation in that folder rather than bootstrapping
-//             a new one. `prompt` is ignored (and normally absent) on a resume
-//             link. An old bridge that doesn't recognise `resume` simply never
-//             sees the param (it's omitted unless truthy) — no version-skew
-//             risk in either direction.
+//             `claude "<prompt>"`. `--continue` resumes whatever's most
+//             recent ON DISK in that folder — NOT necessarily the row the
+//             user clicked (Nick's field test: this is exactly how a Resume
+//             click landed on the wrong conversation). `prompt` is ignored
+//             (and normally absent) on a resume link. An old bridge that
+//             doesn't recognise `resume` simply never sees the param (it's
+//             omitted unless truthy) — no version-skew risk in either
+//             direction.
+//   resume_id — EXACT-CONVERSATION Resume (rework 5, the proper fix): a
+//             validated UUID naming the SPECIFIC claude conversation to
+//             resume (`terminal_sessions.claude_session_id`, tracked from the
+//             moment a session was minted — see terminal/bridge/src/index.js's
+//             resolveClaudeLaunch). The bridge runs `claude --resume <id>`
+//             instead of `--continue`, so the resumed content is always
+//             exactly the row the user clicked, never whatever else has run
+//             in that folder since. Mutually exclusive with `resume` on a
+//             real link (a row either has a tracked id or it doesn't); when
+//             both are somehow present, `resume_id` wins (see parse below) —
+//             it is the verified-safe, exact path. Malformed/non-UUID values
+//             are rejected at parse time (never forwarded to a shell-split
+//             CMD string).
 //
 // `token` and `helperToken` are secrets and `prompt` is user content. NEVER log
 // a raw link — use redactDeepLinkToken first (it elides all three). `prompt` is
@@ -49,6 +65,11 @@ export const LAUNCH_SCHEME = "vibecodes";
 /** The single action this scheme exposes today: `vibecodes://launch?…`. */
 export const LAUNCH_HOST = "launch";
 
+/** Strict UUID shape — mirrors control-frames.mjs's `sanitizeConversationId`.
+ *  Duplicated (not imported) to keep this module dependency-free (see the
+ *  file header) — `resume_id` is validated at the same strictness either way. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…][&prompt=…]`
  * deep link.
@@ -59,10 +80,10 @@ export const LAUNCH_HOST = "launch";
  * (and therefore the app-side prompt budget) is stable. Throws when a required
  * field is missing so a malformed link is never fired.
  *
- * @param {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean }} params
+ * @param {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean, resumeId?: string }} params
  * @returns {string}
  */
-export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt, resume } = {}) {
+export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt, resume, resumeId } = {}) {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
   }
@@ -73,7 +94,14 @@ export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, p
   ];
   if (helperToken) parts.push(`helperToken=${encodeURIComponent(helperToken)}`);
   if (cwd) parts.push(`cwd=${encodeURIComponent(cwd)}`);
-  if (resume) parts.push(`resume=1`);
+  // resumeId (exact-conversation) wins over the legacy resume=1 flag — see the
+  // header comment. A caller should only ever set one, but this keeps a
+  // malformed double-set from firing a link with BOTH params.
+  if (resumeId) {
+    parts.push(`resume_id=${encodeURIComponent(resumeId)}`);
+  } else if (resume) {
+    parts.push(`resume=1`);
+  }
   if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
 }
@@ -88,7 +116,7 @@ export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, p
  * param existed (version-skew safe both ways).
  *
  * @param {unknown} url
- * @returns {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean } | null}
+ * @returns {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean, resumeId?: string } | null}
  */
 export function parseLaunchDeepLink(url) {
   if (typeof url !== "string" || url.length === 0) return null;
@@ -110,13 +138,20 @@ export function parseLaunchDeepLink(url) {
   const helperToken = parsed.searchParams.get("helperToken") || undefined;
   const cwd = parsed.searchParams.get("cwd") || undefined;
   const prompt = parsed.searchParams.get("prompt") || undefined;
-  const resume = parsed.searchParams.get("resume") === "1" || undefined;
+  // resume_id (exact-conversation) wins over the legacy resume=1 flag — same
+  // precedence as the builder. A malformed (non-UUID) resume_id is rejected
+  // outright rather than forwarded — it's about to be interpolated into a
+  // shell-split bridge CMD string, so there is no safe partial value here.
+  const rawResumeId = parsed.searchParams.get("resume_id");
+  const resumeId = rawResumeId && UUID_RE.test(rawResumeId) ? rawResumeId.toLowerCase() : undefined;
+  const resume = !resumeId && parsed.searchParams.get("resume") === "1" ? true : undefined;
   if (!relay || !session || !token) return null;
 
   const out = { relay, session, token };
   if (helperToken) out.helperToken = helperToken;
   if (cwd) out.cwd = cwd;
-  if (resume) out.resume = true;
+  if (resumeId) out.resumeId = resumeId;
+  else if (resume) out.resume = true;
   if (prompt) out.prompt = prompt;
   return out;
 }

--- a/terminal/test/control-frames.test.mjs
+++ b/terminal/test/control-frames.test.mjs
@@ -23,8 +23,10 @@ import {
   isBridgeVersionFrame,
   parseBridgeVersionFrame,
   parseBridgeVersionHost,
+  parseBridgeVersionConv,
   sanitizeHelperVersion,
   sanitizeMachineLabel,
+  sanitizeConversationId,
   encodeHelperCommandFrame,
   isHelperCommandFrame,
   parseHelperCommandFrame,
@@ -153,6 +155,60 @@ test("a bridge-version frame carrying a full-length host stays within the contro
   const frame = encodeBridgeVersionFrame("999.999.999", "x".repeat(80));
   assert.equal(isBridgeVersionFrame(frame), true);
   assert.equal(parseBridgeVersionHost(frame), "x".repeat(80));
+});
+
+// ── exact-conversation resume (rework 5, card cbe60db5) ────────────────────
+
+const CONV_ID = "99999999-8888-7777-6666-555555555555";
+
+test("bridge-version frame's `conv` field encode ⇄ detect ⇄ parse round-trips alongside v/host", () => {
+  const frame = encodeBridgeVersionFrame("0.3.3", "Nicks-MacBook-Pro", CONV_ID);
+  assert.equal(isBridgeVersionFrame(frame), true);
+  assert.equal(parseBridgeVersionFrame(frame), "0.3.3");
+  assert.equal(parseBridgeVersionHost(frame), "Nicks-MacBook-Pro");
+  assert.equal(parseBridgeVersionConv(frame), CONV_ID);
+});
+
+test("a frame with no `conv` (old bridge) parses conv as null — v/host still parse fine", () => {
+  const frame = encodeBridgeVersionFrame("0.3.3", "Nicks-MacBook-Pro");
+  assert.equal(parseBridgeVersionConv(frame), null);
+  assert.equal(parseBridgeVersionFrame(frame), "0.3.3");
+  assert.equal(parseBridgeVersionHost(frame), "Nicks-MacBook-Pro");
+});
+
+test("a frame carrying only `conv` (no version/host) is still a valid, parseable frame", () => {
+  const frame = encodeBridgeVersionFrame(undefined, undefined, CONV_ID);
+  assert.equal(isBridgeVersionFrame(frame), true);
+  assert.equal(parseBridgeVersionFrame(frame), null);
+  assert.equal(parseBridgeVersionHost(frame), null);
+  assert.equal(parseBridgeVersionConv(frame), CONV_ID);
+});
+
+test("parseBridgeVersionConv rejects a non-UUID, non-string, or malformed `conv`", () => {
+  assert.equal(parseBridgeVersionConv(JSON.stringify({ t: "bridge-version", conv: "not-a-uuid" })), null);
+  assert.equal(parseBridgeVersionConv(JSON.stringify({ t: "bridge-version", conv: 42 })), null);
+  assert.equal(parseBridgeVersionConv(JSON.stringify({ t: "bridge-version" })), null);
+  assert.equal(parseBridgeVersionConv("not json"), null);
+  assert.equal(parseBridgeVersionConv(null), null);
+});
+
+test("a bridge-version frame carrying full-length v + host + conv stays within the control-frame length bound", () => {
+  const frame = encodeBridgeVersionFrame("999.999.999", "x".repeat(80), CONV_ID);
+  assert.equal(isBridgeVersionFrame(frame), true);
+  assert.equal(parseBridgeVersionHost(frame), "x".repeat(80));
+  assert.equal(parseBridgeVersionConv(frame), CONV_ID);
+});
+
+test("sanitizeConversationId accepts only a strict UUID shape, case-insensitive, lower-cased", () => {
+  assert.equal(sanitizeConversationId(CONV_ID), CONV_ID);
+  assert.equal(sanitizeConversationId(CONV_ID.toUpperCase()), CONV_ID);
+  assert.equal(sanitizeConversationId(` ${CONV_ID} `), CONV_ID);
+  assert.equal(sanitizeConversationId(""), null);
+  assert.equal(sanitizeConversationId(null), null);
+  assert.equal(sanitizeConversationId(undefined), null);
+  assert.equal(sanitizeConversationId("not-a-uuid"), null);
+  assert.equal(sanitizeConversationId(CONV_ID + "; DROP TABLE users;"), null);
+  assert.equal(sanitizeConversationId(CONV_ID.slice(0, -1)), null); // one char short
 });
 
 test("sanitizeHelperVersion accepts only strict x.y.z", () => {

--- a/terminal/test/deep-link.test.mjs
+++ b/terminal/test/deep-link.test.mjs
@@ -106,6 +106,40 @@ test("redactDeepLinkToken hides helperToken as well as token", () => {
   assert.ok(redacted.includes(`session=${SAMPLE.session}`));
 });
 
+// ── exact-conversation resume (rework 5, card cbe60db5) ────────────────────────
+
+const RESUME_ID = "99999999-8888-7777-6666-555555555555";
+
+test("build ⇄ parse round-trips resume_id, positioned before prompt", () => {
+  const withResumeId = { ...SAMPLE, resumeId: RESUME_ID, prompt: "ignored on a real resume link" };
+  const url = buildLaunchDeepLink(withResumeId);
+  assert.ok(url.includes(`resume_id=${RESUME_ID}`));
+  assert.ok(url.indexOf("resume_id=") < url.indexOf("prompt="), "resume_id precedes the LAST param, prompt");
+  assert.deepEqual(parseLaunchDeepLink(url), withResumeId);
+});
+
+test("omits resume_id entirely when absent", () => {
+  const url = buildLaunchDeepLink(SAMPLE);
+  assert.ok(!url.includes("resume_id="));
+  assert.ok(!("resumeId" in parseLaunchDeepLink(url)));
+});
+
+test("resumeId wins over the legacy resume flag when both are somehow set", () => {
+  const url = buildLaunchDeepLink({ ...SAMPLE, resume: true, resumeId: RESUME_ID });
+  assert.ok(url.includes(`resume_id=${RESUME_ID}`));
+  assert.ok(!url.includes("resume=1"));
+  const parsed = parseLaunchDeepLink(url);
+  assert.equal(parsed.resumeId, RESUME_ID);
+  assert.ok(!("resume" in parsed));
+});
+
+test("a malformed resume_id is rejected outright — never forwarded to the caller", () => {
+  const url = `${LAUNCH_SCHEME}://${LAUNCH_HOST}?relay=r&session=s&token=t&resume_id=not-a-uuid`;
+  const parsed = parseLaunchDeepLink(url);
+  assert.ok(parsed !== null);
+  assert.ok(!("resumeId" in parsed));
+});
+
 test("redactDeepLinkToken elides the prompt (user content) as well as the token", () => {
   const url = buildLaunchDeepLink({ ...SAMPLE, prompt: HOSTILE_PROMPT });
   const redacted = redactDeepLinkToken(url);

--- a/terminal/test/standin-relay.mjs
+++ b/terminal/test/standin-relay.mjs
@@ -42,6 +42,7 @@ import {
   encodeBridgeVersionFrame,
   sanitizeHelperVersion,
   sanitizeMachineLabel,
+  sanitizeConversationId,
   encodeHelperCommandFrame,
   isGoodbyeFrame,
   parseGoodbyeReason,
@@ -379,6 +380,7 @@ export function startStandinRelay(opts = {}) {
         graceTimer: null,
         bridgeHelperVersion: null,
         bridgeHost: null,
+        bridgeConv: null,
       });
     }
     const legs = sessions.get(session);
@@ -426,16 +428,20 @@ export function startStandinRelay(opts = {}) {
     if (role === "bridge") {
       const helperVersion = sanitizeHelperVersion(url.searchParams.get("helperVersion"));
       const host = sanitizeMachineLabel(url.searchParams.get("host"));
+      // Exact-conversation Resume (rework 5) — mirrors the Cloudflare DO's
+      // `conv` handling, same store-durably + forward-combined-state shape.
+      const conv = sanitizeConversationId(url.searchParams.get("conv"));
       if (helperVersion) legs.bridgeHelperVersion = helperVersion;
       if (host) legs.bridgeHost = host;
-      if ((helperVersion || host) && legs.browser && legs.browser.readyState === legs.browser.OPEN) {
+      if (conv) legs.bridgeConv = conv;
+      if ((helperVersion || host || conv) && legs.browser && legs.browser.readyState === legs.browser.OPEN) {
         try {
-          legs.browser.send(encodeBridgeVersionFrame(legs.bridgeHelperVersion, legs.bridgeHost));
+          legs.browser.send(encodeBridgeVersionFrame(legs.bridgeHelperVersion, legs.bridgeHost, legs.bridgeConv));
         } catch { /* closing */ }
       }
-    } else if (role === "browser" && (legs.bridgeHelperVersion || legs.bridgeHost)) {
+    } else if (role === "browser" && (legs.bridgeHelperVersion || legs.bridgeHost || legs.bridgeConv)) {
       try {
-        ws.send(encodeBridgeVersionFrame(legs.bridgeHelperVersion, legs.bridgeHost));
+        ws.send(encodeBridgeVersionFrame(legs.bridgeHelperVersion, legs.bridgeHost, legs.bridgeConv));
       } catch { /* leg already gone */ }
     }
 


### PR DESCRIPTION
Nick's field test exposed that Resume ran "continue the most recent conversation in the folder" — which can be a different conversation than the row promises (his row said 8h 54m ago; it resumed one from 5 minutes earlier). His directive: the proper fix, now.

## Exact-conversation Resume
- The helper's bridge now mints a UUID per session and launches `claude --session-id <uuid>` — so the platform knows every conversation's real ID with certainty (empirically verified: `--resume <id>` appends to the same transcript forever, never forks).
- The ID travels the existing announcement path (relay stores + replays), lands on a new nullable `terminal_sessions.claude_session_id` column (migration 00157), and Resume on a row with an ID launches `claude --resume <id>` via a validated `resume_id` deep-link param.
- Legacy rows without an ID keep the old behaviour with honest copy: "picks up the most recent conversation in {folder}"; ID rows say "Continues this exact conversation in {folder}."

## Also
- Recent-list dedupe hardened with adversarial-order regression tests (audit found it already correct — the field symptom was entirely the old --continue mechanics).
- The dock now restores its expanded state after a refresh (sessionStorage, quota/SSR-safe).
- Helper 0.3.3 + MINIMUM_RECOMMENDED_HELPER_VERSION bump (release published before this deploys; migration applied before this deploys).

Gates: tsc clean · full 2679/2679 · relay 38/38 · shared 27/27 · integration 132/132 · bridge 21/21 · eslint no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)