### PR TITLE
fix(terminal): unify Update Now to always quiesce the old helper before downloading

### DIFF
--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -365,6 +365,16 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     void fetchHelperStatus().then(setHelperStatus);
   }, [enabled]);
 
+  // The chooser's own "Update now" shares the My sessions panel's
+  // quiesce-then-download flow (use-helper-update-flow.ts) but has no fetch
+  // loop of its own to notice the helper has quiesced — reuse the SAME
+  // registry + status fetches the dock already owns to refresh it once the
+  // flow settles, mirroring the panel's own post-quiesce `load()`.
+  const refreshAfterHelperUpdate = useCallback(() => {
+    void refreshRegistry();
+    void fetchHelperStatus().then(setHelperStatus);
+  }, [refreshRegistry]);
+
   // This tab's own snapshot info (session-snapshot.ts) — read once; a tab
   // doesn't gain a NEW "last sid" mid-session except by attaching another
   // session itself, at which point the chooser is long since resolved.
@@ -1274,6 +1284,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onResume={handleChooserResume}
             onStartNew={handleChooserStartNew}
             helperStatus={helperStatus}
+            onHelperUpdateSettled={refreshAfterHelperUpdate}
           />
         )}
 
@@ -1437,6 +1448,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onResume={handleChooserResume}
             onStartNew={handleChooserStartNew}
             helperStatus={helperStatus}
+            onHelperUpdateSettled={refreshAfterHelperUpdate}
           />
         </DialogContent>
       </Dialog>

