### PR TITLE
fix(terminal): show the session picker even when another tab is already open (card cbe60db5)

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -11,17 +11,35 @@
 // zero visibility into other live sessions, exactly the failure mode QA
 // pinned.
 //
-// This file is a FOCUSED harness for that one race, not a full dock test
-// suite (no existing terminal-dock test file to extend — see the card).
-// `TerminalSessionView` / `TerminalMySessionsPanel` / `TerminalSessionChooser`
-// are stubbed so the test can assert purely on "did a session tab get
-// minted" vs. "did the chooser render", without pulling in the real hook's
-// xterm/WebSocket machinery — that machinery is already covered by
+// This file is a FOCUSED harness for that race and for rework 11 (card
+// cbe60db5, same card — QA's follow-up root cause): `deliverLaunch`'s
+// chooser-vs-mint decision was ALSO wrongly gated on
+// `sessionsRef.current.length === 0` (this pageview's own tab count) — once
+// any local tab existed, every subsequent launch (toolbar, "+", task launch)
+// fell straight through to `mintAndDeliver`, bypassing the chooser entirely,
+// regardless of what the registry still knew about. The fix always consults
+// `entryDecisionRef.current`; visibility is now separate from that decision
+// — `showingChooser` keeps the unchanged full-body swap when no local tab
+// exists, and a new `chooserOpen`-gated Dialog overlays the SAME chooser
+// over an already-open tab without ever unmounting it.
+//
+// Not a full dock test suite (no existing terminal-dock test file to extend
+// — see the card). `TerminalSessionView` / `TerminalMySessionsPanel` /
+// `TerminalSessionChooser` are stubbed so the test can assert purely on "did
+// a session tab get minted" vs. "did the chooser render" vs. "did the
+// overlay open", without pulling in the real hook's xterm/WebSocket
+// machinery — that machinery is already covered by
 // terminal-session-view.test.tsx and use-terminal-session.test.ts.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, act, waitFor } from "@testing-library/react";
-import type { ChooserRegistryRow } from "@/lib/terminal/chooser-data";
+import { render, screen, cleanup, act, waitFor, fireEvent } from "@testing-library/react";
+import { useEffect } from "react";
+import type {
+  ChooserRegistryRow,
+  ChooserLiveRow,
+  ChooserRecentRow,
+  ChooserSections,
+} from "@/lib/terminal/chooser-data";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -37,13 +55,28 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
 }));
 
