### PR TITLE
fix(terminal): Reconnect relaunches the idle-quit local helper

### DIFF
--- a/src/app/api/terminal/session/reattach/route.ts
+++ b/src/app/api/terminal/session/reattach/route.ts
@@ -1,9 +1,13 @@
 // Terminal session REATTACH — session entry chooser + reload-reattach (card
 // cbe60db5, design item 4). A SIBLING to the mint route (POST /api/terminal/
-// session), not a variant of it: this mints a fresh BROWSER-role token for a
-// session id that's ALREADY LIVE — the chooser's Reconnect, instant-continue,
-// and the popped-window reload's own reconnect panel all call this instead
-// of the mint route, because none of them are starting a NEW session.
+// session), not a variant of it: this mints fresh browser/bridge/helper
+// tokens for a session id that's ALREADY LIVE — the chooser's Reconnect,
+// instant-continue, "My sessions" Reconnect, and the popped-window reload's
+// own reconnect panel all call this instead of the mint route, because none
+// of them are starting a NEW session. Reconnect-relaunch fix: it used to mint
+// ONLY the browser token, which left nothing able to fire the vibecodes://
+// deep link that relaunches the local helper — see the bridge/helper minting
+// below.
 //
 // Deliberately exempt from the cap (E1) and the mint rate limit (E2) — F2:
 // "no new registry row, exempt from the session cap and the mint rate limit
@@ -16,7 +20,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
-import { mintSessionTokens } from "../../../../../../terminal/shared/session-token.mjs";
+import { mintSessionTokens, mintHelperToken } from "../../../../../../terminal/shared/session-token.mjs";
 import { decideReattach } from "@/lib/terminal/session-registry";
 import { reapExpiredSessions } from "@/lib/terminal/session-reap";
 
@@ -85,17 +89,30 @@ export async function POST(req: Request) {
       return NextResponse.json({ error, code: `reattach_${reason}` }, { status });
     }
 
-    // Mint a fresh BROWSER token for the SAME sid. No registry insert (F2:
-    // not a new session), no cap/rate-limit bookkeeping to touch.
-    const tokens = await mintSessionTokens({ sub: user.id, idea: row.idea_id, sid, secret });
+    // Mint a fresh BROWSER token for the SAME sid — plus a fresh BRIDGE token
+    // (mintSessionTokens mints both off the same sid/claims) and a fresh
+    // HELPER token, exactly like the mint route does. Reconnect-relaunch fix:
+    // a reattach used to hand back ONLY the browser token, so nothing could
+    // ever fire the vibecodes:// deep link that relaunches the local helper —
+    // the browser leg would open and then wait forever for a bridge that had
+    // no way to know it should attach (the helper auto-quits when idle, so in
+    // the common case there's no bridge running at all). These two extra
+    // tokens are exactly what `fireLaunchDeepLink` needs to relaunch it, the
+    // same way the initial mint does for a fresh `connect({autoLaunch:true})`.
+    const [tokens, helperToken] = await Promise.all([
+      mintSessionTokens({ sub: user.id, idea: row.idea_id, sid, secret }),
+      mintHelperToken({ sub: user.id, secret }),
+    ]);
 
-    logger.info("Reattached terminal session (fresh browser token)", { userId: user.id, sid });
+    logger.info("Reattached terminal session (fresh browser/bridge/helper tokens)", { userId: user.id, sid });
 
     return NextResponse.json({
       sessionId: tokens.sid,
       ideaId: tokens.idea,
       expiresAt: tokens.exp,
       browserToken: tokens.browser,
+      bridgeToken: tokens.bridge,
+      helperToken,
       // Bug cbe60db5-followup: the registry row already knows the folder/
       // conversation this session was running — forward it so the reattached
       // browser leg can seed its own cwd/claudeSessionId (attachToExisting),

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -761,6 +761,8 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       const data = (await res.json()) as {
         sessionId: string;
         browserToken: string;
+        bridgeToken?: string;
+        helperToken?: string;
         cwd?: string | null;
         claudeSessionId?: string | null;
       };
@@ -770,9 +772,17 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
       // (now included in the reattach response) into the attach pair, so
       // attachToExisting can seed them — otherwise a reattached session that
       // later ends never offers "Resume this conversation".
+      //
+      // Reconnect-relaunch fix: forward bridgeToken/helperToken too (now also
+      // included in the reattach response) — attachToExisting fires the
+      // vibecodes:// deep link when these are present, which is what
+      // actually relaunches the local helper instead of leaving the browser
+      // leg waiting passively forever.
       const attach: AttachExistingPair = {
         sessionId: data.sessionId,
         browserToken: data.browserToken,
+        bridgeToken: data.bridgeToken,
+        helperToken: data.helperToken,
         initialBuffer,
         cwd: data.cwd,
         claudeSessionId: data.claudeSessionId,
@@ -1249,6 +1259,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
             onPopOut={() => handlePopOut(entry.key)}
             onBringBack={() => bringBackToDock(entry.key)}
             onReconnectTakenOver={(sid) => void performReattach(sid, { focus: true })}
+            onRetryReconnect={(sid) => void performReattach(sid, { focus: true })}
             onResumeEndedSession={(payload) => mintAndDeliver(payload)}
           />
         ))}

