### PR TITLE
feat(terminal): true end times for reaped sessions + Recent lists every resumable conversation (card cbe60db5)

### DIFF
--- a/src/app/api/terminal/session/list/route.ts
+++ b/src/app/api/terminal/session/list/route.ts
@@ -22,16 +22,25 @@
 // browser ever calling mint/reattach again stayed "active" in the registry
 // forever, and the chooser presented it as "Running now" (Nick's field
 // evidence, 2026-08-12: an 8h32m-old row with no live helper/bridge/claude
-// process on his machine). Reap first, using the exact same staleness rule
-// those routes use (`selectExpiredSessionIds`, built on `isSessionExpired`),
-// so a reaped row is returned as a "recent · ended" row in the same response
-// instead of a stale "active" one.
+// process on his machine). Reap first, so a reaped row is returned as a
+// "recent · ended" row in the same response instead of a stale "active" one.
+//
+// TRUE END TIME (rework 8): the reap write is now shared with the mint and
+// reattach routes (session-reap.ts) — a reaped row's `ended_at` is backdated
+// to its OWN `expires_at`, not the moment this route happened to notice it.
+// Nick's follow-up field evidence (2026-08-12): a row created 19:01,
+// expires_at 23:01, reaped 03:58 the next day previously showed "ended 0m
+// ago" instead of the true "ended ~5h ago". One consequence worth flagging:
+// the 48h Recent window (RECENT_WINDOW_MS below) now ages a reaped row from
+// its TRUE death time, so a ghost first noticed more than 48h after it
+// actually died correctly won't appear in Recent at all — that's desired
+// honesty, not a bug.
 
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import { RECENT_WINDOW_MS } from "@/lib/terminal/chooser-data";
-import { selectExpiredSessionIds } from "@/lib/terminal/session-registry";
+import { reapExpiredSessions } from "@/lib/terminal/session-reap";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -50,37 +59,14 @@ export async function GET() {
 
     // ── REAP: mark this user's own expired-but-still-"active" rows ended
     // BEFORE the list read below, so a ghost never renders as "Running now".
-    // Same fields the mint/reattach routes write (status: "ended", ended_at:
-    // now) — Resume still works on the reaped row since claude_session_id is
-    // untouched. The update is guarded by `.eq("status", "active")` (on top
-    // of the `.in("id", ...)` from this user's own just-read active rows) so
-    // a session ending normally (POST .../end) at the same instant is never
+    // Shared with the mint/reattach routes (session-reap.ts, rework 8) — each
+    // reaped row's ended_at is backdated to its own expires_at, and the write
+    // still carries the mandated `.eq("status", "active")` per-row guard so a
+    // session ending normally (POST .../end) at the same instant is never
     // double-written — the codebase's `.eq("status", expected)` concurrency
-    // pattern (see CLAUDE.md's Concurrency Guards).
-    const { data: activeRows, error: activeErr } = await supabase
-      .from("terminal_sessions")
-      .select("id, status, expires_at")
-      .eq("user_id", user.id)
-      .eq("status", "active");
-    if (activeErr) {
-      logger.error("Terminal session list: registry read for reap failed", { error: activeErr.message });
-    }
-    const staleIds = selectExpiredSessionIds(activeRows ?? [], nowMs);
-    if (staleIds.length > 0) {
-      const { error: reapErr } = await supabase
-        .from("terminal_sessions")
-        .update({ status: "ended", ended_at: new Date(nowMs).toISOString() })
-        .in("id", staleIds)
-        .eq("status", "active");
-      if (reapErr) {
-        logger.error("Terminal session list: reap failed", { error: reapErr.message, count: staleIds.length });
-      } else {
-        logger.info("Reaped expired terminal session rows before list", {
-          userId: user.id,
-          count: staleIds.length,
-        });
-      }
-    }
+    // pattern (see CLAUDE.md's Concurrency Guards). Resume still works on a
+    // reaped row since claude_session_id is untouched.
+    await reapExpiredSessions(supabase, user.id, nowMs, "Terminal session list");
 
     const recentSince = new Date(nowMs - RECENT_WINDOW_MS).toISOString();
     const { data: rows, error } = await supabase

--- a/src/app/api/terminal/session/reattach/route.ts
+++ b/src/app/api/terminal/session/reattach/route.ts
@@ -17,7 +17,8 @@ import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import { mintSessionTokens } from "../../../../../../terminal/shared/session-token.mjs";
-import { decideReattach, isSessionExpired } from "@/lib/terminal/session-registry";
+import { decideReattach } from "@/lib/terminal/session-registry";
+import { reapExpiredSessions } from "@/lib/terminal/session-reap";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -50,30 +51,13 @@ export async function POST(req: Request) {
     const nowMs = Date.now();
 
     // Reap this user's own expired-but-still-"active" rows first (same R2
-    // mitigation as the mint route) — mirrors that route's reap step so the
-    // registry never drifts further behind just because reattach reads never
-    // triggered it. Best-effort: a failed reap never blocks the decision
+    // mitigation as the mint route, now shared via session-reap.ts — rework
+    // 8) — mirrors that route's reap step so the registry never drifts
+    // further behind just because reattach reads never triggered it, and so
+    // a reaped row's ended_at is backdated to its own expires_at the same
+    // way everywhere. Best-effort: a failed reap never blocks the decision
     // below (decideReattach checks expires_at itself either way).
-    const { data: activeRows, error: activeErr } = await supabase
-      .from("terminal_sessions")
-      .select("id, expires_at")
-      .eq("user_id", user.id)
-      .eq("status", "active");
-    if (activeErr) {
-      logger.error("Terminal session reattach: registry read failed", { error: activeErr.message });
-    }
-    const staleIds = (activeRows ?? [])
-      .filter((row) => isSessionExpired(row.expires_at, nowMs))
-      .map((row) => row.id);
-    if (staleIds.length > 0) {
-      const { error: reapErr } = await supabase
-        .from("terminal_sessions")
-        .update({ status: "ended", ended_at: new Date(nowMs).toISOString() })
-        .in("id", staleIds);
-      if (reapErr) {
-        logger.error("Terminal session reattach: reap failed", { error: reapErr.message, count: staleIds.length });
-      }
-    }
+    await reapExpiredSessions(supabase, user.id, nowMs, "Terminal session reattach");
 
     // Ownership: the row must belong to THIS user (RLS also scopes this, but
     // the explicit filter keeps the query honest regardless of client).

--- a/src/app/api/terminal/session/route.ts
+++ b/src/app/api/terminal/session/route.ts
@@ -29,9 +29,9 @@ import {
   computeSessionExpiresAt,
   decideCap,
   decideRateLimit,
-  isSessionExpired,
   rateLimitWindowStart,
 } from "@/lib/terminal/session-registry";
+import { reapExpiredSessions } from "@/lib/terminal/session-reap";
 import {
   getTerminalDailyBudget,
   getTerminalBudgetSoftPct,
@@ -149,30 +149,16 @@ export async function POST(req: Request) {
     // BEFORE trusting any count below (R2 mitigation) — the registry is
     // best-effort and can drift from the relay (e.g. a max-duration close the
     // registry was never told about), so an unreaped stale row would wrongly
-    // count against the cap/rate-limit forever.
-    const { data: activeRows, error: activeErr } = await supabase
-      .from("terminal_sessions")
-      .select("id, expires_at")
-      .eq("user_id", user.id)
-      .eq("status", "active");
-    if (activeErr) {
-      logger.error("Terminal session registry read failed", { error: activeErr.message });
-    }
-    const staleIds = (activeRows ?? [])
-      .filter((row) => isSessionExpired(row.expires_at, nowMs))
-      .map((row) => row.id);
-    if (staleIds.length > 0) {
-      const { error: reapErr } = await supabase
-        .from("terminal_sessions")
-        .update({ status: "ended", ended_at: new Date(nowMs).toISOString() })
-        .in("id", staleIds);
-      if (reapErr) {
-        logger.error("Terminal session reap failed", { error: reapErr.message, count: staleIds.length });
-      } else {
-        logger.info("Reaped expired terminal session rows", { userId: user.id, count: staleIds.length });
-      }
-    }
-    const activeCount = (activeRows?.length ?? 0) - staleIds.length;
+    // count against the cap/rate-limit forever. Shared with the reattach and
+    // list routes (session-reap.ts, rework 8) so every reaped row's ended_at
+    // is backdated to its own expires_at the same way everywhere.
+    const { activeBefore, reapedIds } = await reapExpiredSessions(
+      supabase,
+      user.id,
+      nowMs,
+      "Terminal session mint",
+    );
+    const activeCount = activeBefore - reapedIds.length;
 
     // ── (b) CAP (E1) — refuse before minting anything. ──────────────────────
     const cap = getServerTerminalSessionCap();

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -188,7 +188,7 @@ describe("deriveChooserSections", () => {
     expect(recent.find((r) => r.sid === "untracked")?.claudeSessionId).toBeNull();
   });
 
-  it("caps Recent at RECENT_MAX, newest first", () => {
+  it("caps Recent at RECENT_MAX (now 10), newest first", () => {
     const rows = Array.from({ length: RECENT_MAX + 3 }, (_, i) =>
       row({
         sid: `ended-${i}`,
@@ -200,6 +200,124 @@ describe("deriveChooserSections", () => {
     const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
     expect(recent).toHaveLength(RECENT_MAX);
     expect(recent[0].sid).toBe("ended-0"); // newest (smallest offset) first
+  });
+
+  // Rework 8b (card cbe60db5) — Nick's explicit, superseding instruction:
+  // "is there any way we can show MORE than one resume session?" → "yes,
+  // make that change." Every ID-bearing ended session gets its own row; only
+  // ID-less rows (which Resume genuinely can't tell apart) still collapse
+  // one-per-folder. See chooser-data.ts's header comment for the full rule.
+  describe("every resumable conversation (rework 8b — no dedupe for ID-bearing rows)", () => {
+    it("shows every ID-bearing row for the SAME folder — none collapsed", () => {
+      const rows = [
+        row({
+          sid: "convo-1",
+          status: "ended",
+          cwd: "~/projects/multi",
+          endedAt: new Date(NOW - 3 * 60 * 60 * 1000).toISOString(),
+          claudeSessionId: "11111111-1111-1111-1111-111111111111",
+        }),
+        row({
+          sid: "convo-2",
+          status: "ended",
+          cwd: "~/projects/multi",
+          endedAt: new Date(NOW - 2 * 60 * 60 * 1000).toISOString(),
+          claudeSessionId: "22222222-2222-2222-2222-222222222222",
+        }),
+        row({
+          sid: "convo-3",
+          status: "ended",
+          cwd: "~/projects/multi",
+          endedAt: new Date(NOW - 1 * 60 * 60 * 1000).toISOString(),
+          claudeSessionId: "33333333-3333-3333-3333-333333333333",
+        }),
+      ];
+      const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+      // Newest-ended first; all three distinct conversations kept.
+      expect(recent.map((r) => r.sid)).toEqual(["convo-3", "convo-2", "convo-1"]);
+    });
+
+    it("still collapses ID-LESS rows to the single newest per folder", () => {
+      const rows = [
+        row({
+          sid: "idless-older",
+          status: "ended",
+          cwd: "~/projects/legacy",
+          endedAt: new Date(NOW - 3 * 60 * 60 * 1000).toISOString(),
+          claudeSessionId: null,
+        }),
+        row({
+          sid: "idless-newer",
+          status: "ended",
+          cwd: "~/projects/legacy",
+          endedAt: new Date(NOW - 1 * 60 * 60 * 1000).toISOString(),
+          claudeSessionId: null,
+        }),
+      ];
+      const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+      expect(recent.map((r) => r.sid)).toEqual(["idless-newer"]);
+    });
+
+    it("mixed folder: shows every ID-bearing row PLUS the single newest ID-less row for that same folder", () => {
+      const rows = [
+        row({
+          sid: "id-a",
+          status: "ended",
+          cwd: "~/projects/mixed",
+          endedAt: new Date(NOW - 4 * 60 * 60 * 1000).toISOString(),
+          claudeSessionId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        }),
+        row({
+          sid: "id-b",
+          status: "ended",
+          cwd: "~/projects/mixed",
+          endedAt: new Date(NOW - 1 * 60 * 60 * 1000).toISOString(),
+          claudeSessionId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        }),
+        row({
+          sid: "idless-old-1",
+          status: "ended",
+          cwd: "~/projects/mixed",
+          endedAt: new Date(NOW - 5 * 60 * 60 * 1000).toISOString(),
+          claudeSessionId: null,
+        }),
+        row({
+          sid: "idless-old-2",
+          status: "ended",
+          cwd: "~/projects/mixed",
+          endedAt: new Date(NOW - 6 * 60 * 60 * 1000).toISOString(),
+          claudeSessionId: null,
+        }),
+      ];
+      const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+      // Both id-bearing rows shown, plus only the newest of the two id-less
+      // rows ("idless-old-1", 5h ago beats "idless-old-2", 6h ago).
+      expect(recent.map((r) => r.sid)).toEqual(["id-b", "id-a", "idless-old-1"]);
+    });
+
+    it("caps the combined id-bearing + id-less selection at RECENT_MAX, newest first", () => {
+      const idBearing = Array.from({ length: RECENT_MAX }, (_, i) =>
+        row({
+          sid: `id-${i}`,
+          status: "ended",
+          cwd: "~/projects/flood",
+          endedAt: new Date(NOW - i * 60_000).toISOString(),
+          claudeSessionId: `${i}0000000-0000-0000-0000-000000000000`,
+        }),
+      );
+      // An older row (would-be 11th) that must be truncated by the cap.
+      const overflow = row({
+        sid: "id-overflow",
+        status: "ended",
+        cwd: "~/projects/flood",
+        endedAt: new Date(NOW - RECENT_MAX * 60_000).toISOString(),
+        claudeSessionId: "99999999-0000-0000-0000-000000000000",
+      });
+      const recent = deriveChooserSections([...idBearing, overflow], IDEA_A, NOW).recent;
+      expect(recent).toHaveLength(RECENT_MAX);
+      expect(recent.map((r) => r.sid)).not.toContain("id-overflow");
+      expect(recent[0].sid).toBe("id-0"); // newest (smallest offset) first
+    });
   });
 
   it("badges the row matching lastTabSid as wasOpenInThisTab, regardless of freshness", () => {

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -6,11 +6,14 @@
 // of the caller's rows that's either still ACTIVE or ENDED within the last
 // 48h (extended for this card — see that route's doc) — this module turns
 // that flat list into "Running now · this board", "Running now · other
-// boards", and "Recent · ended in the last 48h", applying the design's exact
-// rules (docs/design-terminal-session-entry-options.html §3):
-//   - Recent = ended ≤48h ago, max 5, ONE per project folder (`cwd`), rows
-//     with a null `cwd` hidden entirely (F4: "Resume is hidden entirely when
-//     the project folder wasn't recorded — no disabled ghost button").
+// boards", and "Recent · ended in the last 48h", applying the design's rules
+// (docs/design-terminal-session-entry-options.html §3), AS SUPERSEDED for
+// Recent by Nick's rework 8b instruction below:
+//   - Recent = ended ≤48h ago, max 10, rows with a null `cwd` hidden entirely
+//     (F4: "Resume is hidden entirely when the project folder wasn't
+//     recorded — no disabled ghost button"). Dedupe is per-conversation, not
+//     strictly per-folder any more — see the EVERY RESUMABLE CONVERSATION
+//     section below.
 //   - Live sessions split by whether they belong to the board currently open
 //     (`currentIdeaId`) or another one.
 //
@@ -25,9 +28,42 @@
 // section over data we simply don't have an opinion on yet). "Running now"
 // sections are NEVER filtered — a live session is unambiguously reachable
 // regardless of which machine it's on.
+//
+// EVERY RESUMABLE CONVERSATION (rework 8b, card cbe60db5 — Nick, explicit,
+// 2026-08-12: "is there any way we can show MORE than one resume session?"
+// → "yes, make that change."). The design doc's original binding spec (§3)
+// said Recent is "max 5, one per project folder" — that one-per-folder rule
+// existed only because the legacy Resume path (`claude --continue`) could
+// reopen nothing more specific than "the folder's most recent conversation";
+// showing several rows for one folder would all have resumed the SAME
+// conversation, which is why they were collapsed. Rework 5 gave rows their
+// own exact `claudeSessionId` (a real, distinct conversation to resume) —
+// once a row can point at ITS OWN conversation, collapsing it into another
+// row of the same folder hides genuine history instead of avoiding a
+// duplicate. Nick's instruction above supersedes the one-per-folder spec for
+// those rows; see this module's row-selection rules just below.
+//
+// Selection rules, applied AFTER the existing 48h/machine/null-cwd filtering
+// above (unchanged) and the existing newest-ended-first sort:
+//   1. Every row that carries a `claudeSessionId` is kept, no matter how many
+//      other rows share its `cwd` — each one resumes its own exact
+//      conversation, so none of them is a duplicate of another.
+//   2. Rows WITHOUT a `claudeSessionId` still can't be told apart from one
+//      another by Resume (it falls back to "most recent in this folder", the
+//      pre-rework-5 behaviour) — so they keep the old one-per-folder collapse,
+//      keeping only the newest such row per `cwd`.
+//   3. A folder that already has an ID-bearing row shown ALSO gets its single
+//      newest ID-less row shown (not suppressed) — that ID-less row is a
+//      distinct, older-era conversation pointer (from before the bridge
+//      announced ids, or a bridge too old to ever announce one) that the
+//      ID-bearing rows cannot stand in for. This is the simplest honest rule:
+//      "one ID-less pointer per folder, plus every distinct ID we have."
+//   4. The combined result is capped at RECENT_MAX (raised 5 → 10 for this
+//      rework — more rows are now legitimately distinct, so the old cap would
+//      truncate real history), newest-ended first.
 
 export const RECENT_WINDOW_MS = 48 * 60 * 60 * 1000;
-export const RECENT_MAX = 5;
+export const RECENT_MAX = 10;
 
 /** One row as the (extended) list route returns it — active or recently-ended. */
 export interface ChooserRegistryRow {
@@ -138,25 +174,36 @@ export function deriveChooserSections(
     })
     .sort((a, b) => Date.parse(b.endedAt) - Date.parse(a.endedAt)); // newest-ended first
 
-  const seenCwd = new Set<string>();
-  const recent: ChooserRecentRow[] = [];
+  // Rework 8b (see header comment): rows WITH a claudeSessionId are never
+  // deduped against each other — each resumes its own exact conversation.
+  // Rows WITHOUT one still collapse to the single newest per folder, since
+  // Resume can't tell them apart. `recentCandidates` is already sorted
+  // newest-ended-first, so "first row seen per folder" is "newest per
+  // folder" for the id-less collapse.
+  const seenIdlessCwd = new Set<string>();
+  const selected: (ChooserRegistryRow & { cwd: string; endedAt: string })[] = [];
   for (const r of recentCandidates) {
     const cwd = r.cwd.trim();
-    if (seenCwd.has(cwd)) continue; // one per project folder
-    seenCwd.add(cwd);
-    recent.push({
-      sid: r.sid,
-      ideaId: r.ideaId,
-      ideaTitle: r.ideaTitle,
-      taskId: r.taskId,
-      taskTitle: r.taskTitle,
-      cwd,
-      machineLabel: r.machineLabel,
-      claudeSessionId: r.claudeSessionId,
-      endedAt: r.endedAt,
-    });
-    if (recent.length >= RECENT_MAX) break;
+    if (r.claudeSessionId) {
+      selected.push(r);
+      continue;
+    }
+    if (seenIdlessCwd.has(cwd)) continue; // one id-less row per project folder
+    seenIdlessCwd.add(cwd);
+    selected.push(r);
   }
+
+  const recent: ChooserRecentRow[] = selected.slice(0, RECENT_MAX).map((r) => ({
+    sid: r.sid,
+    ideaId: r.ideaId,
+    ideaTitle: r.ideaTitle,
+    taskId: r.taskId,
+    taskTitle: r.taskTitle,
+    cwd: r.cwd.trim(),
+    machineLabel: r.machineLabel,
+    claudeSessionId: r.claudeSessionId,
+    endedAt: r.endedAt,
+  }));
 
   return { liveHere, liveElsewhere, recent };
 }

--- a/src/lib/terminal/session-reap.test.ts
+++ b/src/lib/terminal/session-reap.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import { reapExpiredSessions } from "./session-reap";
+
+const NOW = Date.parse("2026-08-12T03:58:00.000Z");
+
+interface StubRow {
+  id: string;
+  status: "active" | "ended";
+  expires_at: string;
+}
+
+/**
+ * Mimics just enough of the supabase-js query builder for
+ * `reapExpiredSessions`: a single `.select().eq().eq()` read that resolves
+ * to `rows`, and a per-row `.update(payload).eq("id", …).eq("status", …)`
+ * write whose filters land on the SAME thenable builder object (mirroring
+ * how supabase-js chains additional filters onto one query) so each write's
+ * exact `id` filter, `status` filter, and payload can be asserted.
+ */
+function createMockSupabase(rows: StubRow[]) {
+  const updateCalls: { payload: Record<string, unknown>; filters: Record<string, unknown> }[] = [];
+
+  const supabase = {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ data: rows, error: null }),
+        })),
+      })),
+      update: vi.fn((payload: Record<string, unknown>) => {
+        const record = { payload, filters: {} as Record<string, unknown> };
+        updateCalls.push(record);
+        const builder = {
+          eq: vi.fn((col: string, val: unknown) => {
+            record.filters[col] = val;
+            return builder;
+          }),
+          then: (resolve: (value: { data: null; error: null }) => void) =>
+            resolve({ data: null, error: null }),
+        };
+        return builder;
+      }),
+    })),
+  };
+
+  return { supabase, updateCalls };
+}
+
+describe("reapExpiredSessions", () => {
+  it("backdates a reaped row's ended_at to its OWN expires_at, not now", async () => {
+    const expiresAt = new Date(NOW - 5 * 60 * 60 * 1000).toISOString(); // died ~5h ago
+    const { supabase, updateCalls } = createMockSupabase([{ id: "row-1", status: "active", expires_at: expiresAt }]);
+
+    const result = await reapExpiredSessions(supabase as never, "user-1", NOW);
+
+    expect(result).toEqual({ activeBefore: 1, reapedIds: ["row-1"] });
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].payload).toEqual({ status: "ended", ended_at: expiresAt });
+    expect(updateCalls[0].payload.ended_at).not.toBe(new Date(NOW).toISOString());
+    expect(updateCalls[0].filters).toEqual({ id: "row-1", status: "active" });
+  });
+
+  it("gives each row in a mixed batch ITS OWN expires_at, not one shared value", async () => {
+    const expiresAtA = new Date(NOW - 5 * 60 * 60 * 1000).toISOString();
+    const expiresAtB = new Date(NOW - 30 * 60 * 1000).toISOString();
+    const future = new Date(NOW + 60 * 60 * 1000).toISOString();
+    const { supabase, updateCalls } = createMockSupabase([
+      { id: "stale-a", status: "active", expires_at: expiresAtA },
+      { id: "fresh", status: "active", expires_at: future },
+      { id: "stale-b", status: "active", expires_at: expiresAtB },
+    ]);
+
+    const result = await reapExpiredSessions(supabase as never, "user-1", NOW);
+
+    expect(result.activeBefore).toBe(3);
+    expect(result.reapedIds.sort()).toEqual(["stale-a", "stale-b"]);
+    expect(updateCalls).toHaveLength(2);
+    const byId = Object.fromEntries(updateCalls.map((c) => [c.filters.id, c.payload.ended_at]));
+    expect(byId["stale-a"]).toBe(expiresAtA);
+    expect(byId["stale-b"]).toBe(expiresAtB);
+  });
+
+  it("never writes for a fresh active row", async () => {
+    const future = new Date(NOW + 60_000).toISOString();
+    const { supabase, updateCalls } = createMockSupabase([{ id: "row-1", status: "active", expires_at: future }]);
+
+    const result = await reapExpiredSessions(supabase as never, "user-1", NOW);
+
+    expect(result).toEqual({ activeBefore: 1, reapedIds: [] });
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it("never touches an already-ended row's real ended_at", async () => {
+    const past = new Date(NOW - 1).toISOString();
+    // The read itself filters .eq("status", "active"), so an "ended" row
+    // would never come back from a real query — but reapExpiredSessions'
+    // underlying selectReapUpdates defensively re-checks status too.
+    const { supabase, updateCalls } = createMockSupabase([{ id: "row-1", status: "ended", expires_at: past }]);
+
+    const result = await reapExpiredSessions(supabase as never, "user-1", NOW);
+
+    expect(result).toEqual({ activeBefore: 1, reapedIds: [] });
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it("fails open on a read error, touching nothing", async () => {
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: null, error: { message: "boom" } }),
+          })),
+        })),
+      })),
+    };
+
+    const result = await reapExpiredSessions(supabase as never, "user-1", NOW);
+    expect(result).toEqual({ activeBefore: 0, reapedIds: [] });
+  });
+});

