### PR TITLE
fix(terminal): resume-on-timeout + toolbar launch-race fix (card cbe60db5)

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -1,0 +1,181 @@
+// Card cbe60db5 rework 9 (Bug B — RELEASE-BLOCKING, Nick's field test
+// 2026-08-14): the toolbar's "Launch Claude Code" fires the launch bus,
+// which `TerminalDock`'s `deliverLaunch` is supposed to route into EITHER a
+// direct mint (nothing to choose between) OR the session entry chooser
+// (there's live/recent sessions elsewhere worth knowing about first) —
+// never both, never neither. The bug: `deliverLaunch`'s gate checked
+// `entryDecisionRef.current?.kind === "chooser"`, and `entryDecisionRef` is
+// `null` while the registry fetch that DECIDES that is still in flight.
+// `null?.kind === "chooser"` is `false`, so a click that lands during that
+// window fell through to an unconditional mint — bypassing the chooser with
+// zero visibility into other live sessions, exactly the failure mode QA
+// pinned.
+//
+// This file is a FOCUSED harness for that one race, not a full dock test
+// suite (no existing terminal-dock test file to extend — see the card).
+// `TerminalSessionView` / `TerminalMySessionsPanel` / `TerminalSessionChooser`
+// are stubbed so the test can assert purely on "did a session tab get
+// minted" vs. "did the chooser render", without pulling in the real hook's
+// xterm/WebSocket machinery — that machinery is already covered by
+// terminal-session-view.test.tsx and use-terminal-session.test.ts.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, act, waitFor } from "@testing-library/react";
+import type { ChooserRegistryRow } from "@/lib/terminal/chooser-data";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/ideas/idea-1/board",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+// Renders just enough of a real TerminalSessionView for the test to see HOW
+// MANY tabs actually got minted, and with what payload — the real component
+// (and the hook underneath it) is exercised elsewhere.
+vi.mock("./terminal-session-view", () => ({
+  TerminalSessionView: ({ entry }: { entry: { key: string; taskId?: string } }) => (
+    <div data-testid="session-view" data-key={entry.key} data-task-id={entry.taskId ?? ""} />
+  ),
+  dockStatusMeta: () => ({ label: "Terminal", Icon: () => null, className: "" }),
+}));
+
+vi.mock("./terminal-my-sessions-panel", () => ({
+  TerminalMySessionsPanel: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("./terminal-session-chooser", () => ({
+  TerminalSessionChooser: () => <div data-testid="chooser" />,
+}));
+
+import { TerminalDock } from "./terminal-dock";
+import { requestBrowserLaunch } from "@/lib/terminal/launch-mode";
+
+function deferredRegistryResponse() {
+  let resolve!: (rows: ChooserRegistryRow[]) => void;
+  const promise = new Promise<ChooserRegistryRow[]>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/** Every OTHER fetch the dock's own effects fire (helper status) fails open
+ * to null/[] — never hangs the test, and is irrelevant to this race. Only
+ * `/api/terminal/session/list` (the registry — the ONE fetch this bug races
+ * against) is wired to the caller-controlled deferred promise. */
+function stubFetch(registryPromise: Promise<ChooserRegistryRow[]>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      if (url === "/api/terminal/session/list") {
+        return registryPromise.then((sessions) => ({ ok: true, json: async () => ({ sessions }) }));
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    }),
+  );
+}
+
+function liveElsewhereRow(): ChooserRegistryRow {
+  return {
+    sid: "sid-live-elsewhere",
+    ideaId: "idea-OTHER",
+    ideaTitle: "Another Idea",
+    taskId: null,
+    taskTitle: null,
+    machineLabel: null,
+    cwd: "/Users/nick/projects/other",
+    claudeSessionId: null,
+    createdAt: new Date().toISOString(),
+    status: "active",
+    endedAt: null,
+  };
+}
+
+beforeEach(() => {
+  vi.stubEnv("NEXT_PUBLIC_TERMINAL_ENABLED", "true");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("TerminalDock — launch-bus race with the still-loading registry (Bug B)", () => {
+  it("never mints while the registry fetch is in flight, then delivers the queued launch once it resolves to empty-launch", async () => {
+    const registry = deferredRegistryResponse();
+    stubFetch(registry.promise);
+
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    // The registry fetch is still in flight — nothing has minted yet.
+    expect(screen.getByText(/Checking your sessions/)).toBeInTheDocument();
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+
+    // The toolbar's "Launch Claude Code" fires the launch bus WHILE the
+    // fetch is still unresolved — the exact race QA pinned. The old bug
+    // minted here, synchronously, before the fetch ever landed.
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+
+    // The registry resolves with nothing live/recent anywhere → the decision
+    // is "empty-launch" (nothing to choose between) — NOW it's safe to
+    // deliver the queued launch, exactly as if the fetch had finished before
+    // the click.
+    registry.resolve([]);
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(screen.getByTestId("session-view").dataset.taskId).toBe("task-9");
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1); // never double-minted
+  });
+
+  it("routes a raced launch into the chooser (never a blind mint) once the resolved decision has something to choose between", async () => {
+    const registry = deferredRegistryResponse();
+    stubFetch(registry.promise);
+
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
+
+    // A live session on another board resolves once the fetch lands — the
+    // decision is "chooser" (something worth choosing between), so the
+    // queued launch must route there, never straight to a blind mint.
+    registry.resolve([liveElsewhereRow()]);
+
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+  });
+
+  it("mints immediately with no race when the registry is already loaded before the click (unchanged behaviour)", async () => {
+    stubFetch(Promise.resolve([]));
+
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+    // Registry already resolved to "empty-launch" — the dock seeds its usual
+    // pristine tab with no launch-bus event involved at all.
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+
+    // The pristine slot is reused in place — still exactly one tab, now
+    // carrying the task launch (never a 2nd tab).
+    await waitFor(() => expect(screen.getByTestId("session-view").dataset.taskId).toBe("task-9"));
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+  });
+});

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1154,6 +1154,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
             onPopOut={() => handlePopOut(entry.key)}
             onBringBack={() => bringBackToDock(entry.key)}
             onReconnectTakenOver={(sid) => void performReattach(sid, { focus: true })}
+            onResumeEndedSession={(payload) => mintAndDeliver(payload)}
           />
         ))}
       </div>

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -244,6 +244,16 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     summariesRef.current = summaries;
     posthogRef.current = posthog;
   }, [sessions, summaries, posthog]);
