### PR TITLE
feat(terminal): reap ghost sessions before listing (card cbe60db5)

### DIFF
--- a/src/app/api/terminal/session/list/route.ts
+++ b/src/app/api/terminal/session/list/route.ts
@@ -14,11 +14,24 @@
 // is the exact-conversation Resume field — chooser-data.ts consumes it to
 // decide whether a Recent row can offer an exact `--resume <id>` or falls
 // back to the legacy `--continue`.
+//
+// REAP-BEFORE-LIST (card cbe60db5 rework 7): the mint route and the reattach
+// route already reap this user's own expired-but-still-"active" rows before
+// trusting them (R2 mitigation), but this route never did — a session that
+// died past its `expires_at` (relay's TERMINAL_MAX_MS hard cap) with no
+// browser ever calling mint/reattach again stayed "active" in the registry
+// forever, and the chooser presented it as "Running now" (Nick's field
+// evidence, 2026-08-12: an 8h32m-old row with no live helper/bridge/claude
+// process on his machine). Reap first, using the exact same staleness rule
+// those routes use (`selectExpiredSessionIds`, built on `isSessionExpired`),
+// so a reaped row is returned as a "recent · ended" row in the same response
+// instead of a stale "active" one.
 
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import { RECENT_WINDOW_MS } from "@/lib/terminal/chooser-data";
+import { selectExpiredSessionIds } from "@/lib/terminal/session-registry";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -33,7 +46,43 @@ export async function GET() {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
 
-    const recentSince = new Date(Date.now() - RECENT_WINDOW_MS).toISOString();
+    const nowMs = Date.now();
+
+    // ── REAP: mark this user's own expired-but-still-"active" rows ended
+    // BEFORE the list read below, so a ghost never renders as "Running now".
+    // Same fields the mint/reattach routes write (status: "ended", ended_at:
+    // now) — Resume still works on the reaped row since claude_session_id is
+    // untouched. The update is guarded by `.eq("status", "active")` (on top
+    // of the `.in("id", ...)` from this user's own just-read active rows) so
+    // a session ending normally (POST .../end) at the same instant is never
+    // double-written — the codebase's `.eq("status", expected)` concurrency
+    // pattern (see CLAUDE.md's Concurrency Guards).
+    const { data: activeRows, error: activeErr } = await supabase
+      .from("terminal_sessions")
+      .select("id, status, expires_at")
+      .eq("user_id", user.id)
+      .eq("status", "active");
+    if (activeErr) {
+      logger.error("Terminal session list: registry read for reap failed", { error: activeErr.message });
+    }
+    const staleIds = selectExpiredSessionIds(activeRows ?? [], nowMs);
+    if (staleIds.length > 0) {
+      const { error: reapErr } = await supabase
+        .from("terminal_sessions")
+        .update({ status: "ended", ended_at: new Date(nowMs).toISOString() })
+        .in("id", staleIds)
+        .eq("status", "active");
+      if (reapErr) {
+        logger.error("Terminal session list: reap failed", { error: reapErr.message, count: staleIds.length });
+      } else {
+        logger.info("Reaped expired terminal session rows before list", {
+          userId: user.id,
+          count: staleIds.length,
+        });
+      }
+    }
+
+    const recentSince = new Date(nowMs - RECENT_WINDOW_MS).toISOString();
     const { data: rows, error } = await supabase
       .from("terminal_sessions")
       .select("sid, idea_id, task_id, task_title, machine_label, cwd, claude_session_id, created_at, status, ended_at")

--- a/src/lib/terminal/session-registry.test.ts
+++ b/src/lib/terminal/session-registry.test.ts
@@ -10,6 +10,7 @@ import {
   decideReattach,
   formatSessionAge,
   formatSessionIdentity,
+  selectExpiredSessionIds,
 } from "./session-registry";
 
 const NOW = Date.parse("2026-07-20T12:00:00.000Z");
@@ -113,6 +114,59 @@ describe("formatSessionIdentity", () => {
     expect(formatSessionIdentity({ machineLabel: "Nick's MacBook Pro", cwd: null, sid: "a3f9beef" })).toBe(
       "Nick's MacBook Pro · a3f9beef",
     );
+  });
+});
+
+describe("selectExpiredSessionIds", () => {
+  it("leaves a fresh active row untouched", () => {
+    const future = new Date(NOW + 60_000).toISOString();
+    expect(
+      selectExpiredSessionIds([{ id: "a", status: "active", expires_at: future }], NOW),
+    ).toEqual([]);
+  });
+
+  it("reaps a stale active row", () => {
+    const past = new Date(NOW - 1).toISOString();
+    expect(
+      selectExpiredSessionIds([{ id: "b", status: "active", expires_at: past }], NOW),
+    ).toEqual(["b"]);
+  });
+
+  it("leaves an already-ended row untouched even if its expires_at is in the past", () => {
+    const past = new Date(NOW - 1).toISOString();
+    expect(
+      selectExpiredSessionIds([{ id: "c", status: "ended", expires_at: past }], NOW),
+    ).toEqual([]);
+  });
+
+  it("reaps exactly at the staleness boundary (expires_at === now)", () => {
+    expect(
+      selectExpiredSessionIds(
+        [{ id: "d", status: "active", expires_at: new Date(NOW).toISOString() }],
+        NOW,
+      ),
+    ).toEqual(["d"]);
+  });
+
+  it("mixes fresh, stale, and ended rows correctly in one batch", () => {
+    const past = new Date(NOW - 1).toISOString();
+    const future = new Date(NOW + 60_000).toISOString();
+    const ids = selectExpiredSessionIds(
+      [
+        { id: "fresh", status: "active", expires_at: future },
+        { id: "stale-1", status: "active", expires_at: past },
+        { id: "ended", status: "ended", expires_at: past },
+        { id: "stale-2", status: "active", expires_at: past },
+      ],
+      NOW,
+    );
+    expect(ids).toEqual(["stale-1", "stale-2"]);
+  });
+
+  it("never reaps a malformed timestamp", () => {
+    expect(
+      selectExpiredSessionIds([{ id: "e", status: "active", expires_at: "not-a-date" }], NOW),
+    ).toEqual([]);
   });
 });
 