--- a/src/lib/terminal/session-reap.ts
+++ b/src/lib/terminal/session-reap.ts
@@ -1,0 +1,89 @@
+// Terminal session reap — SHARED write helper (card cbe60db5, rework 8).
+//
+// The mint route (POST /api/terminal/session), the reattach route, and the
+// list route (rework 7) each independently read this user's own "active"
+// rows and mark the expired ones ended — previously three near-identical
+// inline copies that all wrote `ended_at: now()`. Nick's field evidence
+// (2026-08-12) showed that's a lie: a ghost session's row read "ended 0m
+// ago" when it actually died hours earlier, at its own `expires_at` (the
+// relay's 4h ceiling). This is now the ONE place any route reaps, so the
+// timestamp truth (session-registry.ts's `selectReapUpdates`: ended_at =
+// the row's OWN expires_at) can never drift back out of sync between call
+// sites.
+//
+// Per-row `.update()` calls rather than one batched `.in()` update: a batch
+// can contain rows with DIFFERENT `expires_at` values, and PostgREST has no
+// single-query way to write a different value per row. Session counts per
+// user are capped low (session-cap.ts), so N small updates is the honest,
+// unsurprising choice — each still carries the mandated `.eq("status",
+// "active")` concurrency guard (CLAUDE.md Concurrency Guards) so a session
+// ending normally (POST .../end) at the same instant is never double-written.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { logger } from "@/lib/logger";
+import { selectReapUpdates, type ReapCandidateRow } from "./session-registry";
+
+export interface ReapResult {
+  /** How many of the caller's rows were "active" before this call ran. */
+  activeBefore: number;
+  /** Ids just marked ended because their own expires_at had passed. */
+  reapedIds: string[];
+}
+
+/**
+ * Reads this user's own active rows and marks any expired ones ended, each
+ * backdated to its own `expires_at`. Best-effort throughout, matching every
+ * other registry read/write in this feature (design doc §9, R2): a failed
+ * read or write never blocks the caller — it just leaves the registry a
+ * little more stale until the next reap self-corrects.
+ *
+ * `logLabel` prefixes this call's log lines so a specific route (mint /
+ * reattach / list) stays identifiable in structured logs without each route
+ * re-implementing the write.
+ */
+export async function reapExpiredSessions(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any, any, any>,
+  userId: string,
+  nowMs: number = Date.now(),
+  logLabel: string = "Terminal session reap",
+): Promise<ReapResult> {
+  const { data: activeRows, error: activeErr } = await supabase
+    .from("terminal_sessions")
+    .select("id, status, expires_at")
+    .eq("user_id", userId)
+    .eq("status", "active");
+  if (activeErr) {
+    logger.error(`${logLabel}: registry read failed`, { error: activeErr.message });
+    return { activeBefore: 0, reapedIds: [] };
+  }
+
+  const rows: ReapCandidateRow[] = activeRows ?? [];
+  const updates = selectReapUpdates(rows, nowMs);
+
+  if (updates.length > 0) {
+    const results = await Promise.all(
+      updates.map(({ id, endedAt }) =>
+        supabase
+          .from("terminal_sessions")
+          .update({ status: "ended", ended_at: endedAt })
+          .eq("id", id)
+          .eq("status", "active"),
+      ),
+    );
+    const failed = results.filter((result) => result.error);
+    if (failed.length > 0) {
+      logger.error(`${logLabel}: reap write failed`, {
+        count: failed.length,
+        error: failed[0]?.error?.message,
+      });
+    } else {
+      logger.info(`${logLabel}: reaped expired terminal session rows`, {
+        userId,
+        count: updates.length,
+      });
+    }
+  }
+
+  return { activeBefore: rows.length, reapedIds: updates.map((update) => update.id) };
+}