+// Mount/unmount tracking (rework 11's non-disruption guarantee): a real
+// `TerminalSessionView` keeps its xterm instance, socket, and connection
+// state alive for the lifetime of the tab — an unmount+remount would lose
+// all of that. These spies fire once per genuine mount/unmount (empty-deps
+// effect), so a test can assert the overlay opening never triggers either.
+const { sessionViewMountSpy, sessionViewUnmountSpy } = vi.hoisted(() => ({
+  sessionViewMountSpy: vi.fn(),
+  sessionViewUnmountSpy: vi.fn(),
+}));
+
 // Renders just enough of a real TerminalSessionView for the test to see HOW
 // MANY tabs actually got minted, and with what payload — the real component
 // (and the hook underneath it) is exercised elsewhere.
 vi.mock("./terminal-session-view", () => ({
-  TerminalSessionView: ({ entry }: { entry: { key: string; taskId?: string } }) => (
-    <div data-testid="session-view" data-key={entry.key} data-task-id={entry.taskId ?? ""} />
-  ),
+  TerminalSessionView: ({ entry }: { entry: { key: string; taskId?: string } }) => {
+    useEffect(() => {
+      sessionViewMountSpy(entry.key);
+      return () => sessionViewUnmountSpy(entry.key);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <div data-testid="session-view" data-key={entry.key} data-task-id={entry.taskId ?? ""} />;
+  },
   dockStatusMeta: () => ({ label: "Terminal", Icon: () => null, className: "" }),
 }));
 
@@ -51,8 +84,45 @@ vi.mock("./terminal-my-sessions-panel", () => ({
   TerminalMySessionsPanel: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+// Real enough to drive rework 11's overlay tests — exposes one button per
+// action the dock wires up (`onStartNew`/`onReconnectHere`/
+// `onOpenBoardAndReconnect`/`onResume`), skipping the real component's
+// layout/copy (covered by terminal-session-chooser.test.tsx).
 vi.mock("./terminal-session-chooser", () => ({
-  TerminalSessionChooser: () => <div data-testid="chooser" />,
+  TerminalSessionChooser: ({
+    sections,
+    onStartNew,
+    onReconnectHere,
+    onOpenBoardAndReconnect,
+    onResume,
+  }: {
+    sections: ChooserSections;
+    onStartNew: () => void;
+    onReconnectHere: (row: ChooserLiveRow) => void;
+    onOpenBoardAndReconnect: (row: ChooserLiveRow) => void;
+    onResume: (row: ChooserRecentRow) => void;
+  }) => (
+    <div data-testid="chooser">
+      <button data-testid="chooser-start-new" onClick={onStartNew}>
+        Start new
+      </button>
+      {sections.liveHere.map((row) => (
+        <button key={row.sid} data-testid={`chooser-reconnect-here-${row.sid}`} onClick={() => onReconnectHere(row)}>
+          Reconnect here
+        </button>
+      ))}
+      {sections.liveElsewhere.map((row) => (
+        <button key={row.sid} data-testid={`chooser-open-board-${row.sid}`} onClick={() => onOpenBoardAndReconnect(row)}>
+          Open board & reconnect
+        </button>
+      ))}
+      {sections.recent.map((row) => (
+        <button key={row.sid} data-testid={`chooser-resume-${row.sid}`} onClick={() => onResume(row)}>
+          Resume
+        </button>
+      ))}
+    </div>
+  ),
 }));
 
 import { TerminalDock } from "./terminal-dock";
@@ -69,13 +139,21 @@ function deferredRegistryResponse() {
 /** Every OTHER fetch the dock's own effects fire (helper status) fails open
  * to null/[] — never hangs the test, and is irrelevant to this race. Only
  * `/api/terminal/session/list` (the registry — the ONE fetch this bug races
- * against) is wired to the caller-controlled deferred promise. */
+ * against) is wired to the caller-controlled deferred promise. Reattach
+ * (rework 11's Reconnect-inside-the-overlay test) always succeeds — its own
+ * failure handling is covered elsewhere. */
 function stubFetch(registryPromise: Promise<ChooserRegistryRow[]>) {
   vi.stubGlobal(
     "fetch",
     vi.fn((url: string) => {
       if (url === "/api/terminal/session/list") {
         return registryPromise.then((sessions) => ({ ok: true, json: async () => ({ sessions }) }));
+      }
+      if (url === "/api/terminal/session/reattach") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ sessionId: "reattached-session-id", browserToken: "reattached-token" }),
+        });
       }
       return Promise.resolve({ ok: false, json: async () => ({}) });
     }),
@@ -91,6 +169,25 @@ function liveElsewhereRow(): ChooserRegistryRow {
     taskTitle: null,
     machineLabel: null,
     cwd: "/Users/nick/projects/other",
+    claudeSessionId: null,
+    createdAt: new Date().toISOString(),
+    status: "active",
+    endedAt: null,
+  };
+}
+
+/** A live session on THIS board — belongs in `liveHere`, exercises
+ * `onReconnectHere` → `performReattach` (rather than `onOpenBoardAndReconnect`,
+ * which navigates away instead). */
+function liveHereRow(): ChooserRegistryRow {
+  return {
+    sid: "sid-live-here",
+    ideaId: "idea-1",
+    ideaTitle: "My Idea",
+    taskId: null,
+    taskTitle: null,
+    machineLabel: null,
+    cwd: "/Users/nick/projects/here",
     claudeSessionId: null,
     createdAt: new Date().toISOString(),
     status: "active",
@@ -168,6 +265,10 @@ describe("TerminalDock — launch-bus race with the still-loading registry (Bug 
     // pristine tab with no launch-bus event involved at all.
     await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
     expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+    // The empty-registry common case never shows the overlay, chooser, or
+    // any other UI (rework 11 no-regression check).
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
 
     act(() => {
       requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
@@ -177,5 +278,119 @@ describe("TerminalDock — launch-bus race with the still-loading registry (Bug 
     // carrying the task launch (never a 2nd tab).
     await waitFor(() => expect(screen.getByTestId("session-view").dataset.taskId).toBe("task-9"));
     expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("TerminalDock — chooser overlay when a tab is already open (rework 11, card cbe60db5)", () => {
+  /** Gets the dock's registry-loaded chooser to mint a first, genuinely
+   * local tab via its own "Start new session" action — the same path a real
+   * user takes, and the only way to reach a non-empty `sessions` list
+   * without relying on the bug this rework fixes. */
+  async function openFirstTabViaChooser() {
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("chooser-start-new"));
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    return screen.getByTestId("session-view").dataset.key;
+  }
+
+  it("routes a launch into the chooser overlay even though a local tab is already open — no longer gated on sessions.length === 0", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await openFirstTabViaChooser();
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // The old bug: once ANY tab existed, `deliverLaunch` fell straight
+    // through to `mintAndDeliver`, bypassing the chooser regardless of what
+    // the registry still knew about (here, a live session on another
+    // board). Firing the toolbar's launch again must still route through
+    // the chooser — as an overlay, since a tab now exists.
+    act(() => {
+      requestBrowserLaunch();
+    });
+
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    // Never a blind 2nd mint — the overlay is showing instead of minting.
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+  });
+
+  it("never unmounts the already-open tab's TerminalSessionView when the overlay opens", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    const firstKey = await openFirstTabViaChooser();
+    expect(sessionViewMountSpy).toHaveBeenCalledTimes(1);
+    expect(sessionViewMountSpy).toHaveBeenCalledWith(firstKey);
+
+    act(() => {
+      requestBrowserLaunch();
+    });
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    // Same tab, same key — never torn down and remounted underneath the
+    // overlay. A real TerminalSessionView losing its mount would drop the
+    // xterm buffer, the socket, and the heartbeat watchdog.
+    expect(screen.getByTestId("session-view").dataset.key).toBe(firstKey);
+    expect(sessionViewMountSpy).toHaveBeenCalledTimes(1);
+    expect(sessionViewUnmountSpy).not.toHaveBeenCalled();
+  });
+
+  it("Start new inside the overlay mints a 2nd tab and closes the overlay, leaving the first tab untouched", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    const firstKey = await openFirstTabViaChooser();
+    act(() => {
+      requestBrowserLaunch();
+    });
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("chooser-start-new"));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(2));
+    const keys = screen.getAllByTestId("session-view").map((el) => el.dataset.key);
+    expect(keys).toContain(firstKey); // appended a 2nd tab, never replaced the first
+    expect(sessionViewUnmountSpy).not.toHaveBeenCalled();
+  });
+
+  it("Reconnect inside the overlay performs a non-destructive reattach (appends a tab) and closes the overlay, leaving the first tab untouched", async () => {
+    stubFetch(Promise.resolve([liveHereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    const firstKey = await openFirstTabViaChooser();
+    act(() => {
+      requestBrowserLaunch();
+    });
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId(`chooser-reconnect-here-${liveHereRow().sid}`));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(2));
+    const keys = screen.getAllByTestId("session-view").map((el) => el.dataset.key);
+    expect(keys).toContain(firstKey); // appended, never replaced the existing tab
+    expect(sessionViewUnmountSpy).not.toHaveBeenCalled();
+  });
+
+  it("Open board & reconnect inside the overlay closes it without minting or touching the existing tab", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    const firstKey = await openFirstTabViaChooser();
+    act(() => {
+      requestBrowserLaunch();
+    });
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId(`chooser-open-board-${liveElsewhereRow().sid}`));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    // Navigates to the other board — nothing local minted, first tab intact.
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+    expect(screen.getByTestId("session-view").dataset.key).toBe(firstKey);
+    expect(sessionViewUnmountSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -57,6 +57,7 @@ import { ChevronUp, ChevronDown, Circle, ListTree, Loader2, Plus, Terminal as Te
 import { usePostHog } from "posthog-js/react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { logger } from "@/lib/logger";
 import { isTerminalEnabled, relayBaseUrl, type TerminalStatus } from "@/lib/terminal/connection";
@@ -192,6 +193,18 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // Disables every chooser action while a click's async work (reattach mint,
   // resume launch) is in flight — never a silent double-submit.
   const [chooserBusy, setChooserBusy] = useState(false);
+  // Chooser OVERLAY (card cbe60db5, rework 11 — QA root cause: `deliverLaunch`
+  // gated the chooser-vs-mint decision on "no local tabs yet", so once ANY
+  // tab existed every subsequent launch (toolbar, "+", task launch) bypassed
+  // the chooser regardless of what else the registry knew about). Visibility
+  // is now a SEPARATE concern from "does a local tab already exist":
+  // `showingChooser` (below) still owns the sessions.length === 0 full
+  // dock-body swap — today's unchanged behaviour, nothing to protect.
+  // `chooserOpen` gates a small non-destructive Dialog overlay for the case
+  // a tab is already open (possibly actively connected) — the tab strip and
+  // that tab's live `TerminalSessionView` stay mounted, connected, and
+  // visible underneath; only clicking an action inside the overlay closes it.
+  const [chooserOpen, setChooserOpen] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -663,32 +676,40 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
     posthogRef.current?.capture("terminal_tab_opened", { origin: entry.origin });
   }, []);
 
-  // Session entry chooser (card cbe60db5, F1): the actual entry point every
-  // launch source (toolbar bus event, task-launch bus event, "+") calls.
-  // Routes into the chooser instead of minting whenever the chooser is still
-  // the dock's resting state for THIS pageview (no local tabs yet AND the
-  // registry says there's something to choose between) — once any tab
-  // exists, the chooser has already resolved and every launch after that is
-  // `mintAndDeliver`'s unchanged behaviour.
+  // Session entry chooser (card cbe60db5, F1; rework 11 fixes the gate below).
+  // The actual entry point every launch source (toolbar bus event,
+  // task-launch bus event, "+") calls. Always consults `entryDecisionRef`
+  // — NOT gated on whether a local tab already exists — so a launch fired
+  // while another tab is open (or actively connected) still routes through
+  // the chooser instead of blindly minting a duplicate/parallel session
+  // whenever the registry knows about other live/recent sessions.
   const deliverLaunch = useCallback(
     (payload: BrowserLaunchPayload | null) => {
-      if (sessionsRef.current.length === 0) {
-        if (entryDecisionRef.current === null) {
-          // Bug B: the registry fetch that decides chooser-vs-mint hasn't
-          // resolved yet — null here means "don't know", NOT "empty-launch".
-          // Queue exactly like the (already-decided) chooser branch below —
-          // same expand + pendingLaunch — and let the seed effect (keyed on
-          // `entryDecision`) replay this the instant it settles.
-          setExpanded(true);
-          setPendingLaunch(payload);
-          deferredLaunchPendingRef.current = true;
-          return;
-        }
-        if (entryDecisionRef.current.kind === "chooser") {
-          setExpanded(true);
-          setPendingLaunch(payload);
-          return;
-        }
+      if (entryDecisionRef.current === null) {
+        // Bug B (rework 9): the registry fetch that decides chooser-vs-mint
+        // hasn't resolved yet — null here means "don't know", NOT
+        // "empty-launch". Queue regardless of how many tabs are already
+        // open — the seed/replay effect below (keyed on `entryDecision`)
+        // replays this the instant it settles, picking the body-swap or the
+        // overlay exactly as this function would have, had the fetch simply
+        // finished first.
+        setExpanded(true);
+        setPendingLaunch(payload);
+        deferredLaunchPendingRef.current = true;
+        return;
+      }
+      if (entryDecisionRef.current.kind === "chooser") {
+        // Rework 11 (card cbe60db5): no longer gated on
+        // `sessionsRef.current.length === 0`. With no local tabs there's
+        // nothing to protect, so it's today's unchanged full dock-body swap
+        // (`showingChooser` below); with a tab already open, the SAME
+        // chooser renders in a non-destructive overlay instead
+        // (`chooserOpen`) — the existing tab stays mounted, connected, and
+        // visible underneath.
+        setExpanded(true);
+        setPendingLaunch(payload);
+        if (sessionsRef.current.length > 0) setChooserOpen(true);
+        return;
       }
       mintAndDeliver(payload);
     },
@@ -777,18 +798,24 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   // real user action.
   const instantContinueTriggeredRef = useRef(false);
   useEffect(() => {
-    if (!entryDecision || sessions.length > 0) return;
-    // Bug B (card cbe60db5 rework 9): a launch that raced the still-loading
-    // registry (`deliverLaunch` queued it via `deferredLaunchPendingRef`
-    // instead of guessing) gets resolved HERE, the instant the real decision
-    // is known — takes priority over the passive empty-launch/instant-
+    if (!entryDecision) return;
+    // Bug B (card cbe60db5 rework 9) / rework 11: a launch that raced the
+    // still-loading registry (`deliverLaunch` queued it via
+    // `deferredLaunchPendingRef` instead of guessing) gets resolved HERE, the
+    // instant the real decision is known — regardless of how many tabs exist
+    // by then — taking priority over the passive empty-launch/instant-
     // continue defaults below, exactly as if the fetch had finished before
     // the click that triggered it.
     if (deferredLaunchPendingRef.current) {
       deferredLaunchPendingRef.current = false;
       if (entryDecision.kind === "chooser") {
-        // Already expanded with `pendingLaunch` set by `deliverLaunch` — the
-        // chooser renders itself from that state; nothing else to do.
+        // `deliverLaunch` already expanded the dock and set `pendingLaunch`.
+        // With no local tabs, `showingChooser` renders the body-swap chooser
+        // from that state alone — nothing else to do. With a tab already
+        // open, `deliverLaunch` couldn't know the resolved kind yet at queue
+        // time, so the overlay hasn't been shown — open it now,
+        // non-destructively.
+        if (sessions.length > 0) setChooserOpen(true);
         return;
       }
       const payload = pendingLaunch;
@@ -796,6 +823,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       mintAndDeliver(payload);
       return;
     }
+    if (sessions.length > 0) return; // a real tab already exists — nothing left to seed
     if (entryDecision.kind === "empty-launch") {
       const fresh = createPristineEntry();
       setSessions([fresh]);
@@ -826,15 +854,24 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   }, [reconnectParam, registryRows, pathname, performReattach]);
 
   // ── chooser action handlers ─────────────────────────────────────────────────
+  // Shared by BOTH the sessions.length === 0 body-swap chooser and the
+  // sessions.length > 0 overlay (rework 11) — the `setChooserOpen(false)` in
+  // each is a no-op when it was never opened (the body-swap case), and the
+  // one thing that's allowed to close the overlay per the design's
+  // non-disruption guarantee: only an explicit action in here, never an
+  // outside click/Escape (see the Dialog's `onInteractOutside`/
+  // `onEscapeKeyDown` below).
   const handleChooserStartNew = useCallback(() => {
     const payload = pendingLaunch;
     setPendingLaunch(null);
+    setChooserOpen(false);
     mintAndDeliver(payload);
   }, [pendingLaunch, mintAndDeliver]);
 
   const handleChooserReconnectHere = useCallback(
     (row: ChooserLiveRow) => {
       setPendingLaunch(null);
+      setChooserOpen(false);
       void performReattach(row.sid, { focus: true });
     },
     [performReattach],
@@ -842,6 +879,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
 
   const handleChooserOpenBoardAndReconnect = useCallback(
     (row: ChooserLiveRow) => {
+      setChooserOpen(false);
       router.push(`/ideas/${row.ideaId}/board?reconnect=${encodeURIComponent(row.sid)}`);
     },
     [router],
@@ -850,6 +888,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   const handleChooserResume = useCallback(
     (row: ChooserRecentRow) => {
       setPendingLaunch(null);
+      setChooserOpen(false);
       // F4's Resume: the EXISTING (capped) launch flow, carrying the ended
       // row's own recorded folder instead of a bootstrap prompt — see
       // BrowserLaunchPayload's doc and use-terminal-session.ts's
@@ -1199,6 +1238,41 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
           />
         ))}
       </div>
+
+      {/* Chooser OVERLAY (card cbe60db5, rework 11): the same
+          `TerminalSessionChooser` used by `showingChooser` above, but for the
+          sessions.length > 0 case — a launch fired while a tab is already
+          open (possibly actively connected). The tab strip and every
+          `TerminalSessionView` render in the (untouched) block above this
+          one, so opening this Dialog neither unmounts nor re-renders them —
+          it's a Portal-rendered overlay layered on top, nothing more. Forced
+          choice (matches onboarding-dialog.tsx's pattern): no close button,
+          outside-click and Escape are both suppressed — only an action
+          inside the chooser (wired to also call `setChooserOpen(false)`)
+          closes it. */}
+      <Dialog open={chooserOpen && sessions.length > 0} onOpenChange={() => {}}>
+        <DialogContent
+          showCloseButton={false}
+          className="max-w-lg gap-0 border-zinc-700 bg-[#141417] p-0 text-zinc-200 sm:max-w-xl"
+          onInteractOutside={(e) => e.preventDefault()}
+          onEscapeKeyDown={(e) => e.preventDefault()}
+        >
+          <DialogTitle className="sr-only">Choose a terminal session</DialogTitle>
+          <DialogDescription className="sr-only">
+            You already have a terminal open. Pick a session to reconnect to, resume, or start a new one.
+          </DialogDescription>
+          <TerminalSessionChooser
+            sections={chooserSections}
+            pendingTask={pendingTask}
+            busy={chooserBusy}
+            onReconnectHere={handleChooserReconnectHere}
+            onOpenBoardAndReconnect={handleChooserOpenBoardAndReconnect}
+            onResume={handleChooserResume}
+            onStartNew={handleChooserStartNew}
+            helperStatus={helperStatus}
+          />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
Nick's field test: clicking "Launch Claude Code" while a different, unrelated tab was already open silently started a brand-new session — even though two other live sessions for the exact project he wanted were sitting right there, reconnectable. The picker never appeared because the site's rule for "show the picker" only ever checked whether *this browser tab* had anything open, not whether other sessions existed anywhere else. That's now fixed for every way a new session gets started (the toolbar button and the "+" button both go through the same fix).

The fix is specifically designed not to trade one problem for a worse one: when you already have a tab open and connected, the picker now appears as a small overlay on top of it rather than replacing the whole panel — your existing terminal is never torn down or interrupted, proven by a test that watches for exactly that.

Tests: the original bug scenario, proof the existing tab is never disturbed, each picker action behaves correctly and non-destructively, and the ordinary empty-registry case is unchanged. Full suite 2735/2735, tsc + eslint clean. Web-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)