+  // Bug B (card cbe60db5 rework 9 — RELEASE-BLOCKING, Nick's field test
+  // 2026-08-14): `deliverLaunch` below used to treat `entryDecisionRef.current
+  // === null` (the registry fetch is STILL LOADING — genuinely unknown, never
+  // "nothing to choose between") the same as "no chooser needed", falling
+  // through to an unconditional mint that bypassed the chooser entirely on a
+  // fast click. Set true only while a launch is queued specifically because
+  // the decision wasn't known yet; the seed effect below (which reacts to
+  // `entryDecision` settling) reads and clears it, delivering the SAME outcome
+  // `deliverLaunch` would have produced had the fetch simply finished first.
+  const deferredLaunchPendingRef = useRef(false);
 
   // ── dock-open persistence (rework 5, card cbe60db5) ─────────────────────────
   // Correct the collapsed initial paint on mount if this tab last left the
@@ -662,10 +672,23 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // `mintAndDeliver`'s unchanged behaviour.
   const deliverLaunch = useCallback(
     (payload: BrowserLaunchPayload | null) => {
-      if (sessionsRef.current.length === 0 && entryDecisionRef.current?.kind === "chooser") {
-        setExpanded(true);
-        setPendingLaunch(payload);
-        return;
+      if (sessionsRef.current.length === 0) {
+        if (entryDecisionRef.current === null) {
+          // Bug B: the registry fetch that decides chooser-vs-mint hasn't
+          // resolved yet — null here means "don't know", NOT "empty-launch".
+          // Queue exactly like the (already-decided) chooser branch below —
+          // same expand + pendingLaunch — and let the seed effect (keyed on
+          // `entryDecision`) replay this the instant it settles.
+          setExpanded(true);
+          setPendingLaunch(payload);
+          deferredLaunchPendingRef.current = true;
+          return;
+        }
+        if (entryDecisionRef.current.kind === "chooser") {
+          setExpanded(true);
+          setPendingLaunch(payload);
+          return;
+        }
       }
       mintAndDeliver(payload);
     },
@@ -755,6 +778,24 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   const instantContinueTriggeredRef = useRef(false);
   useEffect(() => {
     if (!entryDecision || sessions.length > 0) return;
+    // Bug B (card cbe60db5 rework 9): a launch that raced the still-loading
+    // registry (`deliverLaunch` queued it via `deferredLaunchPendingRef`
+    // instead of guessing) gets resolved HERE, the instant the real decision
+    // is known — takes priority over the passive empty-launch/instant-
+    // continue defaults below, exactly as if the fetch had finished before
+    // the click that triggered it.
+    if (deferredLaunchPendingRef.current) {
+      deferredLaunchPendingRef.current = false;
+      if (entryDecision.kind === "chooser") {
+        // Already expanded with `pendingLaunch` set by `deliverLaunch` — the
+        // chooser renders itself from that state; nothing else to do.
+        return;
+      }
+      const payload = pendingLaunch;
+      setPendingLaunch(null);
+      mintAndDeliver(payload);
+      return;
+    }
     if (entryDecision.kind === "empty-launch") {
       const fresh = createPristineEntry();
       setSessions([fresh]);
@@ -764,7 +805,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       void performReattach(entryDecision.sid, { focus: false });
     }
     // "chooser": nothing to seed — the chooser renders in the body below.
-  }, [entryDecision, sessions.length, performReattach]);
+  }, [entryDecision, sessions.length, performReattach, pendingLaunch, mintAndDeliver]);
 
   // ── other-board Reconnect (`?reconnect=<sid>`, design item 2) ──────────────
   // "Open board & reconnect" navigates here with the target sid on the URL;

