### PR TITLE
feat(terminal): persistent badge when another session is live on this board

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -156,6 +156,7 @@ vi.mock("./terminal-task-launch-choice", () => ({
 
 import { TerminalDock } from "./terminal-dock";
 import { requestBrowserLaunch } from "@/lib/terminal/launch-mode";
+import { rememberLastTabSid } from "@/lib/terminal/session-snapshot";
 import { toast } from "sonner";
 
 function deferredRegistryResponse() {
@@ -635,5 +636,115 @@ describe("TerminalDock — task-launch-skip-chooser (Nick's explicit product dec
     await waitFor(() => expect(screen.getByTestId("task-choice")).toBeInTheDocument());
     expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
     expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+  });
+});
+
+// Card eaa55290 (Nick's field report, 2026-08-17): "no way to tell another
+// session is already active on this board" — Nick ran two terminal tabs on
+// the same board at once with no indication either existed, only noticing
+// via one tab's own internal narration text. The persistent badge below is
+// driven by `liveSessionsElsewhereOnThisBoard` (chooser-data.ts, unit-tested
+// there); this suite covers it wired into the actual dock bar, which is
+// ALWAYS rendered (collapsed and expanded both show the same top bar — only
+// the body below it toggles).
+describe("TerminalDock — another-session-here badge (card eaa55290)", () => {
+  /** A registry fetch stub whose `/api/terminal/session/list` response
+   * changes across calls (`sequence[n]`, clamped to the last entry) and
+   * whose `/api/terminal/session/reattach` always fails — the same
+   * `void refreshRegistry()`-on-failure fallback the "Bug A" retry tests
+   * above exercise, reused here as the trigger for a live registry update. */
+  function stubRegistrySequenceWithFailingReattach(sequence: ChooserRegistryRow[][]) {
+    let call = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url === "/api/terminal/session/list") {
+          const rows = sequence[Math.min(call, sequence.length - 1)];
+          call += 1;
+          return Promise.resolve({ ok: true, json: async () => ({ sessions: rows }) });
+        }
+        if (url === "/api/terminal/session/reattach") {
+          return Promise.resolve({ ok: false, json: async () => ({ error: "Session ended" }) });
+        }
+        return Promise.resolve({ ok: false, json: async () => ({}) });
+      }),
+    );
+  }
+
+  it("stays hidden when no session is live on this board", async () => {
+    stubFetch(Promise.resolve([]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(screen.queryByText(/tabs? .* open here/)).not.toBeInTheDocument();
+  });
+
+  it("stays hidden when the only live session here is this tab's own", async () => {
+    rememberLastTabSid("own-sid");
+    stubFetch(Promise.resolve([{ ...liveHereRow(), sid: "own-sid" }]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    expect(screen.queryByText(/tabs? .* open here/)).not.toBeInTheDocument();
+  });
+
+  it("shows singular copy for exactly one other live session on this board", async () => {
+    rememberLastTabSid("own-sid");
+    stubFetch(
+      Promise.resolve([
+        { ...liveHereRow(), sid: "own-sid" },
+        { ...liveHereRow(), sid: "other-sid" },
+      ]),
+    );
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByText("Another tab is open here")).toBeInTheDocument());
+    // Never worded as a stranger's session — Phase 1 is same-user-only (the
+    // investigation step confirmed terminal_sessions RLS is owner-only).
+    expect(screen.queryByText(/someone else/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a count for 2+ other live sessions on this board", async () => {
+    rememberLastTabSid("own-sid");
+    stubFetch(
+      Promise.resolve([
+        { ...liveHereRow(), sid: "own-sid" },
+        { ...liveHereRow(), sid: "other-sid-1" },
+        { ...liveHereRow(), sid: "other-sid-2" },
+      ]),
+    );
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByText("2 other tabs are open here")).toBeInTheDocument());
+  });
+
+  it("never counts a live session on a DIFFERENT board", async () => {
+    rememberLastTabSid("own-sid");
+    stubFetch(Promise.resolve([{ ...liveHereRow(), sid: "own-sid" }, liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    expect(screen.queryByText(/tabs? .* open here/)).not.toBeInTheDocument();
+  });
+
+  it("updates reactively — appears once a registry refresh reveals a 2nd live session here", async () => {
+    rememberLastTabSid("own-sid");
+    const ownRow = { ...liveHereRow(), sid: "own-sid" };
+    const otherRow = { ...liveHereRow(), sid: "other-sid" };
+    stubRegistrySequenceWithFailingReattach([[ownRow], [ownRow, otherRow]]);
+
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    expect(screen.queryByText(/tabs? .* open here/)).not.toBeInTheDocument();
+
+    // Force a registry refresh via the same fallback `performReattach`'s
+    // failure path already triggers (see the Bug A retry tests above) —
+    // clicking "Reconnect here" on the sole (own) live-here row, whose
+    // reattach is stubbed to fail, so the dock's own `refreshRegistry()`
+    // runs and picks up the 2nd row.
+    fireEvent.click(screen.getByTestId("chooser-reconnect-here-own-sid"));
+
+    await waitFor(() => expect(screen.getByText("Another tab is open here")).toBeInTheDocument());
   });
 });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -80,6 +80,7 @@ import {
   deriveChooserSections,
   chooserHeaderCounts,
   findTaskSessionMatch,
+  liveSessionsElsewhereOnThisBoard,
   type ChooserSections,
   type ChooserRegistryRow,
   type ChooserLiveRow,
@@ -421,6 +422,22 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     [registryRows, ideaId, entrySnapshotInfo],
   );
   const chooserCounts = useMemo(() => chooserHeaderCounts(chooserSections), [chooserSections]);
+  // Card eaa55290 (Nick's field report, 2026-08-17): "no way to tell another
+  // session is already active on this board" — two browser tabs on the same
+  // idea, discovered only by reading one tab's own narration text. Every
+  // sessionId this DOCK currently has mounted (covers a 2nd own tab within
+  // this same dock, and the gap before session-snapshot's `wasOpenInThisTab`
+  // catches up right after a fresh mint) — see liveSessionsElsewhereOnThisBoard's
+  // doc for why this is combined with that per-tab sessionStorage signal
+  // rather than used alone.
+  const ownSessionIds = useMemo(
+    () => new Set(sessions.map((s) => summaries[s.key]?.sessionId).filter((id): id is string => !!id)),
+    [sessions, summaries],
+  );
+  const otherLiveHere = useMemo(
+    () => liveSessionsElsewhereOnThisBoard(chooserSections, ownSessionIds),
+    [chooserSections, ownSessionIds],
+  );
   // Task-launch-skip-chooser: `deliverLaunch` needs a synchronous,
   // always-current read of `chooserSections` (to check whether THIS exact
   // task already has a match) without becoming a dependency that would force
@@ -1192,6 +1209,25 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           )}
         </span>
         <span className="ml-auto inline-flex items-center gap-1.5">
+          {/* Card eaa55290: persistent, glanceable warning — visible in BOTH
+              collapsed and expanded states (this whole bar is, unlike the
+              body below it) — the moment more than one of this user's own
+              sessions is live on THIS board. Phase 1 only (see the
+              investigation step): `terminal_sessions` RLS is owner-only, so
+              every `liveHere` row is guaranteed to be this same person's,
+              never a collaborator's — the copy says "tab", never "someone
+              else". */}
+          {otherLiveHere.length > 0 && (
+            <span
+              className="inline-flex items-center gap-1.5 rounded-md border border-amber-500/50 bg-amber-500/10 px-2 py-0.5 text-[11px] font-semibold text-amber-300"
+              title={`Also open here: ${otherLiveHere.map((r) => r.taskTitle ?? r.cwd ?? "another folder").join(", ")}`}
+            >
+              <span aria-hidden="true">⚠</span>
+              {otherLiveHere.length === 1
+                ? "Another tab is open here"
+                : `${otherLiveHere.length} other tabs are open here`}
+            </span>
+          )}
           {/* Mockup A1: header count pills, only while the chooser is the
               resting state — real text, never badge-only (a11y, design §2). */}
           {showingChooser && registryRows === null && (

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -6,6 +6,7 @@ import {
   chooserHeaderCounts,
   findLiveSessionForTask,
   findTaskSessionMatch,
+  liveSessionsElsewhereOnThisBoard,
   type ChooserRegistryRow,
 } from "./chooser-data";
 
@@ -528,5 +529,66 @@ describe("findTaskSessionMatch", () => {
     ];
     const sections = deriveChooserSections(rows, IDEA_A, NOW);
     expect(findTaskSessionMatch(sections, "task-1")).toBeNull();
+  });
+});
+
+// Card eaa55290 (Nick's field report, 2026-08-17): "no way to tell another
+// session is already active on this board" — two browser tabs on the same
+// idea, discovered only by reading one tab's own narration text.
+describe("liveSessionsElsewhereOnThisBoard", () => {
+  it("returns nothing when no session is live here", () => {
+    const sections = deriveChooserSections([], IDEA_A, NOW);
+    expect(liveSessionsElsewhereOnThisBoard(sections)).toEqual([]);
+  });
+
+  it("returns nothing when the only live-here session is this tab's own (wasOpenInThisTab)", () => {
+    const rows = [row({ sid: "own-sid", ideaId: IDEA_A, status: "active" })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW, "own-sid");
+    expect(sections.liveHere[0].wasOpenInThisTab).toBe(true);
+    expect(liveSessionsElsewhereOnThisBoard(sections)).toEqual([]);
+  });
+
+  it("surfaces a single other live-here session once excluding this tab's own", () => {
+    const rows = [
+      row({ sid: "own-sid", ideaId: IDEA_A, status: "active" }),
+      row({ sid: "other-sid", ideaId: IDEA_A, status: "active" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW, "own-sid");
+    const others = liveSessionsElsewhereOnThisBoard(sections);
+    expect(others.map((r) => r.sid)).toEqual(["other-sid"]);
+  });
+
+  it("surfaces every other live-here session (2+) once excluding this tab's own", () => {
+    const rows = [
+      row({ sid: "own-sid", ideaId: IDEA_A, status: "active" }),
+      row({ sid: "other-1", ideaId: IDEA_A, status: "active" }),
+      row({ sid: "other-2", ideaId: IDEA_A, status: "active" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW, "own-sid");
+    const others = liveSessionsElsewhereOnThisBoard(sections);
+    expect(others.map((r) => r.sid).sort()).toEqual(["other-1", "other-2"]);
+  });
+
+  it("never counts a live session on ANOTHER board — only liveHere is considered", () => {
+    const rows = [
+      row({ sid: "own-sid", ideaId: IDEA_A, status: "active" }),
+      row({ sid: "other-board", ideaId: IDEA_B, status: "active" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW, "own-sid");
+    expect(liveSessionsElsewhereOnThisBoard(sections)).toEqual([]);
+  });
+
+  it("also excludes a row by ownSessionIds — covers a 2nd own tab within the SAME dock, where wasOpenInThisTab can only mark one row", () => {
+    const rows = [
+      row({ sid: "own-sid-1", ideaId: IDEA_A, status: "active" }),
+      row({ sid: "own-sid-2", ideaId: IDEA_A, status: "active" }),
+      row({ sid: "other-sid", ideaId: IDEA_A, status: "active" }),
+    ];
+    // Only one sid can ever be `wasOpenInThisTab` (sessionStorage holds a
+    // single last-sid) — the dock passes its OWN tracked sessionIds to cover
+    // the rest.
+    const sections = deriveChooserSections(rows, IDEA_A, NOW, "own-sid-1");
+    const others = liveSessionsElsewhereOnThisBoard(sections, new Set(["own-sid-1", "own-sid-2"]));
+    expect(others.map((r) => r.sid)).toEqual(["other-sid"]);
   });
 });

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -297,3 +297,33 @@ export function findTaskSessionMatch(
   if (recent) return { kind: "recent", row: recent };
   return null;
 }
+
+/**
+ * Card eaa55290 (Nick's field report, 2026-08-17 — two terminal tabs open on
+ * the same board with no indication either existed): `liveHere` is every
+ * ACTIVE session this user has on the CURRENT idea, which — because
+ * `terminal_sessions` RLS is strictly owner-only (see the investigation step
+ * on this card) — always means "this same person's tabs/windows", never a
+ * collaborator. This is the "is another one of MY tabs already open here"
+ * signal, i.e. `liveHere` minus whichever row(s) belong to the caller.
+ *
+ * A row counts as "ours" when either:
+ *   - `wasOpenInThisTab` is set (this browser TAB's own `sessionStorage`-backed
+ *     memory of the last session it attached — see session-snapshot.ts's
+ *     `rememberLastTabSid`, genuinely per-tab, unlike `localStorage`), or
+ *   - its `sid` is in `ownSessionIds` (the sessionIds this `TerminalDock`
+ *     instance currently has mounted, via its own `summaries` state) — this
+ *     second check covers a 2nd own tab inside the SAME dock (multi-session,
+ *     where only the most-recently-connected sid wins the single
+ *     `wasOpenInThisTab` slot) and the brief window right after a fresh mint,
+ *     before that sessionStorage write has landed.
+ *
+ * Returns the remaining rows — an empty array means nothing to warn about
+ * (0 or 1 live session here, and that one is ours).
+ */
+export function liveSessionsElsewhereOnThisBoard(
+  sections: ChooserSections,
+  ownSessionIds: ReadonlySet<string> = new Set(),
+): ChooserLiveRow[] {
+  return sections.liveHere.filter((r) => !r.wasOpenInThisTab && !ownSessionIds.has(r.sid));
+}


### PR DESCRIPTION
## Summary
- No indicator anywhere told you a second terminal session (e.g. a second browser tab) was already active on the same board — Nick only found out by reading a session's own internal log text.
- Adds a persistent amber pill in the terminal dock's always-visible top bar ("Another tab is open here" / "N other tabs are open here"), driven entirely by data the dock already fetches (`chooserSections.liveHere`), no backend changes.
- Phase 1 scope: same-user only (a second tab of yours). Cross-collaborator visibility needs new RLS (`terminal_sessions` is currently owner-only) and is tracked separately as card 801c62ec, deliberately not bundled here.

Board task: eaa55290-a0cd-43a7-808d-6c3f32255be3

## Test plan
- [x] 6 new unit tests (pure filtering helper)
- [x] 6 new component tests, including a reactive test proving the badge updates as sessions come/go
- [x] 2815/2815 full suite passing
- [x] `npx tsc --noEmit` clean
- [x] eslint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)