### PR TITLE
fix(terminal): protect the find-work launch step from mid-sentence truncation

### DIFF
--- a/src/lib/launch-claude-code.test.ts
+++ b/src/lib/launch-claude-code.test.ts
@@ -1653,7 +1653,18 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
   // silently refused to launch. The REWORK fix keeps the essentials (MCP
   // connect + record_project_path) path-length-independent and folds the
   // worktree protocol in only when it fits (fitCompactWorktreeProtocol).
-  it("BUG1: worst-realistic case (80-char title + ~85-char real path + real UUID) fits under the cap, with the essentials/protocol surviving the clamp intact", () => {
+  //
+  // BUG C fix (6th rework cycle) rewrite: at this exact realistic size,
+  // head (824) + protocol (639) + directory-echo (320) + work (444) together
+  // (2227) exceed the ~1777-char remaining budget even though head+protocol
+  // ALONE would fit — pre-fix, that meant the protocol rode the head and the
+  // TAIL (directory-echo + the "find work" step carrying idea_id/task_id) was
+  // char-trimmed to whatever was left, sometimes shredding the work step
+  // mid-sentence. This test previously asserted the protocol survives here;
+  // that was actually observing the bug, not the fix. Correctly prioritised,
+  // the protocol is what degrades at this size — the essentials AND the work
+  // step (the one thing with no MCP-side recovery path) must survive whole.
+  it("BUG1/BUG C: worst-realistic case (80-char title + ~85-char real path + real UUID) fits under the cap, with essentials AND the work step surviving intact", () => {
     const cwd = "/Users/nicholasmarcusball/Library/CloudStorage/Dropbox/projects/horse-race-predictor";
     expect(cwd.length).toBeGreaterThanOrEqual(80);
     expect(cwd.length).toBeLessThanOrEqual(90);
@@ -1683,25 +1694,30 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
     const link = buildClampedDeepLink(args, { cwd });
     expect(link.length).toBeLessThanOrEqual(MAX_DEEP_LINK_URL_LENGTH);
 
-    // At this (realistic) length the protocol comfortably fits alongside the
-    // essentials, so every load-bearing token — the worktree-isolation
-    // protocol (BUG2's restored clauses included) AND the MCP-connect step —
-    // must survive verbatim inside the final URL.
     const decoded = decodeURIComponent(link.split("q=")[1]);
-    for (const token of [
-      "kill -0", // PID liveness (not a heartbeat)
-      ".vibe/wt-N", // sibling worktree home
-      "-b vibe/wt-N", // branch naming
-      "never push primary", // never-push-primary directive
-      "Not a git repo", // BUG2(a): not-a-git-repo degrade branch
-      "path==$PWD", // BUG2(b): lock path-match tiebreak
-      "lowest free N", // BUG2(c): lowest-free-N collision avoidance
-      "git log @{u}", // BUG3: unpushed-detection command
-      "git status --porcelain", // BUG5: explicit dirty gate
-      "claude mcp add", // MCP-connect step (also head, also load-bearing)
-    ]) {
-      expect(decoded, `token "${token}" must survive the clamp`).toContain(token);
+
+    // The essentials (MCP-connect, record_project_path) always survive whole.
+    for (const step of essentials.headSteps ?? []) {
+      expect(decoded, `head step must survive whole: "${step.slice(0, 40)}..."`).toContain(step);
     }
+
+    // The work step — the ONE thing carrying idea_id/task_id with no MCP-side
+    // recovery path — must survive WHOLE, at this size that used to sacrifice
+    // it for the protocol.
+    expect(essentials.work).toBeTruthy();
+    expect(decoded, "the find-work step must survive whole, never a fragment").toContain(
+      essentials.work!
+    );
+
+    // The worktree-isolation protocol is best-effort and, correctly
+    // prioritised below the work step, does NOT fit at this size — but it
+    // must be an all-or-nothing omission, never a fragment.
+    const protocolTokens = ["kill -0", ".vibe/wt-N", "-b vibe/wt-N", "never push primary"];
+    const presentCount = protocolTokens.filter((t) => decoded.includes(t)).length;
+    expect(
+      [0, protocolTokens.length],
+      `protocol must be all-or-nothing, found ${presentCount}/${protocolTokens.length}`
+    ).toContain(presentCount);
   });
 
   // BUG1 REWORK — path-length SWEEP (replaces the single ~85-char boundary
@@ -1732,7 +1748,7 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
 
     for (const cwdLen of CWD_LENGTHS) {
       for (const titleLen of TITLE_LENGTHS) {
-        it(`cwd=${cwdLen} chars, title=${titleLen} chars: URL <= cap, essentials present, protocol all-or-nothing`, () => {
+        it(`cwd=${cwdLen} chars, title=${titleLen} chars: URL <= cap, essentials + work step present whole, protocol all-or-nothing`, () => {
           const cwd = realisticCwd(cwdLen);
           const title = "T".repeat(titleLen);
           const args: CompactBootstrapArgs = {
@@ -1744,6 +1760,7 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
             existingPath: cwd,
           };
 
+          const essentials = buildCompactPromptEssentials(args);
           const link = buildClampedDeepLink(args, { cwd });
           // (a) NEVER overflow — the core BUG1 REWORK invariant.
           expect(link.length, `cwd=${cwdLen} title=${titleLen}`).toBeLessThanOrEqual(
@@ -1755,11 +1772,23 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
           expect(decoded, `cwd=${cwdLen} title=${titleLen}`).toContain("claude mcp add");
           expect(decoded, `cwd=${cwdLen} title=${titleLen}`).toContain("record_project_path");
 
+          // (b2) BUG C fix: the work step (the "find work" instruction
+          // carrying idea_id/task_id) ALWAYS survives WHOLE too, regardless
+          // of length — it gets the same atomic protection as the essentials
+          // above, never a character-level fragment.
+          expect(essentials.work, `cwd=${cwdLen} title=${titleLen}`).toBeTruthy();
+          expect(decoded, `cwd=${cwdLen} title=${titleLen}: work step must survive whole`).toContain(
+            essentials.work!
+          );
+
           // (c) the protocol is ALL-OR-NOTHING: either every load-bearing
           // token from it is present, or NONE of them are (a clean omission,
-          // never a fragment split mid-protocol by the tail's truncation
-          // ellipsis — the ellipsis MAY legitimately appear elsewhere, e.g.
-          // trimming the confirm-echo/work tail, which is fine).
+          // never a fragment split mid-protocol). BUG C fix: the protocol is
+          // now correctly the LOWEST-priority piece behind the essentials and
+          // the work step, so it may legitimately be omitted well within this
+          // "realistic" range whenever a long path leaves no room for both —
+          // that is the fix, not a regression (see the worst-realistic-case
+          // test above).
           const presentCount = PROTOCOL_TOKENS.filter((t) => decoded.includes(t)).length;
           expect(
             [0, PROTOCOL_TOKENS.length],
@@ -1773,7 +1802,13 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
     // run first / shared mutable state) — recomputes the same matrix and
     // prints it as the path-length -> URL-length -> protocol-present table
     // for the write-up, doubling as a belt-and-braces summary assertion.
-    it("table: every sweep length keeps the URL under the cap with the protocol present (path-length-independent essentials never NEED to degrade in this realistic range)", () => {
+    //
+    // BUG C fix rewrite: previously asserted `protocolPresent` unconditionally
+    // true across this whole range — that was actually the bug (the protocol
+    // was crowding out the work step's budget, silently truncating it). The
+    // invariant that must hold universally is the WORK STEP surviving whole;
+    // the protocol is correctly best-effort and may legitimately drop out.
+    it("table: every sweep length keeps the URL under the cap with the work step always intact (protocol is best-effort and may legitimately degrade)", () => {
       const rows = CWD_LENGTHS.flatMap((cwdLen) =>
         TITLE_LENGTHS.map((titleLen) => {
           const cwd = realisticCwd(cwdLen);
@@ -1785,10 +1820,12 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
             repoUrl: null,
             existingPath: cwd,
           };
+          const essentials = buildCompactPromptEssentials(args);
           const link = buildClampedDeepLink(args, { cwd });
           const decoded = decodeURIComponent(link.split("q=")[1]);
           const protocolPresent = PROTOCOL_TOKENS.every((t) => decoded.includes(t));
-          return { cwdLen, titleLen, urlLen: link.length, protocolPresent };
+          const workPresent = !!essentials.work && decoded.includes(essentials.work);
+          return { cwdLen, titleLen, urlLen: link.length, protocolPresent, workPresent };
         })
       );
       // Intentional: surfaces the sweep table in test output for the write-up.
@@ -1796,7 +1833,7 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
       expect(rows).toHaveLength(CWD_LENGTHS.length * TITLE_LENGTHS.length);
       for (const r of rows) {
         expect(r.urlLen, JSON.stringify(r)).toBeLessThanOrEqual(MAX_DEEP_LINK_URL_LENGTH);
-        expect(r.protocolPresent, JSON.stringify(r)).toBe(true);
+        expect(r.workPresent, JSON.stringify(r)).toBe(true);
       }
     });
   });
@@ -2008,6 +2045,7 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
 
     const essentials = buildCompactPromptEssentials(args);
     expect(essentials.protocol).toBeTruthy();
+    expect(essentials.work).toBeTruthy();
 
     const link = buildClampedDeepLink(args, { cwd });
     expect(link.length).toBeLessThanOrEqual(MAX_DEEP_LINK_URL_LENGTH);
@@ -2015,10 +2053,12 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
     const decoded = decodeURIComponent(link.split("q=")[1]);
     expect(decoded).toContain("claude mcp add");
     expect(decoded).toContain("record_project_path");
+    // BUG C fix: the work step is NEVER character-truncated — it must survive
+    // byte-for-byte here too, even though the protocol had to give way.
+    expect(decoded, "the find-work step must survive whole, never a fragment").toContain(
+      essentials.work!
+    );
     // The protocol was requested but must be CLEANLY absent — not a fragment.
-    // (A trailing "…(truncated)" marker MAY legitimately appear if the tail —
-    // the confirm-echo/work step — also had to shrink; that's unrelated to
-    // protocol integrity, which is what this test is about.)
     for (const token of ["kill -0", ".vibe/wt-N", "-b vibe/wt-N", "never push primary"]) {
       expect(decoded, `token "${token}" must NOT be a stray fragment`).not.toContain(token);
     }
@@ -2095,6 +2135,95 @@ describe("worktree isolation protocol — wired into existing-mode/no-repo launc
       const out = fitCompactWorktreeProtocol(real, MAX_DEEP_LINK_PROMPT_LENGTH);
       expect(out).toContain("kill -0");
       expect(out).toContain(real.protocol!);
+    });
+
+    // BUG C fix (6th rework cycle) — direct unit tests of the atomic-tail
+    // degrade ladder (assembleAtomicTail) via synthetic essentials WITH a
+    // step breakdown (headSteps + work + directoryEcho), which is what every
+    // real caller (buildCompactPromptEssentials) supplies. Proves the exact
+    // priority order from the fix: protocol drops first, then directoryEcho,
+    // and the work step — the "find work" instruction carrying idea_id/
+    // task_id — is NEVER character-fragmented; it's either whole or cleanly
+    // absent.
+    describe("atomic work-step protection — never fragments the work step", () => {
+      const header = "HEADER";
+      const headSteps = ["STEP_ONE", "STEP_TWO"];
+      const protocol = "PROTOCOL_BLOCK";
+      const directoryEcho = "ECHO_LINE";
+      const work = "WORK_STEP_WITH_IDEA_ID";
+
+      const atomicEssentials: CompactPromptEssentials = {
+        header,
+        headSteps,
+        head: `${header}\n\n1. ${headSteps[0]}\n2. ${headSteps[1]}\n`,
+        tail: `3. ${directoryEcho}\n4. ${work}`,
+        protocol,
+        directoryEcho,
+        work,
+      };
+
+      function enc(s: string): number {
+        return encodeURIComponent(s).length;
+      }
+
+      it("includes protocol + directoryEcho + work all whole when the budget comfortably fits everything", () => {
+        const out = fitCompactWorktreeProtocol(atomicEssentials, 1000);
+        expect(out).toContain(protocol);
+        expect(out).toContain(directoryEcho);
+        expect(out).toContain(work);
+        expect(out).toContain(headSteps[0]);
+        expect(out).toContain(headSteps[1]);
+      });
+
+      it("drops the protocol first (not the work step) once the budget can't fit everything", () => {
+        // A budget that fits head+directoryEcho+work but NOT
+        // protocol+head+directoryEcho+work — the exact crossover the fix
+        // targets (this is precisely the shape of the real-content bug: the
+        // protocol alone is often the single biggest chunk).
+        const full = fitCompactWorktreeProtocol(atomicEssentials, 1000);
+        const withoutProtocol = full.replace(`${protocol}\n\n`, "");
+        const budget = enc(withoutProtocol);
+
+        const out = fitCompactWorktreeProtocol(atomicEssentials, budget);
+        expect(out).not.toContain(protocol);
+        expect(out).not.toContain("PROTOCOL"); // clean omission, not a fragment
+        expect(out).toContain(directoryEcho);
+        expect(out).toContain(work); // work step still survives whole
+      });
+
+      it("drops directoryEcho next (still never the work step) when only head+work fits", () => {
+        const withoutProtocol = fitCompactWorktreeProtocol(atomicEssentials, 1000).replace(
+          `${protocol}\n\n`,
+          ""
+        );
+        const workOnly = withoutProtocol.replace(`3. ${directoryEcho}\n`, "").replace("4.", "3.");
+        const budget = enc(workOnly);
+
+        const out = fitCompactWorktreeProtocol(atomicEssentials, budget);
+        expect(out).not.toContain(protocol);
+        expect(out).not.toContain(directoryEcho);
+        expect(out).toContain(work); // still whole, still the last thing dropped
+      });
+
+      it("never fragments the work step at the character level — omits it whole rather than truncating mid-string when even head+work can't fit", () => {
+        // Reserve mirrors fitEssentialHead's own headroom for enforcePromptLength's
+        // trailing marker, so a budget of headLen + reserve + slack is exactly
+        // enough for the full (both-step) head, but not for the head plus even
+        // the bare work step on top.
+        const reserve = enc("\n…(truncated)");
+        const budget = enc(atomicEssentials.head) + reserve + 2;
+        // Sanity: this budget really is too small for head + work together.
+        expect(budget).toBeLessThan(enc(atomicEssentials.head) + enc(`3. ${work}`));
+
+        const out = fitCompactWorktreeProtocol(atomicEssentials, budget);
+        expect(out).toContain(headSteps[0]); // head still survives whole...
+        expect(out).toContain(headSteps[1]);
+        expect(out).not.toContain(protocol);
+        expect(out).not.toContain(directoryEcho);
+        expect(out).not.toContain(work); // ...work omitted whole...
+        expect(out).not.toContain(work.slice(0, 10)); // ...never a fragment of it
+        expect(encodeURIComponent(out).length).toBeLessThanOrEqual(budget);
+      });
     });
   });
 
@@ -2208,10 +2337,12 @@ describe("FIX A: buildBoundedDeepLink (cwd param unclamped, QA BUG A)", () => {
               //
               // Fragment detection is scoped to the `cd '<opening>` MARKER
               // specifically, NOT a bare cwd-prefix substring — the
-              // (deliberately trimmable, per the KEEP list) directory-echo
-              // TAIL step ("You should already be in <path>...") also
-              // legitimately echoes the raw cwd and CAN be truncated by
-              // enforcePromptLength's ordinary tail-trim; that is expected,
+              // (deliberately LOWEST-priority, per the degrade ladder)
+              // directory-echo TAIL step ("You should already be in
+              // <path>...") also legitimately echoes the raw cwd and, like
+              // the protocol, may be omitted WHOLE by fitCompactWorktreeProtocol
+              // when the budget is tight (BUG C fix: never a character-level
+              // fragment, unlike pre-fix behaviour); that is expected,
               // unrelated behaviour, not a cd-line fragment.
               expect(result.url).not.toContain("cwd=");
               const decoded = decodeQ(result.url);

--- a/src/lib/launch-claude-code.ts
+++ b/src/lib/launch-claude-code.ts
@@ -838,8 +838,12 @@ export interface CompactPromptEssentials {
    */
   head: string;
   /**
-   * Trimmable: the existing-folder confirm echo (duplicates the deep link's
-   * `cwd` param — safe to truncate, unlike the protocol) + the work step.
+   * Back-compat, UNCONDITIONAL join of `directoryEcho` (if any) + `work` —
+   * kept for callers with no atomic step breakdown (see `work`/`directoryEcho`
+   * below), which `fitCompactWorktreeProtocol` still char-trims via
+   * enforcePromptLength exactly as before. Real callers (via
+   * `buildCompactPromptEssentials`, which always also supplies `work`) are no
+   * longer read through this field for assembly — see `work` for why.
    */
   tail: string;
   /**
@@ -849,6 +853,29 @@ export interface CompactPromptEssentials {
    * fitCompactWorktreeProtocol, which decides whether it rides the head.
    */
   protocol?: string;
+  /**
+   * BUG C fix (6th rework cycle, QA-confirmed): the "find work" / "work this
+   * task" step, carrying the `idea_id`/`task_id` the agent needs to actually
+   * pick up work — the ONE thing in the whole compact prompt with no recovery
+   * path if it's lost (unlike the head steps, which the agent can self-heal
+   * via the board once connected). ALWAYS present (`buildCompactPromptEssentials`
+   * always supplies it). Given the SAME atomic, whole-step-or-omit protection
+   * as `headSteps`: `fitCompactWorktreeProtocol` never character-truncates it
+   * — it either rides intact or (only when even `head` + this alone can't fit
+   * the budget) is cleanly omitted, never a mid-sentence/mid-UUID fragment.
+   * Optional only for back-compat with a caller that supplies no step
+   * breakdown at all, in which case `tail`'s old char-trim behaviour applies.
+   */
+  work?: string;
+  /**
+   * The existing-folder confirm-echo tail step (duplicates the deep link's
+   * `cwd` param, so it's genuinely disposable — unlike `work`). LOWEST
+   * priority of everything in the trimmable tail: `fitCompactWorktreeProtocol`
+   * drops the protocol before this, and drops this before ever touching
+   * `work`. Whole-or-omitted, same as the other atomic pieces — never a
+   * character fragment.
+   */
+  directoryEcho?: string;
   /**
    * BUG B fix (5th rework cycle): the title-header line, ALONE (no steps).
    * Optional — omitted (with `headSteps`) by any caller that doesn't have a
@@ -909,6 +936,8 @@ export function buildCompactPromptEssentials(args: CompactBootstrapArgs): Compac
     head: `${header}\n\n${numbered}\n`,
     tail: numberedTail,
     protocol,
+    work,
+    directoryEcho,
   };
 }
 
@@ -972,25 +1001,101 @@ export function buildCompactPromptEssentials(args: CompactBootstrapArgs): Compac
  * before (KEPT, unmodified) as the tail's trim mechanism, and as the
  * back-compat fallback for a caller with no step breakdown (see
  * resolveEssentialHead).
+ *
+ * BUG C fix (6th rework cycle, QA-confirmed): once the protocol is (or isn't)
+ * folded in, the ORIGINAL implementation handed the entire trimmable tail —
+ * `essentials.tail`, the directory-confirm echo bundled TOGETHER WITH the
+ * "find work" step that carries `idea_id`/`task_id` — to enforcePromptLength,
+ * which char-trims it like any other disposable text. On a real (no-repo,
+ * previously-recorded-path) launch that combination routinely blew the URL
+ * budget, so the work step got shredded mid-sentence (sometimes mid-UUID)
+ * right alongside the genuinely disposable echo, with no special protection —
+ * even though it's the one piece of the tail an agent can't self-heal (it has
+ * no idea_id/task_id to resume from without it). Whenever a caller supplies
+ * `work` (every real caller, via buildCompactPromptEssentials), that step now
+ * gets the SAME atomic, whole-step-or-omit treatment headSteps already have —
+ * see assembleAtomicTail's degrade ladder. A caller with no step breakdown at
+ * all (`work` undefined — synthetic test fixtures only) keeps the pre-fix
+ * char-trim behaviour unchanged.
  */
 export function fitCompactWorktreeProtocol(
   essentials: CompactPromptEssentials,
   budget: number
 ): string {
-  const { tail, protocol } = essentials;
   const head = resolveEssentialHead(essentials, budget);
-  const withoutProtocol = enforcePromptLength(head, tail, budget);
-  const safeWithoutProtocol = encodedLength(withoutProtocol) <= budget ? withoutProtocol : "";
-  if (!protocol) return safeWithoutProtocol;
 
-  const headWithProtocol = `${protocol}\n\n${head}`;
-  // Pre-check (see BUG 1 priority-inversion note above): only attempt the
-  // protocol-inclusive candidate when the COMBINED head already fits budget
-  // intact — never let enforcePromptLength's head-trim decide this for us.
-  if (encodedLength(headWithProtocol) > budget) return safeWithoutProtocol;
+  if (essentials.work === undefined) {
+    // Back-compat path — no atomic work-step breakdown supplied. Preserve the
+    // exact pre-fix behaviour: the whole tail is one char-trimmable blob.
+    const { tail, protocol } = essentials;
+    const withoutProtocol = enforcePromptLength(head, tail, budget);
+    const safeWithoutProtocol = encodedLength(withoutProtocol) <= budget ? withoutProtocol : "";
+    if (!protocol) return safeWithoutProtocol;
 
-  const withProtocol = enforcePromptLength(headWithProtocol, tail, budget);
-  return encodedLength(withProtocol) <= budget ? withProtocol : safeWithoutProtocol;
+    const headWithProtocol = `${protocol}\n\n${head}`;
+    // Pre-check (see BUG 1 priority-inversion note above): only attempt the
+    // protocol-inclusive candidate when the COMBINED head already fits budget
+    // intact — never let enforcePromptLength's head-trim decide this for us.
+    if (encodedLength(headWithProtocol) > budget) return safeWithoutProtocol;
+
+    const withProtocol = enforcePromptLength(headWithProtocol, tail, budget);
+    return encodedLength(withProtocol) <= budget ? withProtocol : safeWithoutProtocol;
+  }
+
+  return assembleAtomicTail(essentials, head, budget);
+}
+
+/**
+ * BUG C fix (6th rework cycle) — assembles the tail (protocol + directory-echo
+ * + work) atomically against `budget`, in a fixed priority DEGRADE LADDER,
+ * never fragmenting the "find work" step (`work`) at the character level:
+ *
+ *  1. protocol + directoryEcho + work, all whole.
+ *  2. directoryEcho + work, whole (protocol dropped — it's the single
+ *     biggest chunk, so dropping it alone is tried first).
+ *  3. work alone, whole (directoryEcho ALSO dropped — lowest priority of
+ *     everything here, since it only duplicates the URL's own `cwd=` param).
+ *  4. Absolute floor: even `head` + `work` alone doesn't fit. `work` is still
+ *     never fragmented — it's dropped entirely, and `head` runs through
+ *     enforcePromptLength as the final, already-battle-tested safety net
+ *     (guaranteed <= budget in every case, per its own BUG 6 fix).
+ *
+ * Each rung is tried in FULL before falling back to the next — this is what
+ * guarantees `work` either rides byte-for-byte intact or is cleanly absent,
+ * exactly like the `headSteps` atomic degrade (fitEssentialHead) above it.
+ */
+function assembleAtomicTail(
+  essentials: CompactPromptEssentials,
+  head: string,
+  budget: number
+): string {
+  const { protocol, directoryEcho, work, headSteps } = essentials;
+  const stepOffset = headSteps?.length ?? 0;
+
+  const buildTail = (includeDirectoryEcho: boolean): string => {
+    const steps: string[] = [];
+    if (includeDirectoryEcho && directoryEcho) steps.push(directoryEcho);
+    steps.push(work as string);
+    return steps.map((s, i) => `${stepOffset + i + 1}. ${s}`).join("\n");
+  };
+
+  if (protocol) {
+    const withProtocol = `${protocol}\n\n${head}${buildTail(true)}`;
+    if (encodedLength(withProtocol) <= budget) return withProtocol;
+  }
+
+  const withoutProtocol = `${head}${buildTail(true)}`;
+  if (encodedLength(withoutProtocol) <= budget) return withoutProtocol;
+
+  const workOnly = `${head}${buildTail(false)}`;
+  if (encodedLength(workOnly) <= budget) return workOnly;
+
+  // Even the work step alone doesn't fit alongside the head — omit it rather
+  // than fragment it. `head` itself already fits `budget` (resolveEssentialHead
+  // guarantees this), so this is a genuine no-op in practice; the
+  // enforcePromptLength pass is defensive belt-and-suspenders only.
+  const headOnly = enforcePromptLength(head, "", budget);
+  return encodedLength(headOnly) <= budget ? headOnly : "";
 }
 
 /**
@@ -1168,11 +1273,18 @@ export function buildBoundedDeepLink(args: BoundedDeepLinkArgs): BoundedDeepLink
     // Tier 2 — fold `cd '<path>'` in as an atomic prefix. Only accept this
     // candidate when the FULL raw cwd string survives verbatim in the
     // assembled prompt — i.e. the cd line rode whole, never bisected by
-    // enforcePromptLength's tail/head trims.
+    // enforcePromptLength's tail/head trims — AND (BUG C fix) the essentials
+    // + work step also survive whole. Pre-BUG-C this only checked the cd
+    // line, so a cwd long enough to squeeze the work step out at tier 1 could
+    // squeeze it out here too (the cd line eats into the SAME head+tail
+    // budget) and still be accepted as "ok" — landing the agent in the right
+    // folder with no idea what to do next. Reject that and fall through to
+    // tier 3, which drops the path entirely and gives the work step its full,
+    // path-length-independent budget back.
     const cdLine = buildCdLine(cwd);
     const withCd = foldCdIntoEssentials(essentials, cdLine);
     const prompt = fitCompactWorktreeProtocol(withCd, budgetNoCwd);
-    if (prompt.includes(cwd)) {
+    if (prompt.includes(cwd) && essentialsSurviveWhole(essentials, prompt)) {
       const url = buildLink({ prompt });
       if (url.length <= cap) return { ok: true, url, droppedCwd: true };
     }
@@ -1187,15 +1299,26 @@ export function buildBoundedDeepLink(args: BoundedDeepLinkArgs): BoundedDeepLink
 }
 
 /**
- * Whether every essential step (essentials.headSteps) is present, WHOLE, in
- * `prompt`. A caller with no step breakdown (back-compat — see
- * CompactPromptEssentials.headSteps) can't be checked this way, so this
- * degrades to `true` for it — tier 1's gate then reduces to its pre-FIX-A
- * `budgetWithCwd > 0` check alone, unchanged for that caller.
+ * Whether every essential step (essentials.headSteps) AND the work step
+ * (essentials.work) are present, WHOLE, in `prompt`. A caller with no step
+ * breakdown (back-compat — see CompactPromptEssentials.headSteps) can't be
+ * checked this way, so each half degrades to `true` for it — tier 1's gate
+ * then reduces to its pre-FIX-A `budgetWithCwd > 0` check alone, unchanged
+ * for that caller.
+ *
+ * BUG C fix (6th rework cycle): previously this only checked `headSteps`, so
+ * a tier-1 build that squeezed the cwd param in at the cost of silently
+ * dropping (or, pre-fix, fragmenting) the work step still passed as "ok" —
+ * the agent would land in the right folder with no idea what to do next.
+ * Requiring `work` to survive whole here forces the ladder to fall through to
+ * tier 2/3 (drop the cwd param, retry against the full, path-length-
+ * independent budget) whenever a long cwd would otherwise cost the work step.
  */
 function essentialsSurviveWhole(essentials: CompactPromptEssentials, prompt: string): boolean {
-  if (!essentials.headSteps) return true;
-  return essentials.headSteps.every((step) => prompt.includes(step));
+  const headStepsOk =
+    !essentials.headSteps || essentials.headSteps.every((step) => prompt.includes(step));
+  const workOk = essentials.work === undefined || prompt.includes(essentials.work);
+  return headStepsOk && workOk;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Launching into an already-recorded, repo-less project (the common "resume work" case) reliably truncated the launch prompt mid-sentence — cutting off the "find work" instruction that carries `idea_id`/`task_id` — because the worktree-isolation protocol block was treated as protected/verbatim while the directory echo and the work step were both dumped into one opaque tail and character-trimmed together.
- The work step now gets the same atomic, whole-block-or-omit protection the head steps (MCP-connect, `record_project_path`) already had, via a 4-rung degrade ladder that drops the protocol, then the (redundant) directory echo, before ever touching the work step.
- `essentialsSurviveWhole` and the tier-2 fallback gate now both verify the work step survived whole before accepting a build.

Card: 362a9c53 (Bug Fix workflow). Found by Nick's own field report + screenshot; QA root-caused, Implementation fixed and verified.

## Test plan
- [x] tsc clean
- [x] targeted vitest 212/212 (launch-claude-code.test.ts)
- [x] full vitest 2747/2747 (170 files)
- [x] eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)