--- a/src/components/board/terminal-popout-view.test.tsx
+++ b/src/components/board/terminal-popout-view.test.tsx
@@ -63,6 +63,8 @@ function installMockSession(status: "connected" | "error", closeCode: number | n
       peerDegraded: false,
       helperVersion: null,
       pair: { sessionId: "sess-1", bridgeToken: "bridge-tok", browserToken: "browser-tok" },
+      cwd: null,
+      claudeSessionId: null,
       readOnly: false,
       inputEnabled: true,
       platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download", downloadUrl: null },

--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -76,6 +76,8 @@ function installMockSession() {
       peerDegraded: false,
       helperVersion: null,
       pair: { sessionId: "sess-1", bridgeToken: "bridge-tok", browserToken: "browser-tok" },
+      cwd: null,
+      claudeSessionId: null,
       readOnly: false,
       inputEnabled: true,
       platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download", downloadUrl: null },
@@ -111,6 +113,48 @@ function installMockErrorSession(state: Partial<TerminalConnectionState> = {}) {
       peerDegraded: false,
       helperVersion: null,
       pair: { sessionId: "sess-1", bridgeToken: "bridge-tok", browserToken: "browser-tok" },
+      cwd: null,
+      claudeSessionId: null,
+      readOnly: false,
+      inputEnabled: false,
+      platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download", downloadUrl: null },
+      paired: true,
+      xtermReady: true,
+      containerRef,
+      actions: mockActions(),
+    };
+  });
+}
+
+// Card cbe60db5 rework 9 (Bug A): installs the mock hook in a "session-ended"
+// state with a caller-supplied endedReason/cwd/claudeSessionId, standing in
+// for the ended session's own resume bookkeeping (use-terminal-session.ts's
+// `sessionCwd`/`claudeSessionId`) — this file never reaches into the real
+// reducer/socket, it only checks TerminalSessionView renders the right
+// Resume-vs-Launch-again branch for a given state.
+function installMockEndedSession(
+  overrides: Partial<TerminalConnectionState> & { cwd?: string | null; claudeSessionId?: string | null } = {},
+) {
+  const { cwd = null, claudeSessionId = null, ...stateOverrides } = overrides;
+  mockedUseTerminalSession.mockImplementation((): UseTerminalSessionResult => {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    lastContainerRef = containerRef;
+    return {
+      state: {
+        status: "session-ended",
+        sessionId: "sess-1",
+        errorKind: null,
+        endedReason: "idle",
+        closeCode: 1000,
+        closeReason: null,
+        ...stateOverrides,
+      },
+      launchPhase: "idle",
+      peerDegraded: false,
+      helperVersion: null,
+      pair: { sessionId: "sess-1", bridgeToken: "bridge-tok", browserToken: "browser-tok" },
+      cwd,
+      claudeSessionId,
       readOnly: false,
       inputEnabled: false,
       platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download", downloadUrl: null },
@@ -159,6 +203,24 @@ function renderErrorView(onReconnectTakenOver: (sid: string) => void = vi.fn()) 
       onRegisterActions={vi.fn()}
       onAnnounce={vi.fn()}
       onReconnectTakenOver={onReconnectTakenOver}
+    />,
+  );
+}
+
+function renderEndedView(onResumeEndedSession: (payload: unknown) => void = vi.fn()) {
+  return render(
+    <TerminalSessionView
+      entry={baseEntry()}
+      descriptor={{ ideaId: "idea-1", ideaTitle: "My Idea", ideaGithubUrl: null }}
+      label="Session 1"
+      isActive
+      expanded
+      onRequestExpand={vi.fn()}
+      autoConnectWhenExpanded={false}
+      onReportSummary={vi.fn()}
+      onRegisterActions={vi.fn()}
+      onAnnounce={vi.fn()}
+      onResumeEndedSession={onResumeEndedSession}
     />,
   );
 }
@@ -309,5 +371,78 @@ describe("TerminalSessionView — same-owner takeover state", () => {
 
     expect(screen.getByText("This session is already open elsewhere")).toBeInTheDocument();
     expect(screen.queryByText("Taken over")).not.toBeInTheDocument();
+  });
+});
+
+// Card cbe60db5 rework 9 (Bug A, Nick's field test 2026-08-14): a timed-out
+// session's only option used to be a blind "Launch again" mint, with no way
+// back to the conversation that just ended. These pin the new "Resume this
+// conversation" primary action for the non-user endings we know a
+// cwd/claudeSessionId for, its graceful fallback when we don't, and that a
+// deliberate user End never offers it.
+describe("TerminalSessionView — session-ended resume (Bug A)", () => {
+  it("offers Resume as the primary action for an idle ending with a known cwd + claudeSessionId, wired with the exact-conversation payload shape", () => {
+    const onResumeEndedSession = vi.fn();
+    installMockEndedSession({
+      endedReason: "idle",
+      cwd: "/Users/nick/projects/vibe-coding-ideas",
+      claudeSessionId: "claude-conv-abc",
+    });
+    renderEndedView(onResumeEndedSession);
+
+    const resumeButton = screen.getByRole("button", { name: /Resume this conversation/ });
+    fireEvent.click(resumeButton);
+    expect(onResumeEndedSession).toHaveBeenCalledWith({
+      resume: undefined,
+      resumeId: "claude-conv-abc",
+      cwd: "/Users/nick/projects/vibe-coding-ideas",
+      taskId: undefined,
+      taskTitle: undefined,
+    });
+
+    // The blind mint stays available too, but relabelled so it's never
+    // confused with Resume.
+    expect(screen.getByRole("button", { name: /Start fresh/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Launch again$/ })).not.toBeInTheDocument();
+  });
+
+  it("falls back to the legacy --continue shape (resume:true, no resumeId) when only cwd is known", () => {
+    const onResumeEndedSession = vi.fn();
+    installMockEndedSession({
+      endedReason: "max-duration",
+      cwd: "/Users/nick/projects/vibe-coding-ideas",
+      claudeSessionId: null,
+    });
+    renderEndedView(onResumeEndedSession);
+
+    fireEvent.click(screen.getByRole("button", { name: /Resume this conversation/ }));
+    expect(onResumeEndedSession).toHaveBeenCalledWith({
+      resume: true,
+      resumeId: undefined,
+      cwd: "/Users/nick/projects/vibe-coding-ideas",
+      taskId: undefined,
+      taskTitle: undefined,
+    });
+  });
+
+  it("hides Resume entirely and keeps the plain 'Launch again' button when no cwd is known (legacy pre-0.3.3 session)", () => {
+    installMockEndedSession({ endedReason: "idle", cwd: null, claudeSessionId: null });
+    renderEndedView();
+
+    expect(screen.queryByRole("button", { name: /Resume this conversation/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Launch again$/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Start fresh/ })).not.toBeInTheDocument();
+  });
+
+  it("never offers Resume for a deliberate user-initiated end, even with a known cwd + claudeSessionId", () => {
+    installMockEndedSession({
+      endedReason: "user",
+      cwd: "/Users/nick/projects/vibe-coding-ideas",
+      claudeSessionId: "claude-conv-abc",
+    });
+    renderEndedView();
+
+    expect(screen.queryByRole("button", { name: /Resume this conversation/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Launch again$/ })).toBeInTheDocument();
   });
 });

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -60,6 +60,7 @@ import { isSameOwnerPreemptedClose } from "@/lib/terminal/connection";
 import type { TerminalConnectionState, TerminalStatus } from "@/lib/terminal/connection";
 import { type TerminalPlatform, TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
 import { shouldShowHelperUpdateNudge } from "@/lib/terminal/helper-version";
+import type { BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
 import { FIRST_RUN_COPY } from "@/lib/terminal/first-run-copy";
 import { type DockView, type LaunchPhase, resolveDockView } from "@/lib/terminal/first-run-flow";
 import {
@@ -149,6 +150,20 @@ interface TerminalSessionViewProps {
    * practice).
    */
   onReconnectTakenOver?: (sid: string) => void;
+  /**
+   * Card cbe60db5 rework 9 (Bug A — Nick's field test, 2026-08-14): the
+   * session-ended overlay's "Resume this conversation" action for a
+   * NON-user ending (idle / max-duration / a dropped-and-exhausted
+   * reconnect) — the ended session's own `claudeSessionId`/`cwd` (this
+   * hook's `session.claudeSessionId`/`session.cwd`, see use-terminal-
+   * session.ts), carried into a FRESH mint via the SAME capped launch flow
+   * the session chooser's own Resume uses (terminal-dock.tsx's
+   * `handleChooserResume` → `mintAndDeliver`) — mirrors the
+   * `onReconnectTakenOver` prop pattern above. Omitted hides the Resume
+   * button entirely (defensive — the overlay itself already gates on
+   * `session.cwd` being known before ever calling this).
+   */
+  onResumeEndedSession?: (payload: BrowserLaunchPayload) => void;
 }
 
 export function TerminalSessionView({
@@ -167,6 +182,7 @@ export function TerminalSessionView({
   onPopOut,
   onBringBack,
   onReconnectTakenOver,
+  onResumeEndedSession,
 }: TerminalSessionViewProps) {
   const session = useTerminalSession(descriptor, {
     enabled: true,
@@ -188,6 +204,8 @@ export function TerminalSessionView({
     peerDegraded,
     helperVersion,
     pair,
+    cwd: sessionCwd,
+    claudeSessionId,
     readOnly,
     inputEnabled,
     platform,
@@ -308,6 +326,29 @@ export function TerminalSessionView({
     view === "connecting" ||
     view === "connecting-returning" ||
     view === "legacy-waiting";
+  // Card cbe60db5 rework 9 (Bug A): a NON-user ending (idle / max-duration /
+  // an exhausted reconnect) is the whole point of this fix — the user didn't
+  // choose to stop, so a "Resume this conversation" primary action beats a
+  // blind fresh mint. A deliberate `endedReason === "user"` end keeps the
+  // original single "Launch again" action untouched (excluded per the QA
+  // root-cause: only the involuntary endings need the resume path). `cwd` is
+  // REQUIRED to resume anything (legacy `--continue` still needs a folder);
+  // `claudeSessionId` is optional — its absence just falls back to
+  // `--continue` (same graceful degrade the chooser's own Resume already
+  // does for a pre-rework-5 row, or a session whose bridge never announced
+  // one, e.g. pre-0.3.3).
+  const canResume =
+    view === "session-ended" && state.endedReason !== "user" && !!sessionCwd && !!onResumeEndedSession;
+  const handleResume = () => {
+    if (!sessionCwd) return;
+    onResumeEndedSession?.({
+      resume: claudeSessionId ? undefined : true,
+      resumeId: claudeSessionId ?? undefined,
+      cwd: sessionCwd,
+      taskId: entry.taskId,
+      taskTitle: entry.taskTitle,
+    });
+  };
 
   return (
     <div className={cn(!isActive && "hidden")} aria-hidden={!isActive}>
@@ -469,9 +510,11 @@ export function TerminalSessionView({
               platform={platform}
               canLaunch={canLaunch}
               takenOver={takenOver}
+              canResume={canResume}
               onConnect={() => void actions.connect({ autoLaunch: true })}
               onRetry={() => void actions.connect({ autoLaunch: true })}
               onLaunchAgain={actions.beginBrowserLaunch}
+              onResume={handleResume}
               onCopyBridge={actions.copyBridgeCommand}
               onReconnectTakenOver={() => {
                 if (pair) onReconnectTakenOver?.(pair.sessionId);
@@ -580,9 +623,11 @@ function StateOverlay({
   platform,
   canLaunch,
   takenOver,
+  canResume,
   onConnect,
   onRetry,
   onLaunchAgain,
+  onResume,
   onCopyBridge,
   onReconnectTakenOver,
 }: {
@@ -593,9 +638,12 @@ function StateOverlay({
   canLaunch: boolean;
   /** Card cbe60db5 rework 6 — see the same-named const in TerminalSessionView. */
   takenOver: boolean;
+  /** Card cbe60db5 rework 9 (Bug A) — see the same-named const in TerminalSessionView. */
+  canResume: boolean;
   onConnect: () => void;
   onRetry: () => void;
   onLaunchAgain: () => void;
+  onResume: () => void;
   onCopyBridge: () => void;
   onReconnectTakenOver: () => void;
 }) {
@@ -652,9 +700,33 @@ function StateOverlay({
           <Square className="h-7 w-7 text-zinc-400" />
           <div className="text-base font-semibold text-zinc-300">{endedTitle(state)}</div>
           <p className="max-w-md text-[13px] text-zinc-400">{endedMessage(state)}</p>
-          <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onLaunchAgain}>
-            <TerminalIcon className="h-4 w-4" /> Launch again
-          </Button>
+          {/* Card cbe60db5 rework 9 (Bug A, Nick's field test 2026-08-14): a
+              timed-out/dropped session's only option used to be this ONE
+              blind-new-mint button — no path back to the conversation that
+              was running. When we know where to resume it (`canResume`),
+              that becomes the primary action; the blind mint stays as an
+              explicit, clearly-labelled fallback so it's never confused with
+              resuming. A deliberate user End (or a session we have no
+              cwd/claudeSessionId for — legacy pre-0.3.3) keeps the original
+              single "Launch again" button. */}
+          {canResume ? (
+            <div className="flex flex-wrap justify-center gap-2.5">
+              <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onResume}>
+                <RefreshCw className="h-4 w-4" /> Resume this conversation
+              </Button>
+              <Button
+                variant="outline"
+                className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
+                onClick={onLaunchAgain}
+              >
+                <TerminalIcon className="h-4 w-4" /> Start fresh
+              </Button>
+            </div>
+          ) : (
+            <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onLaunchAgain}>
+              <TerminalIcon className="h-4 w-4" /> Launch again
+            </Button>
+          )}
         </>
       )}
 

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -887,4 +887,97 @@ describe("useTerminalSession", () => {
       expect(term.written).toContain("restored content");
     });
   });
+
+  // Card cbe60db5 rework 9 (Bug A — Nick's field test 2026-08-14): the
+  // session-ended overlay's "Resume this conversation" action needs THIS
+  // tab's own cwd/claudeSessionId to survive past the session actually
+  // ending (unlike `promptPartsRef`, which the hook deliberately clears on
+  // session-ended — see that effect). These pin the exposed `cwd`/
+  // `claudeSessionId` result fields' full lifecycle: resolved at connect()
+  // time, seeded from a carried resumeId, overwritten by the bridge's own
+  // announcement, and retained (never reset) once the session ends.
+  describe("cwd/claudeSessionId bookkeeping (Bug A)", () => {
+    it("resolves no cwd/claudeSessionId for a plain (non-resume) launch with no recorded folder", async () => {
+      const { result } = setup();
+      await act(async () => {
+        await result.current.actions.connect({ autoLaunch: false });
+      });
+      // This idea has no GitHub repo, no saved localStorage path, and no
+      // recorded DB path — resolveDefaultLaunchState falls to "new" mode,
+      // whose cwd is the caller's effective target (undefined here), so no
+      // cwd is ever resolved. Deterministic, not a false negative.
+      expect(result.current.cwd).toBeNull();
+      expect(result.current.claudeSessionId).toBeNull();
+    });
+
+    it("seeds claudeSessionId from a carried resumeId and exposes the carried cwd immediately after mint", async () => {
+      window.localStorage.setItem("vibecodes:terminal:paired-v1", "1");
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+        maxTouchPoints: 0,
+      });
+      const { result } = setup();
+      act(() => {
+        result.current.actions.launchFromBus({
+          resumeId: "claude-conv-carried",
+          cwd: "/Users/nick/projects/vibe-coding-ideas",
+        });
+      });
+      await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+      await flushEffects();
+
+      expect(result.current.cwd).toBe("/Users/nick/projects/vibe-coding-ideas");
+      // Seeded from the carried resumeId even before the bridge announces
+      // anything — a legacy bridge that never announces a `conv` still lets a
+      // LATER resume-of-this-resume carry the right id.
+      expect(result.current.claudeSessionId).toBe("claude-conv-carried");
+    });
+
+    it("overwrites the seeded claudeSessionId once the bridge announces its own conv id", async () => {
+      window.localStorage.setItem("vibecodes:terminal:paired-v1", "1");
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+        maxTouchPoints: 0,
+      });
+      const { result } = setup();
+      act(() => {
+        result.current.actions.launchFromBus({
+          resumeId: "claude-conv-carried",
+          cwd: "/Users/nick/projects/vibe-coding-ideas",
+        });
+      });
+      await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+      await flushEffects();
+      act(() => latestSocket().simulateOpen());
+
+      const announced = "99999999-8888-7777-6666-555555555555";
+      act(() => {
+        latestSocket().onmessage?.({ data: JSON.stringify({ t: "bridge-version", conv: announced }) });
+      });
+      expect(result.current.claudeSessionId).toBe(announced);
+    });
+
+    it("keeps cwd/claudeSessionId once the session ends (unlike promptPartsRef, never cleared on session-ended)", async () => {
+      const { result } = setup();
+      await act(async () => {
+        await result.current.actions.connect({ autoLaunch: false });
+      });
+      act(() => latestSocket().simulateOpen());
+      const announced = "99999999-8888-7777-6666-555555555555";
+      act(() => {
+        latestSocket().onmessage?.({ data: JSON.stringify({ t: "bridge-version", conv: announced }) });
+      });
+      expect(result.current.claudeSessionId).toBe(announced);
+
+      act(() => {
+        result.current.actions.end();
+      });
+      expect(result.current.state.status).toBe("session-ended");
+      // The Resume action reads exactly these two fields off the ended
+      // session — they must still be here to read.
+      expect(result.current.claudeSessionId).toBe(announced);
+    });
+  });
 });

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -357,6 +357,21 @@ export interface UseTerminalSessionResult {
   helperVersion: string | null;
   /** The minted session's ids/tokens (null before mint / after end). */
   pair: PairInfo | null;
+  /**
+   * Card cbe60db5 rework 9 (Bug A): the folder this tab's current/just-ended
+   * session launched into. See the `sessionCwd` state doc above for the full
+   * lifecycle — unlike `pair`, this is never cleared on session-ended, so the
+   * session-ended overlay's "Resume this conversation" action can read it.
+   */
+  cwd: string | null;
+  /**
+   * Card cbe60db5 rework 9 (Bug A): the id of the claude conversation this
+   * tab's current/just-ended session is running, once known. See the
+   * `claudeSessionId` state doc above. Null → the session-ended overlay's
+   * Resume falls back to the legacy `--continue` resume (or hides Resume
+   * entirely if `cwd` is also unknown), exactly like the chooser's Resume.
+   */
+  claudeSessionId: string | null;
   readOnly: boolean;
   /** isInputEnabled(state, readOnly) — convenience, the same predicate xterm's onData gates on. */
   inputEnabled: boolean;
@@ -395,6 +410,20 @@ export function useTerminalSession(
   const [readOnly, setReadOnly] = useState(false);
   const [pair, setPair] = useState<PairInfo | null>(null);
   const [xtermReady, setXtermReady] = useState(false);
+  // Card cbe60db5 rework 9 (Bug A — timeout resume): the folder + claude
+  // conversation id THIS tab's current/just-ended session launched with,
+  // captured at connect()-time and (unlike `promptPartsRef`, which clears on
+  // session-ended — see that effect below) kept around so the session-ended
+  // overlay's "Resume this conversation" action has something to carry into
+  // a fresh mint. `sessionCwd` is set from the same resolveLaunchPromptParts()
+  // the deep link itself used; `claudeSessionId` is seeded from this launch's
+  // own carried `resumeId` (if it WAS a resume) and overwritten the moment
+  // the bridge announces its actual `conv` (rework 5's exact-conversation
+  // Resume, see the bridge-version-frame handler below). Both null before any
+  // connect() on this tab, or forever for a plain launch whose bridge is too
+  // old to ever announce a conversation id.
+  const [sessionCwd, setSessionCwd] = useState<string | null>(null);
+  const [claudeSessionId, setClaudeSessionId] = useState<string | null>(null);
   // Same-machine auto-launch UI (the vibecodes:// deep-link path). "idle" = the
   // manual cross-machine flow (copy a command); "opening" = we fired a deep link and
   // are waiting on the local helper; "helper-timeout" = the calm ~8s fallback.
@@ -1031,6 +1060,10 @@ export function useTerminalSession(
             const conv = parseBridgeVersionConv(ev.data);
             if (conv && convIdAnnouncedSidRef.current !== sessionId) {
               convIdAnnouncedSidRef.current = sessionId;
+              // Bug A: the bridge's own announcement is the authoritative id —
+              // supersedes whatever `claudeSessionId` was seeded with at
+              // connect()-time (a carried resumeId, or null).
+              setClaudeSessionId(conv);
               void fetch(`/api/terminal/session/${encodeURIComponent(sessionId)}`, {
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
@@ -1334,6 +1367,13 @@ export function useTerminalSession(
     reconnectAttemptRef.current = 0;
     termRef.current?.clear();
 
+    // Bug A (card cbe60db5 rework 9): seed this tab's own resume bookkeeping
+    // for THIS mint. `claudeSessionId` starts as whatever resumeId this very
+    // launch carried (if it WAS a resume) — the bridge-version-frame handler
+    // above overwrites it with the bridge's own announced `conv` once that
+    // arrives, which is the more authoritative id.
+    setClaudeSessionId(promptPartsRef.current?.resumeId ?? null);
+
     // Best-effort identity PATCH (C4): the browser already resolves a cwd to
     // build the launch prompt — forward it to the registry row so "My
     // sessions" can show it. Never awaited/blocking: a failure here changes
@@ -1341,6 +1381,7 @@ export function useTerminalSession(
     // blank until it lands (or forever, if there's no cwd to report).
     try {
       const { cwd } = resolveLaunchPromptParts();
+      setSessionCwd(cwd && cwd.trim() ? cwd.trim() : null);
       if (cwd && cwd.trim()) {
         void fetch(`/api/terminal/session/${encodeURIComponent(data.sessionId)}`, {
           method: "PATCH",
@@ -1640,6 +1681,8 @@ export function useTerminalSession(
     peerDegraded,
     helperVersion,
     pair,
+    cwd: sessionCwd,
+    claudeSessionId,
     readOnly,
     inputEnabled: isInputEnabled(state, readOnly),
     platform,


### PR DESCRIPTION
Two bugs from Nick's live field test (2026-08-14), both root-caused by QA before any fix was attempted.

## A session that timed out on screen only offered a blind new session
The idle/max-duration ended-state had exactly one button — a fresh mint with no memory of which conversation had been running. It now offers a primary "Resume this conversation" action that reopens the exact conversation when known (falling back honestly to "continue the most recent in this folder" for older sessions with no tracked ID). "Launch again" stays as a clearly separate "Start fresh" option. A deliberate user End, or a session with no known folder at all, still shows just the one button — no dead Resume ever appears.

## RELEASE-BLOCKING: the toolbar "Launch Claude Code" button could silently mint a session during a loading race
Clicking it in the brief window before the page had finished checking for existing sessions caused an unconditional new mint — a direct violation of "nothing connects or mints until a click; the toolbar button routes through the same choice" from the approved design. The check for "is the registry still loading" was being treated identically to "nothing exists" instead of "not yet known". The launch is now queued and resolved (chooser or mint) the instant the check actually completes — as if the click had simply landed a beat later.

Tests: session-ended overlay (exact-resume/fallback/hidden/user-end cases), hook bookkeeping (seed/overwrite/survival), and new first-ever dock-level test coverage proving the race can no longer mint early. Full suite 2724/2724, tsc + eslint clean. Web-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)