### PR TITLE
feat(terminal): task-specific launch skips the chooser, minimal dedupe only

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -39,6 +39,7 @@ import type {
   ChooserLiveRow,
   ChooserRecentRow,
   ChooserSections,
+  TaskSessionMatch,
 } from "@/lib/terminal/chooser-data";
 
 vi.mock("next/navigation", () => ({
@@ -123,6 +124,34 @@ vi.mock("./terminal-session-chooser", () => ({
       ))}
     </div>
   ),
+}));
+
+// Task-launch-skip-chooser (2026-08-16): the minimal task-scoped choice —
+// exposes one button per action (`onReconnect`/`onStartFresh`) and the
+// match's `kind`, skipping the real component's layout/copy (covered by
+// terminal-task-launch-choice.test.tsx).
+vi.mock("./terminal-task-launch-choice", () => ({
+  TerminalTaskLaunchChoice: ({
+    open,
+    match,
+    onReconnect,
+    onStartFresh,
+  }: {
+    open: boolean;
+    match: TaskSessionMatch;
+    onReconnect: () => void;
+    onStartFresh: () => void;
+  }) =>
+    open ? (
+      <div data-testid="task-choice" data-match-kind={match.kind} data-match-sid={match.row.sid}>
+        <button data-testid="task-choice-reconnect" onClick={onReconnect}>
+          Reconnect
+        </button>
+        <button data-testid="task-choice-start-fresh" onClick={onStartFresh}>
+          Start fresh anyway
+        </button>
+      </div>
+    ) : null,
 }));
 
 import { TerminalDock } from "./terminal-dock";
@@ -221,6 +250,29 @@ function liveHereRow(): ChooserRegistryRow {
   };
 }
 
+/** A live session on THIS board, scoped to `taskId` — the exact-task match
+ * task-launch-skip-chooser's dedupe should find. */
+function liveHereRowForTask(taskId: string): ChooserRegistryRow {
+  return { ...liveHereRow(), sid: `sid-live-here-${taskId}`, taskId };
+}
+
+/** An ENDED session (within the 48h recent window), scoped to `taskId`. */
+function recentRowForTask(taskId: string): ChooserRegistryRow {
+  return {
+    sid: `sid-recent-${taskId}`,
+    ideaId: "idea-1",
+    ideaTitle: "My Idea",
+    taskId,
+    taskTitle: "Do the thing",
+    machineLabel: null,
+    cwd: "/Users/nick/projects/here",
+    claudeSessionId: null,
+    createdAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    status: "ended",
+    endedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1h ago — well within 48h
+  };
+}
+
 beforeEach(() => {
   vi.stubEnv("NEXT_PUBLIC_TERMINAL_ENABLED", "true");
 });
@@ -262,14 +314,19 @@ describe("TerminalDock — launch-bus race with the still-loading registry (Bug 
     expect(screen.getAllByTestId("session-view")).toHaveLength(1); // never double-minted
   });
 
