### PR TITLE
fix(terminal): idle session vanishes from history + refresh silently mints a new one

### DIFF
--- a/src/app/api/terminal/session/closed/route.ts
+++ b/src/app/api/terminal/session/closed/route.ts
@@ -1,0 +1,107 @@
+// Terminal session CLOSED — server-to-server callback FROM the relay (card
+// 9fb9fced, Fix 2: real-time relay→app closure notification).
+//
+// `POST { sid, reason }` — called by the Cloudflare relay's DO alarm the
+// instant it force-closes a session (idle-timeout or max-duration; see
+// terminal/relay/src/index.js's `notifyAppSessionClosed`), so the Supabase
+// registry learns the session died IN REAL TIME instead of the app having to
+// separately guess an expiry at mint time and reconcile it lazily on
+// whichever request (mint/reattach/list) happened to run next. That lazy-
+// guess window was the exact race behind bug 9fb9fced: a client's page
+// refresh could land inside it and read a stale "still active" row for a
+// session that had, in fact, already ended a moment earlier — the refresh
+// then found nothing live and nothing recognizably resumable, and silently
+// launched a brand-new session with no "your session ended" messaging at
+// all.
+//
+// AUTH: no user session exists for this call — it's server-to-server from the
+// relay, not a browser request. Authorized instead by a short-lived "notify"
+// token (terminal/shared/session-token.mjs → authorizeNotify), signed by the
+// relay with the SAME TERMINAL_SESSION_SECRET both sides already hold. A
+// service-role Supabase client is required for the same reason (mirrors
+// src/app/api/notifications/email/route.ts, the other webhook with no user
+// session in this codebase) — RLS has no authenticated user to scope to here.
+//
+// SKEW-SAFETY: the write carries the mandated `.eq("status", "active")`
+// concurrency guard (CLAUDE.md's Concurrency Guards) — if the row already
+// ended (the user's own "End", or a reap that raced this callback) this is
+// an honest no-op, never a double-write clobbering a real ended_at.
+
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { z } from "zod";
+import { logger } from "@/lib/logger";
+import { authorizeNotify } from "../../../../../../terminal/shared/session-token.mjs";
+import type { Database } from "@/types/database";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  sid: z.string().min(1).max(128),
+  reason: z.enum(["idle_timeout", "time_limit"]).optional(),
+});
+
+export async function POST(req: Request) {
+  try {
+    const secret = process.env.TERMINAL_SESSION_SECRET;
+    if (!secret) {
+      logger.error("Terminal session closed callback failed: TERMINAL_SESSION_SECRET not configured");
+      return NextResponse.json({ error: "Terminal sessions are not configured" }, { status: 503 });
+    }
+
+    const parsed = BodySchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+    const { sid, reason } = parsed.data;
+
+    const authHeader = req.headers.get("authorization") || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : null;
+    const auth = await authorizeNotify({ token, secret, session: sid });
+    if (!auth.ok) {
+      logger.warn("Terminal session closed callback rejected (auth)", { sid, reason: auth.reason });
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = createClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+
+    const nowIso = new Date().toISOString();
+    const { data, error } = await supabase
+      .from("terminal_sessions")
+      .update({ status: "ended", ended_at: nowIso })
+      .eq("sid", sid)
+      .eq("status", "active")
+      .select("id")
+      .maybeSingle();
+    if (error) {
+      logger.error("Terminal session closed callback: registry update failed", { sid, error: error.message });
+      return NextResponse.json({ error: "Couldn't update the session registry" }, { status: 500 });
+    }
+
+    if (!data) {
+      // Not an error: the row may already be ended (a user's own "End", or a
+      // reap that raced this callback) — an honest no-op, not a failure.
+      logger.info("Terminal session closed callback: no active row to update", {
+        sid,
+        reason: reason ?? null,
+      });
+      return NextResponse.json({ updated: false });
+    }
+
+    logger.info("Terminal session closed callback: registry updated in real time", {
+      sid,
+      reason: reason ?? null,
+      endedAt: nowIso,
+    });
+    return NextResponse.json({ updated: true });
+  } catch (err) {
+    logger.error("Terminal session closed callback error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "An unexpected error occurred" }, { status: 500 });
+  }
+}

--- a/src/app/api/terminal/session/reattach/route.ts
+++ b/src/app/api/terminal/session/reattach/route.ts
@@ -80,6 +80,14 @@ export async function POST(req: Request) {
     if (!decision.ok || !row) {
       const status = !decision.ok && decision.reason !== "not-found" ? 409 : 404;
       const reason = !decision.ok ? decision.reason : "not-found";
+      // Fix 3 (card 9fb9fced): the specific failure path a reconnect/reattach
+      // hits when the target session turns out to already be closed — the
+      // suspected root cause of the original bug, and previously silent
+      // server-side (the client only ever saw a toast). `reason` distinguishes
+      // a genuinely unknown sid ("not-found") from a session this registry
+      // already knows died ("ended"/"expired") — the latter two are exactly
+      // the race this card's Fix 2 (relay session-closed callback) targets.
+      logger.warn("Terminal session reattach: target already unreachable", { sid, reason });
       const error =
         reason === "not-found"
           ? "Session not found"

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1026,7 +1026,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       mintAndDeliver({
         resume: row.claudeSessionId ? undefined : true,
         resumeId: row.claudeSessionId ?? undefined,
-        cwd: row.cwd,
+        cwd: row.cwd ?? undefined,
         taskId: row.taskId ?? undefined,
         taskTitle: row.taskTitle ?? undefined,
       });
@@ -1050,7 +1050,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       mintAndDeliver({
         resume: row.claudeSessionId ? undefined : true,
         resumeId: row.claudeSessionId ?? undefined,
-        cwd: row.cwd,
+        cwd: row.cwd ?? undefined,
         taskId: row.taskId ?? undefined,
         taskTitle: row.taskTitle ?? undefined,
       });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -391,7 +391,23 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   }, [registryRows, entrySnapshotInfo]);
   useEffect(() => {
     entryDecisionRef.current = entryDecision;
-  }, [entryDecision]);
+    // Fix 3 (card 9fb9fced): the client's own page-load/refresh liveness
+    // check — what the registry read found for this browser's sessions, and
+    // which of the three branches it took as a result. `entryDecision.kind`
+    // IS that branch (instant-continue → quiet reattach, chooser → render
+    // the picker/session-ended surface, empty-launch → mint fresh) — this is
+    // the exact decision point where the original bug's silent new-session
+    // launch happened with no trace at all. Fires once per resolved decision,
+    // not per render (this effect only re-runs when `entryDecision` itself
+    // changes).
+    if (entryDecision) {
+      logger.info("Terminal entry decision resolved", {
+        kind: entryDecision.kind,
+        liveCount: registryRows?.filter((r) => r.status === "active").length ?? 0,
+        recentEndedCount: registryRows?.filter((r) => r.status === "ended").length ?? 0,
+      });
+    }
+  }, [entryDecision, registryRows]);
 
   const chooserSections: ChooserSections = useMemo(
     () =>

--- a/src/components/board/terminal-session-chooser.test.tsx
+++ b/src/components/board/terminal-session-chooser.test.tsx
@@ -189,6 +189,38 @@ describe("TerminalSessionChooser", () => {
     expect(screen.queryByText(/Starts a new terminal/)).not.toBeInTheDocument();
   });
 
+  // Bug 9fb9fced (2026-08-17): a null-cwd Recent row used to never reach this
+  // component at all (chooser-data.ts hid it from `sections.recent`
+  // entirely). Now that it does, this proves the UI half of the fix: the row
+  // (sid, ended time) still renders, but Resume is omitted — not shown
+  // disabled — since there's no folder for it to reopen.
+  it("Recent row with no recorded cwd: renders the row but omits the Resume button", () => {
+    const onResume = vi.fn();
+    const row = {
+      sid: "sid-recent-no-cwd",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      cwd: null,
+      machineLabel: "Nick's MacBook",
+      claudeSessionId: null,
+      endedAt: new Date().toISOString(),
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ recent: [row] })}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={onResume}
+        onStartNew={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/no recorded folder/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Resume" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Can.t resume/)).toBeInTheDocument();
+  });
+
   it("Recent row with a tracked claudeSessionId: the confirm copy promises the EXACT conversation (rework 5)", () => {
     const onResume = vi.fn();
     const row = {

--- a/src/components/board/terminal-session-chooser.tsx
+++ b/src/components/board/terminal-session-chooser.tsx
@@ -372,6 +372,12 @@ function RecentRow({
   onConfirm: () => void;
 }) {
   const label = row.taskTitle?.trim() || row.ideaTitle || row.sid.slice(0, 8);
+  // Null-cwd fix (bug 9fb9fced): the row itself is always shown (see
+  // chooser-data.ts's header comment) — Resume is the only thing that's
+  // unavailable when there's no recorded folder to reopen, since the launch
+  // flow Resume calls into (handleChooserResume) requires one. No disabled
+  // ghost button (original F4 intent) — the action is omitted entirely, with
+  // an honest inline note instead of silently doing nothing.
   return (
     <div className={cn("border-t border-zinc-800 px-3.5 py-2.5", confirming && "bg-emerald-500/5")}>
       <div className="flex items-start gap-2.5">
@@ -381,10 +387,10 @@ function RecentRow({
             {row.ideaTitle && <span className="text-[11px] font-normal text-zinc-500">{row.ideaTitle}</span>}
           </div>
           <div className="truncate font-mono text-[11px] text-zinc-500">
-            {row.cwd} · ended {formatSessionAge(row.endedAt)} ago
+            {row.cwd ?? "no recorded folder"} · ended {formatSessionAge(row.endedAt)} ago
           </div>
         </div>
-        {!confirming && (
+        {!confirming && row.cwd && (
           <Button
             size="xs"
             className="flex-none bg-emerald-500 text-emerald-950 hover:bg-emerald-400"
@@ -394,8 +400,11 @@ function RecentRow({
             Resume
           </Button>
         )}
+        {!confirming && !row.cwd && (
+          <span className="flex-none text-[11px] text-zinc-600">Can&apos;t resume — no folder recorded</span>
+        )}
       </div>
-      {confirming && (
+      {confirming && row.cwd && (
         <div className="mt-2 border-l-2 border-emerald-500 pl-2.5 text-[11.5px] text-zinc-400">
           <p>
             {row.claudeSessionId ? (

--- a/src/components/board/terminal-task-launch-choice.test.tsx
+++ b/src/components/board/terminal-task-launch-choice.test.tsx
@@ -88,6 +88,33 @@ describe("TerminalTaskLaunchChoice", () => {
     expect(onReconnect).toHaveBeenCalledOnce();
   });
 
+  // Bug 9fb9fced (2026-08-17): a "recent" match with no recorded cwd used to
+  // never reach this dialog at all — chooser-data.ts's old F4 rule excluded
+  // it from `sections.recent` entirely, so `findTaskSessionMatch` could never
+  // find it. It can now, but Resume has no folder to reopen — mirrors the
+  // cross-board chooser's RecentRow fix: the dialog still opens (so
+  // "start fresh anyway" is reachable) but hides Reconnect/Resume instead of
+  // offering an action that can't work.
+  it("a recent match with no recorded cwd hides Resume, keeps Start fresh anyway", () => {
+    const onReconnect = vi.fn();
+    const noCwdMatch: TaskSessionMatch = {
+      kind: "recent",
+      row: { ...RECENT_MATCH.row, cwd: null },
+    };
+    render(
+      <TerminalTaskLaunchChoice
+        open
+        taskTitle="Fix login bug"
+        match={noCwdMatch}
+        onReconnect={onReconnect}
+        onStartFresh={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Resume" })).not.toBeInTheDocument();
+    expect(screen.getByText(/no folder was recorded/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /start fresh anyway/i })).toBeInTheDocument();
+  });
+
   it("fires onStartFresh from the escape hatch, independent of match kind", () => {
     const onStartFresh = vi.fn();
     render(

--- a/src/components/board/terminal-task-launch-choice.tsx
+++ b/src/components/board/terminal-task-launch-choice.tsx
@@ -47,6 +47,10 @@ export function TerminalTaskLaunchChoice({
     match.kind === "recent"
       ? `Ended ${formatSessionAge(match.row.endedAt)} ago`
       : `Started ${formatSessionAge(match.row.createdAt)} ago`;
+  // Null-cwd fix (bug 9fb9fced): a "recent" match with no recorded folder
+  // still surfaces here (chooser-data.ts no longer hides it), but Resume has
+  // no folder to reopen — same rule as the cross-board chooser's RecentRow.
+  const canReconnect = match.kind !== "recent" || !!match.row.cwd;
 
   return (
     <Dialog open={open} onOpenChange={() => {}}>
@@ -64,21 +68,24 @@ export function TerminalTaskLaunchChoice({
           <DialogDescription className="mt-1 text-[11.5px] text-zinc-500">
             <span className="block truncate">{taskTitle}</span>
             <span className="font-mono">{ageLabel}</span>
+            {!canReconnect && <span className="block text-zinc-600">No folder was recorded for it — can&apos;t resume.</span>}
           </DialogDescription>
         </div>
         <div className="flex items-center justify-end gap-2 border-t border-zinc-800 px-4 py-3">
           <Button variant="ghost" size="xs" disabled={busy} onClick={onStartFresh}>
             <TerminalIcon className="h-3 w-3" /> Start fresh anyway
           </Button>
-          <Button
-            size="xs"
-            className="bg-sky-500 text-sky-950 hover:bg-sky-400"
-            disabled={busy}
-            onClick={onReconnect}
-            autoFocus
-          >
-            <RefreshCw className="h-3 w-3" /> {reconnectLabel}
-          </Button>
+          {canReconnect && (
+            <Button
+              size="xs"
+              className="bg-sky-500 text-sky-950 hover:bg-sky-400"
+              disabled={busy}
+              onClick={onReconnect}
+              autoFocus
+            >
+              <RefreshCw className="h-3 w-3" /> {reconnectLabel}
+            </Button>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -55,12 +55,35 @@ describe("deriveChooserSections", () => {
     expect(sections.recent[0].cwd).toBe("~/projects/recipe-saver");
   });
 
-  it("hides an ended row with no recorded folder — no ghost Resume (F4)", () => {
+  // Bug 9fb9fced (2026-08-17): this used to assert the row was hidden from
+  // Recent entirely (the old F4 rule). Confirmed against live production
+  // data — a session whose cwd never got recorded (the client's post-connect
+  // PATCH only fires when the launch already had a known project path)
+  // vanished from Recent COMPLETELY once it ended, not just its Resume
+  // button, so a refresh right after found nothing live/recent anywhere and
+  // silently launched a brand-new session. The row must now still appear —
+  // with `cwd: null` — so the CALLER (the chooser UI) can render everything
+  // it knows (sid, ended time, machine) and omit only the Resume action.
+  it("keeps an ended row with no recorded folder in Recent, with cwd: null", () => {
     const rows = [
       row({ sid: "no-cwd", status: "ended", cwd: null, endedAt: new Date(NOW - 60_000).toISOString() }),
-      row({ sid: "blank-cwd", status: "ended", cwd: "   ", endedAt: new Date(NOW - 60_000).toISOString() }),
+      row({ sid: "blank-cwd", status: "ended", cwd: "   ", endedAt: new Date(NOW - 30_000).toISOString() }),
     ];
-    expect(deriveChooserSections(rows, IDEA_A, NOW).recent).toEqual([]);
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+    expect(recent.map((r) => r.sid)).toEqual(["blank-cwd", "no-cwd"]); // newest-ended first
+    expect(recent.every((r) => r.cwd === null)).toBe(true);
+  });
+
+  it("never dedupes null-cwd rows against each other — there's no folder to collapse on", () => {
+    const rows = [
+      row({ sid: "no-cwd-a", status: "ended", cwd: null, endedAt: new Date(NOW - 3 * 60_000).toISOString() }),
+      row({ sid: "no-cwd-b", status: "ended", cwd: null, endedAt: new Date(NOW - 2 * 60_000).toISOString() }),
+      row({ sid: "no-cwd-c", status: "ended", cwd: null, endedAt: new Date(NOW - 1 * 60_000).toISOString() }),
+    ];
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent.map((r) => r.sid);
+    // All three kept (newest-ended first) — contrast with the recorded-cwd
+    // dedupe test below, where two rows sharing a folder collapse to one.
+    expect(recent).toEqual(["no-cwd-c", "no-cwd-b", "no-cwd-a"]);
   });
 
   it("excludes an ended row past the 48h window, includes one just inside it", () => {

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -9,13 +9,24 @@
 // boards", and "Recent · ended in the last 48h", applying the design's rules
 // (docs/design-terminal-session-entry-options.html §3), AS SUPERSEDED for
 // Recent by Nick's rework 8b instruction below:
-//   - Recent = ended ≤48h ago, max 10, rows with a null `cwd` hidden entirely
-//     (F4: "Resume is hidden entirely when the project folder wasn't
-//     recorded — no disabled ghost button"). Dedupe is per-conversation, not
+//   - Recent = ended ≤48h ago, max 10. Dedupe is per-conversation, not
 //     strictly per-folder any more — see the EVERY RESUMABLE CONVERSATION
 //     section below.
 //   - Live sessions split by whether they belong to the board currently open
 //     (`currentIdeaId`) or another one.
+//
+// NULL-CWD ROWS (bug 9fb9fced, 2026-08-17 — SUPERSEDES the old F4 rule below):
+// `cwd` is only recorded once the client's post-connect PATCH lands, which
+// never fires at all when the launch had no known project path to begin
+// with. F4 used to hide those rows from Recent COMPLETELY, not just their
+// Resume button — so a session that force-closed before its cwd ever landed
+// vanished from history outright, and a refresh landing in that gap read as
+// "nothing to reconnect to" and silently launched a brand-new session (see
+// entry-decision.ts's matching fix). A null-cwd row is now KEPT in Recent —
+// it still has a sid, an ended time, and often a machine label worth
+// showing — with only its Resume affordance suppressed by the chooser UI
+// (terminal-session-chooser.tsx), since Resume genuinely has no folder to
+// reopen. `ChooserRecentRow.cwd` is `string | null` accordingly.
 //
 // MACHINE IDENTITY (Nick's sign-off change 2 — "hide conversations that
 // aren't on the machine that you're running vibecodes on"): Recent rows also
@@ -24,8 +35,9 @@
 // are known and disagree (`row.machineLabel` set AND differs from the stored
 // one) — a row with no recorded machine label stays visible (honest
 // omission, not assumed foreign), and when this browser has never recorded
-// an identity at all, nothing is filtered (F4-style: never a silently empty
-// section over data we simply don't have an opinion on yet). "Running now"
+// an identity at all, nothing is filtered (same honest-omission spirit as
+// the null-cwd fix above: never a silently empty section over data we simply
+// don't have an opinion on yet). "Running now"
 // sections are NEVER filtered — a live session is unambiguously reachable
 // regardless of which machine it's on.
 //
@@ -43,22 +55,27 @@
 // duplicate. Nick's instruction above supersedes the one-per-folder spec for
 // those rows; see this module's row-selection rules just below.
 //
-// Selection rules, applied AFTER the existing 48h/machine/null-cwd filtering
-// above (unchanged) and the existing newest-ended-first sort:
+// Selection rules, applied AFTER the existing 48h/machine filtering above
+// (unchanged) and the existing newest-ended-first sort:
 //   1. Every row that carries a `claudeSessionId` is kept, no matter how many
 //      other rows share its `cwd` — each one resumes its own exact
 //      conversation, so none of them is a duplicate of another.
-//   2. Rows WITHOUT a `claudeSessionId` still can't be told apart from one
-//      another by Resume (it falls back to "most recent in this folder", the
-//      pre-rework-5 behaviour) — so they keep the old one-per-folder collapse,
-//      keeping only the newest such row per `cwd`.
+//   2. Rows WITHOUT a `claudeSessionId` but WITH a recorded `cwd` still can't
+//      be told apart from one another by Resume (it falls back to "most
+//      recent in this folder", the pre-rework-5 behaviour) — so they keep the
+//      old one-per-folder collapse, keeping only the newest such row per
+//      `cwd`.
 //   3. A folder that already has an ID-bearing row shown ALSO gets its single
 //      newest ID-less row shown (not suppressed) — that ID-less row is a
 //      distinct, older-era conversation pointer (from before the bridge
 //      announced ids, or a bridge too old to ever announce one) that the
 //      ID-bearing rows cannot stand in for. This is the simplest honest rule:
 //      "one ID-less pointer per folder, plus every distinct ID we have."
-//   4. The combined result is capped at RECENT_MAX (raised 5 → 10 for this
+//   4. A row with NEITHER a `claudeSessionId` NOR a recorded `cwd` (null-cwd
+//      fix above) has no folder to collapse it against another row by — it
+//      is never deduped away, only ever capped by RECENT_MAX like everything
+//      else.
+//   5. The combined result is capped at RECENT_MAX (raised 5 → 10 for this
 //      rework — more rows are now legitimately distinct, so the old cap would
 //      truncate real history), newest-ended first.
 
@@ -106,8 +123,8 @@ export interface ChooserRecentRow {
   ideaTitle: string | null;
   taskId: string | null;
   taskTitle: string | null;
-  /** Never null/empty — rows without a recorded folder never reach this list (F4). */
-  cwd: string;
+  /** Null when the folder was never recorded (null-cwd fix above) — the row still appears, but the chooser UI must not offer Resume for it. */
+  cwd: string | null;
   machineLabel: string | null;
   /** Exact-conversation Resume (rework 5) — see ChooserRegistryRow's doc. Null → the chooser falls back to the legacy `--continue` resume. */
   claudeSessionId: string | null;
@@ -162,9 +179,11 @@ export function deriveChooserSections(
   const liveElsewhere = live.filter((r) => r.ideaId !== currentIdeaId).map(toLiveRow);
 
   const recentCandidates = rows
-    .filter((r): r is ChooserRegistryRow & { cwd: string; endedAt: string } => {
+    .filter((r): r is ChooserRegistryRow & { endedAt: string } => {
       if (r.status !== "ended") return false;
-      if (!r.cwd || !r.cwd.trim()) return false; // F4: no recorded folder → never shown
+      // Null-cwd fix (bug 9fb9fced): no cwd check here any more — a row with
+      // no recorded folder still belongs in Recent, just without Resume. See
+      // this module's header comment.
       if (!r.endedAt) return false;
       if (!withinRecentWindow(r.endedAt, nowMs)) return false;
       // Machine identity: hide only when BOTH sides are known and disagree —
@@ -176,16 +195,22 @@ export function deriveChooserSections(
 
   // Rework 8b (see header comment): rows WITH a claudeSessionId are never
   // deduped against each other — each resumes its own exact conversation.
-  // Rows WITHOUT one still collapse to the single newest per folder, since
-  // Resume can't tell them apart. `recentCandidates` is already sorted
-  // newest-ended-first, so "first row seen per folder" is "newest per
-  // folder" for the id-less collapse.
+  // Rows WITHOUT one but WITH a recorded cwd still collapse to the single
+  // newest per folder, since Resume can't tell them apart. A row with
+  // NEITHER (null-cwd fix) has no folder to key a collapse on, so it's never
+  // deduped away. `recentCandidates` is already sorted newest-ended-first, so
+  // "first row seen per folder" is "newest per folder" for the id-less
+  // collapse.
   const seenIdlessCwd = new Set<string>();
-  const selected: (ChooserRegistryRow & { cwd: string; endedAt: string })[] = [];
+  const selected: (ChooserRegistryRow & { endedAt: string })[] = [];
   for (const r of recentCandidates) {
-    const cwd = r.cwd.trim();
     if (r.claudeSessionId) {
       selected.push(r);
+      continue;
+    }
+    const cwd = r.cwd ? r.cwd.trim() : null;
+    if (!cwd) {
+      selected.push(r); // no folder to dedupe against — always kept
       continue;
     }
     if (seenIdlessCwd.has(cwd)) continue; // one id-less row per project folder
@@ -199,7 +224,7 @@ export function deriveChooserSections(
     ideaTitle: r.ideaTitle,
     taskId: r.taskId,
     taskTitle: r.taskTitle,
-    cwd: r.cwd.trim(),
+    cwd: r.cwd && r.cwd.trim() ? r.cwd.trim() : null, // blank/whitespace-only normalizes to null, same as the dedupe loop above
     machineLabel: r.machineLabel,
     claudeSessionId: r.claudeSessionId,
     endedAt: r.endedAt,

--- a/src/lib/terminal/entry-decision.test.ts
+++ b/src/lib/terminal/entry-decision.test.ts
@@ -24,8 +24,27 @@ describe("decideEntryBehaviour", () => {
     expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "chooser" });
   });
 
-  it("empty-launch when the only ended row has no recorded folder", () => {
+  // Bug 9fb9fced (2026-08-17): this used to assert "empty-launch" — a
+  // null-cwd ended row was treated as neither live nor recent, so the dock
+  // silently minted a brand-new session instead of showing the chooser (or
+  // the session-ended screen) for a session that had, in fact, just ended.
+  // `cwd` is no longer part of `isRecentEnded`'s predicate; see
+  // chooser-data.ts's matching fix for how the row renders once "chooser" is
+  // reached (visible, but with Resume unavailable).
+  it("chooser (not empty-launch) when the only ended row has no recorded folder", () => {
     const rows = [row({ sid: "ended-1", status: "ended", cwd: null, endedAt: new Date(NOW - 60_000).toISOString() })];
+    expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "chooser" });
+  });
+
+  it("empty-launch when a null-cwd ended row is past the 48h window (the 48h rule itself is untouched by the null-cwd fix)", () => {
+    const rows = [
+      row({
+        sid: "ended-1",
+        status: "ended",
+        cwd: null,
+        endedAt: new Date(NOW - RECENT_WINDOW_MS - 1000).toISOString(),
+      }),
+    ];
     expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "empty-launch" });
   });
 

--- a/src/lib/terminal/entry-decision.ts
+++ b/src/lib/terminal/entry-decision.ts
@@ -7,12 +7,22 @@
 // Exactly one of three outcomes, in this priority order:
 //   1. instant-continue — a fresh (<60s) snapshot for a sid that IS a live,
 //      owned session in the registry → reattach it immediately, no click.
-//   2. chooser           — any other live session, or any recent (≤48h,
-//      recorded-folder) ended session exists → render the chooser, mint
-//      nothing until a click.
+//   2. chooser           — any other live session, or any recent (≤48h)
+//      ended session exists → render the chooser, mint nothing until a
+//      click.
 //   3. empty-launch      — nothing live or recent anywhere → today's
 //      unchanged open→launch behaviour (F1: "there is nothing to choose
 //      between, and this is explicitly fine").
+//
+// Bug 9fb9fced (2026-08-17): `isRecentEnded` used to also require a recorded
+// `cwd`, mirroring chooser-data.ts's old F4 filter. A session whose cwd was
+// never recorded (the PATCH that saves it only fires when the launch already
+// had a known project path) then read as neither live nor recent — this
+// function returned `empty-launch`, and the dock silently minted a brand-new
+// session instead of showing the chooser/ended screen for a session that had
+// in fact just ended. `cwd` is no longer part of this predicate; a recently-
+// ended row with no recorded folder still routes to `chooser` (it just can't
+// offer Resume there — see chooser-data.ts's matching fix).
 
 import { RECENT_WINDOW_MS } from "./chooser-data";
 import { isSnapshotFresh } from "./session-snapshot";
@@ -37,7 +47,6 @@ export type EntryDecision =
 
 function isRecentEnded(row: EntryRegistryRow, nowMs: number): boolean {
   if (row.status !== "ended") return false;
-  if (!row.cwd || !row.cwd.trim()) return false;
   if (!row.endedAt) return false;
   const t = Date.parse(row.endedAt);
   if (Number.isNaN(t)) return false;

--- a/src/lib/terminal/session-reap.ts
+++ b/src/lib/terminal/session-reap.ts
@@ -78,9 +78,19 @@ export async function reapExpiredSessions(
         error: failed[0]?.error?.message,
       });
     } else {
+      // Fix 3 (card 9fb9fced): per-sid ids (not just a count) and an explicit
+      // "estimated" flag — this reap flips a row to "ended" from a MIRRORED
+      // expires_at guess, never a confirmed relay event (that confirmation is
+      // Fix 2's session-closed callback, when it fires in time). Without this
+      // distinction a log reader can't tell "the app was told this died" from
+      // "the app is guessing this died" for the exact same-looking line — the
+      // ambiguity that made the original race hard to diagnose from logs
+      // alone. `logLabel` already names the trigger (mint/reattach/list).
       logger.info(`${logLabel}: reaped expired terminal session rows`, {
         userId,
         count: updates.length,
+        ids: updates.map((update) => update.id),
+        endedAtEstimated: true,
       });
     }
   }

--- a/terminal/relay/src/index.js
+++ b/terminal/relay/src/index.js
@@ -29,6 +29,20 @@
 // The pairing / single-attach / lifecycle decision logic lives in ./pairing.js and
 // is shared with the Node stand-in relay used by the automated tests, so both
 // enforce identical rules.
+//
+// SESSION-CLOSED CALLBACK (card 9fb9fced, Fix 2): when a DO alarm force-closes
+// a session (idle-timeout or max-duration — see alarm()/endSession() below),
+// the relay now POSTs `{ sid, reason }` back to the app's
+// `/api/terminal/session/closed` webhook (auth: a short-lived "notify" token,
+// signed with the SAME TERMINAL_SESSION_SECRET both sides already hold — see
+// terminal/shared/session-token.mjs). Previously the relay never told the app
+// anything about this closure at all; the app's Supabase registry only found
+// out by separately guessing an expiry at mint time and lazily reconciling it
+// on whichever request happened to run next — a multi-minute window in which
+// a client could read a stale "still active" row for a session that had
+// already died. Requires env var VIBECODES_APP_URL (see wrangler.toml); the
+// callback is skipped (logged, never thrown) when that or the secret is
+// unconfigured, matching this file's existing best-effort conventions.
 
 import {
   decideAttach,
@@ -44,7 +58,12 @@ import {
 } from "./pairing.js";
 import { shouldPersistActivity, DEFAULT_ACTIVITY_PERSIST_THROTTLE_MS } from "./activity-throttle.js";
 import { computeHelperStatus } from "./helper-status.js";
-import { authorizeAttach, authorizeControl, HELPER_MAX_BOUND_MS } from "../../shared/session-token.mjs";
+import {
+  authorizeAttach,
+  authorizeControl,
+  mintNotifyToken,
+  HELPER_MAX_BOUND_MS,
+} from "../../shared/session-token.mjs";
 import {
   encodeAttachedFrame,
   encodePeerDegradedFrame,
@@ -545,6 +564,12 @@ export class TerminalRelay {
     if (sessionStartedAt == null) {
       sessionStartedAt = now;
       await this.state.storage.put("sessionStartedAt", now);
+      // The DO has no other durable memory of its own sid — it's addressed
+      // externally via idFromName(session), never told to itself. Stored
+      // once here (write-once, mirrors sessionStartedAt) so alarm() can log
+      // it and hand it to the session-closed app callback below (card
+      // 9fb9fced, Fix 2 + Fix 3).
+      await this.state.storage.put("sid", session);
     }
     // MITIGATION 1: sessionStartedAt is write-once for the session's life — cache
     // it now so armAlarm() below (and every later call, until clearSessionState())
@@ -895,8 +920,16 @@ export class TerminalRelay {
     const grace = await this.state.storage.get("graceDeadline");
 
     if (started != null && now - started >= this.maxMs()) {
-      this.log("session ended", { why: "max-duration", ageMs: now - started });
-      return this.endSession(maxCloseReason(this.maxMs()));
+      // Card 9fb9fced, Fix 3: sid + which timeout + total duration, on the
+      // SAME log line the old version omitted the sid from entirely — a
+      // session ending here was previously undiagnosable from logs alone.
+      const sid = await this.state.storage.get("sid");
+      const ageMs = now - started;
+      this.log("session ended", { why: "max-duration", sid, ageMs });
+      // Fix 2: tell the app in real time (instead of it lazily reconciling a
+      // mirrored expires_at guess on some later, unrelated request) — see
+      // notifyAppSessionClosed's doc.
+      return this.endSession(maxCloseReason(this.maxMs()), { notifyApp: true, sid, reasonCode: "time_limit" });
     }
 
     // Reconnect grace expiry: the held-open session never became whole again inside
@@ -916,8 +949,10 @@ export class TerminalRelay {
     // Idle only governs a WHOLE session; a held (degraded) session has stale activity
     // by definition and is governed by the grace deadline above instead.
     if (grace == null && last != null && now - last >= this.idleMs()) {
-      this.log("session ended", { why: "idle-timeout", idleMs: now - last });
-      return this.endSession(idleCloseReason(this.idleMs()));
+      const sid = await this.state.storage.get("sid");
+      const idleMs = now - last;
+      this.log("session ended", { why: "idle-timeout", sid, idleMs });
+      return this.endSession(idleCloseReason(this.idleMs()), { notifyApp: true, sid, reasonCode: "idle_timeout" });
     }
 
     // Nothing due yet → re-arm to the next earliest deadline.
@@ -926,14 +961,69 @@ export class TerminalRelay {
     }
   }
 
-  /** Close BOTH legs with the normal code 1000 + lifecycle reason, then clear state. */
-  async endSession(reason) {
+  /**
+   * Close BOTH legs with the normal code 1000 + lifecycle reason, then clear
+   * state. `opts.notifyApp` (card 9fb9fced, Fix 2) fires the session-closed
+   * callback to the app BEFORE clearing state — only for the two alarm-
+   * triggered paths above (idle-timeout, max-duration); the app-initiated
+   * `/end` route (handleEnd, below) calls this with no opts, since the app
+   * already knows it just ended this session and is about to write that
+   * itself — a callback there would be redundant.
+   * @param {string} reason @param {{ notifyApp?: boolean, sid?: string, reasonCode?: "idle_timeout"|"time_limit" }} [opts]
+   */
+  async endSession(reason, opts = {}) {
     for (const ws of this.state.getWebSockets()) {
       try {
         ws.close(NORMAL_CLOSURE, reason);
       } catch { /* already closing */ }
     }
+    if (opts.notifyApp) {
+      await this.notifyAppSessionClosed(opts.sid, opts.reasonCode);
+    }
     await this.clearSessionState();
+  }
+
+  /**
+   * Card 9fb9fced, Fix 2: tell the app IMMEDIATELY when a DO alarm force-
+   * closes a session, instead of leaving its Supabase registry to guess via
+   * its own mirrored `expires_at` and reconcile lazily on the next unrelated
+   * request (mint/reattach/list) — the multi-minute race that let a client's
+   * page refresh observe a stale "still active" row for a session that had,
+   * in fact, already died (bug 9fb9fced's root cause). Best-effort and never
+   * blocks the caller: `endSession` still tears the session down locally
+   * either way, exactly as it always has — the registry is documented
+   * elsewhere as a best-effort mirror (design doc §9, R2), so a failed
+   * callback here just leaves it exactly as stale as it always could be
+   * before this fix, self-correcting on the next lazy reap.
+   * @param {string|undefined} sid @param {"idle_timeout"|"time_limit"|undefined} reasonCode
+   */
+  async notifyAppSessionClosed(sid, reasonCode) {
+    const appUrl = this.env.VIBECODES_APP_URL;
+    const secret = this.env.TERMINAL_SESSION_SECRET;
+    if (!sid || !appUrl || !secret) {
+      this.log("session-closed callback skipped (not configured)", {
+        sid: sid ?? null,
+        reasonCode,
+        hasAppUrl: !!appUrl,
+        hasSecret: !!secret,
+      });
+      return;
+    }
+    try {
+      const token = await mintNotifyToken({ sid, secret });
+      const res = await fetch(`${appUrl.replace(/\/+$/, "")}/api/terminal/session/closed`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: JSON.stringify({ sid, reason: reasonCode }),
+      });
+      if (!res.ok) {
+        this.log("session-closed callback rejected by app", { sid, reasonCode, status: res.status });
+        return;
+      }
+      this.log("session-closed callback delivered", { sid, reasonCode });
+    } catch (e) {
+      this.log("session-closed callback failed", { sid, reasonCode, err: String(e) });
+    }
   }
 
   /** Grace window elapsed without a full reattach → the original teardown: any
@@ -957,6 +1047,7 @@ export class TerminalRelay {
       "bridgeHelperVersion",
       "bridgeHost",
       "bridgeConv",
+      "sid",
     ]);
     await this.state.storage.deleteAlarm();
     // MITIGATION 1: invalidate the per-wake soft caches so a LATER attach to

--- a/terminal/relay/src/notify-token.test.js
+++ b/terminal/relay/src/notify-token.test.js
@@ -1,0 +1,63 @@
+// Unit tests for the relay's session-closed callback token verdicts (card
+// 9fb9fced, Fix 2). `notifyAppSessionClosed` in ./index.js is a thin
+// composition over `mintNotifyToken`/`authorizeNotify`
+// (../../shared/session-token.mjs) — the full valid/expired/wrong-sid/
+// wrong-role/tampered matrix is exercised here, against the SAME shared
+// module the Cloudflare DO signs with and the app's
+// `POST /api/terminal/session/closed` webhook verifies with, so a verdict
+// proven here is the verdict either side produces.
+//
+// Run: cd terminal/relay && node --test   (or: npm test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mintNotifyToken,
+  mintControlToken,
+  mintSessionTokens,
+  authorizeNotify,
+  NOTIFY_TTL_SECONDS,
+} from "../../shared/session-token.mjs";
+
+const SECRET = "relay-notify-token-test-secret";
+const NOW = 1_700_000_000;
+
+test("valid notify token, matching sid → authorized", async () => {
+  const token = await mintNotifyToken({ sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeNotify({ token, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(res.ok, true);
+  assert.equal(res.claims.role, "notify");
+});
+
+test("expired notify token → rejected (no reattach waiver for a callback)", async () => {
+  assert.equal(NOTIFY_TTL_SECONDS, 60);
+  const token = await mintNotifyToken({ sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeNotify({ token, secret: SECRET, session: "sess-1", now: NOW + NOTIFY_TTL_SECONDS + 1 });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "expired");
+});
+
+test("wrong sid (token minted for a different session) → rejected", async () => {
+  const token = await mintNotifyToken({ sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeNotify({ token, secret: SECRET, session: "sess-2", now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "sid mismatch");
+});
+
+test("wrong role (a control token, or a live bridge/browser leg token) → rejected", async () => {
+  const control = await mintControlToken({ sub: "user-A", sid: "sess-1", secret: SECRET, now: NOW });
+  const controlRes = await authorizeNotify({ token: control, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(controlRes.ok, false);
+  assert.equal(controlRes.reason, "role mismatch");
+
+  const { bridge } = await mintSessionTokens({ sub: "user-A", idea: "idea-1", sid: "sess-1", secret: SECRET, now: NOW });
+  const bridgeRes = await authorizeNotify({ token: bridge, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(bridgeRes.ok, false);
+  assert.equal(bridgeRes.reason, "role mismatch");
+});
+
+test("wrong secret (a forged relay) → rejected", async () => {
+  const token = await mintNotifyToken({ sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeNotify({ token, secret: "some-other-secret", session: "sess-1", now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "bad signature");
+});

--- a/terminal/relay/wrangler.toml
+++ b/terminal/relay/wrangler.toml
@@ -43,9 +43,17 @@ new_sqlite_classes = ["TerminalRelay"]
 TERMINAL_IDLE_MS = "1800000"   # 30 minutes
 TERMINAL_MAX_MS  = "14400000"  # 4 hours
 
+# Card 9fb9fced, Fix 2 — session-closed callback: the base URL the relay POSTs
+# `{ sid, reason }` to (via `/api/terminal/session/closed`) the instant a DO
+# alarm force-closes a session, so the app's registry learns in real time
+# instead of lazily reconciling a guessed expiry (see index.js's header
+# comment). No trailing slash. Not a secret — the call itself is authorized by
+# a short-lived token signed with TERMINAL_SESSION_SECRET below.
+VIBECODES_APP_URL = "https://vibecodes.co.uk"
+
 # ── Secret (NOT set here — never commit it) ───────────────────────────────────
 # TERMINAL_SESSION_SECRET is the HMAC key the relay verifies app-minted session
-# tokens with. It MUST match the VibeCodes app's TERMINAL_SESSION_SECRET. Provide
-# it OUT OF BAND:
+# tokens with (and now also signs the session-closed callback above with). It
+# MUST match the VibeCodes app's TERMINAL_SESSION_SECRET. Provide it OUT OF BAND:
 #   - local dev:  terminal/relay/.dev.vars  (gitignored; loaded by `wrangler dev`)
 #   - production: `wrangler secret put TERMINAL_SESSION_SECRET`

--- a/terminal/shared/session-token.mjs
+++ b/terminal/shared/session-token.mjs
@@ -83,10 +83,26 @@ export const DEFAULT_TTL_SECONDS = 300;
  */
 export const DEFAULT_MAX_SESSION_MS = 4 * 60 * 60 * 1000;
 
-const ROLES = Object.freeze(["bridge", "browser", "control", "helper"]);
+const ROLES = Object.freeze(["bridge", "browser", "control", "helper", "notify"]);
 
 /** Control-token lifetime (multi-session stage 3): short-lived, one-shot. */
 export const CONTROL_TTL_SECONDS = 60;
+
+/**
+ * Notify-token lifetime (card 9fb9fced, Fix 2 — real-time relay→app closure
+ * callback): short-lived, one-shot, mirrors CONTROL_TTL_SECONDS. "notify" is
+ * the FIFTH kind of leg/call this module authorizes, and the mirror image of
+ * "control": where a control token authorizes the APP calling the RELAY's
+ * `/end`, a notify token authorizes the RELAY calling the APP's
+ * `POST /api/terminal/session/closed` the instant a DO alarm force-closes a
+ * session (hard 4h max-duration, or 30min idle) — telling the Supabase
+ * registry the session died in REAL TIME instead of leaving it to guess via
+ * its own mirrored `expires_at` and reconcile lazily on the next unrelated
+ * request. That lazy-guess window was the exact race behind bug 9fb9fced: a
+ * client's page refresh could land inside it and observe a stale "still
+ * active" row for a session that had, in fact, already ended.
+ */
+export const NOTIFY_TTL_SECONDS = 60;
 
 /**
  * Belt-and-braces cap on the HELPER reattach waiver (mirrors
@@ -353,6 +369,52 @@ export async function authorizeControl({ token, secret, session, now }) {
   if (c.role !== "control") return { ok: false, reason: "role mismatch" };
   if (c.sid !== session) return { ok: false, reason: "sid mismatch" };
   return { ok: true, sub: c.sub, claims: c };
+}
+
+/**
+ * Mint a short-lived "notify" token authorizing ONE HTTP call FROM the relay
+ * TO the app's `POST /api/terminal/session/closed` webhook (card 9fb9fced,
+ * Fix 2 — see NOTIFY_TTL_SECONDS's doc above). Minted by the relay itself,
+ * immediately before that outbound fetch, using the SAME shared
+ * TERMINAL_SESSION_SECRET both sides already hold — no new secret to
+ * provision. `sub` carries no meaning for this direction (the relay's alarm
+ * path has no reason to read the durable owner binding just for this call);
+ * the app authorizes the callback on the SIGNATURE + role + sid alone, then
+ * looks the row up by sid itself — see `authorizeNotify`'s doc.
+ * @param {{ sid: string, secret: string, ttlSeconds?: number, now?: number }} args
+ * @returns {Promise<string>}
+ */
+export async function mintNotifyToken({
+  sid,
+  secret,
+  ttlSeconds = NOTIFY_TTL_SECONDS,
+  now = Math.floor(Date.now() / 1000),
+}) {
+  const exp = now + ttlSeconds;
+  return signToken({ sub: "relay", sid, idea: "", role: "notify", iat: now, exp }, secret);
+}
+
+/**
+ * Verify a notify token for the app's `/api/terminal/session/closed` webhook.
+ * Deliberately STRICT, mirroring `authorizeControl`: no reattach waiver, an
+ * expired token always fails — this is a one-shot server-to-server call, not
+ * a leg of a live session. Checks signature, shape, `role === "notify"`, and
+ * `sid` match; does NOT check `sub` against anything (see mintNotifyToken's
+ * doc) — the SIGNATURE itself is what proves the call came from a relay
+ * instance holding TERMINAL_SESSION_SECRET, not an arbitrary caller guessing
+ * a sid. The webhook route still re-scopes its own DB write to the row
+ * matching this sid, so a forged-but-somehow-valid sid can only ever affect
+ * that one row.
+ * @param {{ token: unknown, secret: string, session: unknown, now?: number }} args
+ * @returns {Promise<{ ok: true, claims: SessionClaims } | { ok: false, reason: string }>}
+ */
+export async function authorizeNotify({ token, secret, session, now }) {
+  const res = await verifyToken(token, secret, { now });
+  if (!res.ok) return res;
+  const c = res.claims;
+  if (c.role !== "notify") return { ok: false, reason: "role mismatch" };
+  if (c.sid !== session) return { ok: false, reason: "sid mismatch" };
+  return { ok: true, claims: c };
 }
 
 /**

--- a/terminal/shared/session-token.test.mjs
+++ b/terminal/shared/session-token.test.mjs
@@ -9,9 +9,12 @@ import {
   mintSessionTokens,
   mintControlToken,
   authorizeControl,
+  mintNotifyToken,
+  authorizeNotify,
   newSessionId,
   DEFAULT_TTL_SECONDS,
   CONTROL_TTL_SECONDS,
+  NOTIFY_TTL_SECONDS,
   helperSessionId,
   mintHelperToken,
   decodeTokenClaims,
@@ -247,6 +250,58 @@ test("authorizeControl: expiry is ALWAYS strict — no reattach waiver exists fo
   const expired = await authorizeControl({ token, secret: SECRET, session: "sess-1", now: NOW + CONTROL_TTL_SECONDS + 1 });
   assert.equal(expired.ok, false);
   assert.equal(expired.reason, "expired");
+});
+
+// ── notify tokens (card 9fb9fced, Fix 2 — relay→app session-closed callback) ─
+
+test("mintNotifyToken → authorizeNotify happy path", async () => {
+  assert.equal(NOTIFY_TTL_SECONDS, 60);
+  const token = await mintNotifyToken({ sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeNotify({ token, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(res.ok, true);
+  assert.equal(res.claims.role, "notify");
+  assert.equal(res.claims.sid, "sess-1");
+});
+
+test("authorizeNotify: sid mismatch is rejected", async () => {
+  const token = await mintNotifyToken({ sid: "sess-1", secret: SECRET, now: NOW });
+  const res = await authorizeNotify({ token, secret: SECRET, session: "sess-OTHER", now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "sid mismatch");
+});
+
+test("authorizeNotify: a control/bridge/browser token is rejected with role mismatch", async () => {
+  const control = await mintControlToken({ sub: "user-A", sid: "sess-1", secret: SECRET, now: NOW });
+  const controlRes = await authorizeNotify({ token: control, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(controlRes.ok, false);
+  assert.equal(controlRes.reason, "role mismatch");
+
+  const { browser } = await mintSessionTokens({ sub: "user-A", idea: "idea-1", sid: "sess-1", secret: SECRET, now: NOW });
+  const browserRes = await authorizeNotify({ token: browser, secret: SECRET, session: "sess-1", now: NOW });
+  assert.equal(browserRes.ok, false);
+  assert.equal(browserRes.reason, "role mismatch");
+});
+
+test("authorizeNotify: expiry is ALWAYS strict — no reattach waiver exists for notify tokens", async () => {
+  const token = await mintNotifyToken({ sid: "sess-1", secret: SECRET, now: NOW });
+  const stillGood = await authorizeNotify({ token, secret: SECRET, session: "sess-1", now: NOW + NOTIFY_TTL_SECONDS - 1 });
+  assert.equal(stillGood.ok, true);
+  const expired = await authorizeNotify({ token, secret: SECRET, session: "sess-1", now: NOW + NOTIFY_TTL_SECONDS + 1 });
+  assert.equal(expired.ok, false);
+  assert.equal(expired.reason, "expired");
+});
+
+test("authorizeNotify: a tampered notify token is rejected (bad signature)", async () => {
+  const token = await mintNotifyToken({ sid: "sess-1", secret: SECRET, now: NOW });
+  // Forge the sid (trying to redirect the callback at ANOTHER session's row)
+  // while keeping the original signature — the HMAC check must catch this.
+  const [payloadB64, sig] = token.split(".");
+  const forged = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+  forged.sid = "sess-EVIL";
+  const forgedPayload = Buffer.from(JSON.stringify(forged)).toString("base64url");
+  const res = await authorizeNotify({ token: `${forgedPayload}.${sig}`, secret: SECRET, session: "sess-EVIL", now: NOW });
+  assert.equal(res.ok, false);
+  assert.equal(res.reason, "bad signature");
 });
 
 // ── helper tokens (card cc74a067, helper lifecycle) ────────────────────────


### PR DESCRIPTION
## Summary
- A session hidden by having no recorded project folder was excluded entirely from "recent sessions" instead of just losing its Resume button — so it vanished from history the moment it ended.
- The relay's own 4h/30min session timeouts were never reported to the app; the registry only learned a session had died by lazily guessing an expiry on the next unrelated request. A refresh landing inside that guess window could see a stale "still active" row for an already-dead session, find nothing live and nothing recognizable in history, and silently launch a brand-new session with no "session ended" messaging.
- Fixes both: no-folder sessions now stay visible in history (just without Resume), and the relay POSTs a real-time closure callback to the app the instant it force-closes a session (reusing the existing `TERMINAL_SESSION_SECRET`, no new secrets needed — just a `VIBECODES_APP_URL` plain var).
- Adds `logger.*` calls at the relay close, the reconciliation path, the client's entry-decision branch, and the reattach failure path, so this class of race is diagnosable from logs next time.

Board task: 9fb9fced-e4d3-4047-8fa0-097e02d1b594

## Test plan
- [x] 2803 vitest tests pass (app)
- [x] 45 relay `node --test` pass
- [x] 32 shared `node --test` pass (incl. new notify-token + expanded session-token tests)
- [x] `npx tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [ ] Relay redeploy (`wrangler deploy`) required after merge — this PR alone doesn't ship Fix 2 to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)