### PR TITLE
feat(terminal): calm taken-over state in the abandoned tab (card cbe60db5)

### DIFF
--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1153,6 +1153,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
             poppedOut={poppedOutKeys.has(entry.key)}
             onPopOut={() => handlePopOut(entry.key)}
             onBringBack={() => bringBackToDock(entry.key)}
+            onReconnectTakenOver={(sid) => void performReattach(sid, { focus: true })}
           />
         ))}
       </div>

--- a/src/components/board/terminal-popout-view.test.tsx
+++ b/src/components/board/terminal-popout-view.test.tsx
@@ -58,7 +58,7 @@ function installMockSession(status: "connected" | "error", closeCode: number | n
   mockedUseTerminalSession.mockImplementation((): UseTerminalSessionResult => {
     const containerRef = useRef<HTMLDivElement | null>(null);
     return {
-      state: { status, sessionId: "sess-1", errorKind: null, endedReason: null, closeCode },
+      state: { status, sessionId: "sess-1", errorKind: null, endedReason: null, closeCode, closeReason: null },
       launchPhase: "idle",
       peerDegraded: false,
       helperVersion: null,

--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -21,11 +21,12 @@
 
 import { useRef } from "react";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import type {
   UseTerminalSessionResult,
   TerminalSessionActions,
 } from "./use-terminal-session";
+import { RELAY_CLOSE, PREEMPTED_CLOSE_REASON, type TerminalConnectionState } from "@/lib/terminal/connection";
 
 vi.mock("./use-terminal-session", () => ({
   useTerminalSession: vi.fn(),
@@ -63,13 +64,55 @@ function installMockSession() {
     const containerRef = useRef<HTMLDivElement | null>(null);
     lastContainerRef = containerRef;
     return {
-      state: { status: "connected", sessionId: "sess-1", errorKind: null, endedReason: null, closeCode: null },
+      state: {
+        status: "connected",
+        sessionId: "sess-1",
+        errorKind: null,
+        endedReason: null,
+        closeCode: null,
+        closeReason: null,
+      },
       launchPhase: "idle",
       peerDegraded: false,
       helperVersion: null,
       pair: { sessionId: "sess-1", bridgeToken: "bridge-tok", browserToken: "browser-tok" },
       readOnly: false,
       inputEnabled: true,
+      platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download", downloadUrl: null },
+      paired: true,
+      xtermReady: true,
+      containerRef,
+      actions: mockActions(),
+    };
+  });
+}
+
+// Card cbe60db5 rework 6: installs the mock hook in an "error" state with a
+// caller-supplied closeCode/closeReason, standing in for whatever
+// isSameOwnerPreemptedClose (connection.ts) needs to discriminate a same-owner
+// takeover from a genuine attach-rejection — this file never reaches into the
+// real reducer/socket (that's use-terminal-session.test.ts / connection.test.ts);
+// it only checks TerminalSessionView renders the right branch for a given state.
+function installMockErrorSession(state: Partial<TerminalConnectionState> = {}) {
+  mockedUseTerminalSession.mockImplementation((): UseTerminalSessionResult => {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    lastContainerRef = containerRef;
+    return {
+      state: {
+        status: "error",
+        sessionId: "sess-1",
+        errorKind: "duplicate",
+        endedReason: null,
+        closeCode: RELAY_CLOSE.DUP_BROWSER,
+        closeReason: null,
+        ...state,
+      },
+      launchPhase: "idle",
+      peerDegraded: false,
+      helperVersion: null,
+      pair: { sessionId: "sess-1", bridgeToken: "bridge-tok", browserToken: "browser-tok" },
+      readOnly: false,
+      inputEnabled: false,
       platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download", downloadUrl: null },
       paired: true,
       xtermReady: true,
@@ -98,6 +141,24 @@ function renderView(poppedOut: boolean) {
       onAnnounce={vi.fn()}
       poppedOut={poppedOut}
       onBringBack={vi.fn()}
+    />,
+  );
+}
+
+function renderErrorView(onReconnectTakenOver: (sid: string) => void = vi.fn()) {
+  return render(
+    <TerminalSessionView
+      entry={baseEntry()}
+      descriptor={{ ideaId: "idea-1", ideaTitle: "My Idea", ideaGithubUrl: null }}
+      label="Session 1"
+      isActive
+      expanded
+      onRequestExpand={vi.fn()}
+      autoConnectWhenExpanded={false}
+      onReportSummary={vi.fn()}
+      onRegisterActions={vi.fn()}
+      onAnnounce={vi.fn()}
+      onReconnectTakenOver={onReconnectTakenOver}
     />,
   );
 }
@@ -191,5 +252,62 @@ describe("TerminalSessionView — pop-out host mounting", () => {
     // aria-hidden wrapper.
     const placeholder = screen.getByText("Popped out");
     expect(placeholder.closest('[aria-hidden="true"]')).not.toBeNull();
+  });
+});
+
+// Card cbe60db5 rework 6 (Nick's field-test item 4): the abandoned tab a
+// same-owner reconnect took over used to show the alarming, wrongly-worded
+// "This session is already open elsewhere" error. These pin the calm branch
+// to the discriminated "takeover" state only, and confirm the genuine
+// attach-rejection error is completely unchanged.
+describe("TerminalSessionView — same-owner takeover state", () => {
+  it("renders the calm 'Taken over' state — no Error text — and wires Reconnect here to the sid", () => {
+    const onReconnectTakenOver = vi.fn();
+    installMockErrorSession({ closeCode: RELAY_CLOSE.DUP_BROWSER, closeReason: PREEMPTED_CLOSE_REASON });
+    renderErrorView(onReconnectTakenOver);
+
+    expect(screen.getByText("This session was taken over in another tab.")).toBeInTheDocument();
+    // The header pill: a neutral "Taken over" label, never the rose "Error".
+    expect(screen.getAllByText("Taken over").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Error")).not.toBeInTheDocument();
+    expect(screen.queryByText(/already open elsewhere/)).not.toBeInTheDocument();
+
+    // Exactly one action, and it reattaches THIS sid via the reconnect/
+    // take-over flow — not "Try again" (that button belongs to the honest
+    // error state only).
+    expect(screen.queryByText("Try again")).not.toBeInTheDocument();
+    const button = screen.getByRole("button", { name: /Reconnect here/ });
+    fireEvent.click(button);
+    expect(onReconnectTakenOver).toHaveBeenCalledWith("sess-1");
+  });
+
+  it("keeps the genuine attach-rejection error state and copy unchanged — no takeover framing", () => {
+    const onReconnectTakenOver = vi.fn();
+    // Same 4001 code, but the relay's real "someone else already has this"
+    // rejection reason — not the same-owner preemption signal.
+    installMockErrorSession({ closeCode: RELAY_CLOSE.DUP_BROWSER, closeReason: "session already attached (single-attach)" });
+    renderErrorView(onReconnectTakenOver);
+
+    expect(screen.getByText("This session is already open elsewhere")).toBeInTheDocument();
+    expect(
+      screen.getByText("Another browser tab is already attached to this session. Close it, then launch again."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.queryByText("Taken over")).not.toBeInTheDocument();
+    expect(screen.queryByText(/taken over in another tab/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Reconnect here/ })).not.toBeInTheDocument();
+
+    // The existing "Try again" affordance is untouched.
+    const tryAgain = screen.getByRole("button", { name: /Try again/ });
+    fireEvent.click(tryAgain);
+    expect(onReconnectTakenOver).not.toHaveBeenCalled();
+  });
+
+  it("also treats a missing close reason (older relay / raw abnormal close) as the honest error, not a guess", () => {
+    installMockErrorSession({ closeCode: RELAY_CLOSE.DUP_BROWSER, closeReason: null });
+    renderErrorView();
+
+    expect(screen.getByText("This session is already open elsewhere")).toBeInTheDocument();
+    expect(screen.queryByText("Taken over")).not.toBeInTheDocument();
   });
 });

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -51,10 +51,12 @@ import {
   CircleDashed,
   ExternalLink,
   Undo2,
+  RefreshCw,
   X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { isSameOwnerPreemptedClose } from "@/lib/terminal/connection";
 import type { TerminalConnectionState, TerminalStatus } from "@/lib/terminal/connection";
 import { type TerminalPlatform, TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
 import { shouldShowHelperUpdateNudge } from "@/lib/terminal/helper-version";
@@ -136,6 +138,17 @@ interface TerminalSessionViewProps {
   onPopOut?: () => void;
   /** "Bring back to dock" (D3) — only rendered while `poppedOut`. */
   onBringBack?: () => void;
+  /**
+   * Card cbe60db5 rework 6: this tab's leg was closed by a same-owner
+   * takeover (`isSameOwnerPreemptedClose` — see the calm "Taken over" state
+   * below) and the user clicked "Reconnect here". Reattaches THIS sid via
+   * the SAME reattach-mint flow the session chooser's Reconnect uses (a
+   * fresh browser token, no cap consumed — see terminal-dock.tsx's
+   * `performReattach`); omitted hides the button (defensive — the state only
+   * renders once a `pair` is known, so the sid is always available in
+   * practice).
+   */
+  onReconnectTakenOver?: (sid: string) => void;
 }
 
 export function TerminalSessionView({
@@ -153,6 +166,7 @@ export function TerminalSessionView({
   poppedOut = false,
   onPopOut,
   onBringBack,
+  onReconnectTakenOver,
 }: TerminalSessionViewProps) {
   const session = useTerminalSession(descriptor, {
     enabled: true,
@@ -270,7 +284,15 @@ export function TerminalSessionView({
   }, [poppedOut, actions.refreshView]);
 
   const view = resolveDockView(state.status, launchPhase, platform.supported, paired);
-  const meta = dockStatusMeta(view, state.errorKind);
+  // Card cbe60db5 rework 6 (Nick's field-test item 4): the "error"/4001 state
+  // legitimately stays the underlying mechanism (unchanged, same as the
+  // popped-out window's isPreemptedClose) — this only swaps the PRESENTATION
+  // for the one cause that's actually a deliberate, successful hand-off
+  // rather than a failed attach. See connection.ts's isSameOwnerPreemptedClose
+  // doc for why the close REASON (not just the 4001 code) is required to
+  // tell the two apart.
+  const takenOver = view === "error" && isSameOwnerPreemptedClose(state.closeCode, state.closeReason);
+  const meta = takenOver ? TAKEN_OVER_META : dockStatusMeta(view, state.errorKind);
   const showStream = state.status === "connected" || state.status === "disconnected";
   // Only worth showing once there's an actual (live or reconnecting) bridge to
   // update — a setup/coming-soon/idle panel has nothing to nudge about yet.
@@ -446,10 +468,14 @@ export function TerminalSessionView({
               pair={pair}
               platform={platform}
               canLaunch={canLaunch}
+              takenOver={takenOver}
               onConnect={() => void actions.connect({ autoLaunch: true })}
               onRetry={() => void actions.connect({ autoLaunch: true })}
               onLaunchAgain={actions.beginBrowserLaunch}
               onCopyBridge={actions.copyBridgeCommand}
+              onReconnectTakenOver={() => {
+                if (pair) onReconnectTakenOver?.(pair.sessionId);
+              }}
             />
           )}
           {state.status === "disconnected" && (
@@ -532,6 +558,20 @@ export function dockStatusMeta(
   }
 }
 
+// Same-owner takeover pill (card cbe60db5, rework 6): the underlying view
+// legitimately stays "error"/4001 (that's the mechanism — see
+// isSameOwnerPreemptedClose's doc) but a deliberate, successful hand-off to
+// another tab is not an error — the rose "Error" pill dockStatusMeta would
+// otherwise render for this state contradicts the calm overlay below it.
+// Sky/informational, same family + wording as the popped-out window's own
+// "Moved to dock" pill (terminal-popout-view.tsx's MOVED_TO_DOCK_META) for
+// the analogous same-owner-preemption case.
+const TAKEN_OVER_META: StatusMeta = {
+  label: "Taken over",
+  Icon: Undo2,
+  className: "border-sky-500/50 bg-sky-500/10 text-sky-400",
+};
+
 // ── per-view centred overlays (icon + text + next step) ───────────────────────
 function StateOverlay({
   view,
@@ -539,20 +579,25 @@ function StateOverlay({
   pair,
   platform,
   canLaunch,
+  takenOver,
   onConnect,
   onRetry,
   onLaunchAgain,
   onCopyBridge,
+  onReconnectTakenOver,
 }: {
   view: DockView;
   state: TerminalConnectionState;
   pair: PairInfo | null;
   platform: TerminalPlatform;
   canLaunch: boolean;
+  /** Card cbe60db5 rework 6 — see the same-named const in TerminalSessionView. */
+  takenOver: boolean;
   onConnect: () => void;
   onRetry: () => void;
   onLaunchAgain: () => void;
   onCopyBridge: () => void;
+  onReconnectTakenOver: () => void;
 }) {
   return (
     <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 overflow-y-auto bg-[#0c0c0e]/95 px-6 py-6 text-center">
@@ -613,7 +658,24 @@ function StateOverlay({
         </>
       )}
 
-      {view === "error" && (
+      {/* Card cbe60db5 rework 6: a same-owner takeover is a deliberate,
+          successful hand-off — not a failed attach — so it gets its own
+          calm branch instead of falling into the generic error copy below
+          (Nick's field-test item 4: "that's backwards"). */}
+      {view === "error" && takenOver && (
+        <>
+          <Undo2 className="h-7 w-7 text-sky-400" />
+          <div className="text-base font-semibold text-sky-400">Taken over</div>
+          <p className="max-w-md text-[13px] text-zinc-400">
+            This session was taken over in another tab.
+          </p>
+          <Button className="bg-sky-500 text-sky-950 hover:bg-sky-400" onClick={onReconnectTakenOver}>
+            <RefreshCw className="h-3.5 w-3.5" /> Reconnect here
+          </Button>
+        </>
+      )}
+
+      {view === "error" && !takenOver && (
         <>
           <CircleAlert className="h-7 w-7 text-rose-400" />
           <div className="text-base font-semibold text-rose-400">{errorTitle(state)}</div>

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useTerminalSession, type TerminalSessionDescriptor } from "./use-terminal-session";
+import { isSameOwnerPreemptedClose } from "@/lib/terminal/connection";
 
 vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 // Tracks every mock Terminal instance created — used by the scrollback
@@ -676,6 +677,34 @@ describe("useTerminalSession", () => {
       expect(result.current.state.status).toBe("error");
       expect(result.current.state.errorKind).toBe("duplicate");
       expect(result.current.state.closeCode).toBe(4001);
+    });
+
+    // Card cbe60db5 rework 6: the SAME 4001 close, but with the relay's
+    // same-owner PREEMPTION reason — the embedded dock's discriminator
+    // (isSameOwnerPreemptedClose) needs this to render the calm "taken over"
+    // state instead of the generic duplicate-session error (see
+    // terminal-session-view.tsx / connection.ts for where it's consumed).
+    it("carries the relay's preempted close REASON through onclose, not just the code", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: { sessionId: "sid-popped", browserToken: "popped-browser-token" },
+        }),
+      );
+      await flushEffects();
+      act(() => latestSocket().simulateOpen());
+      act(() => latestSocket().simulateBinaryMessage());
+      expect(result.current.state.status).toBe("connected");
+
+      act(() => latestSocket().close(4001, "preempted"));
+      expect(result.current.state.status).toBe("error");
+      expect(result.current.state.closeCode).toBe(4001);
+      expect(result.current.state.closeReason).toBe("preempted");
+      expect(isSameOwnerPreemptedClose(result.current.state.closeCode, result.current.state.closeReason)).toBe(true);
     });
 
     it("only attaches once per distinct transferred sessionId — a stable object on a later render is a no-op", async () => {

--- a/src/lib/terminal/connection.test.ts
+++ b/src/lib/terminal/connection.test.ts
@@ -23,6 +23,8 @@ import {
   claimConnectGeneration,
   isConnectSuperseded,
   decideReconnectNow,
+  isSameOwnerPreemptedClose,
+  PREEMPTED_CLOSE_REASON,
   type TerminalConnectionState,
   type TerminalEvent,
 } from "./connection";
@@ -36,6 +38,7 @@ import {
   isHeartbeatFrame as isSharedHeartbeatFrame,
   encodeBridgeVersionFrame as encodeSharedBridgeVersionFrame,
 } from "../../../terminal/shared/control-frames.mjs";
+import { CLOSE as RELAY_PAIRING_CLOSE } from "../../../terminal/relay/src/pairing.js";
 
 // Helper: fold a sequence of events through the reducer from the initial state.
 function run(events: TerminalEvent[], start = initialConnectionState): TerminalConnectionState {
@@ -213,6 +216,82 @@ describe("mapCloseCode", () => {
     expect(owner.status).toBe("error");
     expect(owner.errorKind).toBe("owner-mismatch");
     expect(owner.closeCode).toBe(RELAY_CLOSE.OWNER_MISMATCH);
+  });
+
+  it("closed event also carries the close REASON alongside closeCode", () => {
+    const live = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+    const closed = terminalReducer(live, { type: "closed", code: RELAY_CLOSE.DUP_BROWSER, reason: "preempted" });
+    expect(closed.closeCode).toBe(RELAY_CLOSE.DUP_BROWSER);
+    expect(closed.closeReason).toBe("preempted");
+  });
+
+  it("a missing reason on the closed event stores null, not undefined", () => {
+    const live = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+    const closed = terminalReducer(live, { type: "closed", code: 1006 });
+    expect(closed.closeReason).toBeNull();
+  });
+});
+
+// ── same-owner takeover vs. genuine attach-rejection (card cbe60db5, rework 6) ─
+//
+// Nick's field-test item 4: the tab a same-owner reconnect TOOK OVER showed the
+// generic "This session is already open elsewhere" error even though it was a
+// deliberate, successful hand-off, not a failed attach. The relay tells the two
+// apart via the close REASON on the shared 4001 code — see
+// terminal/relay/src/pairing.js → CLOSE.DUP_BROWSER vs CLOSE.PREEMPTED, imported
+// here directly (a pure, dependency-free module) so this test is pinned against
+// the RELAY'S OWN literal strings, not a hand-copied guess.
+describe("isSameOwnerPreemptedClose", () => {
+  it("pins PREEMPTED_CLOSE_REASON against the relay's own CLOSE.PREEMPTED.reason", () => {
+    expect(PREEMPTED_CLOSE_REASON).toBe(RELAY_PAIRING_CLOSE.PREEMPTED.reason);
+    // Same code as DUP_BROWSER — only the reason string tells them apart.
+    expect(RELAY_PAIRING_CLOSE.PREEMPTED.code).toBe(RELAY_CLOSE.DUP_BROWSER);
+  });
+
+  it("true for a same-owner takeover close (4001 + \"preempted\")", () => {
+    expect(isSameOwnerPreemptedClose(RELAY_CLOSE.DUP_BROWSER, PREEMPTED_CLOSE_REASON)).toBe(true);
+  });
+
+  it("false for the genuine attach-rejection close — same code, the relay's real rejection reason", () => {
+    expect(isSameOwnerPreemptedClose(RELAY_CLOSE.DUP_BROWSER, RELAY_PAIRING_CLOSE.DUP_BROWSER.reason)).toBe(false);
+  });
+
+  it("false when the reason is missing entirely (older relay, or a raw abnormal close)", () => {
+    expect(isSameOwnerPreemptedClose(RELAY_CLOSE.DUP_BROWSER, null)).toBe(false);
+  });
+
+  it("false for any other close code, even with the preempted reason string", () => {
+    expect(isSameOwnerPreemptedClose(RELAY_CLOSE.DUP_BRIDGE, PREEMPTED_CLOSE_REASON)).toBe(false);
+    expect(isSameOwnerPreemptedClose(null, PREEMPTED_CLOSE_REASON)).toBe(false);
+  });
+
+  it("end to end: a takeover close on a LIVE session reaches the reducer as errorKind duplicate, discriminated as a takeover", () => {
+    const live = run([{ type: "connect" }, { type: "relay-open" }, { type: "data" }]);
+    const takenOver = terminalReducer(live, {
+      type: "closed",
+      code: RELAY_CLOSE.DUP_BROWSER,
+      reason: RELAY_PAIRING_CLOSE.PREEMPTED.reason,
+    });
+    // The mechanism is UNCHANGED — same status/errorKind as any other duplicate
+    // close (mirrors the popped-out window's isPreemptedClose, which also never
+    // touches status). Only the discriminator flips.
+    expect(takenOver.status).toBe("error");
+    expect(takenOver.errorKind).toBe("duplicate");
+    expect(isSameOwnerPreemptedClose(takenOver.closeCode, takenOver.closeReason)).toBe(true);
+  });
+
+  it("end to end: a genuine attach-rejection close reaches the reducer identically on status/errorKind, but is NOT discriminated as a takeover", () => {
+    // This tab never got past the handshake — it tried to attach while another
+    // leg already held the session and was refused outright.
+    const handshaking = run([{ type: "connect" }, { type: "relay-open" }]);
+    const rejected = terminalReducer(handshaking, {
+      type: "closed",
+      code: RELAY_CLOSE.DUP_BROWSER,
+      reason: RELAY_PAIRING_CLOSE.DUP_BROWSER.reason,
+    });
+    expect(rejected.status).toBe("error");
+    expect(rejected.errorKind).toBe("duplicate");
+    expect(isSameOwnerPreemptedClose(rejected.closeCode, rejected.closeReason)).toBe(false);
   });
 });
 

--- a/src/lib/terminal/connection.ts
+++ b/src/lib/terminal/connection.ts
@@ -71,6 +71,15 @@ export interface TerminalConnectionState {
   endedReason: EndedReason | null;
   /** The WebSocket close code that produced the current state (when applicable). */
   closeCode: number | null;
+  /**
+   * The WebSocket close REASON that produced the current state (when
+   * applicable) — travels alongside `closeCode` everywhere it's set/cleared.
+   * Card cbe60db5 rework 6: the relay reuses close code 4001 for TWO distinct
+   * causes (terminal/relay/src/pairing.js → CLOSE.DUP_BROWSER vs
+   * CLOSE.PREEMPTED) that only differ by this string — see
+   * `isSameOwnerPreemptedClose` below for why the embedded dock needs it.
+   */
+  closeReason: string | null;
 }
 
 export type TerminalEvent =
@@ -92,6 +101,7 @@ export const initialConnectionState: TerminalConnectionState = {
   errorKind: null,
   endedReason: null,
   closeCode: null,
+  closeReason: null,
 };
 
 /** A status that means "we are mid-handshake, no bridge stream yet". */
@@ -154,6 +164,47 @@ function parseEndedReason(reason: string | undefined): EndedReason {
   return "remote";
 }
 
+// ── same-owner takeover vs. genuine attach-rejection (card cbe60db5, rework 6) ─
+//
+// Nick's field test item 4: the tab a same-owner reconnect TOOK OVER showed the
+// generic "This session is already open elsewhere" error — alarming, and wrong:
+// that tab didn't fail to attach, it was deliberately (and successfully) handed
+// off. mapCloseCode above deliberately leaves BOTH cases as errorKind "duplicate"
+// (the underlying mechanism/status is unchanged — same as the popped-out window's
+// `isPreemptedClose` in popout-channel.ts, which also never touches `status`) —
+// only the embedded dock's PRESENTATION needs to tell them apart.
+//
+// Close code 4001 alone can't do that: the relay reuses DUP_BROWSER's code for
+// BOTH a plain "someone else already has this" rejection AND a same-owner
+// preemption (terminal/relay/src/pairing.js → CLOSE.DUP_BROWSER vs
+// CLOSE.PREEMPTED) — they only differ by the close REASON string. The popped-out
+// window doesn't need this finer check: within that narrow context (it only ever
+// attaches to an already-live session it was handed) every 4001 IS a preemption.
+// The embedded dock can genuinely race a STRANGER's attach attempt, so it needs
+// the sharper signal.
+
+/**
+ * The relay's same-owner PREEMPTION reason string — the stale leg's 4001 close
+ * when a newer same-owner attach (a reconnect / take-over from another tab)
+ * replaces it. Duplicated (not imported) for the same reason RELAY_CLOSE is:
+ * that module is plain .mjs outside the app's TS build graph; the relay's own
+ * pairing.test.js pins the code, and connection.test.ts pins this string.
+ */
+export const PREEMPTED_CLOSE_REASON = "preempted";
+
+/**
+ * True when a close was the relay's same-owner preemption signal — this leg
+ * was live (or attaching) and a newer same-owner attach just replaced it —
+ * rather than a genuine "another leg already holds this session" rejection.
+ * Any OTHER reason (including undefined/empty — an older relay that predates
+ * this distinction, or a truly sub-less rejection) is treated as the honest
+ * error, never guessed into a takeover: this only trusts the relay's own
+ * close-frame reason, never the rendered error copy.
+ */
+export function isSameOwnerPreemptedClose(closeCode: number | null, closeReason: string | null): boolean {
+  return closeCode === RELAY_CLOSE.DUP_BROWSER && closeReason === PREEMPTED_CLOSE_REASON;
+}
+
 /**
  * The connection state machine. Pure: `(state, event) => state`. Drives the dock's
  * six visible states; the component owns the side effects (fetch, socket, timers)
@@ -166,7 +217,14 @@ export function terminalReducer(
   switch (event.type) {
     case "connect":
       // Fresh attempt — clear any prior error/ended metadata.
-      return { status: "connecting", sessionId: null, errorKind: null, endedReason: null, closeCode: null };
+      return {
+        status: "connecting",
+        sessionId: null,
+        errorKind: null,
+        endedReason: null,
+        closeCode: null,
+        closeReason: null,
+      };
 
     case "session-created":
       // Only meaningful while we're opening a session; ignore stray late arrivals.
@@ -174,7 +232,7 @@ export function terminalReducer(
       return { ...state, sessionId: event.sessionId };
 
     case "session-mint-failed":
-      return { ...state, status: "error", errorKind: "session-mint-failed", closeCode: null };
+      return { ...state, status: "error", errorKind: "session-mint-failed", closeCode: null, closeReason: null };
 
     case "relay-open":
       // Relay reached; the bridge may not have attached yet → waiting-to-pair.
@@ -185,7 +243,7 @@ export function terminalReducer(
       // First (or any) bytes from the bridge prove it's attached and streaming.
       if (state.status === "connected") return state;
       if (state.status === "waiting-to-pair" || state.status === "disconnected" || state.status === "connecting") {
-        return { ...state, status: "connected", errorKind: null, endedReason: null, closeCode: null };
+        return { ...state, status: "connected", errorKind: null, endedReason: null, closeCode: null, closeReason: null };
       }
       // Deliberately NOT "error" here (fix/terminal-bringback-state-reset): a
       // genuine error (duplicate-preemption, owner-mismatch, connect-timeout, …)
@@ -206,7 +264,7 @@ export function terminalReducer(
     case "connect-timeout":
       // Only the connect clock — irrelevant once a stream is live.
       if (!isHandshaking(state.status)) return state;
-      return { ...state, status: "error", errorKind: "connect-timeout", closeCode: null };
+      return { ...state, status: "error", errorKind: "connect-timeout", closeCode: null, closeReason: null };
 
     case "reconnect-exhausted":
       // The grace window / token validity elapsed while disconnected and no reattach
@@ -229,9 +287,11 @@ export function terminalReducer(
     case "closed": {
       // A user-initiated end already produced the terminal state; the socket's own
       // close event must not clobber it back to a generic disconnect.
-      if (state.status === "session-ended") return { ...state, closeCode: event.code };
+      if (state.status === "session-ended") {
+        return { ...state, closeCode: event.code, closeReason: event.reason ?? null };
+      }
       const mapped = mapCloseCode(event.code, event.reason, state.status);
-      return { ...state, ...mapped, closeCode: event.code };
+      return { ...state, ...mapped, closeCode: event.code, closeReason: event.reason ?? null };
     }
 
     case "reset":


### PR DESCRIPTION
Nick's field-test item 4: reconnect-takeover works, but the abandoned tab framed the expected handover as a red Error ("This session is already open elsewhere — close it, then launch again") — wrong story, wrong instructions.

The relay reuses close code 4001 for both a deliberate same-owner takeover ("preempted") and a genuine attach-rejection; only the close reason distinguishes them, and the embedded dock never read it. Now it does: a takeover renders a neutral "Taken over" pill and calm copy — "This session was taken over in another tab." — with a single "Reconnect here" button (same reattach path as the chooser, no cap consumed). Genuine attach-rejections keep the existing error state unchanged; a missing reason (older relay) also falls back to the honest error. Popped-out window untouched.

Tests: reason threading (incl. null), discrimination pinned against the relay's own source literals, component coverage for both states. Full suite 2692/2692, tsc + eslint clean. Web-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)