### PR TITLE
fix(board): guard updateTask/moveTask against concurrent-write races

### DIFF
--- a/mcp-server/src/tools/board-write.test.ts
+++ b/mcp-server/src/tools/board-write.test.ts
@@ -6,7 +6,14 @@ vi.mock("../../../src/lib/workflow-helpers", () => ({
   checkAndApplyAutoRules: (...args: unknown[]) => mockCheckAndApplyAutoRules(...args),
 }));
 
-import { createTask, createTaskSchema } from "./board-write";
+import {
+  createTask,
+  createTaskSchema,
+  updateTask,
+  updateTaskSchema,
+  moveTask,
+  moveTaskSchema,
+} from "./board-write";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -18,6 +25,9 @@ const COLUMN_ID = "00000000-0000-4000-a000-000000000050";
 const TASK_ID = "00000000-0000-4000-a000-000000000010";
 const LABEL_BUG_ID = "00000000-0000-4000-a000-000000000098";
 const LABEL_FRONTEND_ID = "00000000-0000-4000-a000-000000000099";
+const OTHER_USER_ID = "00000000-0000-4000-a000-000000000002";
+const COLUMN_A_ID = "00000000-0000-4000-a000-000000000060";
+const COLUMN_B_ID = "00000000-0000-4000-a000-000000000061";
 
 /** Creates a chainable Supabase query mock resolving to `resolveWith`. */
 function createChain(resolveWith: unknown = null) {
@@ -29,9 +39,12 @@ function createChain(resolveWith: unknown = null) {
 
   chain.select = vi.fn(() => chain);
   chain.eq = vi.fn(() => chain);
+  chain.is = vi.fn(() => chain);
   chain.in = vi.fn(() => chain);
+  chain.not = vi.fn(() => chain);
   chain.insert = vi.fn(() => chain);
   chain.update = vi.fn(() => chain);
+  chain.upsert = vi.fn(() => chain);
 
   chain.single = vi.fn(() =>
     Promise.resolve({ data: resolveWith, error: null })
@@ -48,6 +61,11 @@ function createChain(resolveWith: unknown = null) {
     }).then(resolve);
 
   return chain;
+}
+
+/** Narrows an untyped chain property mocked via vi.fn() so `.mock.calls` can be asserted. */
+function asMock(fn: unknown): ReturnType<typeof vi.fn> {
+  return fn as ReturnType<typeof vi.fn>;
 }
 
 function makeContext(fromFn: (table: string) => unknown): McpContext {
@@ -191,5 +209,272 @@ describe("createTask — add-labels auto-rule adjudication", () => {
 
     expect(result.success).toBe(true);
     expect(mockCheckAndApplyAutoRules).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateTask — assignment optimistic-concurrency guard", () => {
+  // Regression guard for the self-assign race: two concurrent updateTask
+  // calls both read the same pre-update assignee_id (null), so without a
+  // guard both writes would succeed and the last one would silently win.
+  it("blocks a stale assignment when the row's assignee_id no longer matches what was read", async () => {
+    const readChain = createChain({
+      title: "Task",
+      description: null,
+      assignee_id: null,
+      due_date: null,
+      archived: false,
+    });
+    // The guarded UPDATE (.eq/.is on assignee_id) matches no row, because a
+    // "concurrent" caller already claimed the task in between.
+    const writeChain = createChain(null);
+
+    let boardTasksCalls = 0;
+    const fromFn = vi.fn((table: string) => {
+      if (table === "board_tasks") {
+        boardTasksCalls += 1;
+        return boardTasksCalls === 1 ? readChain : writeChain;
+      }
+      return createChain(null);
+    });
+
+    const params = updateTaskSchema.parse({
+      task_id: TASK_ID,
+      idea_id: IDEA_ID,
+      assignee_id: USER_ID,
+    });
+
+    await expect(updateTask(makeContext(fromFn), params)).rejects.toThrow(
+      "This task was already assigned by someone else — refresh and try again."
+    );
+
+    // The guard must actually be present on the write, not just a plain update.
+    expect(
+      asMock(writeChain.is).mock.calls.some(
+        (call: unknown[]) => call[0] === "assignee_id" && call[1] === null
+      )
+    ).toBe(true);
+  });
+
+  it("throws a distinct, actionable error — not the generic 'Failed to update task' message", async () => {
+    const readChain = createChain({
+      title: "Task",
+      description: null,
+      assignee_id: OTHER_USER_ID,
+      due_date: null,
+      archived: false,
+    });
+    const writeChain = createChain(null);
+
+    let boardTasksCalls = 0;
+    const fromFn = vi.fn((table: string) => {
+      if (table === "board_tasks") {
+        boardTasksCalls += 1;
+        return boardTasksCalls === 1 ? readChain : writeChain;
+      }
+      return createChain(null);
+    });
+
+    const params = updateTaskSchema.parse({
+      task_id: TASK_ID,
+      idea_id: IDEA_ID,
+      assignee_id: USER_ID,
+    });
+
+    let caught: Error | null = null;
+    try {
+      await updateTask(makeContext(fromFn), params);
+    } catch (e) {
+      caught = e as Error;
+    }
+
+    expect(caught).not.toBeNull();
+    expect(caught?.message).not.toMatch(/Failed to update task/);
+    expect(caught?.message).toMatch(/already assigned by someone else/);
+    // Guard used .eq (not .is) since the previously-read assignee_id was non-null.
+    expect(
+      asMock(writeChain.eq).mock.calls.some(
+        (call: unknown[]) => call[0] === "assignee_id" && call[1] === OTHER_USER_ID
+      )
+    ).toBe(true);
+  });
+
+  it("succeeds for ordinary single-caller assignment (no race)", async () => {
+    const readChain = createChain({
+      title: "Task",
+      description: null,
+      assignee_id: null,
+      due_date: null,
+      archived: false,
+    });
+    const writeChain = createChain({ id: TASK_ID, title: "Task" });
+    const activityChain = createChain(null);
+    const ideaChain = createChain({ author_id: OTHER_USER_ID });
+    const botProfilesChain = createChain(null); // assignee is not a bot -> no working_started_at branch
+
+    let boardTasksCalls = 0;
+    const fromFn = vi.fn((table: string) => {
+      switch (table) {
+        case "board_tasks":
+          boardTasksCalls += 1;
+          return boardTasksCalls === 1 ? readChain : writeChain;
+        case "board_task_activity":
+          return activityChain;
+        case "ideas":
+          return ideaChain;
+        case "bot_profiles":
+          return botProfilesChain;
+        case "collaborators":
+          return createChain(null);
+        default:
+          return createChain(null);
+      }
+    });
+
+    const params = updateTaskSchema.parse({
+      task_id: TASK_ID,
+      idea_id: IDEA_ID,
+      assignee_id: USER_ID,
+    });
+
+    const result = await updateTask(makeContext(fromFn), params);
+
+    expect(result.success).toBe(true);
+    expect(result.task).toEqual({ id: TASK_ID, title: "Task" });
+  });
+
+  it("does not gate the write on assignee_id for an update that doesn't touch assignment", async () => {
+    const readChain = createChain({
+      title: "Old Title",
+      description: null,
+      assignee_id: null,
+      due_date: null,
+      archived: false,
+    });
+    const writeChain = createChain({ id: TASK_ID, title: "New Title" });
+    const activityChain = createChain(null);
+
+    let boardTasksCalls = 0;
+    const fromFn = vi.fn((table: string) => {
+      switch (table) {
+        case "board_tasks":
+          boardTasksCalls += 1;
+          return boardTasksCalls === 1 ? readChain : writeChain;
+        case "board_task_activity":
+          return activityChain;
+        default:
+          return createChain(null);
+      }
+    });
+
+    const params = updateTaskSchema.parse({
+      task_id: TASK_ID,
+      idea_id: IDEA_ID,
+      title: "New Title",
+    });
+
+    const result = await updateTask(makeContext(fromFn), params);
+
+    expect(result.success).toBe(true);
+    // No assignee_id precondition should be applied to an ordinary field edit.
+    expect(asMock(writeChain.is)).not.toHaveBeenCalled();
+    expect(
+      asMock(writeChain.eq).mock.calls.some((call: unknown[]) => call[0] === "assignee_id")
+    ).toBe(false);
+  });
+});
+
+describe("moveTask — column optimistic-concurrency guard", () => {
+  // Regression guard: moveTask previously had no pre-read of the task's
+  // current column at all, so a stale move couldn't even be detected.
+  it("blocks a stale move when the task's column no longer matches what was read", async () => {
+    const readChain = createChain({ column_id: COLUMN_A_ID });
+    const columnChain = createChain({ title: "In Progress", is_done_column: false });
+    // The guarded UPDATE (.eq on column_id) matches no row: a "concurrent"
+    // mover already relocated the task in between.
+    const writeChain = createChain(null);
+
+    let boardTasksCalls = 0;
+    const fromFn = vi.fn((table: string) => {
+      switch (table) {
+        case "board_tasks":
+          boardTasksCalls += 1;
+          return boardTasksCalls === 1 ? readChain : writeChain;
+        case "board_columns":
+          return columnChain;
+        default:
+          return createChain(null);
+      }
+    });
+
+    const params = moveTaskSchema.parse({
+      task_id: TASK_ID,
+      idea_id: IDEA_ID,
+      column_id: COLUMN_B_ID,
+      position: 500,
+    });
+
+    await expect(moveTask(makeContext(fromFn), params)).rejects.toThrow(
+      "This task was already moved by someone else — refresh and try again."
+    );
+
+    expect(
+      asMock(writeChain.eq).mock.calls.some(
+        (call: unknown[]) => call[0] === "column_id" && call[1] === COLUMN_A_ID
+      )
+    ).toBe(true);
+  });
+
+  it("succeeds for an ordinary single-caller move (no race)", async () => {
+    const readChain = createChain({ column_id: COLUMN_A_ID });
+    const columnChain = createChain({ title: "In Progress", is_done_column: false });
+    const writeChain = createChain({ id: TASK_ID });
+    const activityChain = createChain(null);
+
+    let boardTasksCalls = 0;
+    const fromFn = vi.fn((table: string) => {
+      switch (table) {
+        case "board_tasks":
+          boardTasksCalls += 1;
+          return boardTasksCalls === 1 ? readChain : writeChain;
+        case "board_columns":
+          return columnChain;
+        case "board_task_activity":
+          return activityChain;
+        default:
+          return createChain(null);
+      }
+    });
+
+    const params = moveTaskSchema.parse({
+      task_id: TASK_ID,
+      idea_id: IDEA_ID,
+      column_id: COLUMN_B_ID,
+      position: 500,
+    });
+
+    const result = await moveTask(makeContext(fromFn), params);
+
+    expect(result.success).toBe(true);
+    expect(result.column).toBe("In Progress");
+    expect(result.position).toBe(500);
+  });
+
+  it("throws 'Task not found' — not the generic DB error — when the task no longer exists", async () => {
+    const readChain = createChain(null);
+    const fromFn = vi.fn((table: string) => {
+      if (table === "board_tasks") return readChain;
+      return createChain(null);
+    });
+
+    const params = moveTaskSchema.parse({
+      task_id: TASK_ID,
+      idea_id: IDEA_ID,
+      column_id: COLUMN_B_ID,
+      position: 500,
+    });
+
+    await expect(moveTask(makeContext(fromFn), params)).rejects.toThrow(
+      `Task not found: ${TASK_ID}`
+    );
   });
 });

--- a/mcp-server/src/tools/board-write.ts
+++ b/mcp-server/src/tools/board-write.ts
@@ -172,7 +172,8 @@ export const updateTaskSchema = z.object({
 });
 
 export async function updateTask(ctx: McpContext, params: z.infer<typeof updateTaskSchema>) {
-  // Fetch current task for activity diffs
+  // Fetch current task for activity diffs (and, when assignee_id is part of
+  // this update, as the optimistic-concurrency precondition below).
   const { data: current } = await ctx.supabase
     .from("board_tasks")
     .select("title, description, assignee_id, due_date, archived")
@@ -192,15 +193,38 @@ export async function updateTask(ctx: McpContext, params: z.infer<typeof updateT
     return { success: true, message: "No changes to apply" };
   }
 
-  const { data: task, error } = await ctx.supabase
+  // Assignment is racy across concurrent callers: two self-assign calls can
+  // both read the same pre-update assignee_id and both proceed to write, so
+  // the last writer silently wins. Gate the write on the assignee_id we just
+  // read above, mirroring claim_next_step's read-then-conditionally-write
+  // pattern (see claimNextStep in workflows.ts) — the precondition travels
+  // in the SAME round trip as the write itself, so nothing can slip in
+  // between a separate read and write.
+  const guardingAssignee = params.assignee_id !== undefined;
+  let write = ctx.supabase
     .from("board_tasks")
     .update(updates)
     .eq("id", params.task_id)
-    .eq("idea_id", params.idea_id)
-    .select("id, title")
-    .single();
+    .eq("idea_id", params.idea_id);
+
+  if (guardingAssignee) {
+    write =
+      current.assignee_id === null
+        ? write.is("assignee_id", null)
+        : write.eq("assignee_id", current.assignee_id);
+  }
+
+  const { data: task, error } = await write.select("id, title").maybeSingle();
 
   if (error) throw new Error(`Failed to update task: ${error.message}`);
+  if (!task) {
+    if (guardingAssignee) {
+      throw new Error(
+        "This task was already assigned by someone else — refresh and try again."
+      );
+    }
+    throw new Error(`Task not found: ${params.task_id}`);
+  }
 
   // Log activity for each change
   if (params.title !== undefined && params.title !== current.title) {
@@ -235,21 +259,29 @@ export async function updateTask(ctx: McpContext, params: z.infer<typeof updateT
           .eq("task_id", params.task_id)
           .not("status", "in", '("completed","failed")');
         if ((count ?? 0) === 0) {
+          // Guard against a concurrent reassignment/unassignment racing in
+          // between the guarded assignment write above and this secondary
+          // write — only touch working_started_at if the assignee we just
+          // set is still in place.
           await ctx.supabase
             .from("board_tasks")
             .update({ working_started_at: new Date().toISOString() })
-            .eq("id", params.task_id);
+            .eq("id", params.task_id)
+            .eq("assignee_id", params.assignee_id);
         }
       }
     } else {
       await logActivity(ctx, params.task_id, params.idea_id, "unassigned", {
         assignee_id: current.assignee_id!,
       });
-      // Clear working_started_at when unassigned
+      // Clear working_started_at when unassigned — guarded the same way, so
+      // a concurrent reassignment that raced in doesn't get its
+      // working_started_at wiped out from under it.
       await ctx.supabase
         .from("board_tasks")
         .update({ working_started_at: null })
-        .eq("id", params.task_id);
+        .eq("id", params.task_id)
+        .is("assignee_id", null);
     }
   }
   if (params.due_date !== undefined && params.due_date !== current.due_date) {
@@ -287,6 +319,19 @@ export async function moveTask(ctx: McpContext, params: z.infer<typeof moveTaskS
   const position =
     params.position ?? (await getNextPosition(ctx, params.column_id, params.idea_id));
 
+  // Read the task's CURRENT column (not just the target one, which is fetched
+  // below purely for the activity log / done-column check) so the write can
+  // be gated on it — mirrors claim_next_step's read-then-conditionally-write
+  // pattern, protecting against two concurrent moves of the same task.
+  const { data: currentTask } = await ctx.supabase
+    .from("board_tasks")
+    .select("column_id")
+    .eq("id", params.task_id)
+    .eq("idea_id", params.idea_id)
+    .single();
+
+  if (!currentTask) throw new Error(`Task not found: ${params.task_id}`);
+
   // Get column details for activity log + done column check
   const { data: column } = await ctx.supabase
     .from("board_columns")
@@ -300,13 +345,21 @@ export async function moveTask(ctx: McpContext, params: z.infer<typeof moveTaskS
     taskUpdate.working_started_at = null;
   }
 
-  const { error } = await ctx.supabase
+  const { data: moved, error } = await ctx.supabase
     .from("board_tasks")
     .update(taskUpdate)
     .eq("id", params.task_id)
-    .eq("idea_id", params.idea_id);
+    .eq("idea_id", params.idea_id)
+    .eq("column_id", currentTask.column_id)
+    .select("id")
+    .maybeSingle();
 
   if (error) throw new Error(`Failed to move task: ${error.message}`);
+  if (!moved) {
+    throw new Error(
+      "This task was already moved by someone else — refresh and try again."
+    );
+  }
 
   await logActivity(ctx, params.task_id, params.idea_id, "moved", {
     to_column: column?.title ?? params.column_id,


### PR DESCRIPTION
## Summary
- Two brand-new terminal sessions launched moments apart on the same board could both resolve to the same unworkflowed task, both self-assign and move it to In Progress — last writer silently won, both sessions believed they owned the task.
- `updateTask`'s self-assign path and `moveTask` now use the same optimistic-concurrency guard pattern already standard elsewhere in this codebase (mirrors `claim_next_step`'s read-then-conditionally-write): a losing concurrent call gets a clear "already assigned/moved by someone else — refresh and try again" error instead of a silent overwrite.
- Both MCP transports (local stdio and remote HTTP) share this fix since they use the same `board-write.ts` implementation.

Board task: ad537cf0-cc46-462f-bb03-c158c1607cf2

## Test plan
- [x] 6 new regression tests (updateTask/moveTask previously had zero coverage)
- [x] 522 mcp-server tests pass
- [x] 2810 full repo tests pass
- [x] `npx tsc --noEmit` clean
- [x] eslint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)