--- a/src/lib/terminal/session-registry.ts
+++ b/src/lib/terminal/session-registry.ts
@@ -38,6 +38,31 @@ export function isSessionExpired(expiresAt: string, nowMs: number = Date.now()):
   return t <= nowMs;
 }
 
+export interface ReapCandidateRow {
+  id: string;
+  status: "active" | "ended";
+  expires_at: string;
+}
+
+/**
+ * The reap step's pure decision (R2 mitigation, card cbe60db5 rework 7):
+ * given a batch of the caller's own rows, returns the ids that are still
+ * marked "active" but whose `expires_at` has passed — the exact ids a caller
+ * must mark ended. Originally inlined identically in the mint route (POST
+ * /api/terminal/session) and the reattach route; extracted here so the list
+ * route (GET /api/terminal/session/list) can reap ghost sessions before
+ * returning them too, without a second staleness rule — this reuses
+ * `isSessionExpired` unchanged (same boundary: `expires_at <= now`; same
+ * malformed-timestamp safety: never reaps on a bad timestamp).
+ *
+ * Defensively re-checks `status === "active"` per row rather than trusting
+ * the caller's own `.eq("status", "active")` query filter — a row that
+ * somehow reached here already ended is never re-marked or double-counted.
+ */
+export function selectExpiredSessionIds(rows: ReapCandidateRow[], nowMs: number = Date.now()): string[] {
+  return rows.filter((row) => row.status === "active" && isSessionExpired(row.expires_at, nowMs)).map((row) => row.id);
+}
+
 /** The start of the trailing rate-limit window, as an ISO string for a `.gte()` filter. */
 export function rateLimitWindowStart(
   nowMs: number = Date.now(),


### PR DESCRIPTION
Nick's field test: the session picker showed "Running now — started 8h 30m ago" for a session that died overnight (relay hard-caps at 4h; no process existed on his Mac; the registry row was still status=active with ended_at null).

Root cause: the mint and reattach routes reap the user's expired-but-still-active rows before trusting anything, but the LIST route never did — so ghosts rendered as live.

Fix: the list route now reaps before its main read, using the exact same expiry predicate the other routes use (extracted into a tested pure `selectExpiredSessionIds` — no second staleness rule), with the mandated `.eq("status","active")` concurrency guard. Reaped rows return as Recent in the same response, keep their conversation ID (exact Resume still works), and "Running now" only ever contains genuinely reconnectable sessions. Cap counting was already reap-aware at mint time — verified, untouched.

6 new pure tests (fresh/stale/ended/boundary/mixed/malformed). Full suite 2698/2698, tsc + eslint clean. Web-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)