### PR TITLE
fix(terminal): registry fail-open silently minting new sessions + PTY spawns narrow before real size known

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -127,6 +127,7 @@ vi.mock("./terminal-session-chooser", () => ({
 
 import { TerminalDock } from "./terminal-dock";
 import { requestBrowserLaunch } from "@/lib/terminal/launch-mode";
+import { toast } from "sonner";
 
 function deferredRegistryResponse() {
   let resolve!: (rows: ChooserRegistryRow[]) => void;
@@ -148,6 +149,31 @@ function stubFetch(registryPromise: Promise<ChooserRegistryRow[]>) {
     vi.fn((url: string) => {
       if (url === "/api/terminal/session/list") {
         return registryPromise.then((sessions) => ({ ok: true, json: async () => ({ sessions }) }));
+      }
+      if (url === "/api/terminal/session/reattach") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ sessionId: "reattached-session-id", browserToken: "reattached-token" }),
+        });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    }),
+  );
+}
+
+/** Registry fetch that fails `failCount` times before resolving with `rows`
+ * (or fails on every attempt within the retry budget when `rows` is
+ * omitted) — drives Bug A's retry-then-fail-closed path. Every other
+ * endpoint behaves like `stubFetch`'s defaults. */
+function stubFlakyRegistryFetch(failCount: number, rows?: ChooserRegistryRow[]) {
+  let calls = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      if (url === "/api/terminal/session/list") {
+        calls += 1;
+        if (calls <= failCount) return Promise.reject(new Error("network down"));
+        return Promise.resolve({ ok: true, json: async () => ({ sessions: rows ?? [] }) });
       }
       if (url === "/api/terminal/session/reattach") {
         return Promise.resolve({
@@ -392,5 +418,43 @@ describe("TerminalDock — chooser overlay when a tab is already open (rework 11
     expect(screen.getAllByTestId("session-view")).toHaveLength(1);
     expect(screen.getByTestId("session-view").dataset.key).toBe(firstKey);
     expect(sessionViewUnmountSpy).not.toHaveBeenCalled();
+  });
+});
+
+// Card cbe60db5, Nick's field report 2026-08-15 (Bug A): a hard refresh
+// silently minted a brand-new session instead of reattaching, because the
+// registry fetch's catch block collapsed EVERY failure into `[]` —
+// indistinguishable from a genuinely empty registry, so `decideEntryBehaviour`
+// routed to `empty-launch` and the seed effect auto-minted with no chooser
+// and no visible error. This is the SAME null-vs-`[]` bug rework 9 already
+// fixed for the still-loading path, reintroduced on the error path.
+describe("TerminalDock — registry fetch failure never collapses into confirmed-empty (Bug A)", () => {
+  it("keeps registryRows unresolved (never auto-mints) and surfaces a retryable error once every retry is exhausted", async () => {
+    stubFlakyRegistryFetch(99); // fails every attempt within the retry budget
+
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    // Still "checking…" throughout — a failed fetch must never masquerade as
+    // a confirmed-empty registry.
+    expect(screen.getByText(/Checking your sessions/)).toBeInTheDocument();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled(), { timeout: 5000 });
+    const [, opts] = vi.mocked(toast.error).mock.calls[0] as [string, { action?: { label: string } }];
+    expect(opts.action?.label).toBe("Retry");
+
+    // Never auto-minted a fresh session — the old bug's exact failure mode —
+    // and the dock is still honestly showing "still checking", not a chooser
+    // or an empty-launch tab.
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+    expect(screen.getByText(/Checking your sessions/)).toBeInTheDocument();
+  });
+
+  it("recovers once a retry succeeds and proceeds with the resolved decision", async () => {
+    stubFlakyRegistryFetch(1, []); // first attempt fails, the retry succeeds with a genuinely empty registry
+
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument(), { timeout: 5000 });
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -165,6 +165,10 @@ function dotClass(status: TerminalStatus): string {
   }
 }
 
+// Bug A retry schedule (card cbe60db5) — immediate attempt, then two backoff
+// retries, before `refreshRegistry` gives up and surfaces the failure.
+const REGISTRY_RETRY_DELAYS_MS = [0, 400, 1200];
+
 export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProjectPaths }: TerminalDockProps) {
   // Defence-in-depth: also gated at the page mount. When off, render nothing —
   // no dock, no entry point, board unchanged (B9).
@@ -300,22 +304,45 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // fetches for the My sessions badge)". `refreshRegistry` is also reused
   // after a failed reattach (the row may have just gone stale) and by the
   // `?reconnect=` handler below.
+  // Bug A (card cbe60db5, Nick's field report 2026-08-15 — hard refresh
+  // silently minted a brand-new session instead of reattaching): this used
+  // to be a single, no-retry fetch whose catch collapsed EVERY failure into
+  // `[]`. `decideEntryBehaviour` can't tell a real empty registry apart from
+  // "we never actually asked" — an empty array reads as "confirmed nothing
+  // live or recent", which routes straight to `empty-launch` and the seed
+  // effect auto-mints with no chooser and no error, exactly like a genuinely
+  // fresh session. That's the SAME null-vs-[] confusion rework 9 already
+  // fixed for the still-loading path (see the comment above
+  // `entryDecisionRef`) — just reintroduced on the error path instead.
+  // Retry with backoff first; if every attempt fails, leave `registryRows`
+  // exactly as it was (null on first load keeps the dock in "still
+  // checking…" and blocks the seed effect the same way an in-flight fetch
+  // does; a stale array from an earlier successful load just keeps showing
+  // what we last knew) rather than lying that we confirmed empty.
   const refreshRegistry = useCallback(async () => {
-    try {
-      const res = await fetch("/api/terminal/session/list");
-      if (!res.ok) throw new Error(`status ${res.status}`);
-      const body = (await res.json()) as { sessions: ChooserRegistryRow[] };
-      setRegistryRows(body.sessions);
-    } catch (err) {
-      logger.error("Terminal registry fetch failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      // Fail OPEN (matches the mint route's own R2 read-error posture): never
-      // let a transient registry read wedge the dock in "checking…" forever.
-      // A never-loaded dock falls back to today's empty-launch behaviour; an
-      // already-loaded dock just keeps its last known rows.
-      setRegistryRows((prev) => prev ?? []);
+    let lastErr: unknown;
+    for (const delay of REGISTRY_RETRY_DELAYS_MS) {
+      if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay));
+      try {
+        const res = await fetch("/api/terminal/session/list");
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        const body = (await res.json()) as { sessions: ChooserRegistryRow[] };
+        setRegistryRows(body.sessions);
+        return;
+      } catch (err) {
+        lastErr = err;
+      }
     }
+    logger.error("Terminal registry fetch failed after retries", {
+      error: lastErr instanceof Error ? lastErr.message : String(lastErr),
+    });
+    // Same retry-affordance idiom as the reattach failure toast below
+    // (`Couldn't reconnect…` action: Retry) — never silently strand the user
+    // on a registry we couldn't confirm.
+    toast.error("Couldn't check your terminal sessions", {
+      description: "We couldn't confirm whether a session is already running. Check your connection and retry.",
+      action: { label: "Retry", onClick: () => void refreshRegistry() },
+    });
   }, []);
 
   useEffect(() => {

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -1208,6 +1208,107 @@ describe("useTerminalSession", () => {
     });
   });
 
+  // Bug B (card cbe60db5, Nick's field test 2026-08-15): a promptless
+  // (Resume) launch's PTY used to spawn at a hardcoded 80x24 because the
+  // browser's own resize can't reach a not-yet-existent process in time.
+  // Fixed by carrying the browser's real, already-fitted cols/rows on the
+  // SAME launch deep link — see currentLaunchDims's doc comment above
+  // sendResize(). These tests mount a real containerRef (mountContainer,
+  // matching the scrollback-transfer tests' own rationale above) so the
+  // mocked xterm Terminal actually exists, then mutate its cols/rows the way
+  // a real fit-addon would have computed them from the panel's real size.
+  describe("PTY spawn dims on the launch deep link (Bug B, card cbe60db5)", () => {
+    function mountContainer(result: { current: { containerRef: { current: HTMLDivElement | null } } }) {
+      result.current.containerRef.current = document.createElement("div");
+    }
+
+    it("carries the real fitted cols/rows on a resume launch once xterm has mounted", async () => {
+      window.localStorage.setItem("vibecodes:terminal:paired-v1", "1");
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+        maxTouchPoints: 0,
+      });
+      const { result } = setup();
+      mountContainer(result);
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+      const term = mockTerminals[mockTerminals.length - 1] as unknown as { cols: number; rows: number };
+      term.cols = 137;
+      term.rows = 42;
+
+      act(() => {
+        result.current.actions.launchFromBus({
+          resumeId: "claude-conv-carried",
+          cwd: "/Users/nick/projects/vibe-coding-ideas",
+        });
+      });
+      await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+      await flushEffects();
+
+      const iframes = document.querySelectorAll("iframe");
+      expect(iframes).toHaveLength(1);
+      const src = iframes[0].getAttribute("src") ?? "";
+      expect(src).toContain("cols=137");
+      expect(src).toContain("rows=42");
+      // cols/rows ride AFTER resume_id (rides before prompt either way) per
+      // the shared builder's param ordering (drift-tested in deep-link.test.ts).
+      expect(src.indexOf("resume_id=")).toBeLessThan(src.indexOf("cols="));
+    });
+
+    it("omits cols/rows entirely when xterm hasn't mounted yet (fast-click race) — falls back to the bridge's own default, never worse than before this fix", async () => {
+      window.localStorage.setItem("vibecodes:terminal:paired-v1", "1");
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+        maxTouchPoints: 0,
+      });
+      const { result } = setup();
+      // No mountContainer() — termRef/fitRef stay null, exactly the race a
+      // brand-new tab (no pristine slot to reuse) can hit.
+      act(() => {
+        result.current.actions.launchFromBus({
+          resumeId: "claude-conv-carried",
+          cwd: "/Users/nick/projects/vibe-coding-ideas",
+        });
+      });
+      await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+      await flushEffects();
+
+      const iframes = document.querySelectorAll("iframe");
+      expect(iframes).toHaveLength(1);
+      const src = iframes[0].getAttribute("src") ?? "";
+      expect(src).not.toContain("cols=");
+      expect(src).not.toContain("rows=");
+    });
+
+    it("carries the real fitted cols/rows on a normal (prompt-carrying) launch too", async () => {
+      window.localStorage.setItem("vibecodes:terminal:paired-v1", "1");
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+        maxTouchPoints: 0,
+      });
+      const { result } = setup();
+      mountContainer(result);
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+      const term = mockTerminals[mockTerminals.length - 1] as unknown as { cols: number; rows: number };
+      term.cols = 220;
+      term.rows = 55;
+
+      await act(async () => {
+        await result.current.actions.connect({ autoLaunch: true });
+      });
+
+      const iframes = document.querySelectorAll("iframe");
+      expect(iframes).toHaveLength(1);
+      const src = iframes[0].getAttribute("src") ?? "";
+      expect(src).toContain("cols=220");
+      expect(src).toContain("rows=55");
+      expect(src).toContain("prompt=");
+      expect(src.indexOf("cols=")).toBeLessThan(src.indexOf("prompt="));
+    });
+  });
+
   // Card cbe60db5 rework 10 (stuck-pairing watchdog, 2026-08-14 incident): QA
   // root-caused a session stuck forever on "Waiting for your machine to
   // attach" — attachToExisting (reload-reattach/instant-continue, the

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -59,6 +59,7 @@ import {
   decideReconnectNow,
   decideResize,
   isConnectSuperseded,
+  isValidDim,
   encodeHeartbeatFrame,
   encodeResizeMessage,
   initialConnectionState,
@@ -752,6 +753,31 @@ export function useTerminalSession(
     ws?.send(msg);
   }, []);
 
