### PR TITLE
fix(terminal): stale-liveness relay replay + stuck-pairing recovery watchdog (card cbe60db5)

### DIFF
--- a/src/components/board/terminal-popout-view.test.tsx
+++ b/src/components/board/terminal-popout-view.test.tsx
@@ -71,6 +71,7 @@ function installMockSession(status: "connected" | "error", closeCode: number | n
       paired: true,
       xtermReady: true,
       containerRef,
+      pairingTimedOut: false,
       actions: mockActions(),
     };
   });

--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -84,9 +84,50 @@ function installMockSession() {
       paired: true,
       xtermReady: true,
       containerRef,
+      pairingTimedOut: false,
       actions: mockActions(),
     };
   });
+}
+
+// Card cbe60db5 rework 10 (stuck-pairing watchdog, 2026-08-14 incident):
+// installs the mock hook in the "legacy-waiting" condition
+// (status: "waiting-to-pair", launchPhase: "idle") with a caller-supplied
+// `pairingTimedOut` — standing in for whatever the real hook's watchdog
+// effect (use-terminal-session.test.ts covers that timing logic directly)
+// decided. This file only checks TerminalSessionView renders the right
+// body for a given `pairingTimedOut` value and wires Retry correctly.
+function installMockWaitingSession(pairingTimedOut: boolean) {
+  const actions = mockActions();
+  mockedUseTerminalSession.mockImplementation((): UseTerminalSessionResult => {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    lastContainerRef = containerRef;
+    return {
+      state: {
+        status: "waiting-to-pair",
+        sessionId: "sess-1",
+        errorKind: null,
+        endedReason: null,
+        closeCode: null,
+        closeReason: null,
+      },
+      launchPhase: "idle",
+      peerDegraded: false,
+      helperVersion: null,
+      pair: { sessionId: "sess-1", bridgeToken: "bridge-tok", browserToken: "browser-tok" },
+      cwd: null,
+      claudeSessionId: null,
+      readOnly: false,
+      inputEnabled: false,
+      platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download", downloadUrl: null },
+      paired: true,
+      xtermReady: true,
+      containerRef,
+      pairingTimedOut,
+      actions,
+    };
+  });
+  return actions;
 }
 
 // Card cbe60db5 rework 6: installs the mock hook in an "error" state with a
@@ -121,6 +162,7 @@ function installMockErrorSession(state: Partial<TerminalConnectionState> = {}) {
       paired: true,
       xtermReady: true,
       containerRef,
+      pairingTimedOut: false,
       actions: mockActions(),
     };
   });
@@ -161,6 +203,7 @@ function installMockEndedSession(
       paired: true,
       xtermReady: true,
       containerRef,
+      pairingTimedOut: false,
       actions: mockActions(),
     };
   });
@@ -444,5 +487,43 @@ describe("TerminalSessionView — session-ended resume (Bug A)", () => {
 
     expect(screen.queryByRole("button", { name: /Resume this conversation/ })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Launch again$/ })).toBeInTheDocument();
