### PR TITLE
fix(terminal): resolve recorded folder on fallback connects + link ended panel to My sessions

### DIFF
--- a/src/app/(main)/ideas/[id]/board/page.tsx
+++ b/src/app/(main)/ideas/[id]/board/page.tsx
@@ -332,7 +332,12 @@ export default async function BoardPage({ params, searchParams }: PageProps) {
       {/* In-app local Claude Code terminal — OFF by default (NEXT_PUBLIC_TERMINAL_ENABLED),
           team-members only. Renders nothing when the flag is off → board unchanged. */}
       {isTerminalEnabled() && isTeamMember && (
-        <TerminalDock ideaId={id} ideaTitle={idea.title} ideaGithubUrl={idea.github_url} />
+        <TerminalDock
+          ideaId={id}
+          ideaTitle={idea.title}
+          ideaGithubUrl={idea.github_url}
+          recordedProjectPaths={recordedProjectPaths ?? []}
+        />
       )}
     </div>
   );

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -63,7 +63,7 @@ import { logger } from "@/lib/logger";
 import { isTerminalEnabled, relayBaseUrl, type TerminalStatus } from "@/lib/terminal/connection";
 import { subscribeBrowserLaunch, type BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
 import { resolveDockView } from "@/lib/terminal/first-run-flow";
-import { slugifyIdeaTitle } from "@/lib/launch-claude-code";
+import { slugifyIdeaTitle, type RecordedProjectPath } from "@/lib/launch-claude-code";
 import { newSessionTooltip } from "@/lib/terminal/session-cap";
 import {
   generatePopoutNonce,
@@ -119,6 +119,16 @@ interface TerminalDockProps {
    * build the SAME board-level compact bootstrap prompt the button would.
    */
   ideaGithubUrl: string | null;
+  /**
+   * Bug cbe60db5-followup-2: absolute paths the agent recorded for this user
+   * + idea (idea_project_paths, one row per machine) — the board page already
+   * fetches these for KanbanBoard/LaunchClaudeCodeButton's own resolution
+   * (resolveEffectiveLaunchTarget); forwarded here so every session's
+   * `useTerminalSession` descriptor can resolve the SAME recorded folder for
+   * its fallback (no-bus-payload) launches. Undefined/empty → unchanged
+   * "new project" fallback.
+   */
+  recordedProjectPaths?: RecordedProjectPath[];
 }
 
 let sessionKeySeq = 0;
@@ -155,7 +165,7 @@ function dotClass(status: TerminalStatus): string {
   }
 }
 
-export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockProps) {
+export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProjectPaths }: TerminalDockProps) {
   // Defence-in-depth: also gated at the page mount. When off, render nothing —
   // no dock, no entry point, board unchanged (B9).
   const enabled = isTerminalEnabled();
@@ -370,8 +380,8 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl }: TerminalDockP
   }, []);
 
   const descriptor: TerminalSessionDescriptor = useMemo(
-    () => ({ ideaId, ideaTitle, ideaGithubUrl }),
-    [ideaId, ideaTitle, ideaGithubUrl],
+    () => ({ ideaId, ideaTitle, ideaGithubUrl, recordedProjectPaths }),
+    [ideaId, ideaTitle, ideaGithubUrl, recordedProjectPaths],
   );
   const ideaSlug = useMemo(() => slugifyIdeaTitle(ideaTitle), [ideaTitle]);
 

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1265,6 +1265,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onRegisterActions={registerActions}
             onAnnounce={announce}
             onCapExceeded={openMySessions}
+            onOpenMySessions={openMySessions}
             poppedOut={poppedOutKeys.has(entry.key)}
             onPopOut={() => handlePopOut(entry.key)}
             onBringBack={() => bringBackToDock(entry.key)}

--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -251,7 +251,10 @@ function renderErrorView(onReconnectTakenOver: (sid: string) => void = vi.fn()) 
   );
 }
 