+  // Real panel size for the NEXT launch's PTY spawn (Bug B, card cbe60db5 —
+  // Nick's field test 2026-08-15): a promptless (Resume) launch's PTY used to
+  // spawn at a hardcoded 80x24 because `sendResize()` above can't reach it
+  // until status flips to "connected" — which can't happen before something
+  // spawns and streams a byte (see its own doc comment). Reading dims via the
+  // SAME fit-addon call, right before firing the launch deep link, sidesteps
+  // that entirely: the bridge gets the real size in the SAME request that
+  // tells it what to spawn (terminal/bridge/src/spawn-dims.js), no wire
+  // round-trip or connection-state race involved. `null` when xterm hasn't
+  // mounted yet (an unlikely fast-click race, or a brand-new tab whose xterm
+  // dynamic import is still in flight) — the caller then omits cols/rows and
+  // the bridge falls back to its pre-existing hardcoded default, exactly like
+  // before this fix (never worse than today).
+  const currentLaunchDims = useCallback((): { cols: number; rows: number } | null => {
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit) return null;
+    try {
+      fit.fit();
+    } catch {
+      return null;
+    }
+    return isValidDim(term.cols) && isValidDim(term.rows) ? { cols: term.cols, rows: term.rows } : null;
+  }, []);
+
   // Refit on container resize and whenever the dock expands.
   useEffect(() => {
     if (!xtermReady || !containerRef.current) return;
@@ -958,6 +984,11 @@ export function useTerminalSession(
       // instead of building a prompt (see terminal/bridge/src/index.js).
       // Checked FIRST so the normal essentials/budgeting path below never
       // runs for a resume.
+      // Bug B (card cbe60db5): computed ONCE per fire, used on whichever
+      // buildLaunchDeepLink call below actually runs — see
+      // `currentLaunchDims`'s own doc comment for why this is read here
+      // rather than left to a post-spawn resize.
+      const dims = currentLaunchDims();
       const carriedForResume = promptPartsRef.current;
       if (carriedForResume?.resume || carriedForResume?.resumeId) {
         const cwd = carriedForResume.cwd;
@@ -980,6 +1011,8 @@ export function useTerminalSession(
             cwd,
             resume: carriedForResume.resumeId ? undefined : true,
             resumeId: carriedForResume.resumeId,
+            cols: dims?.cols,
+            rows: dims?.rows,
           });
         } catch (err) {
           logger.error("Terminal resume deep-link build failed", {
@@ -1038,6 +1071,8 @@ export function useTerminalSession(
               helperToken,
               cwd: linkCwd,
               prompt,
+              cols: dims?.cols,
+              rows: dims?.rows,
             }),
         });
         if (!result.ok) {
@@ -1070,7 +1105,7 @@ export function useTerminalSession(
       });
       if (!openLaunchLinkAndArmTimeout(link)) setLaunchPhase("helper-timeout");
     },
-    [resolveLaunchPromptParts, openLaunchLinkAndArmTimeout],
+    [resolveLaunchPromptParts, openLaunchLinkAndArmTimeout, currentLaunchDims],
   );
 
   const teardownSocket = useCallback(() => {

--- a/src/lib/terminal/connection.ts
+++ b/src/lib/terminal/connection.ts
@@ -330,7 +330,11 @@ export function encodeResizeMessage(cols: number, rows: number): string | null {
   return JSON.stringify({ type: "resize", cols, rows });
 }
 
-function isValidDim(n: number): boolean {
+/** A terminal dimension must be a positive, finite, sane integer. Exported so
+ * callers building a resize-shaped payload elsewhere (e.g. the launch
+ * deep-link's cols/rows, card cbe60db5 Bug B) validate with the SAME rule
+ * rather than a hand-rolled duplicate. */
+export function isValidDim(n: number): boolean {
   return Number.isInteger(n) && n > 0 && n <= 1000;
 }
 

--- a/src/lib/terminal/deep-link.test.ts
+++ b/src/lib/terminal/deep-link.test.ts
@@ -139,6 +139,38 @@ describe("buildLaunchDeepLink with resumeId (rework 5, exact-conversation resume
   });
 });
 