+  });
+});
+
+// Card cbe60db5 rework 10 (stuck-pairing watchdog, 2026-08-14 incident): a
+// session stuck on "Waiting for your machine to attach" (legacy-waiting)
+// used to have no timeout at all. Once the hook's watchdog reports
+// `pairingTimedOut`, the body must swap to the existing TimeoutPanel's
+// "returning" copy — reusing it exactly, not the open-ended waiting panel —
+// with Retry wired to a genuine fresh connect({autoLaunch:true}), never a
+// reattach helper. The watchdog's OWN timing (does it actually fire after
+// RECONNECT_GRACE_MS, does the opt-out manual flow ever arm it) is covered
+// in use-terminal-session.test.ts; this file only checks the presentational
+// swap and the Retry wiring, same division of labour as every other view
+// test in here.
+describe("TerminalSessionView — stuck-pairing watchdog timeout panel", () => {
+  it("shows the normal 'Waiting for your machine to attach' panel while pairingTimedOut is false", () => {
+    installMockWaitingSession(false);
+    renderView(false);
+
+    expect(screen.getByText("Waiting for your machine to attach")).toBeInTheDocument();
+    expect(screen.queryByText("Couldn’t reach the helper on this Mac")).not.toBeInTheDocument();
+  });
+
+  it("swaps to the TimeoutPanel's 'returning' copy once pairingTimedOut is true, wiring Retry to a fresh connect({autoLaunch:true})", () => {
+    const actions = installMockWaitingSession(true);
+    renderView(false);
+
+    // The existing "returning" variant's copy, reused exactly — not the
+    // open-ended legacy-waiting text.
+    expect(screen.getByText("Couldn’t reach the helper on this Mac")).toBeInTheDocument();
+    expect(screen.queryByText("Waiting for your machine to attach")).not.toBeInTheDocument();
+    expect(screen.queryByText("Didn’t connect yet")).not.toBeInTheDocument();
+
+    const retry = screen.getByRole("button", { name: /Retry/ });
+    fireEvent.click(retry);
+    expect(actions.connect).toHaveBeenCalledWith({ autoLaunch: true });
+    // Never a reattach helper — connect() is the only action Retry calls.
+    expect(actions.reconnectNow).not.toHaveBeenCalled();
   });
 });

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -211,6 +211,7 @@ export function TerminalSessionView({
     platform,
     paired,
     containerRef,
+    pairingTimedOut,
     actions,
   } = session;
   // Non-blocking "update your terminal helper" nudge (release-gate rework 2a).
@@ -511,6 +512,7 @@ export function TerminalSessionView({
               canLaunch={canLaunch}
               takenOver={takenOver}
               canResume={canResume}
+              pairingTimedOut={pairingTimedOut}
               onConnect={() => void actions.connect({ autoLaunch: true })}
               onRetry={() => void actions.connect({ autoLaunch: true })}
               onLaunchAgain={actions.beginBrowserLaunch}
@@ -624,6 +626,7 @@ function StateOverlay({
   canLaunch,
   takenOver,
   canResume,
+  pairingTimedOut,
   onConnect,
   onRetry,
   onLaunchAgain,
@@ -640,6 +643,17 @@ function StateOverlay({
   takenOver: boolean;
   /** Card cbe60db5 rework 9 (Bug A) — see the same-named const in TerminalSessionView. */
   canResume: boolean;
+  /**
+   * Card cbe60db5 rework 10 (stuck-pairing watchdog): the hook's
+   * legacy-waiting session has sat unpaired for a full RECONNECT_GRACE_MS
+   * with no bridge ever attaching. Overrides the open-ended "legacy-waiting"
+   * body (NOT the header pill) with the existing TimeoutPanel's "returning"
+   * copy — reused as-is rather than resolveDockView's own paired-based
+   * new/returning split, since a stuck-pairing recovery is always the
+   * "we've seen this Mac before" framing regardless of the `paired` flag's
+   * current value.
+   */
+  pairingTimedOut: boolean;
   onConnect: () => void;
   onRetry: () => void;
   onLaunchAgain: () => void;
@@ -664,7 +678,11 @@ function StateOverlay({
         <TimeoutPanel variant="returning" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
       )}
 
-      {view === "legacy-waiting" && (
+      {view === "legacy-waiting" && pairingTimedOut && (
+        <TimeoutPanel variant="returning" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
+      )}
+
+      {view === "legacy-waiting" && !pairingTimedOut && (
         <>
           <Loader2 className="h-7 w-7 animate-spin text-sky-400" />
           <div className="text-base font-semibold text-sky-400">Waiting for your machine to attach</div>

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useTerminalSession, type TerminalSessionDescriptor } from "./use-terminal-session";
-import { isSameOwnerPreemptedClose } from "@/lib/terminal/connection";
+import { isSameOwnerPreemptedClose, RECONNECT_GRACE_MS } from "@/lib/terminal/connection";
 
 vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 // Tracks every mock Terminal instance created — used by the scrollback
@@ -978,6 +978,134 @@ describe("useTerminalSession", () => {
       // The Resume action reads exactly these two fields off the ended
       // session — they must still be here to read.
       expect(result.current.claudeSessionId).toBe(announced);
+    });
+  });
+
+  // Card cbe60db5 rework 10 (stuck-pairing watchdog, 2026-08-14 incident): QA
+  // root-caused a session stuck forever on "Waiting for your machine to
+  // attach" — attachToExisting (reload-reattach/instant-continue, the
+  // chooser's Reconnect) and reconnectNow's fresh-attach-reset (bring-back-
+  // from-pop-out) both reach status "waiting-to-pair" with launchPhase
+  // "idle" and NOTHING re-fires the vibecodes:// deep link, so the existing
+  // 8s helperTimerRef (which only bounds a FRESH same-pageview
+  // connect({autoLaunch:true}) launch) never engages. `pairingTimedOut`
+  // reports the new watchdog's own outcome; the presentational swap to
+  // TimeoutPanel is covered separately in terminal-session-view.test.tsx.
+  describe("pairing watchdog (stuck 'waiting for your machine to attach')", () => {
+    it("a manual connect({autoLaunch:false}) never times out — the one legitimate indefinite wait", async () => {
+      vi.useFakeTimers();
+      const { result } = setup();
+      await act(async () => {
+        await result.current.actions.connect({ autoLaunch: false });
+      });
+      act(() => latestSocket().simulateOpen());
+      expect(result.current.state.status).toBe("waiting-to-pair");
+      expect(result.current.launchPhase).toBe("idle");
+
+      await act(async () => {
+        vi.advanceTimersByTime(RECONNECT_GRACE_MS + 1000);
+      });
+      expect(result.current.pairingTimedOut).toBe(false);
+    });
+
+    it("attachToExisting arms the watchdog — pairingTimedOut fires after RECONNECT_GRACE_MS with no bridge attach", async () => {
+      vi.useFakeTimers();
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: { sessionId: "sid-popped", browserToken: "popped-browser-token" },
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      act(() => latestSocket().simulateOpen());
+      expect(result.current.state.status).toBe("waiting-to-pair");
+      expect(result.current.launchPhase).toBe("idle");
+      expect(result.current.pairingTimedOut).toBe(false);
+
+      // Just short of the deadline — still waiting, no false positive.
+      await act(async () => {
+        vi.advanceTimersByTime(RECONNECT_GRACE_MS - 1000);
+      });
+      expect(result.current.pairingTimedOut).toBe(false);
+
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(result.current.pairingTimedOut).toBe(true);
+    });
+
+    it("cancels the watchdog the instant the bridge attaches before the deadline", async () => {
+      vi.useFakeTimers();
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: { sessionId: "sid-popped", browserToken: "popped-browser-token" },
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      act(() => latestSocket().simulateOpen());
+
+      await act(async () => {
+        vi.advanceTimersByTime(RECONNECT_GRACE_MS / 2);
+      });
+      act(() => latestSocket().simulateBinaryMessage());
+      expect(result.current.state.status).toBe("connected");
+
+      // Advance well past the original deadline — a cleared timer must never
+      // fire late and flip a now-connected session into "timed out".
+      await act(async () => {
+        vi.advanceTimersByTime(RECONNECT_GRACE_MS);
+      });
+      expect(result.current.pairingTimedOut).toBe(false);
+    });
+
+    it("reconnectNow's fresh-attach-reset (bring-back-from-pop-out) arms the watchdog when the bridge never returns", async () => {
+      vi.useFakeTimers();
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: { sessionId: "sid-popped", browserToken: "popped-browser-token" },
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      act(() => latestSocket().simulateOpen());
+      act(() => latestSocket().simulateBinaryMessage());
+      expect(result.current.state.status).toBe("connected");
+
+      // Bring-back-from-pop-out: this window's own leg was preempted (relay
+      // 4001 "preempted") while the popped window took over — decideReconnectNow
+      // routes this to "fresh-attach-reset".
+      act(() => latestSocket().close(4001, "preempted"));
+      expect(result.current.state.status).toBe("error");
+
+      act(() => result.current.actions.reconnectNow());
+      expect(result.current.state.status).toBe("connecting");
+      act(() => latestSocket().simulateOpen());
+      expect(result.current.state.status).toBe("waiting-to-pair");
+      expect(result.current.launchPhase).toBe("idle");
+
+      await act(async () => {
+        vi.advanceTimersByTime(RECONNECT_GRACE_MS + 1000);
+      });
+      expect(result.current.pairingTimedOut).toBe(true);
     });
   });
 });

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -382,6 +382,19 @@ export interface UseTerminalSessionResult {
   xtermReady: boolean;
   /** Attach this to the DOM node that should host the xterm viewport. */
   containerRef: RefObject<HTMLDivElement | null>;
+  /**
+   * Card cbe60db5 (2026-08-14 incident): true once the stuck-pairing
+   * watchdog has fired — the session sat on "waiting-to-pair" with an
+   * idle launchPhase (the "legacy-waiting" view) for a full
+   * RECONNECT_GRACE_MS with no bridge ever attaching, and this wasn't the
+   * one legitimate indefinite-wait case (a manual `connect({autoLaunch:
+   * false})`). The consumer should surface the existing TimeoutPanel's
+   * "returning" variant instead of the open-ended legacy-waiting panel,
+   * with Retry wired to `actions.connect({ autoLaunch: true })`. Resets to
+   * false the instant the stuck condition clears (fresh connect/attach,
+   * data arrives, an error/end supersedes it, …).
+   */
+  pairingTimedOut: boolean;
   actions: TerminalSessionActions;
 }
 
@@ -511,6 +524,57 @@ export function useTerminalSession(
   // via the same shared builder (see resolveLaunchPromptParts), so every launch
   // is primed.
   const promptPartsRef = useRef<BrowserLaunchPayload | null>(null);
+
+  // ── stuck-pairing recovery watchdog (card cbe60db5, 2026-08-14 incident) ───
+  // Nothing re-fires the vibecodes:// deep link for an already-minted sid
+  // except a fresh connect({autoLaunch:true}) — so a session that reaches
+  // "waiting-to-pair" with launchPhase "idle" (the "legacy-waiting" view,
+  // "Waiting for your machine to attach") has NO timeout unless something
+  // arms one: the existing helperTimerRef only bounds the "opening" phase of
+  // a FRESH same-pageview launch, which this state has already passed
+  // through (or, for attachToExisting/fresh-attach-reset, never entered at
+  // all). OPT-OUT design: every path that expects its own auto-attach to
+  // eventually resolve (or time out) arms this true; the ONE legitimate
+  // indefinite wait — a literal manual `connect({autoLaunch:false})`, the
+  // "Advanced — pair a remote machine by hand" cross-machine flow — leaves
+  // it false so that panel keeps waiting forever, as designed.
+  const expectsAutoAttachRef = useRef(true);
+  const pairingWatchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Surfaces the existing TimeoutPanel ("returning" copy) over the
+  // legacy-waiting overlay once the watchdog below expires. Reset back to
+  // false the instant we're no longer sitting in the stuck condition (a
+  // fresh connect/attach moves launchPhase off "idle", data arriving moves
+  // status off "waiting-to-pair", etc.) — see the arming effect.
+  const [pairingTimedOut, setPairingTimedOut] = useState(false);
+
+  const clearPairingWatchdog = useCallback(() => {
+    if (pairingWatchdogRef.current) {
+      clearTimeout(pairingWatchdogRef.current);
+      pairingWatchdogRef.current = null;
+    }
+  }, []);
+
+  // Arm/disarm the watchdog whenever the "legacy-waiting" condition
+  // (status === "waiting-to-pair" && launchPhase === "idle" — see
+  // first-run-flow.ts's resolveDockView) becomes true or false. Re-runs on
+  // every status/launchPhase change, so the effect's own cleanup (returned
+  // below) clears any pending timer before re-evaluating — the same
+  // React-managed cleanup the other per-status effects in this hook rely on,
+  // no separate unmount effect needed. `expectsAutoAttachRef` is a ref (read
+  // at arm-time, not a dependency) so a manual-pairing session that later
+  // times out some OTHER way never retroactively arms a stale watchdog.
+  useEffect(() => {
+    clearPairingWatchdog();
+    const stuck = state.status === "waiting-to-pair" && launchPhase === "idle" && expectsAutoAttachRef.current;
+    if (!stuck) {
+      setPairingTimedOut(false);
+      return;
+    }
+    pairingWatchdogRef.current = setTimeout(() => {
+      setPairingTimedOut(true);
+    }, RECONNECT_GRACE_MS);
+    return clearPairingWatchdog;
+  }, [state.status, launchPhase, clearPairingWatchdog]);
 
   // Mirror live state into refs so the stable xterm onData handler + socket handlers
   // read current values without re-binding on every render.
@@ -1301,6 +1365,10 @@ export function useTerminalSession(
     teardownSocket();
     clearHelperTimer();
     removeLaunchIframe();
+    // Stuck-pairing watchdog (card cbe60db5): the ONE opt-out — a literal
+    // manual connect({autoLaunch:false}) is the legitimate indefinite-wait
+    // cross-machine flow, so it alone leaves this false.
+    expectsAutoAttachRef.current = autoLaunch;
     setLaunchPhase(autoLaunch ? "opening" : "idle");
     requestExpand();
     lastDimsRef.current = "";
@@ -1424,6 +1492,11 @@ export function useTerminalSession(
       clearHelperTimer();
       removeLaunchIframe();
       setLaunchPhase("idle");
+      // Stuck-pairing watchdog (card cbe60db5): a reload-reattach / instant-
+      // continue / chooser Reconnect all expect the bridge to show back up
+      // on its own — no deep link fires here, so nothing else times this
+      // out. See expectsAutoAttachRef's doc above.
+      expectsAutoAttachRef.current = true;
       lastDimsRef.current = "";
       setHelperVersion(null);
       // Two dispatches back-to-back, no await between them — React folds them
@@ -1501,6 +1574,8 @@ export function useTerminalSession(
     const decision = decideReconnectNow(statusRef.current, !!p, now, reconnectDeadlineRef.current);
 
     if (decision === "full-connect" || !p) {
+      // connect({autoLaunch:true}) arms expectsAutoAttachRef itself — no
+      // separate wiring needed here (card cbe60db5's watchdog).
       void connect({ autoLaunch: true });
       return;
     }
@@ -1515,6 +1590,14 @@ export function useTerminalSession(
       teardownSocket();
       reconnectDeadlineRef.current = 0;
       reconnectAttemptRef.current = 0;
+      // Stuck-pairing watchdog (card cbe60db5): this branch never touches
+      // launchPhase (it stays whatever it already was — typically "idle"),
+      // and opens with reconnect:false's honest CONNECT_TIMEOUT_MS bounding
+      // only the RELAY handshake, not the bridge showing back up once
+      // relay-open lands us on "waiting-to-pair". Without arming here, a
+      // bring-back/pop-out reattach whose peer never comes back hangs on
+      // legacy-waiting forever, same as attachToExisting's case.
+      expectsAutoAttachRef.current = true;
       // Two dispatches back-to-back, no await between them — the documented
       // two-dispatch pattern (see attachToExisting): React folds them through
       // the reducer in order against the queued state, so "session-created"'s
@@ -1531,7 +1614,14 @@ export function useTerminalSession(
       return;
     }
 
-    // decision === "grace-reconnect" — unchanged, prod-proven path.
+    // decision === "grace-reconnect" — unchanged, prod-proven path. No
+    // watchdog wiring needed (card cbe60db5): this reopens with
+    // {reconnect:true} against a status that's "disconnected" (never
+    // "connecting"), and the reducer's `relay-open` case only advances to
+    // "waiting-to-pair" from "connecting" — so this path never reaches
+    // legacy-waiting at all. It stays "disconnected" until either `data`
+    // (→ connected) or the grace window's own existing exhaustion
+    // (→ session-ended via reconnect-exhausted), both already bounded.
     clearReconnectTimer();
     if (reconnectDeadlineRef.current === 0) reconnectDeadlineRef.current = now + RECONNECT_GRACE_MS;
     openBrowserLeg(p.sessionId, p.browserToken, { reconnect: true });
@@ -1689,6 +1779,7 @@ export function useTerminalSession(
     paired,
     xtermReady,
     containerRef,
+    pairingTimedOut,
     actions: {
       connect,
       beginBrowserLaunch,

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -40,6 +40,7 @@ import {
   idleCloseReason,
   maxCloseReason,
   resolveMs,
+  shouldReplayStoredBridgeAnnouncement,
 } from "./pairing.js";
 import { shouldPersistActivity, DEFAULT_ACTIVITY_PERSIST_THROTTLE_MS } from "./activity-throttle.js";
 import { computeHelperStatus } from "./helper-status.js";
@@ -628,16 +629,26 @@ export class TerminalRelay {
         }
       }
     } else if (role === "browser") {
-      const [bridgeHelperVersion, bridgeHost, bridgeConv] = await Promise.all([
-        this.state.storage.get("bridgeHelperVersion"),
-        this.state.storage.get("bridgeHost"),
-        this.state.storage.get("bridgeConv"),
-      ]);
-      if (bridgeHelperVersion || bridgeHost || bridgeConv) {
-        try {
-          server.send(encodeBridgeVersionFrame(bridgeHelperVersion, bridgeHost, bridgeConv));
-        } catch (e) {
-          this.log("bridge-version send failed", { session, err: String(e) });
+      // Only replay the durably-stored announcement when a bridge is
+      // genuinely attached RIGHT NOW — `post` (computed just above, after
+      // this leg was already accepted) is the same live getWebSockets()
+      // check computeAttachState() uses for `pairWhole`/`peer-reattached`.
+      // Storage outlives the socket that wrote it, so without this gate a
+      // browser attaching after its bridge is long gone gets told a machine
+      // is live when none is — see shouldReplayStoredBridgeAnnouncement's
+      // doc comment in pairing.js for the incident this fixes.
+      if (shouldReplayStoredBridgeAnnouncement(post.bridge)) {
+        const [bridgeHelperVersion, bridgeHost, bridgeConv] = await Promise.all([
+          this.state.storage.get("bridgeHelperVersion"),
+          this.state.storage.get("bridgeHost"),
+          this.state.storage.get("bridgeConv"),
+        ]);
+        if (bridgeHelperVersion || bridgeHost || bridgeConv) {
+          try {
+            server.send(encodeBridgeVersionFrame(bridgeHelperVersion, bridgeHost, bridgeConv));
+          } catch (e) {
+            this.log("bridge-version send failed", { session, err: String(e) });
+          }
         }
       }
     }

--- a/terminal/relay/src/pairing.js
+++ b/terminal/relay/src/pairing.js
@@ -151,6 +151,34 @@ export function peerRole(role) {
   return role === "bridge" ? "browser" : "bridge";
 }
 
+// ── Stale bridge-announcement replay guard (card cbe60db5) ────────────────────
+//
+// The bridge's helperVersion/host/conv announcement is stored DURABLY
+// (state.storage) so a fast bridge reattach doesn't lose it. But durable
+// storage outlives the socket that wrote it: a bridge that attached once and
+// then dropped for good leaves those fields on file forever. Replaying them
+// unconditionally to every newly-attaching browser only proves a bridge
+// showed up at SOME point in the past — it says nothing about whether one is
+// live right now. A browser that attaches to a session whose bridge already
+// left sees the stored frame, believes a machine is attached, and the
+// "Waiting for your machine to attach" view never times out (2026-08-14
+// incident: exactly this replay kept a stuck pairing session waiting
+// forever). `peer-reattached` already gets this right by gating on
+// computeAttachState()'s LIVE getWebSockets() check — this mirrors that.
+//
+/**
+ * Whether a browser leg attaching right now may be told the durably-stored
+ * bridge announcement. Pure: the caller supplies the live-bridge check
+ * (computeAttachState().bridge, i.e. `getWebSockets("role:bridge").length >
+ * 0`) so this has no socket/storage access of its own.
+ *
+ * @param {boolean} bridgeLive - is a bridge leg attached to this session RIGHT NOW
+ * @returns {boolean}
+ */
+export function shouldReplayStoredBridgeAnnouncement(bridgeLive) {
+  return !!bridgeLive;
+}
+
 // ── Session lifecycle limits (slice 6) ────────────────────────────────────────
 //
 // Two server-side caps end a forgotten session cleanly so a DO can't live (and

--- a/terminal/relay/src/pairing.test.js
+++ b/terminal/relay/src/pairing.test.js
@@ -10,6 +10,7 @@ import {
   detach,
   peerRole,
   CLOSE,
+  shouldReplayStoredBridgeAnnouncement,
 } from "./pairing.js";
 
 test("empty session accepts a first bridge and a first browser", () => {
@@ -163,6 +164,20 @@ test("preemption: the stale-leg close reuses the DUP_BROWSER code with a distinc
   assert.equal(CLOSE.PREEMPTED.code, CLOSE.DUP_BROWSER.code);
   assert.equal(CLOSE.PREEMPTED.code, 4001);
   assert.match(CLOSE.PREEMPTED.reason, /preempted/);
+});
+
+// ── stale bridge-announcement replay guard (card cbe60db5) ───────────────────
+
+test("shouldReplayStoredBridgeAnnouncement: replays only when a bridge is live now", () => {
+  assert.equal(shouldReplayStoredBridgeAnnouncement(true), true);
+  assert.equal(shouldReplayStoredBridgeAnnouncement(false), false);
+});
+
+test("shouldReplayStoredBridgeAnnouncement: coerces truthy/falsy inputs to a strict boolean", () => {
+  assert.equal(shouldReplayStoredBridgeAnnouncement(1), true);
+  assert.equal(shouldReplayStoredBridgeAnnouncement(0), false);
+  assert.equal(shouldReplayStoredBridgeAnnouncement(undefined), false);
+  assert.equal(shouldReplayStoredBridgeAnnouncement(null), false);
 });
 
 test("isValidSession accepts url-safe tokens and rejects junk", () => {


### PR DESCRIPTION
A live session got permanently stuck showing "Waiting for your machine to attach" with no recovery. Root-caused by QA, confirmed against the relay and reattach code paths.

## What was happening
Two gaps combined: (1) the relay was replaying a bridge's *historical* announcement (its name, its conversation ID) to any newly-connecting browser tab, with no check that the bridge was actually still there — so the site looked like it had proof of a live connection when it only had proof of a past one; (2) nothing in the app ever asks the Mac to try connecting again once the initial attempt is lost — not a reload, not clicking Reconnect — so a session that drops mid-handshake stays stuck forever with no way out except manually ending it.

## The fix
The relay now only replays that information when a bridge is genuinely connected right now. Separately, any session that's auto-launched (as opposed to the deliberate manual "pair by hand" option, which is meant to wait indefinitely) now gets a 90-second safety window — if nothing connects in that time, it shows a clear "couldn't reach your machine, try again" screen whose Retry button does a real fresh connection attempt, not a silent no-op.

Tests: relay replay-gate (true/false), and web-side coverage for every path that can reach the stuck state — confirming the manual pairing flow is untouched, the watchdog fires correctly, cancels cleanly if the bridge shows up in time, and Retry does a genuine reconnect. Full suite 2730/2730, relay suite 40/40, tsc + eslint clean.

**Deploy order**: relay before/with web — flagged in the implementation report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)