--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -213,7 +213,7 @@ function baseEntry(): SessionEntry {
   return { key: "tab-1", origin: "toolbar", createdAt: Date.now(), launchSeq: 0, launchPayload: null };
 }
 
-function renderView(poppedOut: boolean) {
+function renderView(poppedOut: boolean, onRetryReconnect?: (sid: string) => void) {
   return render(
     <TerminalSessionView
       entry={baseEntry()}
@@ -228,6 +228,7 @@ function renderView(poppedOut: boolean) {
       onAnnounce={vi.fn()}
       poppedOut={poppedOut}
       onBringBack={vi.fn()}
+      onRetryReconnect={onRetryReconnect}
     />,
   );
 }
@@ -494,13 +495,19 @@ describe("TerminalSessionView — session-ended resume (Bug A)", () => {
 // session stuck on "Waiting for your machine to attach" (legacy-waiting)
 // used to have no timeout at all. Once the hook's watchdog reports
 // `pairingTimedOut`, the body must swap to the existing TimeoutPanel's
-// "returning" copy — reusing it exactly, not the open-ended waiting panel —
-// with Retry wired to a genuine fresh connect({autoLaunch:true}), never a
-// reattach helper. The watchdog's OWN timing (does it actually fire after
-// RECONNECT_GRACE_MS, does the opt-out manual flow ever arm it) is covered
-// in use-terminal-session.test.ts; this file only checks the presentational
+// "returning" copy — reusing it exactly, not the open-ended waiting panel.
+// The watchdog's OWN timing (does it actually fire after RECONNECT_GRACE_MS,
+// does the opt-out manual flow ever arm it) is covered in
+// use-terminal-session.test.ts; this file only checks the presentational
 // swap and the Retry wiring, same division of labour as every other view
 // test in here.
+//
+// Reconnect-relaunch fix: Retry used to be wired to a blind fresh
+// connect({autoLaunch:true}) — minting an entirely unrelated NEW session
+// instead of re-attempting the one stuck on screen. It's now wired to
+// `onRetryReconnect` (terminal-dock.tsx's performReattach, the SAME reattach
+// flow "My sessions"/chooser Reconnect use) with a defensive fallback to the
+// old connect() behaviour for a caller that doesn't wire it.
 describe("TerminalSessionView — stuck-pairing watchdog timeout panel", () => {
   it("shows the normal 'Waiting for your machine to attach' panel while pairingTimedOut is false", () => {
     installMockWaitingSession(false);
@@ -510,9 +517,10 @@ describe("TerminalSessionView — stuck-pairing watchdog timeout panel", () => {
     expect(screen.queryByText("Couldn’t reach the helper on this Mac")).not.toBeInTheDocument();
   });
 
-  it("swaps to the TimeoutPanel's 'returning' copy once pairingTimedOut is true, wiring Retry to a fresh connect({autoLaunch:true})", () => {
+  it("swaps to the TimeoutPanel's 'returning' copy once pairingTimedOut is true, wiring Retry to re-attempt the ORIGINAL sid", () => {
     const actions = installMockWaitingSession(true);
-    renderView(false);
+    const onRetryReconnect = vi.fn();
+    renderView(false, onRetryReconnect);
 
     // The existing "returning" variant's copy, reused exactly — not the
     // open-ended legacy-waiting text.
@@ -522,8 +530,20 @@ describe("TerminalSessionView — stuck-pairing watchdog timeout panel", () => {
 
     const retry = screen.getByRole("button", { name: /Retry/ });
     fireEvent.click(retry);
-    expect(actions.connect).toHaveBeenCalledWith({ autoLaunch: true });
-    // Never a reattach helper — connect() is the only action Retry calls.
+    // The stuck session's own sid ("sess-1", installMockWaitingSession's pair)
+    // — never a blind fresh mint, which orphans the stuck session and burns a
+    // new cap slot for no reason (the bug this fixes).
+    expect(onRetryReconnect).toHaveBeenCalledWith("sess-1");
+    expect(actions.connect).not.toHaveBeenCalled();
     expect(actions.reconnectNow).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a fresh connect({autoLaunch:true}) when no reattach handler is wired (defensive)", () => {
+    const actions = installMockWaitingSession(true);
+    renderView(false); // no onRetryReconnect passed
+
+    const retry = screen.getByRole("button", { name: /Retry/ });
+    fireEvent.click(retry);
+    expect(actions.connect).toHaveBeenCalledWith({ autoLaunch: true });
   });
 });

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -151,6 +151,19 @@ interface TerminalSessionViewProps {
    */
   onReconnectTakenOver?: (sid: string) => void;
   /**
+   * Reconnect-relaunch fix: Retry on the ~8s helper-open timeout panel (a
+   * deep link fired but the helper never attached) AND on the stuck-pairing
+   * watchdog's TimeoutPanel (`pairingTimedOut`) both used to call
+   * `actions.connect({ autoLaunch: true })` — minting an entirely unrelated
+   * NEW session instead of re-attempting the one the user is actually
+   * looking at. Wired to THIS sid's reattach flow instead (the SAME
+   * `performReattach` `onReconnectTakenOver` uses), so Retry fires a fresh
+   * deep link for the ORIGINAL session. Falls back to a fresh
+   * `connect({autoLaunch:true})` when omitted (defensive — mirrors the
+   * pre-fix behaviour for any caller that doesn't wire this).
+   */
+  onRetryReconnect?: (sid: string) => void;
+  /**
    * Card cbe60db5 rework 9 (Bug A — Nick's field test, 2026-08-14): the
    * session-ended overlay's "Resume this conversation" action for a
    * NON-user ending (idle / max-duration / a dropped-and-exhausted
@@ -182,6 +195,7 @@ export function TerminalSessionView({
   onPopOut,
   onBringBack,
   onReconnectTakenOver,
+  onRetryReconnect,
   onResumeEndedSession,
 }: TerminalSessionViewProps) {
   const session = useTerminalSession(descriptor, {
@@ -514,7 +528,18 @@ export function TerminalSessionView({
               canResume={canResume}
               pairingTimedOut={pairingTimedOut}
               onConnect={() => void actions.connect({ autoLaunch: true })}
-              onRetry={() => void actions.connect({ autoLaunch: true })}
+              onRetry={() => {
+                // Reconnect-relaunch fix: re-attempt THIS session (a fresh
+                // reattach → fresh deep link) instead of minting an unrelated
+                // new one — see onRetryReconnect's doc. `pair` is always known
+                // by the time a Retry button can render (every view that
+                // shows one — timeout-new/returning, or the watchdog's
+                // pairingTimedOut — only reaches that state via a status the
+                // reducer sets alongside session-created).
+                const sid = pair?.sessionId;
+                if (sid && onRetryReconnect) onRetryReconnect(sid);
+                else void actions.connect({ autoLaunch: true });
+              }}
               onLaunchAgain={actions.beginBrowserLaunch}
               onResume={handleResume}
               onCopyBridge={actions.copyBridgeCommand}

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -9,7 +9,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { useTerminalSession, type TerminalSessionDescriptor } from "./use-terminal-session";
+import {
+  useTerminalSession,
+  type AttachExistingPair,
+  type TerminalSessionDescriptor,
+} from "./use-terminal-session";
 import { isSameOwnerPreemptedClose, RECONNECT_GRACE_MS } from "@/lib/terminal/connection";
 
 vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
@@ -727,6 +731,122 @@ describe("useTerminalSession", () => {
       rerender({ attachExisting: { ...attachExisting } }); // same sessionId, new object identity
       await flushEffects();
       expect(mockSockets).toHaveLength(1); // no second socket opened
+    });
+
+    // Card cbe60db5-followup / reconnect-relaunch fix: every OTHER test above
+    // mounts the hook with `attachExisting` already populated in
+    // `initialProps` — that's the popped-out window's shape (a fresh
+    // component instance whose payload arrives async but before this
+    // effect's first run), not the dock's own "My sessions"/chooser Reconnect
+    // shape. There, the SAME already-mounted tab slot gets its `attach` field
+    // set on a LATER render (terminal-dock.tsx's pristine-slot-reuse,
+    // `performReattach` around lines 781-796) — `attachExisting` starts out
+    // `null`/absent and flips to a real pair well after mount. This test
+    // exercises THAT transition directly, confirming the effect still fires
+    // (and the watchdog still arms) rather than assuming the dedupe test
+    // above already covers it.
+    it("attaches when attachExisting flips from null to populated on a LATER render (the real pristine-slot-reuse transition, not an already-populated mount)", async () => {
+      vi.useFakeTimers();
+      const requestExpand = vi.fn();
+      const { result, rerender } = renderHook(
+        (props: { attachExisting: AttachExistingPair | null }) =>
+          useTerminalSession(descriptor, {
+            enabled: true,
+            expanded: true,
+            requestExpand,
+            autoConnectWhenExpanded: false,
+            attachExisting: props.attachExisting,
+          }),
+        { initialProps: { attachExisting: null as AttachExistingPair | null } },
+      );
+
+      // Mounted with nothing to attach to yet — an idle pristine slot.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current.state.status).toBe("idle");
+      expect(mockSockets).toHaveLength(0);
+
+      // The dock reuses THIS SAME slot for a reattach — attachExisting flips
+      // null → populated on a later render of the SAME hook instance.
+      rerender({ attachExisting: { sessionId: "sid-late", browserToken: "late-browser-token" } });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.state.status).toBe("connecting");
+      expect(result.current.pair).toEqual({ sessionId: "sid-late", browserToken: "late-browser-token" });
+      expect(mockSockets).toHaveLength(1);
+      expect(latestSocket().url).toBe(
+        "ws://127.0.0.1:8787/?session=sid-late&role=browser&token=late-browser-token",
+      );
+
+      act(() => latestSocket().simulateOpen());
+      expect(result.current.state.status).toBe("waiting-to-pair");
+
+      // The watchdog must still arm for this transition, exactly like the
+      // already-mounted-populated case (see the "pairing watchdog" describe
+      // below) — a bridge that never shows up still surfaces pairingTimedOut.
+      await act(async () => {
+        vi.advanceTimersByTime(RECONNECT_GRACE_MS + 1000);
+      });
+      expect(result.current.pairingTimedOut).toBe(true);
+    });
+
+    // Reconnect-relaunch fix (the bug this file's suite name references): a
+    // reattach whose pair carries a bridgeToken (the reattach route now
+    // mints one — /api/terminal/session/reattach) means a real Reconnect,
+    // not a popped-out window's hand-off. attachToExisting must fire the
+    // SAME vibecodes:// deep link connect({autoLaunch:true}) fires for a
+    // fresh mint, or the local helper (which auto-quits when idle) never
+    // gets told to come back and the session waits forever.
+    it("fires the vibecodes:// deep link when the attach pair carries a bridgeToken (Reconnect actually relaunches the helper)", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: {
+            sessionId: "sid-reconnect",
+            browserToken: "reconnect-browser-token",
+            bridgeToken: "reconnect-bridge-token",
+            helperToken: "reconnect-helper-token",
+          },
+        }),
+      );
+      await flushEffects();
+
+      // openLaunchLinkAndArmTimeout only sets "opening" once a link actually
+      // fired — this is the observable proof fireLaunchDeepLink ran.
+      expect(result.current.launchPhase).toBe("opening");
+      const iframes = document.querySelectorAll("iframe");
+      expect(iframes).toHaveLength(1);
+      const src = iframes[0].getAttribute("src") ?? "";
+      expect(src.startsWith("vibecodes://launch?")).toBe(true);
+      expect(src).toContain("session=sid-reconnect");
+      expect(src).toContain(`token=${encodeURIComponent("reconnect-bridge-token")}`);
+      expect(src).toContain(`helperToken=${encodeURIComponent("reconnect-helper-token")}`);
+      // The browser leg still opens normally alongside the deep link.
+      expect(mockSockets).toHaveLength(1);
+    });
+
+    it("never fires a deep link when the attach pair carries no bridgeToken (popped-out hand-off — unchanged behaviour)", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: { sessionId: "sid-popped", browserToken: "popped-browser-token" },
+        }),
+      );
+      await flushEffects();
+
+      expect(result.current.launchPhase).toBe("idle");
+      expect(document.querySelectorAll("iframe")).toHaveLength(0);
     });
 
     it("never trips the paired auto-connect effect, even on a browser that WOULD otherwise ambient-connect (would double-mint)", async () => {

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -285,6 +285,28 @@ export interface AttachExistingPair {
    */
   cwd?: string | null;
   claudeSessionId?: string | null;
+  /**
+   * Reconnect-relaunch fix: the reattach route (`/api/terminal/session/
+   * reattach`) now mints a fresh BRIDGE token alongside the browser token it
+   * always minted — the credential `fireLaunchDeepLink` needs to relaunch the
+   * local helper. Without this, Reconnect opened a browser leg and then
+   * waited passively forever: the local helper auto-quits when idle, and
+   * nothing ever told it to come back. `attachToExisting` fires the deep
+   * link when this is present, exactly like `connect({autoLaunch:true})`
+   * does for a fresh mint. Absent for a popped-out window's hand-off
+   * (terminal-popout-view.tsx never carries it — the bridge is already
+   * attached elsewhere, nothing to relaunch) or a pre-this-fix reattach
+   * response — attachToExisting simply doesn't fire a deep link then, same
+   * as today's behaviour.
+   */
+  bridgeToken?: string;
+  /**
+   * The matching HELPER-role token (card cc74a067) — rides the SAME deep
+   * link as `bridgeToken` so the same click also (re)establishes the
+   * helper's standing control connection. See `bridgeToken`'s doc; optional
+   * for the same reasons.
+   */
+  helperToken?: string;
 }
 
 export interface PairInfo {
@@ -1558,9 +1580,20 @@ export function useTerminalSession(
       // abort before opening a socket that a newer attempt would immediately
       // have to tear down again.
       if (isConnectSuperseded(gen, connectGenRef.current)) return;
+      // Reconnect-relaunch fix: a bridgeToken riding the attach pair means
+      // this came through the reattach route (My sessions / chooser /
+      // ?reconnect=<sid> Reconnect), not a popped-out window's hand-off —
+      // fire the SAME deep link connect({autoLaunch:true}) fires for a fresh
+      // mint, so the local helper actually relaunches instead of the browser
+      // leg waiting passively forever. Mirrors connect()'s own
+      // `if (autoLaunch) fireLaunchDeepLink(...)` call exactly, just gated on
+      // the token being present instead of an autoLaunch flag.
+      if (p.bridgeToken) {
+        fireLaunchDeepLink(p.sessionId, p.bridgeToken, p.helperToken);
+      }
       openBrowserLeg(p.sessionId, p.browserToken);
     },
-    [teardownSocket, clearHelperTimer, removeLaunchIframe, openBrowserLeg],
+    [teardownSocket, clearHelperTimer, removeLaunchIframe, fireLaunchDeepLink, openBrowserLeg],
   );
 
   // Fire attachToExisting once per distinct transferred session id — the


### PR DESCRIPTION
## Summary
- Clicking "Reconnect" on a session in "My sessions" hung indefinitely on "Waiting for your machine to attach" because the reattach path never fired the `vibecodes://` deep link that relaunches the local helper — and the helper auto-quits when idle, so in the common case nothing was listening.
- `/api/terminal/session/reattach` now also mints `bridgeToken`/`helperToken` (mirroring the main mint route) so `attachToExisting()` can fire the same deep link `connect({autoLaunch:true})` already does.
- Retry on the stuck-pairing timeout panel now re-attempts the *original* session instead of silently minting an unrelated new one.

Card: 54d05d0b (Bug Fix workflow). Found while field-testing cbe60db5; QA root-caused, Implementation fixed and verified.

## Test plan
- [x] tsc clean
- [x] targeted vitest 63/63 (use-terminal-session, terminal-session-view, terminal-dock)
- [x] full vitest 2743/2743 (170 files)
- [x] eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)