+describe("buildLaunchDeepLink with cols/rows (Bug B, card cbe60db5 — real PTY spawn size)", () => {
+  it("includes cols/rows, positioned before prompt, and round-trips", () => {
+    const withDims = { ...SAMPLE, cols: 137, rows: 42, prompt: "hello" };
+    const url = buildLaunchDeepLink(withDims);
+    expect(url).toContain("cols=137");
+    expect(url).toContain("rows=42");
+    expect(url.indexOf("cols=")).toBeLessThan(url.indexOf("prompt="));
+    expect(parseLaunchDeepLink(url)).toEqual(withDims);
+  });
+
+  it("omits cols/rows entirely when absent — no version-skew risk for an old bridge", () => {
+    const url = buildLaunchDeepLink(SAMPLE);
+    expect(url).not.toContain("cols=");
+    expect(url).not.toContain("rows=");
+    expect(parseLaunchDeepLink(url)).toEqual(SAMPLE);
+  });
+
+  it("drops a lone dimension rather than firing a half pair", () => {
+    const url = buildLaunchDeepLink({ ...SAMPLE, cols: 120 }); // rows omitted
+    expect(url).not.toContain("cols=");
+    expect(url).not.toContain("rows=");
+  });
+
+  it("a non-sane dimension on the wire is rejected by the shared parser, never forwarded", () => {
+    const url = `${LAUNCH_SCHEME}://${LAUNCH_HOST}?relay=${encodeURIComponent(SAMPLE.relay)}&session=${SAMPLE.session}&token=${encodeURIComponent(SAMPLE.token)}&cols=0&rows=24`;
+    const parsed = parseLaunchDeepLink(url);
+    expect(parsed).not.toBeNull();
+    expect(parsed).not.toHaveProperty("cols");
+    expect(parsed).not.toHaveProperty("rows");
+  });
+});
+
 describe("redactDeepLinkToken", () => {
   it("replaces the token value with *** and never leaks the secret", () => {
     const url = buildLaunchDeepLink(SAMPLE);

--- a/src/lib/terminal/deep-link.ts
+++ b/src/lib/terminal/deep-link.ts
@@ -73,15 +73,30 @@ export interface LaunchDeepLinkParams {
    * both are somehow set (see buildLaunchDeepLink).
    */
   resumeId?: string;
+  /**
+   * Bug B (card cbe60db5, Nick's field test 2026-08-15): the browser's real
+   * panel size, computed via the SAME fit-addon call `sendResize()` already
+   * uses (see use-terminal-session.ts's `currentLaunchDims`). Carrying it on
+   * the launch link lets the bridge spawn the PTY at the correct size
+   * instead of a hardcoded default — a promptless (Resume) launch spawns its
+   * PTY synchronously, before the browser's own resize can ever reach a
+   * not-yet-existent process (resize send is gated on status "connected",
+   * which itself can't flip before something spawns and streams a byte).
+   * Only meaningful as a pair; a caller that hasn't mounted xterm yet (an
+   * unlikely fast-click race) omits both and the bridge falls back to its
+   * pre-existing hardcoded default, exactly like before this field existed.
+   */
+  cols?: number;
+  rows?: number;
 }
 
 /**
  * Build a `vibecodes://launch?relay=…&session=…&token=…[&helperToken=…]
- * [&cwd=…][&resume=1][&prompt=…]` deep link. Throws when a required field is
- * missing so a malformed link is never fired. `prompt` is always the LAST
- * param so the base-link length (and therefore the prompt budget) is stable —
- * `helperToken`/`resume` are inserted before it, alongside the other
- * credentials.
+ * [&cwd=…][&resume=1][&cols=…&rows=…][&prompt=…]` deep link. Throws when a
+ * required field is missing so a malformed link is never fired. `prompt` is
+ * always the LAST param so the base-link length (and therefore the prompt
+ * budget) is stable — every other optional param, including `cols`/`rows`,
+ * is inserted before it, alongside the other credentials.
  */
 export function buildLaunchDeepLink({
   relay,
@@ -92,6 +107,8 @@ export function buildLaunchDeepLink({
   prompt,
   resume,
   resumeId,
+  cols,
+  rows,
 }: LaunchDeepLinkParams): string {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
@@ -110,8 +127,21 @@ export function buildLaunchDeepLink({
   } else if (resume) {
     parts.push(`resume=1`);
   }
+  // Only ever sent as a pair — a lone dimension is useless to the bridge's
+  // pty.spawn call. Mirrors terminal/shared/deep-link.mjs's `isValidLaunchDim`
+  // guard exactly (drift-tested).
+  if (isValidLaunchDim(cols) && isValidLaunchDim(rows)) {
+    parts.push(`cols=${cols}`, `rows=${rows}`);
+  }
   if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
+}
+
+/** A terminal dimension must be a positive, finite, sane integer — mirrors
+ * connection.ts's `isValidDim` (duplicated, not imported, to keep this
+ * builder dependency-free — same posture as its shared .mjs counterpart). */
+function isValidLaunchDim(n: number | undefined): n is number {
+  return typeof n === "number" && Number.isInteger(n) && n > 0 && n <= 1000;
 }
 
 /**

--- a/src/lib/terminal/helper-version.ts
+++ b/src/lib/terminal/helper-version.ts
@@ -22,8 +22,13 @@
  *  helper ready" opt-in. 0.3.2 (card cbe60db5, sign-off change 2) adds the
  *  bridge's machine-identity (hostname) announcement. 0.3.3 (rework 5,
  *  exact-conversation Resume) adds the bridge's own conversation-id minting
- *  (`--session-id`/`--resume`) and its announcement alongside version/host. */
-export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.3";
+ *  (`--session-id`/`--resume`) and its announcement alongside version/host.
+ *  0.3.4 (Bug B, Nick's field test 2026-08-15) fixes a promptless/Resume
+ *  launch's PTY spawning at a hardcoded 80x24 — it now spawns at the
+ *  browser's real panel size, carried on the SAME launch deep link (see
+ *  terminal/bridge/src/spawn-dims.js). NOT yet built/notarized/published —
+ *  bumped here so the recommended-version gate is ready the moment it is. */
+export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.4";
 
 export type HelperVersionParts = readonly [number, number, number];
 

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -42,6 +42,7 @@ import WebSocket from "ws";
 import { parseControlMessage } from "./framing.js";
 import { createOutputBatcher } from "./output-batcher.js";
 import { resolveClaudeLaunch } from "./resume-cmd.js";
+import { resolveSpawnDims } from "./spawn-dims.js";
 import {
   sanitizeHelperVersion,
   sanitizeMachineLabel,
@@ -174,6 +175,12 @@ const CWD = launched?.cwd || args.cwd || process.env.BRIDGE_CWD || process.cwd()
 // caller somehow sent both, so the resumed command is never followed by a
 // stray argv element.
 const PROMPT = RESUME || RESUME_ID ? "" : launched?.prompt || "";
+// Real PTY spawn size (Bug B, card cbe60db5) — see spawn-dims.js's header
+// comment for why this can't just be a post-spawn resize for a promptless
+// launch. Falls back to the historical 80x24 default when the link didn't
+// carry a validated pair (an old app build, a bare CLI run, or a launch that
+// raced the browser's own xterm mount).
+const { cols: SPAWN_COLS, rows: SPAWN_ROWS } = resolveSpawnDims(launched);
 // ── helper-version announcement (release-gate rework 2a) ─────────────────────
 // Read the RUNNING helper's own version so the relay/dock can nudge stale
 // installs to update. Priority: BRIDGE_HELPER_VERSION (set by the packaged
@@ -468,13 +475,20 @@ async function main() {
    */
   function spawnPty() {
     if (term || shuttingDown) return;
-    log("info", "spawning PTY", { file, args: cmdArgs, cwd: CWD, promptChars: PROMPT.length });
+    log("info", "spawning PTY", {
+      file,
+      args: cmdArgs,
+      cwd: CWD,
+      promptChars: PROMPT.length,
+      cols: SPAWN_COLS,
+      rows: SPAWN_ROWS,
+    });
     let spawned;
     try {
       spawned = pty.spawn(file, spawnArgs, {
         name: "xterm-color",
-        cols: 80,
-        rows: 24,
+        cols: SPAWN_COLS,
+        rows: SPAWN_ROWS,
         cwd: CWD,
         env: resolveSpawnEnv(),
       });

--- a/terminal/bridge/src/spawn-dims.js
+++ b/terminal/bridge/src/spawn-dims.js
@@ -1,0 +1,47 @@
+// PTY spawn dimensions — Bug B (card cbe60db5, Nick's field test 2026-08-15):
+// a promptless (Resume, or any prompt-less) launch used to spawn its PTY at a
+// hardcoded 80x24 because the browser's real panel size could never reach a
+// not-yet-existent process in time. Promptless launches call spawnPty()
+// SYNCHRONOUSLY, before the relay socket even opens (see index.js's R1
+// SEQUENCING comment) — and the browser's own resize send is gated on
+// connection status "connected", which itself only flips on the FIRST
+// inbound PTY byte. Waiting for a post-spawn resize is therefore circular:
+// nothing produces that first byte until the PTY exists.
+//
+// The fix carries the browser's already-computed cols/rows (the SAME
+// fit-addon read `sendResize()` uses — see use-terminal-session.ts's
+// `currentLaunchDims`) on the SAME launch deep link that names the command to
+// run, so the bridge has the real size before it ever calls pty.spawn. No
+// wire round-trip, no timing race.
+//
+// Pure so it's unit-testable without a PTY (same idiom as resume-cmd.js).
+
+import { isValidDim } from "./framing.js";
+
+/** The PTY's default size — unchanged from before this fix, and still what a
+ * non-deep-link CLI run (no launch-url) or a launch that raced xterm's mount
+ * (fast click before the fit-addon was ready) falls back to. */
+export const DEFAULT_SPAWN_COLS = 80;
+export const DEFAULT_SPAWN_ROWS = 24;
+
+/**
+ * Resolve the `{ cols, rows }` to hand `pty.spawn`. `launched` is whatever
+ * `parseLaunchDeepLink` returned (or `null` for a bare CLI run with no
+ * `--launch-url`) — its `cols`/`rows` are re-validated here with the SAME
+ * rule the resize wire format uses (defense in depth, same posture as
+ * RESUME_ID's re-check in index.js) rather than trusted blindly. A
+ * missing/malformed value falls back to the pre-existing hardcoded default —
+ * exactly today's behaviour, so an old app that never sends the params (or a
+ * link with only one of the pair) never regresses.
+ *
+ * @param {{ cols?: unknown, rows?: unknown } | null | undefined} launched
+ * @returns {{ cols: number, rows: number }}
+ */
+export function resolveSpawnDims(launched) {
+  const cols = Number(launched?.cols);
+  const rows = Number(launched?.rows);
+  return {
+    cols: isValidDim(cols) ? cols : DEFAULT_SPAWN_COLS,
+    rows: isValidDim(rows) ? rows : DEFAULT_SPAWN_ROWS,
+  };
+}

--- a/terminal/bridge/src/spawn-dims.test.js
+++ b/terminal/bridge/src/spawn-dims.test.js
@@ -1,0 +1,45 @@
+// Unit tests for the PTY spawn-size resolution (Bug B, card cbe60db5 — Nick's
+// field test 2026-08-15: a promptless/Resume launch rendered narrow because
+// the PTY spawned at a hardcoded 80x24 before any real resize could land).
+// Run: cd terminal/bridge && node --test   (or: npm test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveSpawnDims, DEFAULT_SPAWN_COLS, DEFAULT_SPAWN_ROWS } from "./spawn-dims.js";
+
+test("a validated cols/rows pair on the launch is used verbatim", () => {
+  const result = resolveSpawnDims({ cols: 137, rows: 42 });
+  assert.deepEqual(result, { cols: 137, rows: 42 });
+});
+
+test("no launch (bare CLI run, no --launch-url) falls back to the historical default", () => {
+  assert.deepEqual(resolveSpawnDims(null), { cols: DEFAULT_SPAWN_COLS, rows: DEFAULT_SPAWN_ROWS });
+  assert.deepEqual(resolveSpawnDims(undefined), { cols: DEFAULT_SPAWN_COLS, rows: DEFAULT_SPAWN_ROWS });
+});
+
+test("a launch that carried no dims at all falls back to the default — no regression for an old app build", () => {
+  assert.deepEqual(
+    resolveSpawnDims({ relay: "ws://x", session: "s", token: "t" }),
+    { cols: DEFAULT_SPAWN_COLS, rows: DEFAULT_SPAWN_ROWS },
+  );
+});
+
+test("a lone valid dimension (the other missing/malformed) falls back on the missing side only", () => {
+  assert.deepEqual(resolveSpawnDims({ cols: 120 }), { cols: 120, rows: DEFAULT_SPAWN_ROWS });
+  assert.deepEqual(resolveSpawnDims({ rows: 40 }), { cols: DEFAULT_SPAWN_COLS, rows: 40 });
+});
+
+test("non-sane dims (zero, negative, non-integer, absurdly large, NaN) fall back to the default", () => {
+  for (const bad of [0, -5, 12.5, 100000, NaN, "abc"]) {
+    assert.deepEqual(
+      resolveSpawnDims({ cols: bad, rows: 40 }),
+      { cols: DEFAULT_SPAWN_COLS, rows: 40 },
+      `cols=${bad} must fall back`,
+    );
+  }
+});
+
+test("string-shaped numeric dims (URL params are always strings before parseLaunchDeepLink coerces them) still resolve", () => {
+  // Defense-in-depth: resolveSpawnDims itself re-validates with Number(), so
+  // it stays correct even if a caller hands it raw, un-coerced values.
+  assert.deepEqual(resolveSpawnDims({ cols: "137", rows: "42" }), { cols: 137, rows: 42 });
+});

--- a/terminal/helper/package-lock.json
+++ b/terminal/helper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibecodes-terminal-helper",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "devDependencies": {
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8"

--- a/terminal/helper/package.json
+++ b/terminal/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "description": "macOS helper app: registers the vibecodes:// URL scheme and runs the terminal bridge (node-pty PTY -> relay) on launch. A thin, installable, signable wrapper around terminal/bridge (no logic duplication).",
   "author": "VibeCodes",

--- a/terminal/shared/deep-link.mjs
+++ b/terminal/shared/deep-link.mjs
@@ -50,6 +50,16 @@
 //             it is the verified-safe, exact path. Malformed/non-UUID values
 //             are rejected at parse time (never forwarded to a shell-split
 //             CMD string).
+//   cols/rows — Bug B (card cbe60db5, Nick's field test 2026-08-15): the
+//             browser's real panel size at launch time, so the bridge can
+//             spawn the PTY at the correct size instead of a hardcoded
+//             default. A PROMPTLESS launch spawns its PTY synchronously,
+//             before the browser's own resize control frame can ever reach a
+//             not-yet-existent process — see terminal/bridge/src/index.js's
+//             `resolveSpawnDims`. Only meaningful as a pair; either missing
+//             or non-sane falls back to the bridge's pre-existing hardcoded
+//             default, exactly like before this field existed (no
+//             version-skew risk).
 //
 // `token` and `helperToken` are secrets and `prompt` is user content. NEVER log
 // a raw link — use redactDeepLinkToken first (it elides all three). `prompt` is
@@ -70,8 +80,18 @@ export const LAUNCH_HOST = "launch";
  *  file header) — `resume_id` is validated at the same strictness either way. */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/** A terminal dimension must be a positive, finite, sane integer — mirrors
+ *  src/lib/terminal/connection.ts's `isValidDim` / terminal/bridge/src/
+ *  framing.js's `isValidDim`. Duplicated (not imported) for the same
+ *  dependency-free reason as UUID_RE above.
+ *  @param {unknown} n
+ *  @returns {boolean} */
+function isValidLaunchDim(n) {
+  return Number.isInteger(n) && n > 0 && n <= 1000;
+}
+
 /**
- * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…][&prompt=…]`
+ * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…][&cols=…&rows=…][&prompt=…]`
  * deep link.
  *
  * Uses encodeURIComponent so reserved characters in the relay URL / token /
@@ -80,10 +100,10 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * (and therefore the app-side prompt budget) is stable. Throws when a required
  * field is missing so a malformed link is never fired.
  *
- * @param {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean, resumeId?: string }} params
+ * @param {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean, resumeId?: string, cols?: number, rows?: number }} params
  * @returns {string}
  */
-export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt, resume, resumeId } = {}) {
+export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt, resume, resumeId, cols, rows } = {}) {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
   }
@@ -102,6 +122,11 @@ export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, p
   } else if (resume) {
     parts.push(`resume=1`);
   }
+  // Only ever sent as a pair — a lone dimension is useless to the bridge's
+  // pty.spawn call (see the header comment).
+  if (isValidLaunchDim(cols) && isValidLaunchDim(rows)) {
+    parts.push(`cols=${cols}`, `rows=${rows}`);
+  }
   if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
 }
@@ -116,7 +141,7 @@ export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, p
  * param existed (version-skew safe both ways).
  *
  * @param {unknown} url
- * @returns {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean, resumeId?: string } | null}
+ * @returns {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean, resumeId?: string, cols?: number, rows?: number } | null}
  */
 export function parseLaunchDeepLink(url) {
   if (typeof url !== "string" || url.length === 0) return null;
@@ -145,6 +170,14 @@ export function parseLaunchDeepLink(url) {
   const rawResumeId = parsed.searchParams.get("resume_id");
   const resumeId = rawResumeId && UUID_RE.test(rawResumeId) ? rawResumeId.toLowerCase() : undefined;
   const resume = !resumeId && parsed.searchParams.get("resume") === "1" ? true : undefined;
+  // cols/rows (Bug B — see header comment): re-validated here exactly like
+  // resumeId above — a malformed/absurd value is about to reach pty.spawn, so
+  // there is no safe partial value; only accepted as a validated PAIR.
+  const rawCols = parsed.searchParams.get("cols");
+  const rawRows = parsed.searchParams.get("rows");
+  const parsedCols = rawCols === null ? NaN : Number(rawCols);
+  const parsedRows = rawRows === null ? NaN : Number(rawRows);
+  const dimsValid = isValidLaunchDim(parsedCols) && isValidLaunchDim(parsedRows);
   if (!relay || !session || !token) return null;
 
   const out = { relay, session, token };
@@ -152,6 +185,10 @@ export function parseLaunchDeepLink(url) {
   if (cwd) out.cwd = cwd;
   if (resumeId) out.resumeId = resumeId;
   else if (resume) out.resume = true;
+  if (dimsValid) {
+    out.cols = parsedCols;
+    out.rows = parsedRows;
+  }
   if (prompt) out.prompt = prompt;
   return out;
 }

--- a/terminal/test/deep-link.test.mjs
+++ b/terminal/test/deep-link.test.mjs
@@ -140,6 +140,43 @@ test("a malformed resume_id is rejected outright — never forwarded to the call
   assert.ok(!("resumeId" in parsed));
 });
 
+// ── real panel size at spawn (Bug B, card cbe60db5) ────────────────────────────
+
+test("build ⇄ parse round-trips cols/rows, positioned before prompt", () => {
+  const withDims = { ...SAMPLE, cols: 137, rows: 42, prompt: "hello" };
+  const url = buildLaunchDeepLink(withDims);
+  assert.ok(url.includes("cols=137"));
+  assert.ok(url.includes("rows=42"));
+  assert.ok(url.indexOf("cols=") < url.indexOf("prompt="), "cols precedes the LAST param, prompt");
+  assert.deepEqual(parseLaunchDeepLink(url), withDims);
+});
+
+test("omits cols/rows entirely when absent", () => {
+  const url = buildLaunchDeepLink(SAMPLE);
+  assert.ok(!url.includes("cols="));
+  assert.ok(!url.includes("rows="));
+  const parsed = parseLaunchDeepLink(url);
+  assert.ok(!("cols" in parsed) && !("rows" in parsed));
+});
+
+test("a lone dimension (missing pair) is dropped entirely — never a half pair", () => {
+  const url = buildLaunchDeepLink({ ...SAMPLE, cols: 120 }); // rows omitted
+  assert.ok(!url.includes("cols="));
+  const parsedHalf = parseLaunchDeepLink(
+    `${LAUNCH_SCHEME}://${LAUNCH_HOST}?relay=r&session=s&token=t&cols=120`,
+  );
+  assert.ok(!("cols" in parsedHalf) && !("rows" in parsedHalf));
+});
+
+test("non-sane cols/rows (zero, negative, non-integer, absurdly large) are rejected outright", () => {
+  for (const bad of ["0", "-5", "12.5", "abc", "100000"]) {
+    const url = `${LAUNCH_SCHEME}://${LAUNCH_HOST}?relay=r&session=s&token=t&cols=${bad}&rows=40`;
+    const parsed = parseLaunchDeepLink(url);
+    assert.ok(parsed !== null);
+    assert.ok(!("cols" in parsed) && !("rows" in parsed), `cols=${bad} must not survive parsing`);
+  }
+});
+
 test("redactDeepLinkToken elides the prompt (user content) as well as the token", () => {
   const url = buildLaunchDeepLink({ ...SAMPLE, prompt: HOSTILE_PROMPT });
   const redacted = redactDeepLinkToken(url);


### PR DESCRIPTION
## Summary
- **Bug A (web-only)**: a hard refresh could silently mint a brand-new session instead of reattaching to the live one, whenever the session-registry fetch failed for any reason (network blip, an auth-cookie race right after reload). The failure path collapsed "don't know" into "confirmed empty," bypassing the chooser entirely with no error shown. Now retries with backoff, and never auto-mints on a failed load — only on a genuinely confirmed-empty response — with a Retry toast if it still can't load.
- **Bug B (touches the native helper app, `terminal/bridge`)**: any "promptless" session launch (Resume being the most visible case) spawned its terminal at a hardcoded 80×24 before the browser's real panel width could possibly be known, permanently baking in narrow-wrapped text for the earliest output. Fixed by carrying the browser's real, already-fitted terminal size on the launch link itself, so the bridge spawns at the correct size from the start. **This half needs a new helper build/notarize/publish before it reaches any real machine — source-only in this PR.**

Card: 9157ace8 (Bug Fix workflow). Found via Nick's live field report; QA root-caused both independently, Implementation fixed and verified both.

## Test plan
- [x] tsc clean
- [x] full web vitest 2765/2765 (170 files)
- [x] eslint clean
- [x] terminal/bridge unit tests 27/27
- [x] terminal/test full integration suite (real bridge+relay round-trips) 136/136

🤖 Generated with [Claude Code](https://claude.com/claude-code)