-  it("routes a raced launch into the chooser (never a blind mint) once the resolved decision has something to choose between", async () => {
+  it("routes a raced BOARD-LEVEL launch into the chooser (never a blind mint) once the resolved decision has something to choose between", async () => {
     const registry = deferredRegistryResponse();
     stubFetch(registry.promise);
 
     render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
 
+    // No taskId — a board-level launch (toolbar / dock "+"), unlike the
+    // task-scoped tests further down (task-launch-skip-chooser, 2026-08-16):
+    // a task-scoped launch now keys ONLY on whether ITS task has a match,
+    // never on the global "is anything worth choosing between" decision this
+    // test exercises.
     act(() => {
-      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+      requestBrowserLaunch();
     });
     expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
     expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
@@ -456,5 +513,127 @@ describe("TerminalDock — registry fetch failure never collapses into confirmed
 
     await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument(), { timeout: 5000 });
     expect(toast.error).not.toHaveBeenCalled();
+  });
+});
+
+// Task-launch-skip-chooser (Nick's explicit product decision, 2026-08-16):
+// QA confirmed the cross-board chooser was working exactly as originally
+// designed for EVERY launch source, task-scoped or not — Nick then decided
+// that's wrong for a task-specific launch specifically. Clicking "Launch
+// Claude Code" on a specific task is unambiguous intent: it must start
+// immediately with NO chooser, UNLESS this EXACT task already has a
+// live-or-recent session, in which case a small task-scoped choice (never
+// the full cross-board chooser) is the only interstitial allowed.
+describe("TerminalDock — task-launch-skip-chooser (Nick's explicit product decision, 2026-08-16)", () => {
+  it("auto-starts a task launch with no chooser at all when this exact task has no existing session, even though other sessions exist elsewhere", async () => {
+    // A live session exists (on another board, for no particular task) —
+    // under the OLD behaviour this alone put the global decision at
+    // "chooser" and would have blocked every launch, task-scoped or not.
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(screen.getByTestId("session-view").dataset.taskId).toBe("task-9");
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("task-choice")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows the minimal task-scoped choice (never the full chooser) when this exact task already has a LIVE session", async () => {
+    stubFetch(Promise.resolve([liveHereRowForTask("task-9"), liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("task-choice")).toBeInTheDocument());
+    expect(screen.getByTestId("task-choice").dataset.matchKind).toBe("live-here");
+    expect(screen.getByTestId("task-choice").dataset.matchSid).toBe("sid-live-here-task-9");
+    // Never the full generic chooser — no cross-board content, no other tasks.
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+  });
+
+  it("shows the minimal task-scoped choice when this exact task has a RECENT (ended, ≤48h) session", async () => {
+    stubFetch(Promise.resolve([recentRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("task-choice")).toBeInTheDocument());
+    expect(screen.getByTestId("task-choice").dataset.matchKind).toBe("recent");
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+  });
+
+  it("auto-starts (no false-positive dedupe) when the only existing session belongs to a DIFFERENT task", async () => {
+    stubFetch(Promise.resolve([liveHereRowForTask("task-OTHER")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(screen.getByTestId("session-view").dataset.taskId).toBe("task-9");
+    expect(screen.queryByTestId("task-choice")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
+  });
+
+  it("Reconnect inside the task choice reattaches the exact-task live session", async () => {
+    stubFetch(Promise.resolve([liveHereRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+    await waitFor(() => expect(screen.getByTestId("task-choice")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("task-choice-reconnect"));
+
+    await waitFor(() => expect(screen.queryByTestId("task-choice")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+  });
+
+  it("Start fresh anyway inside the task choice mints a brand-new session for the task, ignoring the match", async () => {
+    stubFetch(Promise.resolve([liveHereRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+    await waitFor(() => expect(screen.getByTestId("task-choice")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("task-choice-start-fresh"));
+
+    await waitFor(() => expect(screen.queryByTestId("task-choice")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(screen.getByTestId("session-view").dataset.taskId).toBe("task-9");
+  });
+
+  it("still queues a task launch during the still-loading registry race, then resolves to the minimal task choice once the match is known", async () => {
+    const registry = deferredRegistryResponse();
+    stubFetch(registry.promise);
+
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("task-choice")).not.toBeInTheDocument();
+
+    registry.resolve([liveHereRowForTask("task-9")]);
+
+    await waitFor(() => expect(screen.getByTestId("task-choice")).toBeInTheDocument());
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
   });
 });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -79,10 +79,12 @@ import type { TransferredBuffer } from "@/lib/terminal/scrollback-transfer";
 import {
   deriveChooserSections,
   chooserHeaderCounts,
+  findTaskSessionMatch,
   type ChooserSections,
   type ChooserRegistryRow,
   type ChooserLiveRow,
   type ChooserRecentRow,
+  type TaskSessionMatch,
 } from "@/lib/terminal/chooser-data";
 import { decideEntryBehaviour, type EntryDecision } from "@/lib/terminal/entry-decision";
 import { loadSessionSnapshot, readLastTabSid, toReconnectBuffer } from "@/lib/terminal/session-snapshot";
@@ -107,6 +109,7 @@ import {
   type SessionSummary,
 } from "./terminal-session-view";
 import { TerminalSessionChooser } from "./terminal-session-chooser";
+import { TerminalTaskLaunchChoice } from "./terminal-task-launch-choice";
 import { TerminalMySessionsPanel } from "./terminal-my-sessions-panel";
 import type { AttachExistingPair, TerminalSessionActions, TerminalSessionDescriptor } from "./use-terminal-session";
 
@@ -219,6 +222,13 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // that tab's live `TerminalSessionView` stay mounted, connected, and
   // visible underneath; only clicking an action inside the overlay closes it.
   const [chooserOpen, setChooserOpen] = useState(false);
+  // Task-launch-skip-chooser (Nick's explicit product decision, 2026-08-16):
+  // a per-task launch (payload carries `taskId`) never opens the full
+  // chooser above — it either mints immediately (no existing session for
+  // THIS exact task) or opens this minimal, task-scoped choice instead (see
+  // `TerminalTaskLaunchChoice`). Mutually exclusive with `chooserOpen` —
+  // `deliverLaunch` only ever sets one of the two.
+  const [taskChoiceOpen, setTaskChoiceOpen] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -385,6 +395,15 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     [registryRows, ideaId, entrySnapshotInfo],
   );
   const chooserCounts = useMemo(() => chooserHeaderCounts(chooserSections), [chooserSections]);
+  // Task-launch-skip-chooser: `deliverLaunch` needs a synchronous,
+  // always-current read of `chooserSections` (to check whether THIS exact
+  // task already has a match) without becoming a dependency that would force
+  // the launch-bus effect to resubscribe — same rationale as
+  // `entryDecisionRef` above.
+  const chooserSectionsRef = useRef(chooserSections);
+  useEffect(() => {
+    chooserSectionsRef.current = chooserSections;
+  }, [chooserSections]);
 
   // Close every open pop-out hand-off channel if the dock itself unmounts
   // (board navigation away) — the popped windows keep running independently
@@ -735,6 +754,24 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         deferredLaunchPendingRef.current = true;
         return;
       }
+      if (payload?.taskId) {
+        // Task-launch-skip-chooser (Nick's explicit product decision,
+        // 2026-08-16): a task-specific launch is unambiguous intent — it
+        // NEVER routes through the full cross-board chooser, regardless of
+        // `entryDecisionRef.current.kind`. It keys ONLY on whether THIS
+        // exact task already has a live-or-recent match; unrelated sessions
+        // elsewhere (which would put the global decision at "chooser") are
+        // irrelevant here.
+        const match = findTaskSessionMatch(chooserSectionsRef.current, payload.taskId);
+        if (!match) {
+          mintAndDeliver(payload);
+          return;
+        }
+        setExpanded(true);
+        setPendingLaunch(payload);
+        setTaskChoiceOpen(true);
+        return;
+      }
       if (entryDecisionRef.current.kind === "chooser") {
         // Rework 11 (card cbe60db5): no longer gated on
         // `sessionsRef.current.length === 0`. With no local tabs there's
@@ -870,6 +907,23 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     // the click that triggered it.
     if (deferredLaunchPendingRef.current) {
       deferredLaunchPendingRef.current = false;
+      if (pendingLaunch?.taskId) {
+        // Task-launch-skip-chooser: the same per-task predicate
+        // `deliverLaunch` uses, replayed here now that the registry (and so
+        // `chooserSections`) has actually resolved — never the global
+        // `entryDecision.kind`, which would wrongly route on unrelated
+        // sessions elsewhere.
+        const match = findTaskSessionMatch(chooserSections, pendingLaunch.taskId);
+        if (!match) {
+          const payload = pendingLaunch;
+          setPendingLaunch(null);
+          mintAndDeliver(payload);
+          return;
+        }
+        // `pendingLaunch` stays set — `TerminalTaskLaunchChoice` reads it below.
+        setTaskChoiceOpen(true);
+        return;
+      }
       if (entryDecision.kind === "chooser") {
         // `deliverLaunch` already expanded the dock and set `pendingLaunch`.
         // With no local tabs, `showingChooser` renders the body-swap chooser
@@ -895,7 +949,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       void performReattach(entryDecision.sid, { focus: false });
     }
     // "chooser": nothing to seed — the chooser renders in the body below.
-  }, [entryDecision, sessions.length, performReattach, pendingLaunch, mintAndDeliver]);
+  }, [entryDecision, sessions.length, performReattach, pendingLaunch, mintAndDeliver, chooserSections]);
 
   // ── other-board Reconnect (`?reconnect=<sid>`, design item 2) ──────────────
   // "Open board & reconnect" navigates here with the target sid on the URL;
@@ -970,6 +1024,42 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     [mintAndDeliver],
   );
 
+  // Task-launch-skip-chooser: the minimal task-scoped choice's two actions.
+  // Re-derives the match from the CURRENT `chooserSections` (rather than
+  // trusting a stale value captured when the dialog opened) so a registry
+  // refresh in the meantime — the row expiring past 48h, for instance — is
+  // never acted on with a match that no longer exists.
+  const handleTaskChoiceReconnect = useCallback(() => {
+    const taskId = pendingLaunch?.taskId;
+    const match = taskId ? findTaskSessionMatch(chooserSectionsRef.current, taskId) : null;
+    setPendingLaunch(null);
+    setTaskChoiceOpen(false);
+    if (!match) return; // the match expired between render and click — nothing safe to reconnect to
+    if (match.kind === "recent") {
+      const row = match.row;
+      mintAndDeliver({
+        resume: row.claudeSessionId ? undefined : true,
+        resumeId: row.claudeSessionId ?? undefined,
+        cwd: row.cwd,
+        taskId: row.taskId ?? undefined,
+        taskTitle: row.taskTitle ?? undefined,
+      });
+      return;
+    }
+    if (match.kind === "live-here") {
+      void performReattach(match.row.sid, { focus: true });
+    } else {
+      router.push(`/ideas/${match.row.ideaId}/board?reconnect=${encodeURIComponent(match.row.sid)}`);
+    }
+  }, [pendingLaunch, mintAndDeliver, performReattach, router]);
+
+  const handleTaskChoiceStartFresh = useCallback(() => {
+    const payload = pendingLaunch;
+    setPendingLaunch(null);
+    setTaskChoiceOpen(false);
+    mintAndDeliver(payload);
+  }, [pendingLaunch, mintAndDeliver]);
+
   // My sessions panel Reconnect (design item 9) — the SAME reattach flow;
   // "this board" attaches in place, any other board navigates + reconnects.
   const handleMySessionsReconnect = useCallback(
@@ -1022,9 +1112,22 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // Session entry chooser (card cbe60db5): the dock's resting state for this
   // pageview — no local tab yet, and the registry says there's something to
   // choose between (mockup A1's collapsed header + A2's chooser body).
-  const showingChooser = sessions.length === 0 && entryDecision?.kind === "chooser";
+  // Task-launch-skip-chooser: excludes `taskChoiceOpen` — the board's
+  // resting state (nothing minted yet, and SOME unrelated live/recent
+  // session exists somewhere) would otherwise still satisfy this predicate
+  // while a task-scoped launch's minimal choice is the one interstitial
+  // that's actually allowed to show; the full chooser must never render
+  // underneath/alongside it.
+  const showingChooser = sessions.length === 0 && entryDecision?.kind === "chooser" && !taskChoiceOpen;
   const pendingTask = pendingLaunch?.taskId
     ? { taskId: pendingLaunch.taskId, taskTitle: pendingLaunch.taskTitle ?? "" }
+    : null;
+  // Task-launch-skip-chooser: re-derived every render (not cached at the
+  // moment the dialog opened) so a registry refresh while it's showing —
+  // e.g. the matched row expiring past the 48h recent window — is always
+  // reflected; `taskChoiceOpen` alone gates whether the dialog is mounted.
+  const pendingTaskMatch: TaskSessionMatch | null = pendingLaunch?.taskId
+    ? findTaskSessionMatch(chooserSections, pendingLaunch.taskId)
     : null;
 
   // Substitute "popped-out" for any tab the dock knows it popped — its real
@@ -1337,6 +1440,25 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           />
         </DialogContent>
       </Dialog>
+
+      {/* Task-launch-skip-chooser (Nick's explicit product decision,
+          2026-08-16): the per-task launch's ONLY interstitial — rendered
+          instead of (never alongside) either Dialog above, and only when
+          `pendingTaskMatch` is non-null (this exact task has a live/recent
+          session). Mounted conditionally rather than just `open`-gated, so a
+          match that expires out from under an open dialog (a registry
+          refresh crossing the 48h window) unmounts it instead of leaving a
+          dialog with nothing to act on. */}
+      {pendingTaskMatch && (
+        <TerminalTaskLaunchChoice
+          open={taskChoiceOpen}
+          taskTitle={pendingTask?.taskTitle ?? ""}
+          match={pendingTaskMatch}
+          busy={chooserBusy}
+          onReconnect={handleTaskChoiceReconnect}
+          onStartFresh={handleTaskChoiceStartFresh}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/board/terminal-task-launch-choice.test.tsx
+++ b/src/components/board/terminal-task-launch-choice.test.tsx
@@ -1,0 +1,120 @@
+// Task-launch-skip-chooser (Nick's explicit product decision, 2026-08-16) —
+// the minimal task-scoped choice's own render contract: label wording per
+// match kind (live vs. recent) and the two click callbacks. The dock's
+// integration (when this renders instead of the full chooser, dedupe
+// keying) is covered by terminal-dock.test.tsx.
+
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { TerminalTaskLaunchChoice } from "./terminal-task-launch-choice";
+import type { TaskSessionMatch } from "@/lib/terminal/chooser-data";
+
+afterEach(cleanup);
+
+const LIVE_HERE_MATCH: TaskSessionMatch = {
+  kind: "live-here",
+  row: {
+    sid: "sid-live-here",
+    ideaId: "idea-1",
+    ideaTitle: "VibeCodes",
+    taskId: "task-1",
+    taskTitle: "Fix login bug",
+    machineLabel: "Nick's MacBook",
+    cwd: "~/projects/vibecodes",
+    createdAt: new Date().toISOString(),
+    wasOpenInThisTab: false,
+  },
+};
+
+const RECENT_MATCH: TaskSessionMatch = {
+  kind: "recent",
+  row: {
+    sid: "sid-recent",
+    ideaId: "idea-1",
+    ideaTitle: "VibeCodes",
+    taskId: "task-1",
+    taskTitle: "Fix login bug",
+    cwd: "~/projects/vibecodes",
+    machineLabel: null,
+    claudeSessionId: null,
+    endedAt: new Date().toISOString(),
+  },
+};
+
+describe("TerminalTaskLaunchChoice", () => {
+  it("renders nothing when closed", () => {
+    render(
+      <TerminalTaskLaunchChoice
+        open={false}
+        taskTitle="Fix login bug"
+        match={LIVE_HERE_MATCH}
+        onReconnect={vi.fn()}
+        onStartFresh={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("terminal-task-launch-choice")).not.toBeInTheDocument();
+  });
+
+  it("labels a live match 'Reconnect' and fires onReconnect", () => {
+    const onReconnect = vi.fn();
+    render(
+      <TerminalTaskLaunchChoice
+        open
+        taskTitle="Fix login bug"
+        match={LIVE_HERE_MATCH}
+        onReconnect={onReconnect}
+        onStartFresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/already has a terminal running/i)).toBeInTheDocument();
+    expect(screen.getByText("Fix login bug")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Reconnect" }));
+    expect(onReconnect).toHaveBeenCalledOnce();
+  });
+
+  it("labels a recent match 'Resume' and fires onReconnect", () => {
+    const onReconnect = vi.fn();
+    render(
+      <TerminalTaskLaunchChoice
+        open
+        taskTitle="Fix login bug"
+        match={RECENT_MATCH}
+        onReconnect={onReconnect}
+        onStartFresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/recent session/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    expect(onReconnect).toHaveBeenCalledOnce();
+  });
+
+  it("fires onStartFresh from the escape hatch, independent of match kind", () => {
+    const onStartFresh = vi.fn();
+    render(
+      <TerminalTaskLaunchChoice
+        open
+        taskTitle="Fix login bug"
+        match={LIVE_HERE_MATCH}
+        onReconnect={vi.fn()}
+        onStartFresh={onStartFresh}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /start fresh anyway/i }));
+    expect(onStartFresh).toHaveBeenCalledOnce();
+  });
+
+  it("disables both actions while busy", () => {
+    render(
+      <TerminalTaskLaunchChoice
+        open
+        busy
+        taskTitle="Fix login bug"
+        match={LIVE_HERE_MATCH}
+        onReconnect={vi.fn()}
+        onStartFresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Reconnect" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /start fresh anyway/i })).toBeDisabled();
+  });
+});

--- a/src/components/board/terminal-task-launch-choice.tsx
+++ b/src/components/board/terminal-task-launch-choice.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+// Task-launch-skip-chooser (Nick's explicit product decision, 2026-08-16):
+// the per-task "Launch Claude Code" (task-card menu item, task-detail
+// terminal icon — anything that fires the launch bus with a `taskId`) never
+// shows the full cross-board `TerminalSessionChooser` any more. The ONE
+// exception is THIS component: it renders only when
+// `findTaskSessionMatch` (chooser-data.ts) finds a live-or-recent (≤48h)
+// session for the EXACT task being launched — dedupe-for-this-exact-task,
+// nothing more. No other tasks, no other boards, no Recent/Running-now
+// section headers — just "here's the one match, reconnect/resume it or
+// start fresh anyway."
+
+import { RefreshCw, Terminal as TerminalIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { formatSessionAge } from "@/lib/terminal/session-registry";
+import type { TaskSessionMatch } from "@/lib/terminal/chooser-data";
+
+export interface TerminalTaskLaunchChoiceProps {
+  open: boolean;
+  taskTitle: string;
+  match: TaskSessionMatch;
+  /** Disables both actions while a click's async work (reattach/resume) is in flight. */
+  busy?: boolean;
+  /** Live match → reattach (this board attaches in place, another board navigates). Recent match → resume (`claude --continue`/`--resume`). */
+  onReconnect: () => void;
+  /** The "start fresh anyway" escape hatch — mints a brand-new session for this task, ignoring the match entirely. */
+  onStartFresh: () => void;
+}
+
+export function TerminalTaskLaunchChoice({
+  open,
+  taskTitle,
+  match,
+  busy = false,
+  onReconnect,
+  onStartFresh,
+}: TerminalTaskLaunchChoiceProps) {
+  // Narrow on `match.kind` directly at each use (rather than a derived
+  // boolean) — `ChooserLiveRow`/`ChooserRecentRow` don't share a `createdAt`/
+  // `endedAt` field, so TS can only follow the discriminant through a direct
+  // check on `match.kind` itself.
+  const isLive = match.kind !== "recent";
+  const reconnectLabel = match.kind === "recent" ? "Resume" : "Reconnect";
+  const ageLabel =
+    match.kind === "recent"
+      ? `Ended ${formatSessionAge(match.row.endedAt)} ago`
+      : `Started ${formatSessionAge(match.row.createdAt)} ago`;
+
+  return (
+    <Dialog open={open} onOpenChange={() => {}}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-sm gap-0 border-zinc-700 bg-[#141417] p-0 text-zinc-200"
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        data-testid="terminal-task-launch-choice"
+      >
+        <div className="px-4 pt-4 pb-3">
+          <DialogTitle className="text-[13px] font-semibold text-zinc-100">
+            {isLive ? "This task already has a terminal running" : "This task has a recent session"}
+          </DialogTitle>
+          <DialogDescription className="mt-1 text-[11.5px] text-zinc-500">
+            <span className="block truncate">{taskTitle}</span>
+            <span className="font-mono">{ageLabel}</span>
+          </DialogDescription>
+        </div>
+        <div className="flex items-center justify-end gap-2 border-t border-zinc-800 px-4 py-3">
+          <Button variant="ghost" size="xs" disabled={busy} onClick={onStartFresh}>
+            <TerminalIcon className="h-3 w-3" /> Start fresh anyway
+          </Button>
+          <Button
+            size="xs"
+            className="bg-sky-500 text-sky-950 hover:bg-sky-400"
+            disabled={busy}
+            onClick={onReconnect}
+            autoFocus
+          >
+            <RefreshCw className="h-3 w-3" /> {reconnectLabel}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -5,6 +5,7 @@ import {
   deriveChooserSections,
   chooserHeaderCounts,
   findLiveSessionForTask,
+  findTaskSessionMatch,
   type ChooserRegistryRow,
 } from "./chooser-data";
 
@@ -420,5 +421,89 @@ describe("findLiveSessionForTask", () => {
     const rows = [row({ sid: "other-task", ideaId: IDEA_A, status: "active", taskId: "task-2" })];
     const sections = deriveChooserSections(rows, IDEA_A, NOW);
     expect(findLiveSessionForTask(sections, "task-1")).toBeNull();
+  });
+});
+
+// Task-launch-skip-chooser (Nick's explicit product decision, 2026-08-16):
+// `findTaskSessionMatch` is the ONE predicate the per-task launch keys on —
+// unlike `findLiveSessionForTask` (live rows only, used for the full
+// chooser's "already running for this task" badge), this also considers the
+// Recent (ended, ≤48h) section, since a task launch must dedupe against a
+// recently-ended session for that exact task too, never just a live one.
+describe("findTaskSessionMatch", () => {
+  function endedRow(overrides: Partial<ChooserRegistryRow> & { sid: string }): ChooserRegistryRow {
+    return row({
+      status: "ended",
+      cwd: `~/projects/${overrides.sid}`,
+      endedAt: new Date(NOW - 60_000).toISOString(),
+      ...overrides,
+    });
+  }
+
+  it("returns null for a board-level launch (no taskId)", () => {
+    const sections = deriveChooserSections([], IDEA_A, NOW);
+    expect(findTaskSessionMatch(sections, undefined)).toBeNull();
+    expect(findTaskSessionMatch(sections, null)).toBeNull();
+  });
+
+  it("returns null when nothing anywhere matches the task — the auto-start case", () => {
+    const rows = [
+      row({ sid: "unrelated-live", ideaId: IDEA_B, status: "active", taskId: "task-OTHER" }),
+      endedRow({ sid: "unrelated-recent", taskId: "task-OTHER" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(findTaskSessionMatch(sections, "task-1")).toBeNull();
+  });
+
+  it("matches a live 'here' row for the exact task, over an 'elsewhere' or recent one", () => {
+    const rows = [
+      row({ sid: "here", ideaId: IDEA_A, status: "active", taskId: "task-1" }),
+      row({ sid: "elsewhere", ideaId: IDEA_B, status: "active", taskId: "task-1" }),
+      endedRow({ sid: "recent", taskId: "task-1" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    const match = findTaskSessionMatch(sections, "task-1");
+    expect(match?.kind).toBe("live-here");
+    expect(match?.row.sid).toBe("here");
+  });
+
+  it("falls back to a live 'elsewhere' row for the exact task when there is no 'here' match", () => {
+    const rows = [
+      row({ sid: "elsewhere", ideaId: IDEA_B, status: "active", taskId: "task-1" }),
+      endedRow({ sid: "recent", taskId: "task-1" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    const match = findTaskSessionMatch(sections, "task-1");
+    expect(match?.kind).toBe("live-elsewhere");
+    expect(match?.row.sid).toBe("elsewhere");
+  });
+
+  it("falls back to a Recent (ended, ≤48h) row for the exact task when nothing is live", () => {
+    const rows = [endedRow({ sid: "recent", taskId: "task-1" })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    const match = findTaskSessionMatch(sections, "task-1");
+    expect(match?.kind).toBe("recent");
+    expect(match?.row.sid).toBe("recent");
+  });
+
+  it("never matches a DIFFERENT task's live or recent row (no false-positive dedupe)", () => {
+    const rows = [
+      row({ sid: "other-live", ideaId: IDEA_A, status: "active", taskId: "task-OTHER" }),
+      endedRow({ sid: "other-recent", taskId: "task-OTHER" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(findTaskSessionMatch(sections, "task-1")).toBeNull();
+  });
+
+  it("ignores a Recent row past the 48h window for the exact task (deriveChooserSections already dropped it)", () => {
+    const rows = [
+      endedRow({
+        sid: "stale",
+        taskId: "task-1",
+        endedAt: new Date(NOW - RECENT_WINDOW_MS - 60_000).toISOString(),
+      }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(findTaskSessionMatch(sections, "task-1")).toBeNull();
   });
 });

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -239,3 +239,36 @@ export function findLiveSessionForTask(
     null
   );
 }
+
+/**
+ * Task-launch-skip-chooser (Nick's explicit product decision, 2026-08-16):
+ * clicking the per-task "Launch Claude Code" is unambiguous intent — it
+ * should start a new session immediately, with NO chooser/interstitial,
+ * UNLESS this EXACT task already has a live-or-recent (≤48h) session, in
+ * which case a small task-scoped choice (reconnect/resume vs. start fresh)
+ * replaces the full cross-board chooser. This is the single predicate that
+ * decision keys on — it never looks at any OTHER task or board, unlike
+ * `entryDecision`'s global "is there anything worth choosing between at
+ * all" question that still governs board-level (no-taskId) launches.
+ *
+ * Priority mirrors `findLiveSessionForTask`: a live row here beats a live
+ * row elsewhere beats a recent (ended, ≤48h) row — the most actionable
+ * match for THIS task wins.
+ */
+export type TaskSessionMatch =
+  | { kind: "live-here" | "live-elsewhere"; row: ChooserLiveRow }
+  | { kind: "recent"; row: ChooserRecentRow };
+
+export function findTaskSessionMatch(
+  sections: ChooserSections,
+  taskId: string | null | undefined,
+): TaskSessionMatch | null {
+  if (!taskId) return null;
+  const here = sections.liveHere.find((r) => r.taskId === taskId);
+  if (here) return { kind: "live-here", row: here };
+  const elsewhere = sections.liveElsewhere.find((r) => r.taskId === taskId);
+  if (elsewhere) return { kind: "live-elsewhere", row: elsewhere };
+  const recent = sections.recent.find((r) => r.taskId === taskId);
+  if (recent) return { kind: "recent", row: recent };
+  return null;
+}


### PR DESCRIPTION
## Summary
- Clicking "Launch Claude Code" on a specific task showed the full generic chooser, including live/recent sessions from completely unrelated boards — confirmed against the original design doc to be working exactly as approved, not a bug, but Nick gave fresh, explicit direction after hitting it live.
- Task-specific launches now skip any chooser UI entirely by default — clicking a task's launch option starts a new session immediately, no interstitial screen.
- The one exception: if that exact task already has a live or recent (≤48h) session, a minimal task-scoped dialog appears (Reconnect/Resume vs "Start fresh anyway") — no cross-board content, no other tasks.
- Board-level entry points (dock chevron, toolbar "Launch Claude Code") are completely unchanged — same full chooser as before.

Card: dca1d798 (Bug Fix workflow, used for a product decision + implementation). Found via Nick's live field report; QA correctly identified it as design-compliant-but-worth-revisiting rather than guessing it was a bug; Nick made the call; Implementation built and verified it.

## Test plan
- [x] tsc clean
- [x] targeted vitest all green (chooser-data, terminal-dock, terminal-task-launch-choice, terminal-session-chooser)
- [x] full vitest 2784/2784 (171 files)
- [x] eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)