-function renderEndedView(onResumeEndedSession: (payload: unknown) => void = vi.fn()) {
+function renderEndedView(
+  onResumeEndedSession: (payload: unknown) => void = vi.fn(),
+  onOpenMySessions?: () => void,
+) {
   return render(
     <TerminalSessionView
       entry={baseEntry()}
@@ -265,6 +268,7 @@ function renderEndedView(onResumeEndedSession: (payload: unknown) => void = vi.f
       onRegisterActions={vi.fn()}
       onAnnounce={vi.fn()}
       onResumeEndedSession={onResumeEndedSession}
+      onOpenMySessions={onOpenMySessions}
     />,
   );
 }
@@ -488,6 +492,43 @@ describe("TerminalSessionView — session-ended resume (Bug A)", () => {
 
     expect(screen.queryByRole("button", { name: /Resume this conversation/ })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Launch again$/ })).toBeInTheDocument();
+  });
+
+  // Bug cbe60db5-followup-2 (low-medium): the ended panel had no path to a
+  // user's other live/recent sessions in either button configuration
+  // (Resume+Start-fresh, or Launch-again-alone) — this reuses the same
+  // openMySessions trigger onCapExceeded already wires (E1, design §7b).
+  it("renders a 'View my other sessions' link that calls onOpenMySessions, alongside the Resume+Start-fresh buttons", () => {
+    const onOpenMySessions = vi.fn();
+    installMockEndedSession({
+      endedReason: "idle",
+      cwd: "/Users/nick/projects/vibe-coding-ideas",
+      claudeSessionId: "claude-conv-abc",
+    });
+    renderEndedView(vi.fn(), onOpenMySessions);
+
+    const link = screen.getByRole("button", { name: /View my other sessions/ });
+    fireEvent.click(link);
+    expect(onOpenMySessions).toHaveBeenCalledTimes(1);
+  });
+
+  it("also renders the link alongside the plain 'Launch again' button (no cwd known)", () => {
+    const onOpenMySessions = vi.fn();
+    installMockEndedSession({ endedReason: "idle", cwd: null, claudeSessionId: null });
+    renderEndedView(vi.fn(), onOpenMySessions);
+
+    expect(screen.getByRole("button", { name: /View my other sessions/ })).toBeInTheDocument();
+  });
+
+  it("omits the link entirely when onOpenMySessions isn't wired (matches the optional-callback-gated-UI pattern used elsewhere in this file)", () => {
+    installMockEndedSession({
+      endedReason: "idle",
+      cwd: "/Users/nick/projects/vibe-coding-ideas",
+      claudeSessionId: "claude-conv-abc",
+    });
+    renderEndedView();
+
+    expect(screen.queryByRole("button", { name: /View my other sessions/ })).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -177,6 +177,16 @@ interface TerminalSessionViewProps {
    * `session.cwd` being known before ever calling this).
    */
   onResumeEndedSession?: (payload: BrowserLaunchPayload) => void;
+  /**
+   * Opens the dock's "My sessions" panel — the SAME trigger `onCapExceeded`
+   * already uses (E1, design §7b). Rendered as a small tertiary link under
+   * the ended-panel's button row: a user staring at one ended session had no
+   * way to see their other live/recent ones without hunting for the
+   * collapsed-bar trigger. Omitted hides the link entirely (defensive, the
+   * same optional-callback-gated-UI pattern `onPopOut`/`onResumeEndedSession`
+   * already use in this file).
+   */
+  onOpenMySessions?: () => void;
 }
 
 export function TerminalSessionView({
@@ -197,6 +207,7 @@ export function TerminalSessionView({
   onReconnectTakenOver,
   onRetryReconnect,
   onResumeEndedSession,
+  onOpenMySessions,
 }: TerminalSessionViewProps) {
   const session = useTerminalSession(descriptor, {
     enabled: true,
@@ -546,6 +557,7 @@ export function TerminalSessionView({
               onReconnectTakenOver={() => {
                 if (pair) onReconnectTakenOver?.(pair.sessionId);
               }}
+              onOpenMySessions={onOpenMySessions}
             />
           )}
           {state.status === "disconnected" && (
@@ -658,6 +670,7 @@ function StateOverlay({
   onResume,
   onCopyBridge,
   onReconnectTakenOver,
+  onOpenMySessions,
 }: {
   view: DockView;
   state: TerminalConnectionState;
@@ -685,6 +698,8 @@ function StateOverlay({
   onResume: () => void;
   onCopyBridge: () => void;
   onReconnectTakenOver: () => void;
+  /** See TerminalSessionViewProps' same-named prop. */
+  onOpenMySessions?: () => void;
 }) {
   return (
     <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 overflow-y-auto bg-[#0c0c0e]/95 px-6 py-6 text-center">
@@ -769,6 +784,21 @@ function StateOverlay({
             <Button className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400" onClick={onLaunchAgain}>
               <TerminalIcon className="h-4 w-4" /> Launch again
             </Button>
+          )}
+          {/* Bug cbe60db5-followup-2 (low-medium): the ended panel used to be
+              a dead end for anyone who forgot where the collapsed bar's "My
+              sessions" trigger lives — this reuses the exact same
+              openMySessions callback onCapExceeded already wires (E1, design
+              §7b), just from a second entry point. Tertiary, so it never
+              competes with the primary Resume/Launch-again action above. */}
+          {onOpenMySessions && (
+            <button
+              type="button"
+              className="text-[11px] text-zinc-500 underline hover:text-zinc-300"
+              onClick={onOpenMySessions}
+            >
+              View my other sessions
+            </button>
           )}
         </>
       )}

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -1030,6 +1030,52 @@ describe("useTerminalSession", () => {
       expect(result.current.claudeSessionId).toBeNull();
     });
 
+    // Bug cbe60db5-followup-2 (QA, high severity): a fallback connect() —
+    // paired auto-connect on panel open, or Retry — never had access to
+    // recordedProjectPaths, so it always passed `undefined` into
+    // resolveDefaultLaunchState even when the agent HAD recorded a real
+    // folder for this idea+machine (idea_project_paths). That silently
+    // dropped `cwd`, which meant a later session-ended overlay's Resume
+    // button (requires a known cwd) never showed even though the folder was
+    // fully known server-side. Fixed by threading recordedProjectPaths
+    // through the descriptor into resolveLaunchPromptParts, mirroring the
+    // launch button's own resolveEffectiveLaunchTarget resolution.
+    it("resolves a recorded folder for a fallback (no-bus-payload) launch, when one is recorded for this idea", async () => {
+      const { result } = renderHook(() =>
+        useTerminalSession(
+          { ...descriptor, recordedProjectPaths: [{ absolute_path: "/Users/nick/projects/recipe-saver", hostname: "nicks-mac" }] },
+          { enabled: true, expanded: true, requestExpand: vi.fn() },
+        ),
+      );
+      await act(async () => {
+        await result.current.actions.connect({ autoLaunch: false });
+      });
+      expect(result.current.cwd).toBe("/Users/nick/projects/recipe-saver");
+    });
+
+    // The don't-break-it-for-the-common-case half of the same fix: >1
+    // recorded machines is ambiguous (chooseLaunchCwd's own contract), so it
+    // must still fall through to the "new project" flow exactly like having
+    // none recorded at all — never guess a machine.
+    it("still falls back to 'new project' (no cwd) when the recorded paths are ambiguous (more than one machine)", async () => {
+      const { result } = renderHook(() =>
+        useTerminalSession(
+          {
+            ...descriptor,
+            recordedProjectPaths: [
+              { absolute_path: "/Users/nick/projects/recipe-saver", hostname: "nicks-mac" },
+              { absolute_path: "/home/nick/recipe-saver", hostname: "nicks-linux-box" },
+            ],
+          },
+          { enabled: true, expanded: true, requestExpand: vi.fn() },
+        ),
+      );
+      await act(async () => {
+        await result.current.actions.connect({ autoLaunch: false });
+      });
+      expect(result.current.cwd).toBeNull();
+    });
+
     it("seeds claudeSessionId from a carried resumeId and exposes the carried cwd immediately after mint", async () => {
       window.localStorage.setItem("vibecodes:terminal:paired-v1", "1");
       vi.stubGlobal("navigator", {

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -86,9 +86,12 @@ import { type BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
 import {
   buildBoundedDeepLink,
   buildCompactPromptEssentials,
+  readLaunchPath,
   resolveAppUrl,
   resolveDefaultLaunchState,
+  resolveEffectiveLaunchTarget,
   resolveLaunchCwd,
+  type RecordedProjectPath,
 } from "@/lib/launch-claude-code";
 import {
   type TerminalPlatform,
@@ -181,6 +184,21 @@ export interface TerminalSessionDescriptor {
    * (shared resolveDefaultLaunchState + buildCompactPromptEssentials).
    */
   ideaGithubUrl: string | null;
+  /**
+   * Bug cbe60db5-followup-2 (fallback connect() never resolves a recorded
+   * folder): absolute paths the agent recorded for this user + idea, one per
+   * machine (idea_project_paths, RLS-scoped to the human) — the SAME data the
+   * launch button already threads through resolveEffectiveLaunchTarget
+   * (launch-claude-code-button.tsx). Hook-initiated launches (paired
+   * auto-connect on open, Retry) never go through the button, so without
+   * this `resolveLaunchPromptParts` always passed `undefined` for the
+   * recorded-path slot — a session started this way recorded `cwd=null` even
+   * when a real folder was on file, so the ended-session overlay's Resume
+   * button (which requires a known `cwd` — see terminal-session-view.tsx's
+   * `canResume`) never showed. Optional; undefined/empty behaves exactly like
+   * before (falls through to "new project" — see resolveDefaultLaunchState).
+   */
+  recordedProjectPaths?: RecordedProjectPath[];
 }
 
 export interface UseTerminalSessionOptions {
@@ -440,7 +458,7 @@ export function useTerminalSession(
   descriptor: TerminalSessionDescriptor,
   options: UseTerminalSessionOptions,
 ): UseTerminalSessionResult {
-  const { ideaId, ideaTitle, ideaGithubUrl } = descriptor;
+  const { ideaId, ideaTitle, ideaGithubUrl, recordedProjectPaths } = descriptor;
   const {
     enabled,
     expanded,
@@ -847,15 +865,21 @@ export function useTerminalSession(
   // not the unconditional buildCompactBootstrapPromptParts this used to call —
   // that builder bakes the worktree-isolation protocol into a never-trimmed
   // head, so fireLaunchDeepLink's own budget clamp had no clean way to drop it
-  // on overflow. The fallback's cwd uses the same shared rule (resolveLaunchCwd);
-  // the hook has no recordedProjectPaths, so it passes no effective cwd — a
-  // pinned existing-mode folder still resolves (rule 1), while the
-  // recorded-path injection only flows through the button payload, exactly as
-  // the terminal-window default path would behave.
+  // on overflow. Bug cbe60db5-followup-2: `effectiveTarget` mirrors the launch
+  // button's own resolveEffectiveLaunchTarget call — the hook now DOES have
+  // recordedProjectPaths (threaded via the descriptor), so a hook-initiated
+  // launch picks up a recorded DB folder exactly like the button does, instead
+  // of always falling to "new project" (the bug: cwd=null recorded even when a
+  // real folder was on file, hiding the ended-session overlay's Resume button).
   const resolveLaunchPromptParts = useCallback((): BrowserLaunchPayload => {
     const carried = promptPartsRef.current;
     if (carried) return carried;
-    const s = resolveDefaultLaunchState(ideaId, ideaTitle, ideaGithubUrl);
+    const effectiveTarget = resolveEffectiveLaunchTarget({
+      hasRepo: !!ideaGithubUrl,
+      saved: readLaunchPath(ideaId),
+      recordedPaths: recordedProjectPaths,
+    });
+    const s = resolveDefaultLaunchState(ideaId, ideaTitle, ideaGithubUrl, effectiveTarget);
     const essentials = buildCompactPromptEssentials({
       appUrl: resolveAppUrl(),
       ideaId,
@@ -863,14 +887,13 @@ export function useTerminalSession(
       mode: s.mode,
       repoUrl: ideaGithubUrl,
       newProject: s.mode === "new" ? { newProjectPath: s.path } : undefined,
-      // Parity with the launch button: a pinned existing folder emits the same
-      // verify-folder step. The hook has no recorded DB paths, so this only fires
-      // for a user-pinned localStorage path (resolveDefaultLaunchState → existing).
+      // Parity with the launch button: a pinned existing folder (localStorage
+      // or, now, a recorded DB path) emits the same verify-folder step.
       existingPath:
         s.mode === "existing" && s.path.trim() ? s.path.trim() : undefined,
     });
-    return { essentials, cwd: resolveLaunchCwd(s, undefined) };
-  }, [ideaId, ideaTitle, ideaGithubUrl]);
+    return { essentials, cwd: resolveLaunchCwd(s, effectiveTarget.cwd) };
+  }, [ideaId, ideaTitle, ideaGithubUrl, recordedProjectPaths]);
 
   // Fire the signed vibecodes:// deep link so a same-machine helper attaches as the
   // bridge leg with no copied command. The bridge token is a secret — it travels in


### PR DESCRIPTION
## Summary
- Paired auto-connect (opening the dock panel) and Retry never looked up a project's already-recorded local folder — only the explicit "Launch Claude Code" button did. So sessions started either of those two ways got `cwd=null` recorded even when a real folder was on file, meaning no "Resume" button when they later ended, despite the folder and conversation both being fully known server-side.
- `resolveLaunchPromptParts()` now resolves the recorded path the same way the launch button already does; threaded `recordedProjectPaths` from the board page through the dock into the hook.
- The session-ended panel also had no way to see other live/recent sessions — added a small "View my other sessions" link that opens the existing My sessions panel.

Card: cea7e23b (Bug Fix workflow). Found via Nick's live field report; QA root-caused (including pulling the actual production DB row to confirm), Implementation fixed both and verified.

## Test plan
- [x] tsc clean
- [x] targeted vitest 73/73
- [x] full vitest 2752/2752 (170 files)
- [x] eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)