### PR TITLE
fix(terminal): thread cwd/claudeSessionId through reattach so Resume works

### DIFF
--- a/src/app/api/terminal/session/reattach/route.ts
+++ b/src/app/api/terminal/session/reattach/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: Request) {
     // the explicit filter keeps the query honest regardless of client).
     const { data: row, error: rowErr } = await supabase
       .from("terminal_sessions")
-      .select("sid, idea_id, status, expires_at")
+      .select("sid, idea_id, status, expires_at, cwd, claude_session_id")
       .eq("sid", sid)
       .eq("user_id", user.id)
       .maybeSingle();
@@ -96,6 +96,16 @@ export async function POST(req: Request) {
       ideaId: tokens.idea,
       expiresAt: tokens.exp,
       browserToken: tokens.browser,
+      // Bug cbe60db5-followup: the registry row already knows the folder/
+      // conversation this session was running — forward it so the reattached
+      // browser leg can seed its own cwd/claudeSessionId (attachToExisting),
+      // exactly like a fresh connect() seeds them from the launch prompt.
+      // Without this, a session that ends AFTER a reload-reattach / instant-
+      // continue / chooser-Reconnect / pop-out bring-back never offers
+      // "Resume this conversation" (canResume requires sessionCwd), even
+      // though the server has known the folder the whole time.
+      cwd: row.cwd,
+      claudeSessionId: row.claude_session_id,
     });
   } catch (err) {
     logger.error("Terminal session reattach error", {

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -758,10 +758,25 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
         void refreshRegistry(); // the row may have just ended/expired — let the chooser reflect that
         return;
       }
-      const data = (await res.json()) as { sessionId: string; browserToken: string };
+      const data = (await res.json()) as {
+        sessionId: string;
+        browserToken: string;
+        cwd?: string | null;
+        claudeSessionId?: string | null;
+      };
       const snapshot = loadSessionSnapshot(sid);
       const initialBuffer = snapshot ? toReconnectBuffer(snapshot) : null;
-      const attach: AttachExistingPair = { sessionId: data.sessionId, browserToken: data.browserToken, initialBuffer };
+      // Bug cbe60db5-followup: forward the registry's cwd/claudeSessionId
+      // (now included in the reattach response) into the attach pair, so
+      // attachToExisting can seed them — otherwise a reattached session that
+      // later ends never offers "Resume this conversation".
+      const attach: AttachExistingPair = {
+        sessionId: data.sessionId,
+        browserToken: data.browserToken,
+        initialBuffer,
+        cwd: data.cwd,
+        claudeSessionId: data.claudeSessionId,
+      };
 
       const currentSessions = sessionsRef.current;
       const pristineKey = findPristineSlot(

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -979,6 +979,67 @@ describe("useTerminalSession", () => {
       // session — they must still be here to read.
       expect(result.current.claudeSessionId).toBe(announced);
     });
+
+    // Bug cbe60db5-followup (QA, 2026-08-16): a reload-reattach / instant-
+    // continue / chooser-Reconnect never showed "Resume this conversation"
+    // once the reattached session later ended for a non-user reason, even
+    // though the server had the folder on record — attachToExisting() never
+    // called setSessionCwd/setClaudeSessionId, unlike connect(). Fixed by
+    // threading the reattach route's cwd/claudeSessionId through
+    // AttachExistingPair into attachToExisting.
+    it("attachToExisting seeds cwd/claudeSessionId from the attach pair, and they survive a non-user session end", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: {
+            sessionId: "sid-reattached",
+            browserToken: "reattached-browser-token",
+            cwd: "/Users/nick/projects/vibe-coding-ideas",
+            claudeSessionId: "claude-conv-from-registry",
+          },
+        }),
+      );
+      await flushEffects();
+
+      // Seeded immediately, before the socket ever opens — mirrors connect()'s
+      // seeding, not something that only shows up once a bridge announces.
+      expect(result.current.cwd).toBe("/Users/nick/projects/vibe-coding-ideas");
+      expect(result.current.claudeSessionId).toBe("claude-conv-from-registry");
+
+      act(() => latestSocket().simulateOpen());
+      act(() => latestSocket().simulateBinaryMessage());
+      expect(result.current.state.status).toBe("connected");
+
+      // Ends for a NON-user reason (the bridge's own idle/max-duration close,
+      // or an exhausted reconnect) — exactly the case canResume in
+      // terminal-session-view.tsx cares about.
+      act(() => latestSocket().close(1000, "idle timeout"));
+      expect(result.current.state.status).toBe("session-ended");
+      expect(result.current.state.endedReason).toBe("idle");
+      expect(result.current.cwd).toBe("/Users/nick/projects/vibe-coding-ideas");
+      expect(result.current.claudeSessionId).toBe("claude-conv-from-registry");
+    });
+
+    it("attachToExisting falls back to null cwd/claudeSessionId when the attach pair omits them (pop-out hand-off, or a pre-fix reattach response)", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: { sessionId: "sid-popped", browserToken: "popped-browser-token" },
+        }),
+      );
+      await flushEffects();
+
+      expect(result.current.cwd).toBeNull();
+      expect(result.current.claudeSessionId).toBeNull();
+    });
   });
 
   // Card cbe60db5 rework 10 (stuck-pairing watchdog, 2026-08-14 incident): QA

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -269,6 +269,22 @@ export interface AttachExistingPair {
    * today's pre-this-card behaviour.
    */
   initialBuffer?: TransferredBuffer | null;
+  /**
+   * Bug cbe60db5-followup: the registry's own record of the folder/
+   * conversation this session was running, forwarded by the reattach route
+   * (`/api/terminal/session/reattach`) for reload-reattach / instant-
+   * continue / chooser-Reconnect. `attachToExisting` seeds `sessionCwd`/
+   * `claudeSessionId` from these — mirroring exactly what `connect()` seeds
+   * from `resolveLaunchPromptParts()` — so a session that later ends for a
+   * non-user reason can still offer "Resume this conversation" (`canResume`
+   * in terminal-session-view.tsx requires `sessionCwd`). Undefined/null for
+   * a popped-out window's hand-off (terminal-popout-view.tsx never carries
+   * these — the pop-out channel doesn't transfer them) or a pre-this-fix
+   * reattach response — falls back to the pre-existing null/no-resume
+   * behaviour, same as any other missing optional field here.
+   */
+  cwd?: string | null;
+  claudeSessionId?: string | null;
 }
 
 export interface PairInfo {
@@ -1507,6 +1523,18 @@ export function useTerminalSession(
       dispatch({ type: "connect" });
       dispatch({ type: "session-created", sessionId: p.sessionId });
       setPair({ sessionId: p.sessionId, browserToken: p.browserToken });
+      // Bug cbe60db5-followup: mirror connect()'s cwd/claudeSessionId seeding
+      // (lines ~1443/1452 above) so a reload-reattach / instant-continue /
+      // chooser-Reconnect / pop-out bring-back can still resume once this
+      // session later ends for a non-user reason. `p.cwd`/`p.claudeSessionId`
+      // come from the reattach route's registry read; a pop-out hand-off
+      // (attachExisting prop, no reattach round-trip) simply omits them, same
+      // as today's null/no-resume behaviour. The bridge's own bridge-version
+      // "conv" announcement (line ~1124 above) is still authoritative and
+      // will overwrite this the moment it arrives — last-write-wins, same as
+      // it already does over connect()'s seeded resumeId.
+      setSessionCwd(p.cwd ?? null);
+      setClaudeSessionId(p.claudeSessionId ?? null);
       reconnectDeadlineRef.current = 0;
       reconnectAttemptRef.current = 0;
       // Scrollback transfer (card 35cffc10, Flow A): a handed-over buffer


### PR DESCRIPTION
## Summary
- Reattached sessions (reload/Reconnect/instant-continue/pop-out bring-back) never showed a "Resume this conversation" option once they later ended — only "Launch again" — because the reattach path never carried `cwd`/`claude_session_id` through to the browser, unlike a fresh `connect()`.
- Threads those two fields from the reattach API response through `AttachExistingPair` into `attachToExisting()`, mirroring what `connect()` already does.

Card: cbe60db5 (rework 12). QA root-caused, Implementation fixed and verified.

## Test plan
- [x] tsc clean
- [x] targeted vitest 59/59 (use-terminal-session, terminal-session-view, terminal-dock)
- [x] full vitest 2739/2739 (170 files)
- [x] eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)