### PR TITLE
fix(terminal): reattach relaunch always resumes instead of booting fresh

### DIFF
--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -832,6 +832,120 @@ describe("useTerminalSession", () => {
       expect(mockSockets).toHaveLength(1);
     });
 
+    // URGENT reattach fix (task 27d19c68, 2026-08-17 incident): Nick hit this
+    // TWICE live — a hard refresh, then a cross-tab Reconnect, both reattached
+    // successfully and then <1s later replaced the live conversation with an
+    // empty boot screen. Root cause: fireLaunchDeepLink used to decide
+    // resume-vs-fresh from promptPartsRef, which is null on BOTH triggers
+    // (wiped by reload; never populated by a brand-new tab) — exactly the
+    // state every test in this describe block is already in, since none of
+    // them ever call launchFromBus/connect on this hook instance. The fix
+    // forces the relaunch to be resume-shaped from the reattach payload's own
+    // cwd/claudeSessionId instead, whenever those are present.
+    it("forces an EXACT resume-shaped deep link on reattach when the pair carries cwd + claudeSessionId — even though promptPartsRef is null (regression, task 27d19c68)", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: {
+            sessionId: "sid-reattach-live",
+            browserToken: "reattach-browser-token",
+            bridgeToken: "reattach-bridge-token",
+            helperToken: "reattach-helper-token",
+            cwd: "/Users/nick/projects/vibe-coding-ideas",
+            claudeSessionId: "live-conv-id",
+          },
+        }),
+      );
+      await flushEffects();
+
+      expect(result.current.launchPhase).toBe("opening");
+      const iframes = document.querySelectorAll("iframe");
+      expect(iframes).toHaveLength(1);
+      const src = iframes[0].getAttribute("src") ?? "";
+      expect(src.startsWith("vibecodes://launch?")).toBe(true);
+      expect(src).toContain("session=sid-reattach-live");
+      expect(src).toContain(`resume_id=${encodeURIComponent("live-conv-id")}`);
+      expect(src).toContain(`cwd=${encodeURIComponent("/Users/nick/projects/vibe-coding-ideas")}`);
+      // Never a fresh-boot prompt for a live reattach — that's the whole bug:
+      // a duplicate process still gets spawned (unchanged, lower-risk
+      // plumbing), but it must resume the SAME conversation, not boot empty.
+      expect(src).not.toContain("prompt=");
+      // Exact resume_id wins over the legacy resume=1 flag (buildLaunchDeepLink's
+      // own precedence — drift-tested in deep-link.test.ts).
+      expect(src).not.toContain("resume=1");
+      // The browser leg still opens normally alongside the forced relaunch.
+      expect(mockSockets).toHaveLength(1);
+    });
+
+    it("forces a legacy resume (--continue style) on reattach when the pair carries cwd but no claudeSessionId yet", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: {
+            sessionId: "sid-reattach-no-conv-id",
+            browserToken: "reattach-browser-token",
+            bridgeToken: "reattach-bridge-token",
+            helperToken: "reattach-helper-token",
+            cwd: "/Users/nick/projects/vibe-coding-ideas",
+            // claudeSessionId intentionally omitted — e.g. a pre-2a bridge
+            // that never announced one, or a session still mid-first-turn.
+            // The registry's own two columns are independent/uncoordinated,
+            // so this combination is real, not hypothetical.
+          },
+        }),
+      );
+      await flushEffects();
+
+      expect(result.current.launchPhase).toBe("opening");
+      const iframes = document.querySelectorAll("iframe");
+      expect(iframes).toHaveLength(1);
+      const src = iframes[0].getAttribute("src") ?? "";
+      expect(src).toContain(`cwd=${encodeURIComponent("/Users/nick/projects/vibe-coding-ideas")}`);
+      expect(src).toContain("resume=1");
+      expect(src).not.toContain("resume_id=");
+      expect(src).not.toContain("prompt=");
+    });
+
+    it("falls back to the fresh-launch deep link when the reattach pair has no recorded cwd at all (edge case — never worse than the pre-fix behaviour)", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, {
+          enabled: true,
+          expanded: true,
+          requestExpand,
+          autoConnectWhenExpanded: false,
+          attachExisting: {
+            sessionId: "sid-reattach-no-cwd",
+            browserToken: "reattach-browser-token",
+            bridgeToken: "reattach-bridge-token",
+            helperToken: "reattach-helper-token",
+            // No cwd, no claudeSessionId — the registry row itself never
+            // resolved a folder (e.g. a "new project" launch). Nothing to
+            // resume into, so this intentionally falls through to the
+            // pre-existing fresh-launch branch (logged as a warning in
+            // fireLaunchDeepLink so the gap stays visible).
+          },
+        }),
+      );
+      await flushEffects();
+
+      expect(result.current.launchPhase).toBe("opening");
+      const iframes = document.querySelectorAll("iframe");
+      expect(iframes).toHaveLength(1);
+      const src = iframes[0].getAttribute("src") ?? "";
+      expect(src).not.toContain("resume_id=");
+      expect(src).not.toContain("resume=1");
+      expect(src).toContain("prompt=");
+    });
+
     it("never fires a deep link when the attach pair carries no bridgeToken (popped-out hand-off — unchanged behaviour)", async () => {
       const requestExpand = vi.fn();
       const { result } = renderHook(() =>

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -975,7 +975,48 @@ export function useTerminalSession(
   );
 
   const fireLaunchDeepLink = useCallback(
-    (sessionId: string, bridgeToken: string, helperToken?: string) => {
+    (
+      sessionId: string,
+      bridgeToken: string,
+      helperToken?: string,
+      opts?: {
+        /**
+         * Reattach-vs-connect visibility (Reproduce & Investigate step's
+         * logging-gap note): which call site fired this link, so the
+         * structured logs below can tell a fresh mint's autoLaunch apart
+         * from a reattach's relaunch without cross-referencing timestamps.
+         * Defaults to "connect" so connect()'s existing call site (which
+         * predates this option) doesn't need updating just for the log field.
+         */
+        trigger?: "connect" | "attach-existing";
+        /**
+         * URGENT reattach fix (task 27d19c68, 2026-08-17 incident — a hard
+         * refresh AND a cross-tab Reconnect both killed a live conversation
+         * and replaced it with an empty boot screen): when set, this fire is
+         * FORCED resume-shaped, bypassing the promptPartsRef-based branch
+         * below entirely. `attachToExisting` passes the reattach API's own
+         * `cwd`/`claudeSessionId` here — the terminal_sessions registry
+         * row's ground truth for the session actually being reattached to —
+         * instead of relying on `promptPartsRef`, which is reliably null in
+         * exactly the cases that broke this: wiped by a hard refresh
+         * (in-memory ref, not persisted), and never populated at all by a
+         * brand-new tab reconnecting to someone else's already-live
+         * session. With `promptPartsRef` null, this branch used to fall
+         * through to the fresh-launch path below — spawning a brand-new
+         * `claude` process that the relay's preempt logic then let win,
+         * killing the original. A genuinely active/live session's reattach
+         * payload carries a `cwd` (confirmed via production evidence in the
+         * task), so this covers the real incident; a row with no recorded
+         * `cwd` at all (edge case — e.g. a "new project" launch that never
+         * resolved one) falls through to the pre-existing fresh-launch
+         * branch, logged below so that gap stays visible instead of
+         * silently regressing.
+         */
+        forceResumeCwd?: string | null;
+        forceResumeId?: string | null;
+      },
+    ) => {
+      const trigger = opts?.trigger ?? "connect";
       // Session entry chooser — Resume (card cbe60db5, design item 7/F4): a
       // resume launch carries no bootstrap prompt at all — a minimal link
       // with `resumeId` (exact-conversation, rework 5) or the legacy
@@ -983,15 +1024,25 @@ export function useTerminalSession(
       // bridge runs `claude --resume <id>` or `claude --continue` there
       // instead of building a prompt (see terminal/bridge/src/index.js).
       // Checked FIRST so the normal essentials/budgeting path below never
-      // runs for a resume.
+      // runs for a resume. The resume source is EITHER a forced reattach
+      // override (opts.forceResumeCwd — see its doc; checked first so a
+      // stale/unrelated promptPartsRef can never veto a real reattach) OR
+      // the legacy promptPartsRef-carried intent (a chooser Resume click
+      // via launchFromBus/connect).
       // Bug B (card cbe60db5): computed ONCE per fire, used on whichever
       // buildLaunchDeepLink call below actually runs — see
       // `currentLaunchDims`'s own doc comment for why this is read here
       // rather than left to a post-spawn resize.
       const dims = currentLaunchDims();
       const carriedForResume = promptPartsRef.current;
-      if (carriedForResume?.resume || carriedForResume?.resumeId) {
-        const cwd = carriedForResume.cwd;
+      const forcedCwd = opts?.forceResumeCwd?.trim() || null;
+      const resumeSource = forcedCwd
+        ? { cwd: forcedCwd, resumeId: opts?.forceResumeId ?? undefined, forced: true }
+        : carriedForResume?.resume || carriedForResume?.resumeId
+          ? { cwd: carriedForResume.cwd, resumeId: carriedForResume.resumeId, forced: false }
+          : null;
+      if (resumeSource) {
+        const { cwd, resumeId, forced } = resumeSource;
         if (!cwd) {
           // Should never happen — the chooser only offers Resume for a row
           // with a recorded folder (F4) — but stay honest rather than fire a
@@ -1009,8 +1060,8 @@ export function useTerminalSession(
             token: bridgeToken,
             helperToken,
             cwd,
-            resume: carriedForResume.resumeId ? undefined : true,
-            resumeId: carriedForResume.resumeId,
+            resume: resumeId ? undefined : true,
+            resumeId,
             cols: dims?.cols,
             rows: dims?.rows,
           });
@@ -1023,12 +1074,27 @@ export function useTerminalSession(
         }
         logger.info("Terminal firing resume deep link", {
           sessionId,
-          exact: !!carriedForResume.resumeId,
+          trigger,
+          forced,
+          exact: !!resumeId,
           url: redactDeepLinkToken(link).replace(/([?&]cwd=)[^&]*/g, "$1***"),
           urlChars: link.length,
         });
         if (!openLaunchLinkAndArmTimeout(link)) setLaunchPhase("helper-timeout");
         return;
+      }
+
+      // Reattach relaunch with nowhere to resume into (the registry row
+      // itself never recorded a cwd) — falls through to the fresh-launch
+      // branch below same as before this fix, but say so loudly: this is
+      // the ONE gap the reattach fix (task 27d19c68) doesn't close, and it
+      // must stay visible rather than silently look identical to a normal
+      // fresh mint in the logs.
+      if (trigger === "attach-existing") {
+        logger.warn(
+          "Terminal reattach relaunch has no recorded cwd — falling back to fresh-launch deep link (will not resume)",
+          { sessionId },
+        );
       }
 
       let link: string;
@@ -1098,6 +1164,7 @@ export function useTerminalSession(
       // its PRESENCE and the prompt's length are logged.
       logger.info("Terminal firing launch deep link", {
         sessionId,
+        trigger,
         url: redactDeepLinkToken(link).replace(/([?&]cwd=)[^&]*/g, "$1***"),
         urlChars,
         hasCwd,
@@ -1558,7 +1625,7 @@ export function useTerminalSession(
     }
 
     // Same-machine: hand the bridge token to the local helper via the deep link.
-    if (autoLaunch) fireLaunchDeepLink(data.sessionId, data.bridgeToken, data.helperToken);
+    if (autoLaunch) fireLaunchDeepLink(data.sessionId, data.bridgeToken, data.helperToken, { trigger: "connect" });
 
     openBrowserLeg(data.sessionId, data.browserToken);
   }, [
@@ -1646,8 +1713,32 @@ export function useTerminalSession(
       // leg waiting passively forever. Mirrors connect()'s own
       // `if (autoLaunch) fireLaunchDeepLink(...)` call exactly, just gated on
       // the token being present instead of an autoLaunch flag.
+      //
+      // URGENT reattach fix (task 27d19c68, 2026-08-17): that relaunch used
+      // to be UNCONDITIONALLY fresh-boot-shaped (decided by promptPartsRef,
+      // which is null on both a hard refresh and a brand-new tab's
+      // Reconnect — see fireLaunchDeepLink's forceResumeCwd doc). The local
+      // helper always forks a brand-new bridge with no liveness check, and
+      // the relay always lets it preempt the still-live original — so that
+      // fresh-boot deep link was what killed the running conversation and
+      // replaced it with an empty boot screen, even though the server-side
+      // session record never changed. `p.cwd`/`p.claudeSessionId` are the
+      // reattach route's OWN read of the registry row being reattached to —
+      // passing them here forces this relaunch to always be resume-shaped
+      // for a genuinely live session, instead of depending on a ref that's
+      // reliably empty in exactly this path.
       if (p.bridgeToken) {
-        fireLaunchDeepLink(p.sessionId, p.bridgeToken, p.helperToken);
+        logger.info("Terminal reattach firing relaunch deep link", {
+          sessionId: p.sessionId,
+          hasResumeCwd: !!(p.cwd && p.cwd.trim()),
+          hasClaudeSessionId: !!p.claudeSessionId,
+          promptPartsPopulated: !!promptPartsRef.current,
+        });
+        fireLaunchDeepLink(p.sessionId, p.bridgeToken, p.helperToken, {
+          trigger: "attach-existing",
+          forceResumeCwd: p.cwd,
+          forceResumeId: p.claudeSessionId,
+        });
       }
       openBrowserLeg(p.sessionId, p.browserToken);
     },


### PR DESCRIPTION
## Summary
- URGENT live regression: reconnecting to an already-active terminal session (hard refresh, or clicking Reconnect from another tab) reconnected successfully, then under a second later silently replaced it with a brand-new empty session — the original, live conversation was lost.
- Root cause: `attachToExisting()` always fires a relaunch deep link on reattach, and that link's resume-vs-fresh decision depends on an in-memory ref that is reliably empty in both trigger cases (wiped by page reload; never set on a different tab) — so it always chose "start fresh." The local helper then forks a second process with no liveness check, and the relay's newer-wins preemption (built for wifi-drop recovery) kills the original live process in favor of the empty new one.
- Fix, scoped to app-side only (no helper/bridge/relay changes): `attachToExisting()` now uses the folder path + conversation id the server already returns on reattach to force the relaunch to resume the exact existing conversation, instead of depending on the unreliable ref. Falls back to prior behavior (now logged) if that data is ever missing.
- Confirmed via production database before/after reproduction: only one `terminal_sessions` row existed throughout both incidents — never a server-registry bug.

Board task: 27d19c68-f017-4da8-aeb0-ad56f2ae8eba

## Test plan
- [x] 3 new regression tests
- [x] 2861 tests pass
- [x] `npx tsc --noEmit` clean
- [x] eslint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)