--- a/src/lib/terminal/session-registry.test.ts
+++ b/src/lib/terminal/session-registry.test.ts
@@ -11,6 +11,7 @@ import {
   formatSessionAge,
   formatSessionIdentity,
   selectExpiredSessionIds,
+  selectReapUpdates,
 } from "./session-registry";
 
 const NOW = Date.parse("2026-07-20T12:00:00.000Z");
@@ -167,6 +168,58 @@ describe("selectExpiredSessionIds", () => {
     expect(
       selectExpiredSessionIds([{ id: "e", status: "active", expires_at: "not-a-date" }], NOW),
     ).toEqual([]);
+  });
+});
+
+describe("selectReapUpdates", () => {
+  it("leaves a fresh active row untouched", () => {
+    const future = new Date(NOW + 60_000).toISOString();
+    expect(selectReapUpdates([{ id: "a", status: "active", expires_at: future }], NOW)).toEqual([]);
+  });
+
+  it("backdates a stale active row's ended_at to its OWN expires_at, not now", () => {
+    const past = new Date(NOW - 5 * 60 * 60 * 1000).toISOString(); // died ~5h before "now"
+    expect(selectReapUpdates([{ id: "b", status: "active", expires_at: past }], NOW)).toEqual([
+      { id: "b", endedAt: past },
+    ]);
+  });
+
+  it("leaves an already-ended row's real ended_at alone even if expires_at is in the past", () => {
+    const past = new Date(NOW - 1).toISOString();
+    expect(selectReapUpdates([{ id: "c", status: "ended", expires_at: past }], NOW)).toEqual([]);
+  });
+
+  it("reaps exactly at the staleness boundary (expires_at === now)", () => {
+    const boundary = new Date(NOW).toISOString();
+    expect(selectReapUpdates([{ id: "d", status: "active", expires_at: boundary }], NOW)).toEqual([
+      { id: "d", endedAt: boundary },
+    ]);
+  });
+
+  it("gives each row in a mixed batch ITS OWN expires_at — never one shared value", () => {
+    const pastA = new Date(NOW - 5 * 60 * 60 * 1000).toISOString();
+    const pastB = new Date(NOW - 30 * 60 * 1000).toISOString();
+    const future = new Date(NOW + 60_000).toISOString();
+    const updates = selectReapUpdates(
+      [
+        { id: "fresh", status: "active", expires_at: future },
+        { id: "stale-a", status: "active", expires_at: pastA },
+        { id: "ended", status: "ended", expires_at: pastB },
+        { id: "stale-b", status: "active", expires_at: pastB },
+      ],
+      NOW,
+    );
+    expect(updates).toEqual([
+      { id: "stale-a", endedAt: pastA },
+      { id: "stale-b", endedAt: pastB },
+    ]);
+    // The two stale rows died at different times — asserting distinctness
+    // guards against a regression back to one shared "now" timestamp.
+    expect(updates[0].endedAt).not.toBe(updates[1].endedAt);
+  });
+
+  it("never reaps a malformed timestamp", () => {
+    expect(selectReapUpdates([{ id: "e", status: "active", expires_at: "not-a-date" }], NOW)).toEqual([]);
   });
 });
 

