### PR TITLE
fix(board): find-work instruction excludes In Progress/Blocked/Verify (card 4cdcb33a)

### DIFF
--- a/src/lib/launch-claude-code.test.ts
+++ b/src/lib/launch-claude-code.test.ts
@@ -316,6 +316,31 @@ describe("buildBoardBootstrapPrompt", () => {
     expect(p).not.toContain("mkdir -p");
   });
 
+  // Card 4cdcb33a: a fresh session's "find work" instruction must never pick up
+  // a task another live session is already driving. To Do/Backlog were only a
+  // *preference* before this fix — never an explicit exclusion — so a session
+  // could "helpfully" grab an In Progress/Blocked/Verify task that looked
+  // interrupted. Assert the actual exclusion wording, not just "To Do"/"Backlog"
+  // presence (those pass before AND after the fix and prove nothing).
+  it("explicitly excludes In Progress/Blocked/Verify tasks from the find-work step", () => {
+    // mode "existing" + repoUrl (repo-backed dir block) rather than the
+    // no-repo "existing" fixture used above — that one triggers the full
+    // worktree-isolation protocol text, which alone can consume the whole
+    // 5000-char budget and truncate the trimmable work tail before this
+    // sentence, unrelated to this fix (pre-existing budget behavior, not
+    // something this test is about).
+    const p = buildBoardBootstrapPrompt({
+      appUrl: APP_URL,
+      ideaId: "idea-1",
+      ideaTitle: "My Idea",
+      mode: "existing",
+      repoUrl: "https://github.com/acme/widget",
+    });
+    expect(p).toContain("Only ever pick a task from To Do or Backlog");
+    expect(p).toMatch(/NEVER touch a task already in In Progress, Blocked, or Verify/);
+    expect(p).toMatch(/Another live session may be actively working it right now/);
+  });
+
   it("create-new mode injects mkdir and git clone when repo present", () => {
     const p = buildBoardBootstrapPrompt({
       appUrl: APP_URL,
@@ -943,6 +968,24 @@ describe("buildCompactBootstrapPrompt (deep-link prompt)", () => {
     expect(p).toContain("In Progress");
     // dir step comes before the MCP step
     expect(p.indexOf("mkdir -p")).toBeLessThan(p.indexOf("claude mcp add"));
+  });
+
+  // Card 4cdcb33a: same hard exclusion as the full board bootstrap prompt, but
+  // in the compact/terse phrasing this deep-link builder is budget-constrained
+  // to. Assert the actual exclusion substring, not just "To Do"/"Backlog"
+  // presence (those pass before AND after the fix and prove nothing) — and
+  // confirm the fix didn't blow the deep link's hard URL ceiling.
+  it("board-level (no taskId) work step explicitly excludes In Progress/Blocked/Verify tasks", () => {
+    const p = buildCompactBootstrapPrompt({
+      appUrl: APP_URL,
+      ideaId: "idea-1",
+      ideaTitle: "My Idea",
+      mode: "existing",
+      repoUrl: null,
+    });
+    expect(p).toContain("Only To Do/Backlog, never In Progress/Blocked/Verify");
+    expect(p).toMatch(/may be live/);
+    expect(buildClaudeDeepLink({ prompt: p }).length).toBeLessThanOrEqual(MAX_DEEP_LINK_URL_LENGTH);
   });
 
   it("existing-no-repo skips the directory step (the deep link cwd handles it)", () => {

--- a/src/lib/launch-claude-code.ts
+++ b/src/lib/launch-claude-code.ts
@@ -619,7 +619,7 @@ export function buildBoardBootstrapPrompt({
   const work = `Then, pick up my work on the VibeCodes board for this idea:
   • Idea: "${ideaTitle}"  (idea_id: ${ideaId})
   • Call get_board with idea_id ${ideaId} to see the columns and tasks. Do NOT use get_my_tasks here — it only returns tasks already ASSIGNED to you, and a freshly created board has none, so it would look (wrongly) like there's no work.
-  • Pick the top unstarted task (e.g. the first item in To Do, then Backlog), read it with get_task, assign it to yourself, and move it to In Progress.
+  • Pick the top unstarted task (e.g. the first item in To Do, then Backlog), read it with get_task, assign it to yourself, and move it to In Progress. Only ever pick a task from To Do or Backlog — NEVER touch a task already in In Progress, Blocked, or Verify, even if it looks interrupted or interesting. Another live session may be actively working it right now.
   • If that task has a workflow attached, use claim_next_step to claim its next step and follow the orchestration loop instead.
 
 Use the MCP tools (get_board / get_task / claim_next_step / move_task / add_task_comment / …) to do the work. Move the task to In Progress and comment as you go.`;
@@ -778,7 +778,7 @@ function buildCompactStepPieces({
 
   const work = taskId
     ? `Work this task: get_task (task_id ${taskId}, idea_id ${ideaId}), move it to In Progress, then start. Comment as you go.`
-    : `Find work: call get_board (idea_id ${ideaId}) — NOT get_my_tasks, which only returns tasks already assigned to you (a new board has none). Take the top task in To Do (then Backlog), get_task it, assign it to yourself, move it to In Progress, then start. Comment as you go.`;
+    : `Find work: call get_board (idea_id ${ideaId}) — NOT get_my_tasks, which only returns tasks already assigned to you (a new board has none). Only To Do/Backlog, never In Progress/Blocked/Verify (may be live). get_task it, assign it to yourself, move it to In Progress, then start. Comment as you go.`;
 
   const header = taskId
     ? `Set up VibeCodes and work a board task for "${title}".`


### PR DESCRIPTION
A freshly launched terminal, told to find its own work on the board, could pick up a task another live terminal was already actively driving — confirmed on a real transcript where a new session explicitly decided to "pick up where it left off" on someone else's in-flight work.

Root cause: the instruction given to a new session named To Do/Backlog as the *preferred* place to look, but never said other columns were off-limits — so an agent could reason its way past a soft preference. The board data already tells the agent which tasks are actively being worked (column name + workflow status), so this needed a wording fix, not new data. Both places that build this instruction (the full launch prompt and the shorter one used for URL-length-constrained launches, including the in-browser terminal) now state it as a hard rule instead of a suggestion.

Tests assert the actual new wording appears (not just that "To Do"/"Backlog" are mentioned, which would have passed before the fix too). Full suite 2737/2737, tsc + eslint clean. Text-only change — no helper, relay, or schema involved.

A related but separate gap (no protection if two brand-new terminals somehow raced onto the very same task at the same instant) is logged as its own follow-up card, not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)