### PR TITLE
feat(terminal): drag-to-resize the dock height, remembered across reloads

### DIFF
--- a/src/components/board/terminal-dock-resize.test.tsx
+++ b/src/components/board/terminal-dock-resize.test.tsx
@@ -1,0 +1,150 @@
+// Drag-to-resize handle + hook (card b885ebfd) — exercised through a tiny host
+// component so the real pointer/keyboard wiring, the CSS variable on the root
+// and the localStorage persistence are all covered end-to-end in jsdom.
+
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import { useDockHeight, TerminalDockResizeHandle, DOCK_HEIGHT_CSS_VAR } from "./terminal-dock-resize";
+import {
+  DOCK_HEIGHT_KEY,
+  DOCK_HEIGHT_KEY_STEP_PX,
+  MIN_DOCK_HEIGHT_PX,
+  defaultDockHeight,
+  maxDockHeight,
+} from "@/lib/terminal/dock-height";
+
+const VH = 1000;
+
+function Host() {
+  const controller = useDockHeight();
+  return (
+    <div data-testid="root" style={controller.rootStyle}>
+      <TerminalDockResizeHandle controller={controller} />
+      <span data-testid="height">{controller.height ?? "null"}</span>
+      <span data-testid="dragging">{String(controller.dragging)}</span>
+    </div>
+  );
+}
+
+const rootVar = () =>
+  (screen.getByTestId("root") as HTMLElement).style.getPropertyValue(DOCK_HEIGHT_CSS_VAR);
+const handle = () => screen.getByTestId("terminal-dock-resize-handle");
+const heightText = () => screen.getByTestId("height").textContent;
+
+beforeEach(() => {
+  window.localStorage.clear();
+  Object.defineProperty(window, "innerHeight", { value: VH, configurable: true, writable: true });
+  // jsdom has no pointer-capture implementation — stub the three methods the handle uses.
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.hasPointerCapture ??= () => false;
+});
+afterEach(() => {
+  cleanup();
+});
+
+describe("useDockHeight — hydration + CSS variable", () => {
+  it("uses the default (38vh) after mount when nothing is stored, and exposes it as the CSS variable", () => {
+    render(<Host />);
+    expect(heightText()).toBe(String(defaultDockHeight(VH)));
+    expect(rootVar()).toBe(`${defaultDockHeight(VH)}px`);
+  });
+  it("hydrates a stored preference on mount", () => {
+    window.localStorage.setItem(DOCK_HEIGHT_KEY, "520");
+    render(<Host />);
+    expect(heightText()).toBe("520");
+    expect(rootVar()).toBe("520px");
+  });
+  it("clamps a stored preference to the live viewport, and restores it when the window grows back", () => {
+    window.localStorage.setItem(DOCK_HEIGHT_KEY, "700");
+    Object.defineProperty(window, "innerHeight", { value: 600, configurable: true, writable: true });
+    render(<Host />);
+    expect(heightText()).toBe(String(maxDockHeight(600)));
+    act(() => {
+      Object.defineProperty(window, "innerHeight", { value: VH, configurable: true, writable: true });
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(heightText()).toBe("700");
+    // The stored preference itself was never overwritten by the clamp.
+    expect(window.localStorage.getItem(DOCK_HEIGHT_KEY)).toBe("700");
+  });
+});
+
+describe("TerminalDockResizeHandle — pointer drag", () => {
+  it("dragging up makes the panel taller with live feedback, and persists once on release", () => {
+    render(<Host />);
+    const start = defaultDockHeight(VH);
+    fireEvent.pointerDown(handle(), { clientY: 500, button: 0, pointerId: 1, pointerType: "mouse" });
+    expect(screen.getByTestId("dragging").textContent).toBe("true");
+    fireEvent.pointerMove(handle(), { clientY: 450, pointerId: 1 });
+    expect(heightText()).toBe(String(start + 50));
+    // Not persisted mid-drag.
+    expect(window.localStorage.getItem(DOCK_HEIGHT_KEY)).toBeNull();
+    fireEvent.pointerMove(handle(), { clientY: 400, pointerId: 1 });
+    expect(heightText()).toBe(String(start + 100));
+    fireEvent.pointerUp(handle(), { clientY: 400, pointerId: 1 });
+    expect(screen.getByTestId("dragging").textContent).toBe("false");
+    expect(window.localStorage.getItem(DOCK_HEIGHT_KEY)).toBe(String(start + 100));
+    expect(rootVar()).toBe(`${start + 100}px`);
+  });
+  it("dragging down makes it shorter and never below the minimum", () => {
+    render(<Host />);
+    fireEvent.pointerDown(handle(), { clientY: 500, button: 0, pointerId: 1, pointerType: "mouse" });
+    fireEvent.pointerMove(handle(), { clientY: 5000, pointerId: 1 });
+    expect(heightText()).toBe(String(MIN_DOCK_HEIGHT_PX));
+    fireEvent.pointerUp(handle(), { clientY: 5000, pointerId: 1 });
+    expect(window.localStorage.getItem(DOCK_HEIGHT_KEY)).toBe(String(MIN_DOCK_HEIGHT_PX));
+  });
+  it("never grows past the viewport cap (the board above always stays visible)", () => {
+    render(<Host />);
+    fireEvent.pointerDown(handle(), { clientY: 500, button: 0, pointerId: 1, pointerType: "mouse" });
+    fireEvent.pointerMove(handle(), { clientY: -5000, pointerId: 1 });
+    expect(heightText()).toBe(String(maxDockHeight(VH)));
+  });
+  it("ignores a right-click drag", () => {
+    render(<Host />);
+    fireEvent.pointerDown(handle(), { clientY: 500, button: 2, pointerId: 1, pointerType: "mouse" });
+    fireEvent.pointerMove(handle(), { clientY: 400, pointerId: 1 });
+    expect(heightText()).toBe(String(defaultDockHeight(VH)));
+  });
+  it("a pointer move with no drag in flight does nothing", () => {
+    render(<Host />);
+    fireEvent.pointerMove(handle(), { clientY: 100, pointerId: 1 });
+    expect(heightText()).toBe(String(defaultDockHeight(VH)));
+  });
+});
+
+describe("TerminalDockResizeHandle — keyboard + reset + a11y", () => {
+  it("ArrowUp/ArrowDown nudge by the step (Shift ×4), Home/End jump to the bounds, all persisted", () => {
+    render(<Host />);
+    const start = defaultDockHeight(VH);
+    fireEvent.keyDown(handle(), { key: "ArrowUp" });
+    expect(heightText()).toBe(String(start + DOCK_HEIGHT_KEY_STEP_PX));
+    expect(window.localStorage.getItem(DOCK_HEIGHT_KEY)).toBe(String(start + DOCK_HEIGHT_KEY_STEP_PX));
+    fireEvent.keyDown(handle(), { key: "ArrowDown", shiftKey: true });
+    expect(heightText()).toBe(String(start + DOCK_HEIGHT_KEY_STEP_PX - 4 * DOCK_HEIGHT_KEY_STEP_PX));
+    fireEvent.keyDown(handle(), { key: "End" });
+    expect(heightText()).toBe(String(maxDockHeight(VH)));
+    fireEvent.keyDown(handle(), { key: "Home" });
+    expect(heightText()).toBe(String(MIN_DOCK_HEIGHT_PX));
+    expect(window.localStorage.getItem(DOCK_HEIGHT_KEY)).toBe(String(MIN_DOCK_HEIGHT_PX));
+  });
+  it("double-click resets to the default and forgets the stored preference", () => {
+    window.localStorage.setItem(DOCK_HEIGHT_KEY, "520");
+    render(<Host />);
+    expect(heightText()).toBe("520");
+    fireEvent.doubleClick(handle());
+    expect(heightText()).toBe(String(defaultDockHeight(VH)));
+    expect(window.localStorage.getItem(DOCK_HEIGHT_KEY)).toBeNull();
+  });
+  it("is an ARIA separator with live value bounds", () => {
+    render(<Host />);
+    const h = handle();
+    expect(h.getAttribute("role")).toBe("separator");
+    expect(h.getAttribute("aria-orientation")).toBe("horizontal");
+    expect(h.getAttribute("aria-valuemin")).toBe(String(MIN_DOCK_HEIGHT_PX));
+    expect(h.getAttribute("aria-valuemax")).toBe(String(maxDockHeight(VH)));
+    expect(h.getAttribute("aria-valuenow")).toBe(String(defaultDockHeight(VH)));
+    expect(h.getAttribute("tabindex")).toBe("0");
+  });
+});

--- a/src/components/board/terminal-dock-resize.tsx
+++ b/src/components/board/terminal-dock-resize.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+// In-app terminal — user-resizable dock height (Nick's request 2026-08-17,
+// card b885ebfd: "let Nick resize the panel height by dragging").
+//
+// Two pieces, both consumed by terminal-dock.tsx:
+//
+//   `useDockHeight()` — owns the PREFERRED height (what the user picked, kept
+//   in localStorage via lib/terminal/dock-height.ts), tracks the live viewport
+//   height, and derives the EFFECTIVE height (preference clamped to the
+//   viewport). Returns drag/keyboard/reset callbacks the handle wires up.
+//
+//   `<TerminalDockResizeHandle>` — the grab strip along the dock's TOP edge.
+//   Pointer events (mouse + touch, via pointer capture so a fast drag that
+//   leaves the strip keeps tracking), keyboard (ArrowUp/Down, Shift ×4,
+//   Home/End) and double-click-to-reset. Exposed as an ARIA `separator` with
+//   `aria-valuenow` so screen readers can announce and adjust it.
+//
+// HOW THE HEIGHT REACHES THE TERMINAL: the dock sets a CSS custom property
+// `--vc-term-dock-h` on its root and the per-session body in
+// terminal-session-view.tsx sizes itself with `h-[var(--vc-term-dock-h,38vh)]`
+// — the pre-this-card `38vh` is the SSR/first-paint fallback (the preference
+// is only known after mount, same install-first pattern as dock-open
+// persistence). No prop threading through the (many) `TerminalSessionView`
+// props, and the existing ResizeObserver in use-terminal-session.ts already
+// refits xterm + sends the PTY a resize on any container size change — the
+// drag needs no extra plumbing to give live feedback.
+//
+// COMPOSITION WITH COLLAPSE: resizing and collapsing are independent. The
+// handle is only rendered while the dock is expanded (nothing to size when
+// collapsed — the body is `hidden`), the CSS variable stays set regardless,
+// so the remembered height applies the instant the dock re-expands.
+
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type KeyboardEvent, type PointerEvent } from "react";
+import { cn } from "@/lib/utils";
+import {
+  DOCK_HEIGHT_KEY_STEP_PX,
+  MIN_DOCK_HEIGHT_PX,
+  clearDockHeight,
+  dragDockHeight,
+  maxDockHeight,
+  readDockHeight,
+  resolveDockHeight,
+  stepDockHeight,
+  writeDockHeight,
+} from "@/lib/terminal/dock-height";
+
+/** The CSS custom property the dock root sets and the session body reads. */
+export const DOCK_HEIGHT_CSS_VAR = "--vc-term-dock-h";
+
+export type DockHeightController = {
+  /** Effective body height in px, or `null` before mount (SSR / first paint → CSS fallback applies). */
+  height: number | null;
+  /** Inline style for the dock root — sets the CSS variable once the height is known. */
+  rootStyle: CSSProperties | undefined;
+  /** True while a pointer drag is in flight (for cursor/selection suppression + handle styling). */
+  dragging: boolean;
+  /** Current clamp bounds for ARIA. */
+  minHeight: number;
+  maxHeight: number;
+  /** Begin a pointer drag from `clientY`. */
+  beginDrag: (clientY: number) => void;
+  /** Continue a pointer drag at `clientY` — no-op unless `beginDrag` ran. */
+  moveDrag: (clientY: number) => void;
+  /** Finish the drag and persist the result. */
+  endDrag: () => void;
+  /** Keyboard nudge (px, positive = taller); persists. */
+  nudge: (deltaPx: number) => void;
+  /** Jump to the min or max; persists. */
+  jumpTo: (edge: "min" | "max") => void;
+  /** Forget the preference and go back to the default height. */
+  reset: () => void;
+};
+
+/** Read the live viewport height, SSR-safe (0 → callers treat as "unknown"). */
+function readViewportHeight(): number {
+  return typeof window === "undefined" ? 0 : window.innerHeight;
+}
+
+export function useDockHeight(): DockHeightController {
+  // `preferred` is the user's choice (null = never chosen / use default).
+  // `viewportHeight` is 0 until mount so the first paint keeps the CSS
+  // fallback — matches the collapsed-initial-paint pattern used everywhere
+  // else in the dock (SSR-safe, no hydration mismatch).
+  const [preferred, setPreferred] = useState<number | null>(null);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const [dragging, setDragging] = useState(false);
+  const dragStartRef = useRef<{ y: number; height: number } | null>(null);
+  // Mirror of the latest effective height for the drag/keyboard callbacks,
+  // so they never close over a stale value mid-gesture.
+  const heightRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    // Mount-only hydration from two external systems (localStorage + the
+    // window size) — the same install-first correction pattern the dock's
+    // own `readDockOpen()` effect uses. SSR paints the CSS fallback; this
+    // flips to the real preference right after mount.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- hydrate the stored preference + viewport on mount
+    setPreferred(readDockHeight());
+    setViewportHeight(readViewportHeight());
+    const onResize = () => setViewportHeight(readViewportHeight());
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  const height = viewportHeight > 0 ? resolveDockHeight(preferred, viewportHeight) : null;
+  useEffect(() => {
+    heightRef.current = height;
+  }, [height]);
+
+  const commit = useCallback((next: number) => {
+    setPreferred(next);
+    writeDockHeight(next);
+  }, []);
+
+  const beginDrag = useCallback((clientY: number) => {
+    const current = heightRef.current;
+    if (current === null) return;
+    dragStartRef.current = { y: clientY, height: current };
+    setDragging(true);
+  }, []);
+
+  const moveDrag = useCallback(
+    (clientY: number) => {
+      const start = dragStartRef.current;
+      if (!start) return;
+      const vh = readViewportHeight();
+      if (vh <= 0) return;
+      // Live feedback: update the preference as the pointer moves (cheap —
+      // one state write per move; xterm refits via its ResizeObserver and the
+      // PTY resize is deduped on cols×rows so the wire only sees real changes).
+      // Persisted once on `endDrag`, not per move.
+      setPreferred(dragDockHeight(start.height, start.y, clientY, vh));
+    },
+    [],
+  );
+
+  const endDrag = useCallback(() => {
+    if (!dragStartRef.current) return;
+    dragStartRef.current = null;
+    setDragging(false);
+    const finalHeight = heightRef.current;
+    if (finalHeight !== null) writeDockHeight(finalHeight);
+  }, []);
+
+  const nudge = useCallback(
+    (deltaPx: number) => {
+      const current = heightRef.current;
+      const vh = readViewportHeight();
+      if (current === null || vh <= 0) return;
+      commit(stepDockHeight(current, deltaPx, vh));
+    },
+    [commit],
+  );
+
+  const jumpTo = useCallback(
+    (edge: "min" | "max") => {
+      const vh = readViewportHeight();
+      if (vh <= 0) return;
+      commit(edge === "min" ? MIN_DOCK_HEIGHT_PX : maxDockHeight(vh));
+    },
+    [commit],
+  );
+
+  const reset = useCallback(() => {
+    setPreferred(null);
+    clearDockHeight();
+  }, []);
+
+  // Suppress text selection + force the resize cursor page-wide for the
+  // duration of a drag (the pointer inevitably crosses the board and the
+  // xterm canvas). Restored on the same effect's cleanup — including on
+  // unmount mid-drag.
+  useEffect(() => {
+    if (!dragging) return;
+    const body = document.body;
+    const prevCursor = body.style.cursor;
+    const prevSelect = body.style.userSelect;
+    body.style.cursor = "row-resize";
+    body.style.userSelect = "none";
+    return () => {
+      body.style.cursor = prevCursor;
+      body.style.userSelect = prevSelect;
+    };
+  }, [dragging]);
+
+  const rootStyle = height === null ? undefined : ({ [DOCK_HEIGHT_CSS_VAR]: `${height}px` } as CSSProperties);
+  const maxHeight = viewportHeight > 0 ? maxDockHeight(viewportHeight) : MIN_DOCK_HEIGHT_PX;
+
+  return {
+    height,
+    rootStyle,
+    dragging,
+    minHeight: MIN_DOCK_HEIGHT_PX,
+    maxHeight,
+    beginDrag,
+    moveDrag,
+    endDrag,
+    nudge,
+    jumpTo,
+    reset,
+  };
+}
+
+type TerminalDockResizeHandleProps = {
+  controller: DockHeightController;
+  className?: string;
+};
+
+/**
+ * The grab strip on the dock's top edge. Absolutely positioned so it straddles
+ * the dock's top border (4px above, 4px below) — a comfortable 8px hit target
+ * that doesn't push the collapsed bar down. `touch-none` stops a touch drag
+ * from scrolling the page underneath.
+ */
+export function TerminalDockResizeHandle({ controller, className }: TerminalDockResizeHandleProps) {
+  const { height, dragging, minHeight, maxHeight, beginDrag, moveDrag, endDrag, nudge, jumpTo, reset } = controller;
+
+  const onPointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    // Primary button / any touch or pen contact only.
+    if (e.pointerType === "mouse" && e.button !== 0) return;
+    e.preventDefault();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    beginDrag(e.clientY);
+  };
+  const onPointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    // `moveDrag` is a no-op unless a drag began — no need to gate on the
+    // (possibly one-render-stale) `dragging` state here.
+    moveDrag(e.clientY);
+  };
+  const onPointerUp = (e: PointerEvent<HTMLDivElement>) => {
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) e.currentTarget.releasePointerCapture(e.pointerId);
+    endDrag();
+  };
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const step = DOCK_HEIGHT_KEY_STEP_PX * (e.shiftKey ? 4 : 1);
+    switch (e.key) {
+      case "ArrowUp":
+        e.preventDefault();
+        nudge(step);
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        nudge(-step);
+        break;
+      case "Home":
+        e.preventDefault();
+        jumpTo("min");
+        break;
+      case "End":
+        e.preventDefault();
+        jumpTo("max");
+        break;
+      default:
+    }
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="horizontal"
+      aria-label="Resize terminal panel"
+      aria-valuemin={minHeight}
+      aria-valuemax={maxHeight}
+      aria-valuenow={height ?? undefined}
+      aria-valuetext={height === null ? undefined : `${height} pixels tall`}
+      tabIndex={0}
+      title="Drag to resize · double-click to reset"
+      data-testid="terminal-dock-resize-handle"
+      data-dragging={dragging || undefined}
+      className={cn(
+        "group absolute inset-x-0 -top-1 z-10 h-2 cursor-row-resize touch-none select-none outline-none",
+        className,
+      )}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      onLostPointerCapture={onPointerUp}
+      onDoubleClick={reset}
+      onKeyDown={onKeyDown}
+    >
+      {/* Full-width highlight line — visible on hover / drag / keyboard focus. */}
+      <div
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-x-0 top-1 h-px bg-sky-400 opacity-0 transition-opacity group-hover:opacity-70 group-focus-visible:opacity-100",
+          dragging && "opacity-100",
+        )}
+      />
+      {/* Centred grip pill — the always-visible affordance. */}
+      <div
+        aria-hidden="true"
+        className={cn(
+          "absolute left-1/2 top-[3px] h-[3px] w-10 -translate-x-1/2 rounded-full bg-zinc-600 transition-colors group-hover:bg-sky-400 group-focus-visible:bg-sky-400",
+          dragging && "bg-sky-400",
+        )}
+      />
+    </div>
+  );
+}

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -89,6 +89,7 @@ import {
 import { decideEntryBehaviour, type EntryDecision } from "@/lib/terminal/entry-decision";
 import { loadSessionSnapshot, readLastTabSid, toReconnectBuffer } from "@/lib/terminal/session-snapshot";
 import { readDockOpen, writeDockOpen } from "@/lib/terminal/dock-open-persistence";
+import { useDockHeight, TerminalDockResizeHandle } from "./terminal-dock-resize";
 import { getMachineIdentity } from "@/lib/terminal/machine-identity";
 import { fetchHelperStatus, type HelperStatus } from "@/lib/terminal/helper-row";
 import {
@@ -307,6 +308,12 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   useEffect(() => {
     writeDockOpen(expanded);
   }, [expanded]);
+
+  // ── user-resizable height (card b885ebfd) ─────────────────────────────────
+  // Preferred body height (localStorage) + live viewport → effective height,
+  // exposed to the per-session bodies as a CSS variable on the root below.
+  // See terminal-dock-resize.tsx for the full contract.
+  const dockHeight = useDockHeight();
 
   // ── session entry chooser (card cbe60db5) — registry fetch + entry decision ──
   //
@@ -1169,7 +1176,17 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   const singleMeta = dockStatusMeta(singleView, activeSummary?.errorKind ?? null);
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-zinc-700 bg-[#141417] text-zinc-200 shadow-[0_-8px_30px_rgba(0,0,0,0.4)]">
+    <div
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-zinc-700 bg-[#141417] text-zinc-200 shadow-[0_-8px_30px_rgba(0,0,0,0.4)]"
+      style={dockHeight.rootStyle}
+    >
+      {/* Drag-to-resize handle on the top edge (card b885ebfd). Only while
+          expanded AND at least one session body is rendered — collapsed there
+          is nothing to size, and the chooser/loading faces size themselves.
+          The remembered height still applies the moment the dock re-expands
+          (the CSS variable on the root above is always set). */}
+      {expanded && sessions.length > 0 && <TerminalDockResizeHandle controller={dockHeight} />}
+
       {/* Shared aria-live region — background-tab attention only (a11y §14). */}
       <div aria-live="polite" role="status" className="sr-only">
         {announcement}

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -393,7 +393,7 @@ export function TerminalSessionView({
           this is purely this component's PRESENTATION. The tab strip above
           this component is unaffected (owned by terminal-dock.tsx). */}
       <div className={cn(!poppedOut && "hidden")} aria-hidden={!poppedOut}>
-        <div className="flex h-[38vh] min-h-[220px] flex-col items-center justify-center gap-3 bg-[#0c0c0e] px-6 py-6 text-center">
+        <div className="flex h-[var(--vc-term-dock-h,38vh)] min-h-[160px] flex-col items-center justify-center gap-3 bg-[#0c0c0e] px-6 py-6 text-center">
           <span className="text-2xl text-violet-400" aria-hidden="true">
             ⧉
           </span>
@@ -522,8 +522,13 @@ export function TerminalSessionView({
         )}
 
         {/* Terminal body — the xterm host plus a state overlay. The host stays
-            mounted under every state so scrollback is frozen + readable on end. */}
-        <div className="relative h-[38vh] min-h-[220px]">
+            mounted under every state so scrollback is frozen + readable on end.
+            HEIGHT (card b885ebfd): read from the `--vc-term-dock-h` CSS
+            variable the dock sets on its root (user-resizable via the drag
+            handle — terminal-dock-resize.tsx); `38vh` is the SSR/first-paint
+            fallback and the popped-out placeholder above uses the same value
+            so the two faces never differ in size. */}
+        <div className="relative h-[var(--vc-term-dock-h,38vh)] min-h-[160px]">
           <div
             ref={containerRef}
             className={cn("h-full w-full px-3 py-2", state.status === "disconnected" && "opacity-45")}

--- a/src/lib/terminal/dock-height.test.ts
+++ b/src/lib/terminal/dock-height.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import {
+  DOCK_HEIGHT_KEY,
+  MIN_DOCK_HEIGHT_PX,
+  DOCK_VIEWPORT_RESERVE_PX,
+  maxDockHeight,
+  clampDockHeight,
+  defaultDockHeight,
+  resolveDockHeight,
+  dragDockHeight,
+  stepDockHeight,
+  writeDockHeight,
+  readDockHeight,
+  clearDockHeight,
+} from "./dock-height";
+
+/** Minimal in-memory `Storage` stub — mirrors dock-open-persistence.test.ts's fixture. */
+class FakeStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+/** Always throws — simulates quota exceeded / disabled storage / privacy mode. */
+class ThrowingStorage extends FakeStorage {
+  setItem(): never {
+    throw new Error("QuotaExceededError");
+  }
+  getItem(): never {
+    throw new Error("SecurityError");
+  }
+  removeItem(): never {
+    throw new Error("QuotaExceededError");
+  }
+}
+
+const VH = 1000; // a comfortable desktop viewport for most cases
+
+describe("maxDockHeight", () => {
+  it("leaves the reserve for the page above the dock", () => {
+    expect(maxDockHeight(VH)).toBe(VH - DOCK_VIEWPORT_RESERVE_PX);
+  });
+  it("never drops below the minimum on a tiny viewport", () => {
+    expect(maxDockHeight(100)).toBe(MIN_DOCK_HEIGHT_PX);
+    expect(maxDockHeight(0)).toBe(MIN_DOCK_HEIGHT_PX);
+  });
+});
+
+describe("clampDockHeight", () => {
+  it("passes through an in-range height, rounded to whole px", () => {
+    expect(clampDockHeight(400.4, VH)).toBe(400);
+    expect(clampDockHeight(400.6, VH)).toBe(401);
+  });
+  it("floors at the minimum", () => {
+    expect(clampDockHeight(10, VH)).toBe(MIN_DOCK_HEIGHT_PX);
+    expect(clampDockHeight(-500, VH)).toBe(MIN_DOCK_HEIGHT_PX);
+  });
+  it("caps at the viewport max so the dock can never cover the whole page", () => {
+    expect(clampDockHeight(5000, VH)).toBe(maxDockHeight(VH));
+  });
+  it("treats NaN/Infinity as 'use the default'", () => {
+    expect(clampDockHeight(Number.NaN, VH)).toBe(defaultDockHeight(VH));
+    expect(clampDockHeight(Number.POSITIVE_INFINITY, VH)).toBe(defaultDockHeight(VH));
+  });
+});
+
+describe("defaultDockHeight", () => {
+  it("is 38% of the viewport (the old h-[38vh]) on a normal desktop", () => {
+    expect(defaultDockHeight(VH)).toBe(380);
+  });
+  it("respects the minimum on a short viewport", () => {
+    // 38% of 300 = 114 < min
+    expect(defaultDockHeight(300)).toBe(MIN_DOCK_HEIGHT_PX);
+  });
+  it("respects the max on a viewport where 38% would breach the reserve", () => {
+    // Only possible when the viewport is barely bigger than min + reserve; check the invariant holds.
+    const vh = MIN_DOCK_HEIGHT_PX + DOCK_VIEWPORT_RESERVE_PX + 10;
+    expect(defaultDockHeight(vh)).toBeLessThanOrEqual(maxDockHeight(vh));
+    expect(defaultDockHeight(vh)).toBeGreaterThanOrEqual(MIN_DOCK_HEIGHT_PX);
+  });
+});
+
+describe("resolveDockHeight", () => {
+  it("uses the default when nothing is stored", () => {
+    expect(resolveDockHeight(null, VH)).toBe(defaultDockHeight(VH));
+  });
+  it("uses the stored preference when it fits the viewport", () => {
+    expect(resolveDockHeight(520, VH)).toBe(520);
+  });
+  it("clamps a stored preference that no longer fits a smaller viewport — without losing it", () => {
+    const preferred = 700;
+    expect(resolveDockHeight(preferred, 600)).toBe(maxDockHeight(600));
+    // Same preference, viewport grows back → the original choice is restored.
+    expect(resolveDockHeight(preferred, VH)).toBe(700);
+  });
+});
+
+describe("dragDockHeight", () => {
+  it("dragging UP (smaller clientY) makes the bottom-docked panel taller", () => {
+    expect(dragDockHeight(300, 500, 400, VH)).toBe(400);
+  });
+  it("dragging DOWN makes it shorter", () => {
+    expect(dragDockHeight(300, 500, 560, VH)).toBe(240);
+  });
+  it("no pointer movement → unchanged", () => {
+    expect(dragDockHeight(300, 500, 500, VH)).toBe(300);
+  });
+  it("clamps at both ends mid-drag", () => {
+    expect(dragDockHeight(300, 500, 5000, VH)).toBe(MIN_DOCK_HEIGHT_PX);
+    expect(dragDockHeight(300, 500, -5000, VH)).toBe(maxDockHeight(VH));
+  });
+});
+
+describe("stepDockHeight", () => {
+  it("nudges by the delta and clamps", () => {
+    expect(stepDockHeight(300, 24, VH)).toBe(324);
+    expect(stepDockHeight(300, -24, VH)).toBe(276);
+    expect(stepDockHeight(MIN_DOCK_HEIGHT_PX, -24, VH)).toBe(MIN_DOCK_HEIGHT_PX);
+    expect(stepDockHeight(maxDockHeight(VH), 24, VH)).toBe(maxDockHeight(VH));
+  });
+});
+
+describe("writeDockHeight / readDockHeight", () => {
+  it("round-trips a valid height under the owned key", () => {
+    const s = new FakeStorage();
+    writeDockHeight(432, s);
+    expect(s.getItem(DOCK_HEIGHT_KEY)).toBe("432");
+    expect(readDockHeight(s)).toBe(432);
+  });
+  it("rounds fractional heights on write", () => {
+    const s = new FakeStorage();
+    writeDockHeight(432.7, s);
+    expect(readDockHeight(s)).toBe(433);
+  });
+  it("returns null when nothing was written", () => {
+    expect(readDockHeight(new FakeStorage())).toBeNull();
+  });
+  it("returns the stored value UNCLAMPED (clamping is the caller's job against the live viewport)", () => {
+    const s = new FakeStorage();
+    writeDockHeight(5000, s);
+    expect(readDockHeight(s)).toBe(5000);
+  });
+  it("treats garbage / sub-minimum stored values as absent", () => {
+    const s = new FakeStorage();
+    s.setItem(DOCK_HEIGHT_KEY, "banana");
+    expect(readDockHeight(s)).toBeNull();
+    s.setItem(DOCK_HEIGHT_KEY, "12");
+    expect(readDockHeight(s)).toBeNull();
+    s.setItem(DOCK_HEIGHT_KEY, "");
+    expect(readDockHeight(s)).toBeNull();
+  });
+  it("refuses to write NaN or sub-minimum values (never replaces a good preference with garbage)", () => {
+    const s = new FakeStorage();
+    writeDockHeight(400, s);
+    writeDockHeight(Number.NaN, s);
+    writeDockHeight(5, s);
+    expect(readDockHeight(s)).toBe(400);
+  });
+  it("never throws when storage is unavailable or throws", () => {
+    expect(() => writeDockHeight(400, null)).not.toThrow();
+    expect(readDockHeight(null)).toBeNull();
+    const t = new ThrowingStorage();
+    expect(() => writeDockHeight(400, t)).not.toThrow();
+    expect(readDockHeight(t)).toBeNull();
+    expect(() => clearDockHeight(t)).not.toThrow();
+  });
+});
+
+describe("clearDockHeight", () => {
+  it("forgets the stored preference so the next read falls back to the default", () => {
+    const s = new FakeStorage();
+    writeDockHeight(400, s);
+    clearDockHeight(s);
+    expect(readDockHeight(s)).toBeNull();
+    expect(resolveDockHeight(readDockHeight(s), VH)).toBe(defaultDockHeight(VH));
+  });
+});

--- a/src/lib/terminal/dock-height.ts
+++ b/src/lib/terminal/dock-height.ts
@@ -1,0 +1,142 @@
+// Terminal dock — user-resizable body height (Nick's request 2026-08-17, card
+// b885ebfd: "let Nick resize the panel height by dragging").
+//
+// The dock's terminal body used to be a hardcoded `h-[38vh] min-h-[220px]`.
+// This module owns every PURE piece of the resizable replacement — the
+// clamps, the default, the drag/keyboard arithmetic and the localStorage
+// read/write — so the React side (terminal-dock.tsx) is just event wiring.
+//
+// Persistence is `localStorage` (NOT the per-tab `sessionStorage` that
+// dock-open-persistence.ts uses): a chosen height is a lasting preference
+// ("I like the terminal about this tall"), not a "this tab, as I left it"
+// signal, so it should survive a new tab/window too. Same quota-safe,
+// NEVER-THROW contract as that file: a failed write just means the next load
+// uses the default height, never a crash or a surfaced error.
+//
+// The stored value is the user's PREFERRED body height in px. The EFFECTIVE
+// height is that preference clamped to the current viewport at render time —
+// so shrinking the window temporarily doesn't overwrite what they picked, and
+// re-growing it restores their choice.
+
+/** The `localStorage` key this module owns. */
+export const DOCK_HEIGHT_KEY = "vc:term:dock-height";
+
+/** Smallest the terminal body may get — enough for a handful of prompt lines. */
+export const MIN_DOCK_HEIGHT_PX = 160;
+
+/**
+ * Viewport space the dock must ALWAYS leave for the page above it (nav +
+ * board column headers), so it can never grow to swallow the whole screen.
+ * The dock's own chrome (collapsed bar + tab strip + session header ≈ 110px)
+ * sits ON TOP of the body, so this is deliberately generous.
+ */
+export const DOCK_VIEWPORT_RESERVE_PX = 220;
+
+/** Default body height as a fraction of the viewport — matches the old `38vh`. */
+export const DEFAULT_DOCK_HEIGHT_VH = 0.38;
+
+/** Keyboard step for the resize handle (ArrowUp/ArrowDown); Shift multiplies by 4. */
+export const DOCK_HEIGHT_KEY_STEP_PX = 24;
+
+/** The largest body height the given viewport allows — never below the minimum. */
+export function maxDockHeight(viewportHeight: number): number {
+  return Math.max(MIN_DOCK_HEIGHT_PX, Math.floor(viewportHeight - DOCK_VIEWPORT_RESERVE_PX));
+}
+
+/** Clamp a candidate body height into `[MIN, maxDockHeight(viewport)]`, rounding to whole px. */
+export function clampDockHeight(height: number, viewportHeight: number): number {
+  const max = maxDockHeight(viewportHeight);
+  if (!Number.isFinite(height)) return Math.min(defaultDockHeight(viewportHeight), max);
+  return Math.min(max, Math.max(MIN_DOCK_HEIGHT_PX, Math.round(height)));
+}
+
+/** The height used when nothing has been chosen yet — the old 38vh, clamped. */
+export function defaultDockHeight(viewportHeight: number): number {
+  const target = Math.round(viewportHeight * DEFAULT_DOCK_HEIGHT_VH);
+  return Math.min(maxDockHeight(viewportHeight), Math.max(MIN_DOCK_HEIGHT_PX, target));
+}
+
+/**
+ * The height to actually render: the stored preference (if any) clamped to
+ * the current viewport, else the default. `preferred` is `null` when nothing
+ * has been chosen or storage was unavailable.
+ */
+export function resolveDockHeight(preferred: number | null, viewportHeight: number): number {
+  if (preferred === null) return defaultDockHeight(viewportHeight);
+  return clampDockHeight(preferred, viewportHeight);
+}
+
+/**
+ * Body height for a drag in progress. The dock is docked to the BOTTOM of the
+ * viewport and the handle sits on its TOP edge, so dragging the pointer UP
+ * (smaller clientY) makes the panel TALLER. `startHeight` is the height at
+ * pointerdown, `startY`/`currentY` are clientY values.
+ */
+export function dragDockHeight(
+  startHeight: number,
+  startY: number,
+  currentY: number,
+  viewportHeight: number,
+): number {
+  return clampDockHeight(startHeight + (startY - currentY), viewportHeight);
+}
+
+/** Body height after a keyboard nudge — `delta` px (positive = taller), clamped. */
+export function stepDockHeight(current: number, delta: number, viewportHeight: number): number {
+  return clampDockHeight(current + delta, viewportHeight);
+}
+
+/** `window.localStorage`, or `null` when unavailable (SSR, privacy mode, disabled storage) — never throws. */
+function defaultStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the user's preferred body height. Best-effort: a `localStorage`
+ * write can throw (quota, privacy mode, disabled storage) — caught and
+ * silently dropped. Non-finite or sub-minimum values are NOT written (they
+ * would only ever come from a bug), so a stale-but-valid preference is never
+ * replaced by garbage.
+ */
+export function writeDockHeight(height: number, storage: Storage | null = defaultStorage()): void {
+  if (!storage) return;
+  if (!Number.isFinite(height) || height < MIN_DOCK_HEIGHT_PX) return;
+  try {
+    storage.setItem(DOCK_HEIGHT_KEY, String(Math.round(height)));
+  } catch {
+    /* best-effort only — a failed write just means the next load uses the default */
+  }
+}
+
+/**
+ * The stored preferred body height, or `null` when nothing valid was ever
+ * written (or storage is unavailable / throws). Returned UNCLAMPED — the
+ * caller clamps to the live viewport via `resolveDockHeight`. Anything that
+ * isn't a finite number at or above the minimum is treated as absent.
+ */
+export function readDockHeight(storage: Storage | null = defaultStorage()): number | null {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(DOCK_HEIGHT_KEY);
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed < MIN_DOCK_HEIGHT_PX) return null;
+    return Math.round(parsed);
+  } catch {
+    return null;
+  }
+}
+
+/** Forget the stored preference (used by the handle's double-click "reset to default"). */
+export function clearDockHeight(storage: Storage | null = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(DOCK_HEIGHT_KEY);
+  } catch {
+    /* best-effort only */
+  }
+}


### PR DESCRIPTION
## Summary
Board card b885ebfd — Nick: "let me resize the terminal panel height by dragging".

- Grab strip along the top edge of the terminal dock — drag it up/down to make the panel taller/shorter, with live feedback (xterm refits through the existing ResizeObserver; the PTY resize is still deduped on cols×rows so the wire only sees real row changes).
- Clamped: min 160px, max = viewport − 220px so the board above can never be fully covered. Default stays the old 38vh.
- Remembered in `localStorage` (a lasting preference, not per-tab like the open/closed flag). A shrunken window clamps the effective height but never overwrites the preference — grow the window back and your height returns.
- Composes with Collapse: the handle only renders while expanded and a session body exists; the CSS variable stays set so the remembered height applies the instant you re-expand.
- Keyboard + a11y: ARIA `separator` with value bounds; ArrowUp/Down ±24px (Shift ×4), Home/End to the bounds, double-click to reset to default.

## Files
- `src/lib/terminal/dock-height.ts` (+ tests): pure clamps / default / drag + keyboard maths / never-throw storage.
- `src/components/board/terminal-dock-resize.tsx` (+ tests): `useDockHeight()` hook + `TerminalDockResizeHandle`.
- `terminal-dock.tsx`: sets `--vc-term-dock-h` on the root, renders the handle.
- `terminal-session-view.tsx`: body + popped-out placeholder use `h-[var(--vc-term-dock-h,38vh)]`, min-h 220→160.

## Test plan
- [x] `vitest` — 25 new unit + 11 new component tests; all 626 terminal tests green
- [x] `tsc --noEmit`, `eslint` clean
- [x] Compiled Tailwind CSS confirmed to contain `height: var(--vc-term-dock-h, 38vh)`
- [ ] Manual on staging: drag the top edge of the dock; reload → height kept; collapse/expand → height kept; shrink window → clamps; double-click handle → back to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)