--- a/src/lib/terminal/session-registry.ts
+++ b/src/lib/terminal/session-registry.ts
@@ -44,23 +44,49 @@ export interface ReapCandidateRow {
   expires_at: string;
 }
 
+export interface ReapUpdate {
+  id: string;
+  /** The row's TRUE death time — its own `expires_at`, never "now". */
+  endedAt: string;
+}
+
 /**
- * The reap step's pure decision (R2 mitigation, card cbe60db5 rework 7):
- * given a batch of the caller's own rows, returns the ids that are still
- * marked "active" but whose `expires_at` has passed — the exact ids a caller
- * must mark ended. Originally inlined identically in the mint route (POST
- * /api/terminal/session) and the reattach route; extracted here so the list
- * route (GET /api/terminal/session/list) can reap ghost sessions before
- * returning them too, without a second staleness rule — this reuses
- * `isSessionExpired` unchanged (same boundary: `expires_at <= now`; same
- * malformed-timestamp safety: never reaps on a bad timestamp).
+ * The reap step's pure decision (R2 mitigation, card cbe60db5; rework 8:
+ * tells the truth about WHEN a row died). Given a batch of the caller's own
+ * rows, returns the write each still-"active"-but-expired row needs: its
+ * `ended_at` backdated to ITS OWN `expires_at` — the relay's 4h ceiling
+ * (REGISTRY_SESSION_TTL_MS) is the moment the session actually died, not
+ * whenever a caller happened to notice (Nick's field evidence, 2026-08-12: a
+ * row created 19:01, expires_at 23:01, reaped 03:58 the next day previously
+ * showed "ended 0m ago" instead of "ended ~5h ago"). Rows are only selected
+ * when `isSessionExpired` says `expires_at` has passed, and that function
+ * never reaps on a malformed timestamp — so `endedAt` here is always a
+ * well-formed timestamp in the past.
  *
  * Defensively re-checks `status === "active"` per row rather than trusting
  * the caller's own `.eq("status", "active")` query filter — a row that
- * somehow reached here already ended is never re-marked or double-counted.
+ * somehow reached here already ended is never re-marked or double-counted,
+ * and its real `ended_at` is left alone.
+ *
+ * Originally inlined as an id-only batch update identically in the mint
+ * route (POST /api/terminal/session) and the reattach route (rework 7
+ * extracted the list route's copy into `selectExpiredSessionIds` below);
+ * rework 8 unifies all three onto this richer per-row form via the shared
+ * `reapExpiredSessions` write helper (session-reap.ts) so the timestamp
+ * truth can't drift between call sites again.
+ */
+export function selectReapUpdates(rows: ReapCandidateRow[], nowMs: number = Date.now()): ReapUpdate[] {
+  return rows
+    .filter((row) => row.status === "active" && isSessionExpired(row.expires_at, nowMs))
+    .map((row) => ({ id: row.id, endedAt: row.expires_at }));
+}
+
+/**
+ * Id-only view of `selectReapUpdates`, kept for callers that only need to
+ * know WHICH rows are stale, not what to backdate them to.
  */
 export function selectExpiredSessionIds(rows: ReapCandidateRow[], nowMs: number = Date.now()): string[] {
-  return rows.filter((row) => row.status === "active" && isSessionExpired(row.expires_at, nowMs)).map((row) => row.id);
+  return selectReapUpdates(rows, nowMs).map((update) => update.id);
 }
 
 /** The start of the trailing rate-limit window, as an ISO string for a `.gte()` filter. */


### PR DESCRIPTION
Two field-test follow-ups from Nick, shipped together:

## Reaped ghosts get their true end time
A ghost session cleaned up by the reap showed "ended 0m ago" — the moment we noticed, not the moment it died. Reaped rows now stamp `ended_at = their own expires_at` (the 4h relay ceiling). All three reap sites (mint/reattach/list) are unified onto one shared helper so they can't drift; each row in a batch gets its own death time, with the mandated per-row concurrency guard. Normal session ends are untouched. Honest consequence: the 48h Recent window ages ghosts from true death — one noticed 50h late correctly won't appear.

## Recent lists every resumable conversation
The one-per-folder collapse existed because legacy Resume couldn't tell conversations apart. With exact conversation IDs that's obsolete — Nick explicitly superseded the rule. Rows with an ID are never deduped (each resumes its own conversation, like Claude Code's own resume picker); ID-less legacy rows still collapse to newest-per-folder; cap raised 5 → 10, newest first. Machine filtering, 48h window, and Running-now behaviour unchanged.

Tests: reap-backdating suites (pure + mocked-client, mixed batches) and five new chooser selection cases. Full suite 2713/2713, tsc + eslint clean. Web-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)