--- a/src/components/board/terminal-my-sessions-panel.test.tsx
+++ b/src/components/board/terminal-my-sessions-panel.test.tsx
@@ -1,0 +1,260 @@
+// Focused regression coverage for the My sessions panel's "Update now" flow
+// (card cc74a067 design §3 flows A/D). No test file previously existed for
+// this component; this one exists specifically because the flow moved out
+// into a shared hook (src/lib/terminal/use-helper-update-flow.ts) so the
+// session chooser's own "Update now" (terminal-session-chooser.tsx) could
+// drive the exact same sequence — Nick's binding decision: "both buttons
+// need to stop the old version first". These tests pin the panel's own
+// behaviour so that extraction is provably a no-op here: confirm-before-end
+// when sessions are live, straight-to-quiesce when they aren't, the
+// quiesce-times-out-but-still-downloads edge case, and the stale
+// "Ready to update" notice getting cleared on the popover's next open.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import { TerminalMySessionsPanel } from "./terminal-my-sessions-panel";
+import type { HelperStatus } from "@/lib/terminal/helper-row";
+import { TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
+
+// Radix Popover uses ResizeObserver, which jsdom lacks (same stub used
+// elsewhere for Radix-positioned surfaces, e.g. label-picker.test.tsx).
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
+afterEach(cleanup);
+
+interface MockSession {
+  sid: string;
+  ideaId: string;
+  ideaTitle: string | null;
+  taskId: string | null;
+  taskTitle: string | null;
+  machineLabel: string | null;
+  cwd: string | null;
+  createdAt: string;
+  status: "active" | "ended";
+  endedAt: string | null;
+}
+
+function mockSession(sid: string, overrides: Partial<MockSession> = {}): MockSession {
+  return {
+    sid,
+    ideaId: "idea-1",
+    ideaTitle: "VibeCodes",
+    taskId: null,
+    taskTitle: null,
+    machineLabel: "Nick's MacBook",
+    cwd: "~/projects/vibecodes",
+    createdAt: new Date().toISOString(),
+    status: "active",
+    endedAt: null,
+    ...overrides,
+  };
+}
+
+function helperStatus(overrides: Partial<HelperStatus> = {}): HelperStatus {
+  return {
+    connected: true,
+    version: "0.1.0", // old enough that the update nudge (and its button) render
+    machineLabel: null,
+    alwaysOn: false,
+    stoppedUnexpectedly: false,
+    lastEventAt: null,
+    ...overrides,
+  };
+}
+
+let assignSpy: ReturnType<typeof vi.fn>;
+let originalLocation: Location;
+let fetchMock: ReturnType<typeof vi.fn>;
+let sessionsResponse: MockSession[];
+let statusQueue: HelperStatus[];
+let defaultStatus: HelperStatus;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  originalLocation = window.location;
+  assignSpy = vi.fn();
+  // jsdom's `window.location.assign` isn't spy-able directly — swap in a
+  // plain object carrying the real Location's properties plus a spy-able
+  // `assign` (same idiom as launch-claude-code-button.test.tsx).
+  Object.defineProperty(window, "location", {
+    value: Object.assign(Object.create(Object.getPrototypeOf(originalLocation) as object), originalLocation, {
+      assign: assignSpy,
+    }),
+    configurable: true,
+    writable: true,
+  });
+
+  sessionsResponse = [];
+  statusQueue = [];
+  defaultStatus = helperStatus();
+  fetchMock = vi.fn((url: string, init?: RequestInit) => {
+    if (url === "/api/terminal/session/list") {
+      return Promise.resolve({ ok: true, json: async () => ({ sessions: sessionsResponse }) } as Response);
+    }
+    if (url === "/api/terminal/helper/status") {
+      const next = statusQueue.shift() ?? defaultStatus;
+      return Promise.resolve({ ok: true, json: async () => next } as Response);
+    }
+    if (url === "/api/terminal/session/end" || url === "/api/terminal/helper/command") {
+      return Promise.resolve({ ok: true, json: async () => ({ delivered: true }) } as Response);
+    }
+    return Promise.reject(new Error(`unexpected fetch: ${url} ${init?.method ?? ""}`));
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", { value: originalLocation, configurable: true, writable: true });
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+function renderPanel(open = true) {
+  const onOpenChange = vi.fn();
+  const utils = render(
+    <TerminalMySessionsPanel open={open} onOpenChange={onOpenChange}>
+      <button>My sessions</button>
+    </TerminalMySessionsPanel>,
+  );
+  return { ...utils, onOpenChange };
+}
+
+/** Waits for the initial `load()` (session list + helper status) to settle. */
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}
+
+/**
+ * Advances the fake clock in the SAME 500ms increments the quiesce poll
+ * itself waits between checks, up to `maxTicks` — a single large
+ * `advanceTimersByTimeAsync` jump can race ahead of the fetch mock's own
+ * microtask hop through the extra Popover/Portal render layers and stall
+ * mid-loop, so step through it instead (bounded — stops once the download
+ * fires, never spins the full 25 ticks in the settling-immediately case).
+ */
+async function pollUntilDownload(maxTicks = 25) {
+  for (let i = 0; i < maxTicks && assignSpy.mock.calls.length === 0; i++) {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+  }
+}
+
+describe("TerminalMySessionsPanel — Update now (shared quiesce-then-download flow)", () => {
+  it("no live sessions: Update now skips the confirm, quiesces (no end-all call), then downloads", async () => {
+    sessionsResponse = [];
+    renderPanel();
+    await flush(); // the initial load() consumes the default (connected) status
+
+    statusQueue = [helperStatus({ connected: false })]; // the quiesce poll's first check
+    fireEvent.click(screen.getByRole("button", { name: "Update now" }));
+    expect(screen.queryByText("Update the helper?")).not.toBeInTheDocument();
+
+    await pollUntilDownload();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/terminal/helper/command",
+      expect.objectContaining({ body: JSON.stringify({ cmd: "quiesce" }) }),
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/terminal/session/end", expect.anything());
+    expect(assignSpy).toHaveBeenCalledWith(TERMINAL_HELPER_DOWNLOAD_URL);
+    expect(screen.getByText(/Ready to update/)).toBeInTheDocument();
+  });
+
+  it("live sessions: Update now confirms first, ends every session, then quiesces and downloads", async () => {
+    sessionsResponse = [mockSession("s1"), mockSession("s2")];
+    renderPanel();
+    await flush(); // the initial load() consumes the default (connected) status
+
+    fireEvent.click(screen.getByRole("button", { name: "Update now" }));
+    expect(screen.getByText("Update the helper?")).toBeInTheDocument();
+    expect(screen.getByText(/Your 2 running sessions will end first/)).toBeInTheDocument();
+
+    statusQueue = [helperStatus({ connected: false })]; // the quiesce poll's first check
+    const preConfirmCalls = fetchMock.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: "End sessions & update" }));
+    await pollUntilDownload();
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(preConfirmCalls);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/terminal/session/end",
+      expect.objectContaining({ body: JSON.stringify({ all: true }) }),
+    );
+    expect(assignSpy).toHaveBeenCalledWith(TERMINAL_HELPER_DOWNLOAD_URL);
+  });
+
+  it("Not now cancels the confirm without touching the network", async () => {
+    sessionsResponse = [mockSession("s1")];
+    renderPanel();
+    await flush();
+
+    fireEvent.click(screen.getByRole("button", { name: "Update now" }));
+    expect(screen.getByText("Update the helper?")).toBeInTheDocument();
+    const callsBeforeCancel = fetchMock.mock.calls.length;
+
+    fireEvent.click(screen.getByRole("button", { name: "Not now" }));
+    expect(screen.queryByText("Update the helper?")).not.toBeInTheDocument();
+    expect(fetchMock.mock.calls.length).toBe(callsBeforeCancel);
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
+
+  it("quiesce-timeout: the poll never settles, but the flow still proceeds and downloads regardless", async () => {
+    sessionsResponse = [];
+    // statusQueue stays empty -> every poll reports still-connected (the
+    // default `defaultStatus`), so the deadline branch is what fires.
+    renderPanel();
+    await flush();
+
+    fireEvent.click(screen.getByRole("button", { name: "Update now" }));
+    for (let i = 0; i < 25 && assignSpy.mock.calls.length === 0; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+    }
+
+    expect(assignSpy).toHaveBeenCalledWith(TERMINAL_HELPER_DOWNLOAD_URL);
+    expect(screen.getByText(/The helper is taking a moment to close/)).toBeInTheDocument();
+  });
+
+  it("a stale 'Ready to update' notice is cleared the next time the popover opens", async () => {
+    sessionsResponse = [];
+    const { rerender, onOpenChange } = renderPanel();
+    await flush(); // the initial load() consumes the default (connected) status
+
+    statusQueue = [helperStatus({ connected: false })]; // the quiesce poll's first check
+    fireEvent.click(screen.getByRole("button", { name: "Update now" }));
+    await pollUntilDownload();
+    expect(screen.getByText(/Ready to update/)).toBeInTheDocument();
+    void onOpenChange; // popover's own open state is owned by the caller in this component
+
+    // Close, then reopen — the panel's own state (this component, not
+    // PopoverContent) survives the close, so the stale notice must be
+    // cleared by the dedicated reset effect rather than lingering forever.
+    rerender(
+      <TerminalMySessionsPanel open={false} onOpenChange={vi.fn()}>
+        <button>My sessions</button>
+      </TerminalMySessionsPanel>,
+    );
+    statusQueue = [helperStatus({ connected: true })];
+    rerender(
+      <TerminalMySessionsPanel open onOpenChange={vi.fn()}>
+        <button>My sessions</button>
+      </TerminalMySessionsPanel>,
+    );
+    await flush();
+
+    expect(screen.queryByText(/Ready to update/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/board/terminal-my-sessions-panel.tsx
+++ b/src/components/board/terminal-my-sessions-panel.tsx
@@ -30,7 +30,6 @@ import {
   MINIMUM_RECOMMENDED_HELPER_VERSION,
   shouldShowHelperUpdateNudge,
 } from "@/lib/terminal/helper-version";
-import { TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
 import { recordHelperIdleQuitObserved } from "@/lib/terminal/helper-relaunch-signal";
 import {
   ALWAYS_ON_CONSENT_BODY,
@@ -50,17 +49,14 @@ import {
   type HelperStatus,
 } from "@/lib/terminal/helper-row";
 import {
-  INITIAL_UPDATE_FLOW_STATE,
-  QUIESCE_TIMEOUT_MS,
   UPDATE_CONFIRM_ACCEPT_LABEL,
   UPDATE_CONFIRM_CANCEL_LABEL,
   UPDATE_CONFIRM_HEADING,
   UPDATE_QUIESCE_TIMEOUT_COPY,
   UPDATE_READY_COPY,
   updateConfirmBody,
-  updateFlowReducer,
-  type UpdateFlowState,
 } from "@/lib/terminal/helper-update-flow";
+import { useHelperUpdateFlow } from "@/lib/terminal/use-helper-update-flow";
 
 interface ListedSession {
   sid: string;
@@ -136,7 +132,6 @@ export function TerminalMySessionsPanel({
   const [confirmingStopHelper, setConfirmingStopHelper] = useState(false);
   const [stoppingHelper, setStoppingHelper] = useState(false);
   const [dismissedHelperNudge, setDismissedHelperNudge] = useState(false);
-  const [updateFlow, setUpdateFlow] = useState<UpdateFlowState>(INITIAL_UPDATE_FLOW_STATE);
   const [alwaysOnConsentOpen, setAlwaysOnConsentOpen] = useState(false);
   const [togglingAlwaysOn, setTogglingAlwaysOn] = useState(false);
   // Last chip kind we observed, so `load()` can notice a winding-down ->
@@ -187,14 +182,31 @@ export function TerminalMySessionsPanel({
     if (open) void load();
   }, [open, load]);
 
+  // Shared quiesce-then-download flow (src/lib/terminal/use-helper-update-flow.ts)
+  // — the session chooser's "Update now" drives the exact same hook.
+  const {
+    phase: updateFlowPhase,
+    confirmSessionCount,
+    start: startHelperUpdate,
+    confirm: confirmHelperUpdate,
+    cancel: cancelHelperUpdate,
+    resetIfSettled: resetHelperUpdateIfSettled,
+  } = useHelperUpdateFlow({
+    sessionCount: running.length,
+    onQuiesceStart: () => {
+      suppressIdleQuitSignalRef.current = true; // an update-triggered quiesce is not an idle-quit
+    },
+    onSettled: () => void load(),
+  });
+
   // A stale "Ready to update" / timeout notice must not linger forever once
   // the popover is closed and reopened later — the update flow's own state is
   // otherwise held in this always-mounted component (PopoverContent unmounts
   // on close, this doesn't), same as confirmingEndAll already does.
   useEffect(() => {
     if (!open) return;
-    setUpdateFlow((s) => (s.phase === "ready" || s.phase === "quiesce-timeout" ? INITIAL_UPDATE_FLOW_STATE : s));
-  }, [open]);
+    resetHelperUpdateIfSettled();
+  }, [open, resetHelperUpdateIfSettled]);
 
   const endOne = useCallback(
     async (sid: string) => {
@@ -290,84 +302,9 @@ export function TerminalMySessionsPanel({
     void setAlwaysOnRemote(true);
   }, [setAlwaysOnRemote]);
 
-  const startHelperUpdate = useCallback(() => {
-    setUpdateFlow(updateFlowReducer(INITIAL_UPDATE_FLOW_STATE, { type: "update-clicked", sessionCount: running.length }));
-  }, [running.length]);
-
-  // Drive the "quiescing" phase: end any live sessions first (only reached via
-  // "confirming" when sessions existed), send the quiesce command, then poll
-  // helper status until it reports not-connected or QUIESCE_TIMEOUT_MS elapses
-  // (design §3 flow A's fallback notice) — the download starts regardless
-  // (§3 flow A caption), just with a different notice.
-  useEffect(() => {
-    if (updateFlow.phase !== "quiescing") return;
-    let cancelled = false;
-    suppressIdleQuitSignalRef.current = true; // an update-triggered quiesce is not an idle-quit
-    const hadSessions = running.length > 0;
-    (async () => {
-      if (hadSessions) {
-        try {
-          await fetch("/api/terminal/session/end", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ all: true }),
-          });
-        } catch {
-          /* best effort — the quiesce command below still proceeds */
-        }
-      }
-      try {
-        await fetch("/api/terminal/helper/command", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ cmd: "quiesce" }),
-        });
-      } catch {
-        /* best effort — the poll below still resolves via timeout */
-      }
-
-      const deadline = Date.now() + QUIESCE_TIMEOUT_MS;
-      while (!cancelled) {
-        let settled = false;
-        try {
-          const res = await fetch("/api/terminal/helper/status");
-          if (res.ok) {
-            const status = (await res.json()) as HelperStatus;
-            settled = status.connected === false;
-          }
-        } catch {
-          /* transient — keep polling until the deadline */
-        }
-        if (cancelled) return;
-        if (settled) {
-          setUpdateFlow((s) => updateFlowReducer(s, { type: "quiesce-settled" }));
-          return;
-        }
-        if (Date.now() >= deadline) {
-          setUpdateFlow((s) => updateFlowReducer(s, { type: "quiesce-timed-out" }));
-          return;
-        }
-        await new Promise((r) => setTimeout(r, 500));
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [updateFlow.phase, running.length]);
-
-  // Either outcome of quiescing starts the download (design: the whole point
-  // is drag-to-Applications always succeeds because nothing is running by
-  // now) and refreshes the row so it reflects the now-quiesced helper.
-  useEffect(() => {
-    if (updateFlow.phase !== "ready" && updateFlow.phase !== "quiesce-timeout") return;
-    window.location.assign(TERMINAL_HELPER_DOWNLOAD_URL);
-    void load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [updateFlow.phase]);
-
   const helperChip: HelperChip | null = deriveHelperChip(helperStatus, running.length);
   const showHelperNudge =
-    updateFlow.phase === "idle" &&
+    updateFlowPhase === "idle" &&
     !dismissedHelperNudge &&
     shouldShowHelperUpdateNudge(helperStatus?.version ?? null);
 
@@ -590,18 +527,18 @@ export function TerminalMySessionsPanel({
           </div>
         )}
 
-        {updateFlow.phase === "confirming" && (
+        {updateFlowPhase === "confirming" && (
           <div className="border-t border-l-2 border-l-sky-500 bg-sky-500/5 px-3.5 py-2.5">
             <div className="text-[12.5px] font-bold text-sky-300">{UPDATE_CONFIRM_HEADING}</div>
-            <div className="text-[11px] text-zinc-500">{updateConfirmBody(updateFlow.sessionCount)}</div>
+            <div className="text-[11px] text-zinc-500">{updateConfirmBody(confirmSessionCount)}</div>
             <div className="mt-2 flex items-center justify-end gap-2">
-              <Button variant="ghost" size="xs" onClick={() => setUpdateFlow((s) => updateFlowReducer(s, { type: "cancelled" }))}>
+              <Button variant="ghost" size="xs" onClick={cancelHelperUpdate}>
                 {UPDATE_CONFIRM_CANCEL_LABEL}
               </Button>
               <Button
                 size="xs"
                 className="bg-sky-500 text-sky-950 hover:bg-sky-400"
-                onClick={() => setUpdateFlow((s) => updateFlowReducer(s, { type: "confirmed" }))}
+                onClick={confirmHelperUpdate}
               >
                 {UPDATE_CONFIRM_ACCEPT_LABEL}
               </Button>
@@ -609,22 +546,22 @@ export function TerminalMySessionsPanel({
           </div>
         )}
 
-        {updateFlow.phase === "quiescing" && (
+        {updateFlowPhase === "quiescing" && (
           <div className="flex items-center gap-2 border-t border-sky-500/30 bg-sky-500/5 px-3.5 py-1.5 text-[11.5px] text-sky-300">
             <Loader2 className="h-3 w-3 flex-none animate-spin" /> Closing the helper…
           </div>
         )}
 
-        {(updateFlow.phase === "ready" || updateFlow.phase === "quiesce-timeout") && (
+        {(updateFlowPhase === "ready" || updateFlowPhase === "quiesce-timeout") && (
           <div
             className={cn(
               "border-t px-3.5 py-2 text-[11.5px]",
-              updateFlow.phase === "ready"
+              updateFlowPhase === "ready"
                 ? "border-sky-500/30 bg-sky-500/5 text-sky-300"
                 : "border-amber-500/30 bg-amber-500/5 text-amber-300",
             )}
           >
-            {updateFlow.phase === "ready" ? UPDATE_READY_COPY : UPDATE_QUIESCE_TIMEOUT_COPY}
+            {updateFlowPhase === "ready" ? UPDATE_READY_COPY : UPDATE_QUIESCE_TIMEOUT_COPY}
           </div>
         )}
 

--- a/src/components/board/terminal-session-chooser.test.tsx
+++ b/src/components/board/terminal-session-chooser.test.tsx
@@ -3,13 +3,14 @@
 // itself is covered by chooser-data.test.ts) and prove the click contract:
 // Start new / Reconnect / Open board & reconnect / Resume's inline confirm.
 
-import { afterEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
 import { TerminalSessionChooser } from "./terminal-session-chooser";
 import type { ChooserSections } from "@/lib/terminal/chooser-data";
 import { MINIMUM_RECOMMENDED_HELPER_VERSION } from "@/lib/terminal/helper-version";
 import type { HelperStatus } from "@/lib/terminal/helper-row";
+import { TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
 
 afterEach(cleanup);
 
@@ -363,8 +364,13 @@ describe("TerminalSessionChooser", () => {
     it("shows the nudge, above the sections, when the last-known helper is older than the minimum", () => {
       renderChooser(helperStatus({ version: "0.3.0" }));
       expect(screen.getByText(/A newer terminal helper is available/)).toBeInTheDocument();
-      const link = screen.getByRole("link", { name: "Update now" });
-      expect(link).toHaveAttribute("href", "/download/terminal-helper");
+      // Regression (Nick's binding decision — "both buttons need to stop the
+      // old version first"): this used to be a bare `<a href>` straight to
+      // the download, no quiesce. It's now the same clickable button as the
+      // My sessions panel's, driving the shared quiesce flow — see the
+      // "helper update flow" describe block below.
+      expect(screen.getByRole("button", { name: "Update now" })).toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Update now" })).not.toBeInTheDocument();
     });
 
     it("hides the nudge when the last-known helper is already current", () => {
@@ -394,6 +400,148 @@ describe("TerminalSessionChooser", () => {
       expect(screen.getByText(/A newer terminal helper is available/)).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: "Dismiss helper update notice" }));
       expect(screen.queryByText(/A newer terminal helper is available/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("helper update flow — 'Update now' quiesces before downloading (Nick's binding decision)", () => {
+    // QA found the session chooser's "Update now" was a bare `<a href>`
+    // straight to the download — no quiesce — while the My sessions panel's
+    // version safely ended live sessions, sent `quiesce`, and waited for the
+    // old helper to disconnect first. These prove the chooser now drives
+    // the SAME shared flow (src/lib/terminal/use-helper-update-flow.ts),
+    // including the "quiesce times out but the download still proceeds"
+    // edge case.
+    function helperStatus(overrides: Partial<HelperStatus> = {}): HelperStatus {
+      return {
+        connected: true,
+        version: "0.1.0", // old enough that the nudge (and its button) render
+        machineLabel: null,
+        alwaysOn: false,
+        stoppedUnexpectedly: false,
+        lastEventAt: null,
+        ...overrides,
+      };
+    }
+
+    let assignSpy: ReturnType<typeof vi.fn>;
+    let originalLocation: Location;
+    let fetchMock: ReturnType<typeof vi.fn>;
+    let statusQueue: Array<{ connected: boolean }>;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      originalLocation = window.location;
+      assignSpy = vi.fn();
+      // jsdom's `window.location.assign` isn't spy-able directly — swap in a
+      // plain object carrying the real Location's properties plus a
+      // spy-able `assign` (same idiom as launch-claude-code-button.test.tsx).
+      Object.defineProperty(window, "location", {
+        value: Object.assign(Object.create(Object.getPrototypeOf(originalLocation) as object), originalLocation, {
+          assign: assignSpy,
+        }),
+        configurable: true,
+        writable: true,
+      });
+      statusQueue = [];
+      fetchMock = vi.fn((url: string) => {
+        if (url === "/api/terminal/helper/status") {
+          const next = statusQueue.shift() ?? { connected: true };
+          return Promise.resolve({ ok: true, json: async () => next } as Response);
+        }
+        return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", { value: originalLocation, configurable: true, writable: true });
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    it("no live sessions: Update now skips the confirm, quiesces straight away (no end-all call), then downloads", async () => {
+      statusQueue = [{ connected: false }];
+      render(
+        <TerminalSessionChooser
+          sections={EMPTY}
+          onReconnectHere={vi.fn()}
+          onOpenBoardAndReconnect={vi.fn()}
+          onResume={vi.fn()}
+          onStartNew={vi.fn()}
+          helperStatus={helperStatus()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Update now" }));
+      expect(screen.queryByText("Update the helper?")).not.toBeInTheDocument(); // no sessions -> no confirm
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/terminal/helper/command",
+        expect.objectContaining({ body: JSON.stringify({ cmd: "quiesce" }) }),
+      );
+      expect(fetchMock).not.toHaveBeenCalledWith("/api/terminal/session/end", expect.anything());
+      expect(assignSpy).toHaveBeenCalledWith(TERMINAL_HELPER_DOWNLOAD_URL);
+    });
+
+    it("live sessions: Update now confirms first, ends every session, then quiesces and downloads", async () => {
+      statusQueue = [{ connected: false }];
+      render(
+        <TerminalSessionChooser
+          sections={sections({ liveHere: [liveRow("live-1")], liveElsewhere: [liveRow("live-2")] })}
+          onReconnectHere={vi.fn()}
+          onOpenBoardAndReconnect={vi.fn()}
+          onResume={vi.fn()}
+          onStartNew={vi.fn()}
+          helperStatus={helperStatus()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Update now" }));
+      expect(screen.getByText("Update the helper?")).toBeInTheDocument();
+      expect(screen.getByText(/Your 2 running sessions will end first/)).toBeInTheDocument();
+      expect(fetchMock).not.toHaveBeenCalled(); // nothing happens until confirmed
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "End sessions & update" }));
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/terminal/session/end",
+        expect.objectContaining({ body: JSON.stringify({ all: true }) }),
+      );
+      expect(assignSpy).toHaveBeenCalledWith(TERMINAL_HELPER_DOWNLOAD_URL);
+    });
+
+    it("quiesce-timeout: the poll never settles, but the chooser still downloads regardless — identical to the My sessions panel", async () => {
+      // statusQueue stays empty -> every poll reports still-connected.
+      const onHelperUpdateSettled = vi.fn();
+      render(
+        <TerminalSessionChooser
+          sections={EMPTY}
+          onReconnectHere={vi.fn()}
+          onOpenBoardAndReconnect={vi.fn()}
+          onResume={vi.fn()}
+          onStartNew={vi.fn()}
+          helperStatus={helperStatus()}
+          onHelperUpdateSettled={onHelperUpdateSettled}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Update now" }));
+      for (let i = 0; i < 25 && assignSpy.mock.calls.length === 0; i++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(500);
+        });
+      }
+
+      expect(assignSpy).toHaveBeenCalledWith(TERMINAL_HELPER_DOWNLOAD_URL);
+      expect(screen.getByText(/The helper is taking a moment to close/)).toBeInTheDocument();
+      expect(onHelperUpdateSettled).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/components/board/terminal-session-chooser.tsx
+++ b/src/components/board/terminal-session-chooser.tsx
@@ -14,7 +14,7 @@
 // clicks to the callbacks the dock supplies.
 
 import { useEffect, useRef, useState } from "react";
-import { Info, RefreshCw, Terminal as TerminalIcon, X } from "lucide-react";
+import { Info, Loader2, RefreshCw, Terminal as TerminalIcon, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { formatSessionAge } from "@/lib/terminal/session-registry";
@@ -27,7 +27,15 @@ import {
 } from "@/lib/terminal/chooser-data";
 import { updateNudgeCopy, type HelperStatus } from "@/lib/terminal/helper-row";
 import { MINIMUM_RECOMMENDED_HELPER_VERSION, shouldShowChooserHelperNudge } from "@/lib/terminal/helper-version";
-import { TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
+import {
+  UPDATE_CONFIRM_ACCEPT_LABEL,
+  UPDATE_CONFIRM_CANCEL_LABEL,
+  UPDATE_CONFIRM_HEADING,
+  UPDATE_QUIESCE_TIMEOUT_COPY,
+  UPDATE_READY_COPY,
+  updateConfirmBody,
+} from "@/lib/terminal/helper-update-flow";
+import { useHelperUpdateFlow } from "@/lib/terminal/use-helper-update-flow";
 import { HelperUpdateButton } from "./terminal-helper-update-button";
 
 // F3 (common foundations): the SAME generic warning, visible before every
@@ -61,6 +69,14 @@ export interface TerminalSessionChooserProps {
    * renders no nudge, never an error state.
    */
   helperStatus?: HelperStatus | null;
+  /**
+   * Fires once the shared quiesce-then-download flow (below) has settled or
+   * timed out, right before the download starts — mirrors the My sessions
+   * panel's own post-quiesce `load()`. The dock owns the underlying
+   * registry/status fetches, so it's the one that supplies this; omitted
+   * (e.g. in tests) simply skips the refresh.
+   */
+  onHelperUpdateSettled?: () => void;
 }
 
 export function TerminalSessionChooser({
@@ -73,6 +89,7 @@ export function TerminalSessionChooser({
   onStartNew,
   cap,
   helperStatus = null,
+  onHelperUpdateSettled,
 }: TerminalSessionChooserProps) {
   const [confirmingResumeSid, setConfirmingResumeSid] = useState<string | null>(null);
   const firstFocusRef = useRef<HTMLButtonElement | null>(null);
@@ -81,7 +98,28 @@ export function TerminalSessionChooser({
   // the browser session only — component-local state, not persisted, same
   // mechanism as `dismissedHelperNudge` in terminal-session-view.tsx.
   const [dismissedHelperNudge, setDismissedHelperNudge] = useState(false);
-  const showHelperNudge = !dismissedHelperNudge && shouldShowChooserHelperNudge(helperStatus?.version);
+
+  // Every session this browser already knows about across BOTH live sections
+  // (the cap is per-user, not per-board) — also the universe the shared
+  // quiesce flow below needs to end before it can safely download, mirroring
+  // the My sessions panel's own `running` list.
+  const liveCount = sections.liveHere.length + sections.liveElsewhere.length;
+
+  // Shared quiesce-then-download flow (src/lib/terminal/use-helper-update-flow.ts,
+  // same hook the My sessions panel drives) — Nick's binding instruction:
+  // "both buttons need to stop the old version first".
+  const {
+    phase: updateFlowPhase,
+    confirmSessionCount,
+    start: startHelperUpdate,
+    confirm: confirmHelperUpdate,
+    cancel: cancelHelperUpdate,
+  } = useHelperUpdateFlow({
+    sessionCount: liveCount,
+    onSettled: onHelperUpdateSettled,
+  });
+  const showHelperNudge =
+    updateFlowPhase === "idle" && !dismissedHelperNudge && shouldShowChooserHelperNudge(helperStatus?.version);
 
   // Focus the first row's primary action when the chooser opens (design:
   // "focus lands on the first live session's primary action when the choice
@@ -100,11 +138,8 @@ export function TerminalSessionChooser({
     null;
 
   // Resume confirm's honesty limit line (Nick's sign-off change 1): shown only
-  // when the user is close enough to the cap that resuming matters — the live
-  // count is every session this browser already knows about across BOTH live
-  // sections (the cap itself is per-user, not per-board).
+  // when the user is close enough to the cap that resuming matters.
   const resolvedCap = cap ?? getTerminalSessionCap();
-  const liveCount = sections.liveHere.length + sections.liveElsewhere.length;
   const limitLine = isNearSessionCap(liveCount, resolvedCap) ? terminalLimitLine(liveCount, resolvedCap) : null;
 
   const startNewLabel = pendingTask
@@ -117,7 +152,7 @@ export function TerminalSessionChooser({
         <div className="flex items-center gap-2 border-b border-sky-500/30 bg-sky-500/5 px-3.5 py-1.5 text-[11px] text-sky-300">
           <Info className="h-3 w-3 shrink-0" />
           <span className="flex-1">{updateNudgeCopy(MINIMUM_RECOMMENDED_HELPER_VERSION)}</span>
-          <HelperUpdateButton href={TERMINAL_HELPER_DOWNLOAD_URL} />
+          <HelperUpdateButton onClick={startHelperUpdate} />
           <button
             type="button"
             className="shrink-0 text-sky-400 hover:text-sky-200"
@@ -126,6 +161,48 @@ export function TerminalSessionChooser({
           >
             <X className="h-3 w-3" />
           </button>
+        </div>
+      )}
+
+      {/* Shared quiesce-then-download flow (same states/copy as the My
+          sessions panel's Helper row — helper-update-flow.ts): the old
+          helper is always stood down before the new DMG downloads, whether
+          "Update now" was clicked here or from that panel. */}
+      {updateFlowPhase === "confirming" && (
+        <div className="border-b border-l-2 border-l-sky-500 bg-sky-500/5 px-3.5 py-2.5">
+          <div className="text-[12.5px] font-bold text-sky-300">{UPDATE_CONFIRM_HEADING}</div>
+          <div className="text-[11px] text-zinc-500">{updateConfirmBody(confirmSessionCount)}</div>
+          <div className="mt-2 flex items-center justify-end gap-2">
+            <Button variant="ghost" size="xs" onClick={cancelHelperUpdate}>
+              {UPDATE_CONFIRM_CANCEL_LABEL}
+            </Button>
+            <Button
+              size="xs"
+              className="bg-sky-500 text-sky-950 hover:bg-sky-400"
+              onClick={confirmHelperUpdate}
+            >
+              {UPDATE_CONFIRM_ACCEPT_LABEL}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {updateFlowPhase === "quiescing" && (
+        <div className="flex items-center gap-2 border-b border-sky-500/30 bg-sky-500/5 px-3.5 py-1.5 text-[11px] text-sky-300">
+          <Loader2 className="h-3 w-3 flex-none animate-spin" /> Closing the helper…
+        </div>
+      )}
+
+      {(updateFlowPhase === "ready" || updateFlowPhase === "quiesce-timeout") && (
+        <div
+          className={cn(
+            "border-b px-3.5 py-2 text-[11px]",
+            updateFlowPhase === "ready"
+              ? "border-sky-500/30 bg-sky-500/5 text-sky-300"
+              : "border-amber-500/30 bg-amber-500/5 text-amber-300",
+          )}
+        >
+          {updateFlowPhase === "ready" ? UPDATE_READY_COPY : UPDATE_QUIESCE_TIMEOUT_COPY}
         </div>
       )}
 

--- a/src/lib/terminal/use-helper-update-flow.test.ts
+++ b/src/lib/terminal/use-helper-update-flow.test.ts
@@ -1,0 +1,177 @@
+// Regression coverage for the shared quiesce-then-download flow (extracted
+// from terminal-my-sessions-panel.tsx so terminal-session-chooser.tsx's
+// "Update now" can drive the exact same sequence — see that component's
+// header comment). The pure phase transitions are already covered by
+// helper-update-flow.test.ts; this file covers the actual network glue at
+// each transition: ending live sessions, sending `quiesce`, polling status,
+// and — the load-bearing edge case — proceeding to download even when the
+// poll never settles before QUIESCE_TIMEOUT_MS.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useHelperUpdateFlow } from "./use-helper-update-flow";
+import { TERMINAL_HELPER_DOWNLOAD_URL } from "./platform";
+
+/** jsdom's `window.location.assign` isn't spy-able directly (its property
+ *  descriptor isn't configurable) — swap in a plain object carrying the real
+ *  Location's properties plus a spy-able `assign`, same idiom as
+ *  launch-claude-code-button.test.tsx. */
+function stubLocationAssign() {
+  const original = window.location;
+  const assign = vi.fn();
+  Object.defineProperty(window, "location", {
+    value: Object.assign(Object.create(Object.getPrototypeOf(original) as object), original, { assign }),
+    configurable: true,
+    writable: true,
+  });
+  return {
+    assign,
+    restore: () => {
+      Object.defineProperty(window, "location", { value: original, configurable: true, writable: true });
+    },
+  };
+}
+
+type StatusResponse = { connected: boolean };
+
+let location: ReturnType<typeof stubLocationAssign>;
+let fetchMock: ReturnType<typeof vi.fn>;
+let statusQueue: StatusResponse[];
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({ ok: true, json: async () => body } as Response);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  location = stubLocationAssign();
+  statusQueue = [];
+  fetchMock = vi.fn((url: string) => {
+    if (url === "/api/terminal/session/end") return jsonResponse({});
+    if (url === "/api/terminal/helper/command") return jsonResponse({});
+    if (url === "/api/terminal/helper/status") {
+      const next = statusQueue.shift() ?? { connected: true };
+      return jsonResponse(next);
+    }
+    return Promise.reject(new Error(`unexpected fetch: ${url}`));
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  location.restore();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("useHelperUpdateFlow", () => {
+  it("no live sessions: start() skips the confirm, quiesces (no end-all call), and downloads once settled", async () => {
+    statusQueue = [{ connected: false }];
+    const onSettled = vi.fn();
+    const { result } = renderHook(() => useHelperUpdateFlow({ sessionCount: 0, onSettled }));
+
+    await act(async () => {
+      result.current.start();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.phase).toBe("ready");
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/terminal/session/end", expect.anything());
+    expect(fetchMock).toHaveBeenCalledWith("/api/terminal/helper/command", expect.objectContaining({
+      body: JSON.stringify({ cmd: "quiesce" }),
+    }));
+    expect(location.assign).toHaveBeenCalledWith(TERMINAL_HELPER_DOWNLOAD_URL);
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("live sessions: start() goes to confirming with the count carried, confirm() ends all sessions then quiesces", async () => {
+    statusQueue = [{ connected: false }];
+    const { result } = renderHook(() => useHelperUpdateFlow({ sessionCount: 3 }));
+
+    act(() => result.current.start());
+    expect(result.current.phase).toBe("confirming");
+    expect(result.current.confirmSessionCount).toBe(3);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.confirm();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/terminal/session/end", expect.objectContaining({
+      body: JSON.stringify({ all: true }),
+    }));
+    expect(result.current.phase).toBe("ready");
+    expect(location.assign).toHaveBeenCalledWith(TERMINAL_HELPER_DOWNLOAD_URL);
+  });
+
+  it("cancel() from confirming returns to idle without touching the network", () => {
+    const { result } = renderHook(() => useHelperUpdateFlow({ sessionCount: 2 }));
+    act(() => result.current.start());
+    expect(result.current.phase).toBe("confirming");
+
+    act(() => result.current.cancel());
+    expect(result.current.phase).toBe("idle");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("calls onQuiesceStart exactly once, right as quiescing begins", async () => {
+    statusQueue = [{ connected: false }];
+    const onQuiesceStart = vi.fn();
+    const { result } = renderHook(() => useHelperUpdateFlow({ sessionCount: 0, onQuiesceStart }));
+
+    await act(async () => {
+      result.current.start();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(onQuiesceStart).toHaveBeenCalledOnce();
+  });
+
+  it("quiesce-timeout: the poll never settles, but the flow still proceeds to 'quiesce-timeout' and downloads regardless", async () => {
+    // Every status poll reports still-connected (the default in the mock above).
+    const onSettled = vi.fn();
+    const { result } = renderHook(() => useHelperUpdateFlow({ sessionCount: 0, onSettled }));
+
+    act(() => result.current.start());
+    // The poll rechecks every 500ms until Date.now() clears the deadline —
+    // advance in the same increments rather than one large jump, so each
+    // fetch-then-reschedule hop actually gets flushed (a single big
+    // `advanceTimersByTimeAsync`/`runAllTimersAsync` call can race ahead of
+    // the fetch mock's own microtask hop and stall mid-loop).
+    for (let i = 0; i < 25 && result.current.phase === "quiescing"; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+    }
+
+    expect(result.current.phase).toBe("quiesce-timeout");
+    // The whole point of the design: drag-to-Applications must always
+    // succeed, so the download fires even though quiescing never settled.
+    expect(location.assign).toHaveBeenCalledWith(TERMINAL_HELPER_DOWNLOAD_URL);
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("resetIfSettled clears a 'ready' phase back to idle", async () => {
+    statusQueue = [{ connected: false }];
+    const { result } = renderHook(() => useHelperUpdateFlow({ sessionCount: 0 }));
+
+    await act(async () => {
+      result.current.start();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.phase).toBe("ready");
+
+    act(() => result.current.resetIfSettled());
+    expect(result.current.phase).toBe("idle");
+  });
+
+  it("resetIfSettled is a no-op from any non-settled phase", () => {
+    const { result } = renderHook(() => useHelperUpdateFlow({ sessionCount: 2 }));
+    act(() => result.current.start());
+    expect(result.current.phase).toBe("confirming");
+
+    act(() => result.current.resetIfSettled());
+    expect(result.current.phase).toBe("confirming");
+  });
+});

--- a/src/lib/terminal/use-helper-update-flow.ts
+++ b/src/lib/terminal/use-helper-update-flow.ts
@@ -1,0 +1,180 @@
+"use client";
+
+// In-app terminal — the effectful half of the "stand-down-first" update flow
+// (card cc74a067, design §3 flows A/D). `helper-update-flow.ts` owns the pure
+// phase reducer + copy; this hook owns the actual network calls at each
+// transition (end any live sessions, send the `quiesce` command, poll
+// `/api/terminal/helper/status` until the helper disconnects or
+// QUIESCE_TIMEOUT_MS elapses, then download) so every "Update now" button
+// drives the EXACT same sequence instead of one re-implementing (or
+// skipping) it.
+//
+// Extracted from `terminal-my-sessions-panel.tsx` (the only safe
+// implementation) so `terminal-session-chooser.tsx`'s "Update now" — which
+// used to be a bare `<a href>` straight to the download, no quiesce at all —
+// can share it too. Nick's binding instruction: "both buttons need to stop
+// the old version first."
+//
+// Either outcome of quiescing (settled or timed out) starts the download
+// regardless (design: the whole point is drag-to-Applications always
+// succeeds because nothing is running by then) — see the "ready" /
+// "quiesce-timeout" effect below.
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  INITIAL_UPDATE_FLOW_STATE,
+  QUIESCE_TIMEOUT_MS,
+  updateFlowReducer,
+  type UpdateFlowPhase,
+  type UpdateFlowState,
+} from "./helper-update-flow";
+import { TERMINAL_HELPER_DOWNLOAD_URL } from "./platform";
+import type { HelperStatus } from "./helper-row";
+
+export interface UseHelperUpdateFlowOptions {
+  /** The caller's current live-session count (across all of the user's
+   *  ideas) — read whenever "Update now" is clicked, to decide confirm-first
+   *  vs straight-to-quiescing (see `updateFlowReducer`'s `update-clicked`),
+   *  and again once quiescing starts, to decide whether there's anything to
+   *  end first. */
+  sessionCount: number;
+  /** Fires once, right as quiescing begins (before ending sessions / sending
+   *  the quiesce command). The My sessions panel uses this to mark the
+   *  resulting disconnect as deliberate so it isn't mis-recorded as an
+   *  "idle-quit" (see helper-relaunch-signal.ts) — optional, since callers
+   *  without that bookkeeping (the chooser) have nothing to do here. */
+  onQuiesceStart?: () => void;
+  /** Fires once quiescing has settled (or timed out), right before the
+   *  download navigation — callers use this to refresh their own
+   *  session-list / helper-status view so it reflects the now-quiesced
+   *  helper. */
+  onSettled?: () => void;
+}
+
+export interface UseHelperUpdateFlowResult {
+  phase: UpdateFlowPhase;
+  /** Only meaningful while `phase === "confirming"` — the live-session count
+   *  that will end if the user confirms. */
+  confirmSessionCount: number;
+  /** "Update now" was clicked. */
+  start: () => void;
+  /** The inline confirm's "End sessions & update". */
+  confirm: () => void;
+  /** The inline confirm's "Not now". */
+  cancel: () => void;
+  /** Clears a lingering "ready"/"quiesce-timeout" notice — a no-op from any
+   *  other phase. For callers whose own state (and this hook's) outlives a
+   *  single open/close cycle of the surface that shows it (the My sessions
+   *  panel's popover), so a stale notice doesn't linger forever once
+   *  reopened. */
+  resetIfSettled: () => void;
+}
+
+/**
+ * Drives the shared quiesce-then-download flow described above. Both
+ * `TerminalMySessionsPanel` and `TerminalSessionChooser` call this from
+ * their "Update now" button so the old helper is always stood down before
+ * the new DMG downloads.
+ */
+export function useHelperUpdateFlow({
+  sessionCount,
+  onQuiesceStart,
+  onSettled,
+}: UseHelperUpdateFlowOptions): UseHelperUpdateFlowResult {
+  const [state, setState] = useState<UpdateFlowState>(INITIAL_UPDATE_FLOW_STATE);
+
+  const start = useCallback(() => {
+    setState((s) => updateFlowReducer(s, { type: "update-clicked", sessionCount }));
+  }, [sessionCount]);
+  const confirm = useCallback(() => {
+    setState((s) => updateFlowReducer(s, { type: "confirmed" }));
+  }, []);
+  const cancel = useCallback(() => {
+    setState((s) => updateFlowReducer(s, { type: "cancelled" }));
+  }, []);
+  const resetIfSettled = useCallback(() => {
+    setState((s) => (s.phase === "ready" || s.phase === "quiesce-timeout" ? INITIAL_UPDATE_FLOW_STATE : s));
+  }, []);
+
+  // Drive the "quiescing" phase: end any live sessions first (only reached
+  // via "confirming" when sessions existed), send the quiesce command, then
+  // poll helper status until it reports not-connected or QUIESCE_TIMEOUT_MS
+  // elapses (design §3 flow A's fallback notice) — the download starts
+  // regardless (§3 flow A caption), just with a different notice.
+  useEffect(() => {
+    if (state.phase !== "quiescing") return;
+    let cancelled = false;
+    onQuiesceStart?.();
+    const hadSessions = sessionCount > 0;
+    (async () => {
+      if (hadSessions) {
+        try {
+          await fetch("/api/terminal/session/end", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ all: true }),
+          });
+        } catch {
+          /* best effort — the quiesce command below still proceeds */
+        }
+      }
+      try {
+        await fetch("/api/terminal/helper/command", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cmd: "quiesce" }),
+        });
+      } catch {
+        /* best effort — the poll below still resolves via timeout */
+      }
+
+      const deadline = Date.now() + QUIESCE_TIMEOUT_MS;
+      while (!cancelled) {
+        let settled = false;
+        try {
+          const res = await fetch("/api/terminal/helper/status");
+          if (res.ok) {
+            const status = (await res.json()) as HelperStatus;
+            settled = status.connected === false;
+          }
+        } catch {
+          /* transient — keep polling until the deadline */
+        }
+        if (cancelled) return;
+        if (settled) {
+          setState((s) => updateFlowReducer(s, { type: "quiesce-settled" }));
+          return;
+        }
+        if (Date.now() >= deadline) {
+          setState((s) => updateFlowReducer(s, { type: "quiesce-timed-out" }));
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase, sessionCount]);
+
+  // Either outcome of quiescing starts the download (design: the whole point
+  // is drag-to-Applications always succeeds because nothing is running by
+  // now) and lets the caller refresh whatever it shows for the now-quiesced
+  // helper.
+  useEffect(() => {
+    if (state.phase !== "ready" && state.phase !== "quiesce-timeout") return;
+    window.location.assign(TERMINAL_HELPER_DOWNLOAD_URL);
+    onSettled?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase]);
+
+  return {
+    phase: state.phase,
+    confirmSessionCount: state.phase === "confirming" ? state.sessionCount : 0,
+    start,
+    confirm,
+    cancel,
+    resetIfSettled,
+  };
+}


### PR DESCRIPTION
## Summary
- The session-chooser's "Update now" button was a bare download link with no safety step — clicking it re-downloaded the new helper while the old process was potentially still running, silently reproducing the exact "nudge won't clear" confusion Nick hit. The My-sessions-panel version already did this safely (end sessions → quiesce old process → wait for disconnect → download).
- Extracted the safe flow into a shared hook (`useHelperUpdateFlow`) so both buttons now drive the identical end-sessions → quiesce → wait-for-disconnect (or 10s timeout, still proceeds) → download sequence, instead of the chooser skipping straight to a bare link.

Card: 7d92795d (Bug Fix workflow, used for a confirmed non-bug + a real follow-up UX gap Nick explicitly asked to close). Found via Nick's live field report; QA correctly separated "old process still running (not a bug)" from "inconsistent Update buttons (real gap)"; Nick made the call to fix the gap; Implementation unified both buttons.

## Test plan
- [x] tsc clean
- [x] targeted vitest 59/59
- [x] full vitest 2799/2799 (173 files)
- [x] eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)