### PR TITLE
fix: close human-approval bypass — approve_step/fail_step are web-UI-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Move to "Blocked/Requires User Input" with a comment explaining why.
 ### Identity Enforcement
 - MCP `complete_step`/`fail_step` verify the step's `claim_token`; completion is attributed to `step.bot_id` regardless of the caller's connection identity
 - Agent-voiced comments require the step's live `work_token`; rejected tokens log a structured warn (the attribution-anomaly signal)
-- `approve_step`/rejection of `awaiting_approval` steps are human-gated (no claim token needed; bot identities blocked)
+- `approve_step` MCP tool and `fail_step` on an `awaiting_approval` step are hard-error stubs — the human-approval gate can ONLY be satisfied from the web UI's workflow panel (`approveWorkflowStep`/`failWorkflowStep` in `src/actions/workflow.ts`), never over any MCP connection, even one authenticated as the human's own account. A `BEFORE UPDATE` trigger on `task_workflow_steps` enforces this in the DB: `awaiting_approval` → `completed` requires `approved_by`/`approval_method` to be set.
 - Steps with `bot_id = null` are not affected
 
 ### AI Access Resolution

--- a/mcp-server/src/register-tools.test.ts
+++ b/mcp-server/src/register-tools.test.ts
@@ -373,6 +373,67 @@ describe("registerTools", () => {
     );
   });
 
+  // Board task d572c4d1-bb45-468d-94b0-f3ac01855601: the old approve_step
+  // description promised working, identity-gated approval ("HUMAN-ONLY...
+  // approve from a connection authenticated as the human account") — that
+  // promise was the bug (ctx.userId IS the human's own id on the remote
+  // transport). The description must no longer make it, mirroring how
+  // set_agent_identity's retirement description reads.
+  it("approve_step's description no longer promises identity-based approval", () => {
+    const server = createMockServer();
+    registerTools(server, vi.fn());
+
+    const approveCall = server.tool.mock.calls.find(
+      (call: unknown[]) => call[0] === "approve_step"
+    );
+    const description = approveCall![1] as string;
+
+    expect(description).toMatch(/RETIRED|no longer approve/i);
+    expect(description).not.toMatch(/bot identities are rejected/i);
+    expect(description).not.toMatch(/connection authenticated as the human account/i);
+  });
+
+  it("approve_step's callback always errors and never resolves", async () => {
+    const server = createMockServer();
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }));
+    const mockContext: McpContext = {
+      supabase: { from: mockFrom } as unknown as McpContext["supabase"],
+      userId: "test-user",
+    };
+    const getContext = vi.fn(() => mockContext);
+
+    registerTools(server, getContext);
+
+    const approveCall = server.tool.mock.calls.find(
+      (call: unknown[]) => call[0] === "approve_step"
+    );
+    const callback = approveCall![3];
+    const result = await callback(
+      { step_id: "00000000-0000-4000-a000-000000000020" },
+      {}
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("approve_step no longer approves anything");
+  });
+
+  it("fail_step's description no longer promises a token-free awaiting_approval rejection", () => {
+    const server = createMockServer();
+    registerTools(server, vi.fn());
+
+    const failCall = server.tool.mock.calls.find(
+      (call: unknown[]) => call[0] === "fail_step"
+    );
+    const description = failCall![1] as string;
+
+    expect(description).toMatch(/CANNOT reject an awaiting_approval step/i);
+    expect(description).not.toMatch(/not needed when rejecting an awaiting_approval step/i);
+  });
+
   it("get_idea_enhancement_prompt is registered with an attachment-context provider passed through", async () => {
     const server = createMockServer();
     const IDEA_ID = "00000000-0000-4000-a000-00000000abcd";

--- a/mcp-server/src/register-tools.ts
+++ b/mcp-server/src/register-tools.ts
@@ -1242,7 +1242,7 @@ export function registerTools(
 
   server.tool(
     "fail_step",
-    "Mark a workflow step as failed. Pass the `claim_token` from claim_next_step (not needed when rejecting an awaiting_approval step — human gate). Pass the failure reason in the `output` parameter (NOT `reason`). Use `reset_to_step_id` for cascade rejection — resets that step and all subsequent steps back to pending (and invalidates their claim tokens) so the workflow can be reworked from that point (the run stays 'running'). Without `reset_to_step_id`, the entire workflow run is marked as failed and stops. The `output` text is saved as a 'failure' comment on the step and becomes rework context when the step is later re-claimed via `claim_next_step`. Pass `model_used` = the Task-tool model alias the step's subagent actually ran on (self-reported — VibeCodes records it but does not verify it).",
+    "Mark an in_progress workflow step as failed. Pass the `claim_token` from claim_next_step. Pass the failure reason in the `output` parameter (NOT `reason`). Use `reset_to_step_id` for cascade rejection — resets that step and all subsequent steps back to pending (and invalidates their claim tokens) so the workflow can be reworked from that point (the run stays 'running'). Without `reset_to_step_id`, the entire workflow run is marked as failed and stops. The `output` text is saved as a 'failure' comment on the step and becomes rework context when the step is later re-claimed via `claim_next_step`. Pass `model_used` = the Task-tool model alias the step's subagent actually ran on (self-reported — VibeCodes records it but does not verify it). CANNOT reject an awaiting_approval step — that's a human gate, same as approve_step; rejecting it is only possible from the task's workflow panel in the web UI.",
     failStepSchema.shape,
     async (args: Record<string, unknown>, extra: ServerExtra) => {
       try {
@@ -1289,7 +1289,7 @@ export function registerTools(
 
   server.tool(
     "approve_step",
-    "Approve a workflow step that is awaiting human approval. HUMAN-ONLY: Only call when a human user has explicitly instructed you to approve — never self-approve. Bot identities are rejected — approve from a connection authenticated as the human account, or from the task's workflow panel in the web UI. Moves the step to completed. The step's existing output is preserved. Optionally adds an approval comment.",
+    "RETIRED — always errors. approve_step can no longer approve anything, from any MCP connection (stdio or remote, even one authenticated as the human's own account) — there is no reliable way to tell 'a human clicked Approve' apart from 'an agent called this tool' over MCP, so the human-approval gate can now ONLY be satisfied from the task's workflow panel in the VibeCodes web UI. Kept registered so a stale client gets this instructive error instead of an unknown-tool failure. If a step is awaiting_approval, STOP and tell the human to review and approve it in the web UI — do not call this tool expecting it to work.",
     approveStepSchema.shape,
     async (args: Record<string, unknown>, extra: ServerExtra) => {
       try {

--- a/mcp-server/src/tools/workflows.test.ts
+++ b/mcp-server/src/tools/workflows.test.ts
@@ -1155,7 +1155,7 @@ describe("completeStep", () => {
     expect(result.status).toBe("awaiting_approval");
     expect(result).toHaveProperty("message");
     expect((result as { message: string }).message).toContain("STOP");
-    expect((result as { message: string }).message).toContain("do NOT call approve_step");
+    expect((result as { message: string }).message).toContain("approve_step no longer works");
   });
 
   it("does not return stop message for normal completion", async () => {
@@ -2234,148 +2234,83 @@ describe("claimNextStep — approval_notes", () => {
 });
 
 // ---------------------------------------------------------------------------
-// approveStep — bot rejection test
+// approveStep — hard-error stub (board task d572c4d1-bb45-468d-94b0-f3ac01855601)
 // ---------------------------------------------------------------------------
+// The old version only blocked callers where users.is_bot was true — but
+// ctx.userId on the remote OAuth transport is always the HUMAN's own id, so
+// an autonomous agent orchestrating under that connection sailed straight
+// through (that's the bug this task fixes). approve_step now rejects EVERY
+// caller, unconditionally, and never issues a DB update — the only surviving
+// approval path is approveWorkflowStep (src/actions/workflow.ts), covered in
+// src/actions/workflow.test.ts.
 
 describe("approveStep", () => {
-  it("rejects bot callers", async () => {
+  it("rejects a bot-flagged caller and never touches task_workflow_steps.update", async () => {
+    let updateCalled = false;
     const ctx = makeContext(((table: string) => {
+      if (table === "task_workflow_steps") {
+        const chain = createChain({ idea_id: IDEA_ID, task_id: TASK_ID });
+        chain.chain.update = vi.fn(() => {
+          updateCalled = true;
+          return chain.chain;
+        });
+        return chain.chain;
+      }
+      // A stray users-table lookup would indicate the retired is_bot check
+      // is back — fail loudly rather than silently answering it.
       if (table === "users") {
-        const chain = createChain({ is_bot: true });
+        throw new Error("approveStep must not query users — the is_bot check is retired");
+      }
+      return createChain(null).chain;
+    }) as unknown as McpContext["supabase"]["from"]);
+
+    await expect(approveStep(ctx, { step_id: STEP_ID })).rejects.toThrow(
+      /approve_step no longer approves anything/i
+    );
+    expect(updateCalled).toBe(false);
+  });
+
+  it("rejects a human-authenticated caller identically — approval is web-UI-only", async () => {
+    let updateCalled = false;
+    const ctx = makeContext(((table: string) => {
+      if (table === "task_workflow_steps") {
+        const chain = createChain({ idea_id: IDEA_ID, task_id: TASK_ID });
+        chain.chain.update = vi.fn(() => {
+          updateCalled = true;
+          return chain.chain;
+        });
         return chain.chain;
       }
       return createChain(null).chain;
     }) as unknown as McpContext["supabase"]["from"]);
 
     await expect(
-      approveStep(ctx, { step_id: STEP_ID })
-    ).rejects.toThrow("Only humans can approve");
+      approveStep(ctx, { step_id: STEP_ID, comment: "looks good" })
+    ).rejects.toThrow(/task's workflow panel in the VibeCodes web UI/i);
+    expect(updateCalled).toBe(false);
   });
 
-  it("allows human callers", async () => {
-    const stepData = {
-      claim_token_hash: TCT.hash,
-      id: STEP_ID,
-      run_id: RUN_ID,
-      idea_id: IDEA_ID,
-      status: "awaiting_approval",
-    };
-    const updatedStep = {
-      id: STEP_ID,
-      task_id: TASK_ID,
-      run_id: RUN_ID,
-      title: "Test Step",
-      agent_role: "developer",
-      status: "completed",
-      output: "output",
-      completed_at: "2026-01-01T00:00:00Z",
-    };
-
-    const tableCounts: Record<string, number> = {};
+  it("includes a deep link to the task's board when the step lookup succeeds", async () => {
     const ctx = makeContext(((table: string) => {
-      tableCounts[table] = (tableCounts[table] ?? 0) + 1;
-
-      if (table === "users") {
-        return createChain({ is_bot: false }).chain;
-      }
-
       if (table === "task_workflow_steps") {
-        const callNum = tableCounts[table];
-        if (callNum === 1) {
-          // Fetch step
-          return createChain(stepData).chain;
-        }
-        // Update step
-        const chain = createChain(null);
-        chain.chain.maybeSingle = vi.fn(() =>
-          Promise.resolve({ data: updatedStep, error: null })
-        );
-        return chain.chain;
+        return createChain({ idea_id: IDEA_ID, task_id: TASK_ID }).chain;
       }
-
-      if (table === "workflow_runs") {
-        const chain = createChain(null);
-        chain.chain.then = (resolve: (val: unknown) => void) =>
-          Promise.resolve({ data: [], error: null }).then(resolve);
-        chain.chain.maybeSingle = vi.fn(() =>
-          Promise.resolve({ data: null, error: null })
-        );
-        return chain.chain;
-      }
-
       return createChain(null).chain;
     }) as unknown as McpContext["supabase"]["from"]);
 
-    const result = await approveStep(ctx, { step_id: STEP_ID });
-    expect(result.step).toMatchObject({ status: "completed" });
+    await expect(approveStep(ctx, { step_id: STEP_ID })).rejects.toThrow(
+      new RegExp(`/ideas/${IDEA_ID}/board\\?taskId=${TASK_ID}`)
+    );
   });
 
-  // Design Review condition 2 (agent-voice-comments-design.html §1.2, §7):
-  // approve_step is belt-and-braces — the hashes are normally already gone
-  // by awaiting_approval — but the design's own traceability table (§6,
-  // AC-14) names it as one of the five sites the unit tests should cover,
-  // and it had no assertion at all before this.
-  it("clears work_token_hash alongside claim_token_hash on approval (belt-and-braces)", async () => {
-    const stepData = {
-      claim_token_hash: TCT.hash,
-      id: STEP_ID,
-      run_id: RUN_ID,
-      idea_id: IDEA_ID,
-      status: "awaiting_approval",
-    };
-    const updatedStep = {
-      id: STEP_ID,
-      task_id: TASK_ID,
-      run_id: RUN_ID,
-      title: "Test Step",
-      agent_role: "developer",
-      status: "completed",
-      output: "output",
-      completed_at: "2026-01-01T00:00:00Z",
-    };
-
-    const tableCounts: Record<string, number> = {};
-    let stepUpdateData: Record<string, unknown> | null = null;
-    const ctx = makeContext(((table: string) => {
-      tableCounts[table] = (tableCounts[table] ?? 0) + 1;
-
-      if (table === "users") {
-        return createChain({ is_bot: false }).chain;
-      }
-
-      if (table === "task_workflow_steps") {
-        const callNum = tableCounts[table];
-        if (callNum === 1) {
-          return createChain(stepData).chain;
-        }
-        const chain = createChain(null);
-        chain.chain.update = vi.fn((data: unknown) => {
-          stepUpdateData = data as Record<string, unknown>;
-          return chain.chain;
-        });
-        chain.chain.maybeSingle = vi.fn(() =>
-          Promise.resolve({ data: updatedStep, error: null })
-        );
-        return chain.chain;
-      }
-
-      if (table === "workflow_runs") {
-        const chain = createChain(null);
-        chain.chain.then = (resolve: (val: unknown) => void) =>
-          Promise.resolve({ data: [], error: null }).then(resolve);
-        chain.chain.maybeSingle = vi.fn(() =>
-          Promise.resolve({ data: null, error: null })
-        );
-        return chain.chain;
-      }
-
-      return createChain(null).chain;
+  it("still rejects with the instructive error (no deep link) when the step lookup throws", async () => {
+    const ctx = makeContext((() => {
+      throw new Error("supabase unavailable");
     }) as unknown as McpContext["supabase"]["from"]);
 
-    await approveStep(ctx, { step_id: STEP_ID });
-
-    expect(stepUpdateData!.claim_token_hash).toBeNull();
-    expect(stepUpdateData!.work_token_hash).toBeNull();
+    await expect(approveStep(ctx, { step_id: STEP_ID })).rejects.toThrow(
+      /approve_step no longer approves anything/i
+    );
   });
 });
 
@@ -3990,20 +3925,53 @@ describe("claim-token protocol", () => {
     expect(updateData!.claim_token_hash).toBeNull();
   });
 
-  it("failStep on an awaiting_approval step needs no token (human gate)", async () => {
+  // Board task d572c4d1-bb45-468d-94b0-f3ac01855601: rejecting an
+  // awaiting_approval step used to skip the claim-token check with NO
+  // replacement identity gate at all — any MCP caller could reject (or,
+  // via approve_step, approve) a human gate. fail_step can no longer touch
+  // an awaiting_approval step at all; rejecting one is web-UI-only, same
+  // as approving one.
+  it("rejects fail_step on an awaiting_approval step — human gate, no DB update issued", async () => {
     const { hash } = mintClaimToken();
+    let updateCalled = false;
+    const ctx = makeCompleteCtx(
+      {
+        id: STEP_ID,
+        task_id: TASK_ID,
+        run_id: RUN_ID,
+        step_order: 3,
+        idea_id: IDEA_ID,
+        bot_id: BOT_ID,
+        agent_role: "developer",
+        status: "awaiting_approval",
+        claim_token_hash: hash,
+      },
+      () => { updateCalled = true; }
+    );
+
+    await expect(
+      failStep(ctx, { step_id: STEP_ID, output: "Rejected by human" })
+    ).rejects.toThrow(/can't reject an awaiting_approval step/i);
+    expect(updateCalled).toBe(false);
+  });
+
+  // Regression guard: the in_progress claim-token path must be completely
+  // unaffected by the awaiting_approval lockdown above.
+  it("still fails an in_progress step with a valid claim_token", async () => {
+    const { token, hash } = mintClaimToken();
     const ctx = makeCompleteCtx({
       id: STEP_ID,
+      task_id: TASK_ID,
       run_id: RUN_ID,
       step_order: 3,
       idea_id: IDEA_ID,
       bot_id: BOT_ID,
       agent_role: "developer",
-      status: "awaiting_approval",
+      status: "in_progress",
       claim_token_hash: hash,
     });
 
-    const result = await failStep(ctx, { step_id: STEP_ID, output: "Rejected by human" });
+    const result = await failStep(ctx, { step_id: STEP_ID, claim_token: token, output: "bad output" });
     expect(result.step).toBeTruthy();
   });
 });
@@ -4101,48 +4069,8 @@ describe("workflow step mutations touch board_tasks for realtime", () => {
     expect(boardTaskTouched).toBe(true);
   });
 
-  it("approveStep touches board_tasks.updated_at", async () => {
-    let boardTaskTouched = false;
-
-    const ctx = makeContext(((table: string) => {
-      if (table === "users") {
-        const chain = createChain(null);
-        chain.chain.single = vi.fn(() =>
-          Promise.resolve({ data: { is_bot: false }, error: null })
-        );
-        return chain.chain;
-      }
-
-      if (table === "task_workflow_steps") {
-        const chain = createChain(null);
-        chain.chain.single = vi.fn(() =>
-          Promise.resolve({
-            data: { id: STEP_ID, run_id: RUN_ID, idea_id: IDEA_ID, status: "awaiting_approval" },
-            error: null,
-          })
-        );
-        chain.chain.maybeSingle = vi.fn(() =>
-          Promise.resolve({
-            data: { id: STEP_ID, task_id: TASK_ID, run_id: RUN_ID, title: "Step", agent_role: "dev", status: "completed", output: null, completed_at: "2026-01-01" },
-            error: null,
-          })
-        );
-        chain.chain.then = (resolve: (val: unknown) => void) =>
-          Promise.resolve({ data: [], error: null }).then(resolve);
-        return chain.chain;
-      }
-
-      if (table === "board_tasks") {
-        boardTaskTouched = true;
-        return createChain(null).chain;
-      }
-
-      return createChain(null).chain;
-    }) as unknown as McpContext["supabase"]["from"]);
-
-    await approveStep(ctx, { step_id: STEP_ID });
-    expect(boardTaskTouched).toBe(true);
-  });
+  // approveStep no longer touches board_tasks (or any table) — it's a
+  // hard-error stub, covered under describe("approveStep") above.
 
   it("failStep touches board_tasks.updated_at", async () => {
     let boardTaskTouched = false;

--- a/mcp-server/src/tools/workflows.test.ts
+++ b/mcp-server/src/tools/workflows.test.ts
@@ -1838,7 +1838,11 @@ describe("claimNextStep — human approval directive", () => {
 
     const r = result as { instruction: string };
     expect(r.instruction).toContain("HUMAN APPROVAL REQUIRED");
-    expect(r.instruction).toContain("Do NOT call approve_step");
+    // Board task d572c4d1: approve_step no longer works at all, even with
+    // human instruction — the directive must say so, not just "don't call it
+    // yourself" (which implied a human-instructed call would still work).
+    expect(r.instruction).toContain("approve_step no longer works from any MCP connection, even with human instruction");
+    expect(r.instruction).toContain("workflow panel in the VibeCodes web UI");
   });
 
   it("omits human approval directive when step does not require human check", async () => {

--- a/mcp-server/src/tools/workflows.ts
+++ b/mcp-server/src/tools/workflows.ts
@@ -29,6 +29,13 @@ import { notifyMentions } from "../lib/mention-notify";
 import { notifyComplianceViolation } from "../lib/compliance-notify";
 import { stepTaskUnresolvedMentions } from "../lib/mentions";
 import { mentionedUserIdsSchema } from "./comments";
+import { buildNotificationUrl } from "../../../src/lib/notification-url";
+
+// Mirrors notifications.ts's own APP_BASE_URL — kept local (not shared) since
+// it's a one-line derivation and this file already has no dependency on
+// notifications.ts. Strip keeps buildNotificationUrl's `{appUrl}/ideas/…`
+// concatenation clean.
+const APP_BASE_URL = (process.env.NEXT_PUBLIC_APP_URL ?? "https://vibecodes.co.uk").replace(/\/+$/, "");
 
 // Column names that indicate "in progress", checked in priority order (case-insensitive)
 const IN_PROGRESS_COLUMN_NAMES = [
@@ -1332,7 +1339,7 @@ export async function completeStep(
     run_complete: runComplete,
     status: newStatus,
     ...(newStatus === "awaiting_approval" && {
-      message: "This step is now awaiting human approval. STOP here — do NOT call approve_step yourself. Present your output to the user and wait for them to explicitly instruct you to approve it.",
+      message: "This step is now awaiting human approval. STOP here — approve_step no longer works from any MCP connection, even with human instruction. Present your output to the user and ask them to approve it from the task's workflow panel in the VibeCodes web UI.",
     }),
   };
 }
@@ -1345,7 +1352,7 @@ export const failStepSchema = z.object({
     .string()
     .optional()
     .describe(
-      "The one-time claim token returned by claim_next_step for this step. Not needed when rejecting an awaiting_approval step (human gate)."
+      "The one-time claim token returned by claim_next_step for this step. Required — fail_step cannot reject an awaiting_approval step (human gate); reject those from the web UI instead."
     ),
   output: z.string().max(10000).optional().describe(
     "Failure reason or error details (use `output`, not `reason`). Stored on the step's `output` column and auto-posted as a 'failure' comment. When cascade rejection is used and this step is re-claimed, this text is returned as `rework_instructions` to give the next agent context for retry."
@@ -1383,53 +1390,72 @@ export async function failStep(
   params: z.infer<typeof failStepSchema>
 ) {
   // Fetch current step (include claim_token_hash + bot_id for the two-layer check;
-  // model_tier for P2c tier-adherence computation below)
+  // model_tier for P2c tier-adherence computation below; task_id only to build
+  // the awaiting_approval rejection's deep link)
   const { data: step, error: fetchError } = await ctx.supabase
     .from("task_workflow_steps")
-    .select("id, run_id, step_order, idea_id, bot_id, agent_role, status, claim_token_hash, model_tier")
+    .select("id, task_id, run_id, step_order, idea_id, bot_id, agent_role, status, claim_token_hash, model_tier")
     .eq("id", params.step_id)
     .single();
 
   if (fetchError || !step) throw new Error(`Step not found: ${params.step_id}`);
 
-  // Capability check, mirroring complete_step. Skipped for awaiting_approval
-  // steps — humans reject those regardless of bot_id/token, and they hold no
-  // claim token (design §3d boundary). Never mutates state on failure. The
-  // former persona-consistency warning was deleted alongside complete_step's
-  // (docs/agent-voice-comments-design.html §4.2) — see that function's
-  // comment for why.
-  if (step.status !== "awaiting_approval") {
-    // err-6: a work_token (wt_…) was presented here instead of a claim_token.
-    if (params.claim_token?.startsWith("wt_")) {
-      logger.warn("claim token rejected", {
-        tool: "fail_step",
-        reason: "work_token_in_completion_tool",
-        stepId: params.step_id,
-        callerUserId: ctx.userId,
-        ownerUserId: ctx.ownerUserId,
-      });
-      throw new Error(WORK_TOKEN_IN_COMPLETION_TOOL_MESSAGE);
-    }
-
-    if (!verifyClaimToken(step.claim_token_hash, params.claim_token)) {
-      logger.warn("claim token rejected", {
-        tool: "fail_step",
-        reason: "invalid_or_missing_claim_token",
-        stepId: params.step_id,
-        callerUserId: ctx.userId,
-        ownerUserId: ctx.ownerUserId,
-      });
-      throw new Error(
-        "This step isn't claimed by you. Call claim_next_step to (re)claim it — " +
-        "you'll receive a claim_token to pass to fail_step."
-      );
-    }
+  // Human-gate lockdown (board task d572c4d1-bb45-468d-94b0-f3ac01855601):
+  // rejecting an awaiting_approval step is a human decision, exactly like
+  // approving one — it used to skip the claim-token check with NO
+  // replacement identity gate, so any MCP caller could reject a human gate.
+  // Route it through the same web-UI-only story as approve_step. The
+  // in_progress claim-token path below is completely unchanged.
+  if (step.status === "awaiting_approval") {
+    const url = buildNotificationUrl({
+      type: "task_mention",
+      ideaId: step.idea_id,
+      taskId: step.task_id,
+      commentId: null,
+      discussionId: null,
+      replyId: null,
+      appUrl: APP_BASE_URL,
+    });
+    throw new Error(
+      "fail_step can't reject an awaiting_approval step — rejecting a human gate is a human action, same as " +
+      "approving one. Reject or request changes from the task's workflow panel in the VibeCodes web UI. " +
+      `Task: ${url}`
+    );
   }
 
-  // Attribute this failure to the persona the claim token was minted for
-  // (falls back to the caller for awaiting_approval rejections, where bot_id
-  // may still be set but the human gate owns the decision).
-  const attributedTo = step.status !== "awaiting_approval" && step.bot_id ? step.bot_id : ctx.userId;
+  // Capability check, mirroring complete_step. Never mutates state on
+  // failure. The former persona-consistency warning was deleted alongside
+  // complete_step's (docs/agent-voice-comments-design.html §4.2) — see that
+  // function's comment for why.
+  // err-6: a work_token (wt_…) was presented here instead of a claim_token.
+  if (params.claim_token?.startsWith("wt_")) {
+    logger.warn("claim token rejected", {
+      tool: "fail_step",
+      reason: "work_token_in_completion_tool",
+      stepId: params.step_id,
+      callerUserId: ctx.userId,
+      ownerUserId: ctx.ownerUserId,
+    });
+    throw new Error(WORK_TOKEN_IN_COMPLETION_TOOL_MESSAGE);
+  }
+
+  if (!verifyClaimToken(step.claim_token_hash, params.claim_token)) {
+    logger.warn("claim token rejected", {
+      tool: "fail_step",
+      reason: "invalid_or_missing_claim_token",
+      stepId: params.step_id,
+      callerUserId: ctx.userId,
+      ownerUserId: ctx.ownerUserId,
+    });
+    throw new Error(
+      "This step isn't claimed by you. Call claim_next_step to (re)claim it — " +
+      "you'll receive a claim_token to pass to fail_step."
+    );
+  }
+
+  // Attribute this failure to the persona the claim token was minted for.
+  // (awaiting_approval never reaches here — it throws above.)
+  const attributedTo = step.bot_id ? step.bot_id : ctx.userId;
 
   // P2c: resolve executed_model/tier_honored from the self-reported model_used
   // (same rules as complete_step — see resolveTierAdherence). Only run the
@@ -1472,12 +1498,18 @@ export async function failStep(
     .from("task_workflow_steps")
     .update(updateFields)
     .eq("id", params.step_id)
-    .in("status", ["in_progress", "awaiting_approval"])
+    // Narrowed to in_progress only (was ["in_progress", "awaiting_approval"]):
+    // the awaiting_approval case now throws above, before this query runs, but
+    // the concurrency guard here still has to match — otherwise a step that
+    // races into awaiting_approval between the fetch above and this UPDATE
+    // (e.g. a concurrent complete_step) would slip through this filter and
+    // get failed anyway, reopening the exact bypass this change closes.
+    .eq("status", "in_progress")
     .select("id, task_id, run_id, title, agent_role, status, output, model_tier, executed_model, tier_honored, persona_used, persona_honored, skills_used")
     .maybeSingle();
 
   if (updateError) throw new Error(`Failed to fail step: ${updateError.message}`);
-  if (!updated) throw new Error("Step is not in a state that can be failed (must be in_progress or awaiting_approval)");
+  if (!updated) throw new Error("Step is not in a state that can be failed (must be in_progress)");
 
   // Touch board_tasks so Realtime fires before denormalized counts arrive
   await touchBoardTask(ctx, updated.task_id);
@@ -1698,92 +1730,66 @@ export async function updateStep(
 
 // --- Approve Step ---
 
+// Schema kept unchanged (including the now-unused `comment` field) so a
+// stale client's existing call shape still parses and reaches the
+// instructive stub error below, instead of failing validation first.
 export const approveStepSchema = z.object({
-  step_id: z.string().uuid().describe("The workflow step ID (must be in awaiting_approval status)"),
-  comment: z.string().max(5000).optional().describe("Optional approval comment"),
+  step_id: z.string().uuid().describe("The workflow step ID"),
+  comment: z.string().max(5000).optional().describe("Unused — approve_step no longer approves anything. See the tool description."),
 });
 
+// approve_step is a hard-error stub (board task d572c4d1-bb45-468d-94b0-f3ac01855601,
+// modelled on set_agent_identity's retirement — register-tools.ts's
+// setBotIdentity). The prior version only checked users.is_bot on ctx.userId,
+// which is the HUMAN's own id on the remote OAuth transport — any agent
+// running under a connection authenticated as the human (the normal case for
+// an autonomous orchestrator) sailed straight through, defeating the gate
+// entirely. There is no reliable signal that distinguishes "a human clicked
+// Approve" from "an agent called approve_step" over MCP, so this tool no
+// longer approves anything, from any transport, ever. The ONLY path to
+// approval is approveWorkflowStep in src/actions/workflow.ts, which runs
+// inside the human's authenticated browser session and stamps approved_by/
+// approved_at/approval_method. A BEFORE UPDATE trigger (migration 00159)
+// enforces this in the database as defence in depth. Kept registered (never
+// unregistered) so a stale/confused client gets this instructive error
+// instead of an unknown-tool failure.
 export async function approveStep(
   ctx: McpContext,
   params: z.infer<typeof approveStepSchema>
-) {
-  // Block bot callers — only humans can approve human-gated steps
-  const { data: caller } = await ctx.supabase
-    .from("users")
-    .select("is_bot")
-    .eq("id", ctx.userId)
-    .single();
-
-  if (caller?.is_bot) {
-    // set_agent_identity is retired — this connection's agent identity is now
-    // either a stdio install's static VIBECODES_BOT_ID or (remotely) can no
-    // longer happen at all, since ctx.userId is always the real human there.
-    // The guard stays (docs/agent-voice-comments-design.html §4.1, Q7 §5):
-    // it still protects a bot-configured stdio install, and it keeps
-    // "approval is a human act" enforced rather than assumed.
-    throw new Error(
-      "Only humans can approve workflow steps. This connection is authenticated as an agent " +
-      "(a stdio install configured with VIBECODES_BOT_ID). Ask the human to approve from the " +
-      "task's workflow panel in the web UI, or run approval from a connection authenticated as " +
-      "the human account. Do NOT approve without explicit human instruction."
-    );
-  }
-
-  // Fetch step — must be awaiting_approval
-  const { data: step, error: fetchError } = await ctx.supabase
-    .from("task_workflow_steps")
-    .select("id, run_id, idea_id, status")
-    .eq("id", params.step_id)
-    .single();
-
-  if (fetchError || !step) throw new Error(`Step not found: ${params.step_id}`);
-  if (step.status !== "awaiting_approval") {
-    throw new Error(`Step is not awaiting approval (current status: ${step.status})`);
-  }
-
-  const { data: updated, error: updateError } = await ctx.supabase
-    .from("task_workflow_steps")
-    .update({
-      status: "completed",
-      completed_at: new Date().toISOString(),
-      claim_token_hash: null, // token lifecycle ends with the step
-      work_token_hash: null, // belt-and-braces — normally already null by this point
-    })
-    .eq("id", params.step_id)
-    .eq("status", "awaiting_approval")
-    .select("id, task_id, run_id, title, agent_role, status, output, completed_at")
-    .maybeSingle();
-
-  if (updateError) throw new Error(`Failed to approve step: ${updateError.message}`);
-  if (!updated) throw new Error("Step is no longer awaiting approval — it may have been modified concurrently");
-
-  // Touch board_tasks so Realtime fires before denormalized counts arrive
-  await touchBoardTask(ctx, updated.task_id);
-
-  // Insert approval comment if provided
-  if (params.comment && step.idea_id) {
-    const { error: commentError } = await ctx.supabase
-      .from("workflow_step_comments")
-      .insert({
-        step_id: params.step_id,
-        idea_id: step.idea_id,
-        author_id: ctx.userId,
-        type: "approval",
-        content: params.comment,
+): Promise<never> {
+  // Best-effort deep link to the task's workflow panel — never mutates
+  // anything and never blocks the error on failure (e.g. the step doesn't
+  // exist, or a test context's mock doesn't implement this table).
+  let deepLinkSuffix = "";
+  try {
+    const { data: step } = await ctx.supabase
+      .from("task_workflow_steps")
+      .select("idea_id, task_id")
+      .eq("id", params.step_id)
+      .maybeSingle();
+    if (step?.idea_id && step?.task_id) {
+      const url = buildNotificationUrl({
+        type: "task_mention",
+        ideaId: step.idea_id,
+        taskId: step.task_id,
+        commentId: null,
+        discussionId: null,
+        replyId: null,
+        appUrl: APP_BASE_URL,
       });
-    if (commentError) {
-      // Non-fatal: step is already approved, just log
-      logger.warn("Failed to insert approval comment", { error: commentError.message, stepId: params.step_id });
+      deepLinkSuffix = ` Task: ${url}`;
     }
+  } catch {
+    // Deep link is a nicety, not a requirement — the error text below still
+    // tells the caller where to go.
   }
 
-  // Check if all steps in the run are done
-  let runComplete = false;
-  if (step.run_id) {
-    runComplete = await checkAndCompleteRun(ctx.supabase, step.run_id);
-  }
-
-  return { step: updated, run_complete: runComplete };
+  throw new Error(
+    "approve_step no longer approves anything — human-approval gates can only be approved from the task's " +
+    "workflow panel in the VibeCodes web UI, by a human clicking Approve. No MCP connection (stdio or remote, " +
+    "even one authenticated as the human's own account) can complete this action anymore. Stop here: show the " +
+    "human the deliverable and wait for them to approve it in the UI." + deepLinkSuffix
+  );
 }
 
 

--- a/mcp-server/src/tools/workflows.ts
+++ b/mcp-server/src/tools/workflows.ts
@@ -1040,7 +1040,7 @@ export async function claimNextStep(
 
   if (updated.human_check_required) {
     contextParts.push(
-      `HUMAN APPROVAL REQUIRED: This step requires human approval. After producing your deliverable and calling complete_step, you MUST STOP. Do NOT call approve_step yourself. Present your deliverable to the user and wait for them to explicitly instruct you to approve it.`
+      `HUMAN APPROVAL REQUIRED: This step requires human approval. After producing your deliverable and calling complete_step, you MUST STOP. approve_step no longer works from any MCP connection, even with human instruction — present your deliverable to the user and ask them to approve or reject it from the task's workflow panel in the VibeCodes web UI.`
     );
   }
 

--- a/src/actions/workflow.test.ts
+++ b/src/actions/workflow.test.ts
@@ -39,7 +39,7 @@ vi.mock("@/lib/workflow-helpers", () => ({
   checkAndCompleteRun: vi.fn().mockResolvedValue(false),
 }));
 
-import { completeWorkflowStep, failWorkflowStep } from "./workflow";
+import { completeWorkflowStep, failWorkflowStep, approveWorkflowStep } from "./workflow";
 
 describe("completeWorkflowStep — manual UI submission", () => {
   beforeEach(() => {
@@ -133,6 +133,41 @@ describe("failWorkflowStep — manual UI rejection", () => {
 
     await expect(failWorkflowStep("step-1")).rejects.toThrow(
       /not in a state that can be failed/i
+    );
+  });
+});
+
+// Board task d572c4d1-bb45-468d-94b0-f3ac01855601: this Server Action is the
+// ONLY remaining path that can move a step out of awaiting_approval — the
+// MCP approve_step tool is a hard-error stub. It must stamp who/how/when on
+// every such UPDATE, both for the UI's own provenance display and because a
+// DB trigger (migration 00159) now rejects an awaiting_approval -> completed
+// UPDATE that omits approved_by/approval_method.
+describe("approveWorkflowStep — manual UI approval", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stamps approved_by, approved_at, and approval_method: 'web_ui' on the update payload", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: { id: "step-1", run_id: null, status: "completed" },
+      error: null,
+    });
+
+    await approveWorkflowStep("step-1");
+
+    const updateArgs = mockUpdate.mock.calls[0]?.[0];
+    expect(updateArgs?.status).toBe("completed");
+    expect(updateArgs?.approved_by).toBe(HUMAN_USER_ID);
+    expect(updateArgs?.approval_method).toBe("web_ui");
+    expect(updateArgs?.approved_at).toBeTypeOf("string");
+  });
+
+  it("throws when the row is no longer awaiting approval", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    await expect(approveWorkflowStep("step-1")).rejects.toThrow(
+      /no longer awaiting approval/i
     );
   });
 });

--- a/src/actions/workflow.ts
+++ b/src/actions/workflow.ts
@@ -378,9 +378,19 @@ export async function approveWorkflowStep(stepId: string, output?: string) {
 
   if (!user) throw new Error("Not authenticated");
 
+  // Approval provenance (board task d572c4d1): this Server Action, running
+  // inside the human's own authenticated browser session, is the ONLY path
+  // that can move a step out of awaiting_approval into completed — the MCP
+  // `approve_step` tool is a hard-error stub. Stamping who/how/when here is
+  // what a DB trigger (migration 00159) now requires on every such
+  // transition, and what the step card displays as approval provenance.
+  const now = new Date().toISOString();
   const updateFields: Record<string, unknown> = {
     status: "completed",
-    completed_at: new Date().toISOString(),
+    completed_at: now,
+    approved_by: user.id,
+    approved_at: now,
+    approval_method: "web_ui",
   };
   // Only overwrite output if the approver explicitly provides one;
   // otherwise preserve the agent's original deliverable.

--- a/src/app/guide/mcp-integration/page.tsx
+++ b/src/app/guide/mcp-integration/page.tsx
@@ -348,7 +348,7 @@ export default function McpIntegrationPage() {
                   { name: "complete_step", description: "Mark a step as complete with optional output" },
                   { name: "fail_step", description: "Fail a step with optional cascade rejection to an earlier step" },
                   { name: "skip_step", description: "Skip a pending step that isn't applicable" },
-                  { name: "approve_step", description: "Approve a step awaiting human review (humans only)" },
+                  { name: "approve_step", description: "Retired — always errors. Approve a step awaiting human review from the task's workflow panel in the web UI instead" },
                   { name: "add_step_comment", description: "Add a comment to a workflow step" },
                   { name: "rematch_workflow_agents", description: "Re-match unmatched pending steps against the agent team" },
                   { name: "reset_workflow", description: "Reset all steps to pending and restart the workflow" },

--- a/src/components/board/step-detail-dialog.tsx
+++ b/src/components/board/step-detail-dialog.tsx
@@ -763,6 +763,15 @@ export function StepDetailDialog({
                     {new Date(step.completed_at).toLocaleString()}
                   </span>
                 )}
+                {/* Approval provenance (board task d572c4d1) — only a web UI
+                    approval can ever set these three columns together. */}
+                {step.approved_by && step.approval_method && (
+                  <span>
+                    Approved by {step.approver?.full_name ?? "a team member"} via{" "}
+                    {step.approval_method === "web_ui" ? "web UI" : step.approval_method}
+                    {step.approved_at && ` · ${new Date(step.approved_at).toLocaleString()}`}
+                  </span>
+                )}
               </div>
             </>
           )}

--- a/src/components/board/task-workflow-section.tsx
+++ b/src/components/board/task-workflow-section.tsx
@@ -180,7 +180,10 @@ export function TaskWorkflowSection({ taskId, ideaId, isReadOnly = false }: Task
     const [stepsRes, runRes] = await Promise.all([
       supabase
         .from("task_workflow_steps")
-        .select("*")
+        // approver: joined for the approval-provenance line in
+        // step-detail-dialog.tsx ("Approved by X via web UI · date") —
+        // null on every step except one approved via the web UI.
+        .select("*, approver:users!task_workflow_steps_approved_by_fkey(full_name)")
         .eq("task_id", taskId)
         .order("step_order", { ascending: true }),
       supabase

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -888,6 +888,9 @@ export type Database = {
           persona_honored: boolean | null;
           skills_used: string[] | null;
           updated_at: string;
+          approved_by: string | null;
+          approved_at: string | null;
+          approval_method: string | null;
         };
         Insert: {
           id?: string;
@@ -919,6 +922,9 @@ export type Database = {
           completed_at?: string | null;
           created_at?: string;
           updated_at?: string;
+          approved_by?: string | null;
+          approved_at?: string | null;
+          approval_method?: string | null;
         };
         Update: {
           id?: string;
@@ -950,6 +956,9 @@ export type Database = {
           completed_at?: string | null;
           created_at?: string;
           updated_at?: string;
+          approved_by?: string | null;
+          approved_at?: string | null;
+          approval_method?: string | null;
         };
         Relationships: [
           {
@@ -983,6 +992,13 @@ export type Database = {
           {
             foreignKeyName: "task_workflow_steps_claimed_by_fkey";
             columns: ["claimed_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "task_workflow_steps_approved_by_fkey";
+            columns: ["approved_by"];
             isOneToOne: false;
             referencedRelation: "users";
             referencedColumns: ["id"];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,7 +51,11 @@ export type BoardTask = Database["public"]["Tables"]["board_tasks"]["Row"];
 export type BoardLabel = Database["public"]["Tables"]["board_labels"]["Row"];
 export type BoardTaskLabel = Database["public"]["Tables"]["board_task_labels"]["Row"];
 export type AiPromptTemplate = Database["public"]["Tables"]["ai_prompt_templates"]["Row"];
-export type TaskWorkflowStep = Database["public"]["Tables"]["task_workflow_steps"]["Row"];
+export type TaskWorkflowStep = Database["public"]["Tables"]["task_workflow_steps"]["Row"] & {
+  // Populated only when the fetching query joins users!task_workflow_steps_approved_by_fkey
+  // (task-workflow-section.tsx) — mirrors WorkflowRun's optional template_name pattern below.
+  approver?: { full_name: string | null } | null;
+};
 export type WorkflowStepComment = Database["public"]["Tables"]["workflow_step_comments"]["Row"];
 export type WorkflowTemplate = Database["public"]["Tables"]["workflow_templates"]["Row"];
 export type WorkflowAutoRule = Database["public"]["Tables"]["workflow_auto_rules"]["Row"];

--- a/supabase/migrations/00159_workflow_step_approval_provenance.sql
+++ b/supabase/migrations/00159_workflow_step_approval_provenance.sql
@@ -1,0 +1,66 @@
+-- Human-approval gate enforcement (board task d572c4d1-bb45-468d-94b0-f3ac01855601):
+-- "URGENT: human-approval gates aren't enforced — an orchestrating agent can
+-- call approve_step on its own workflow."
+--
+-- BUG: the MCP `approve_step` tool only checked `users.is_bot` on
+-- `ctx.userId`. On the remote OAuth transport, `ctx.userId` is always the
+-- authenticated HUMAN's own id — an autonomous agent orchestrating a
+-- workflow over a connection authenticated as its human owner sailed
+-- straight through that check and could self-approve its own
+-- human_check_required step, defeating the gate entirely. `fail_step`'s
+-- awaiting_approval rejection branch had no identity gate of any kind.
+--
+-- FIX (Option 1 — "approvals only via the web UI"): the MCP tools
+-- `approve_step` and `fail_step` (on an awaiting_approval step) are now hard-
+-- error stubs — see mcp-server/src/tools/workflows.ts. The ONLY remaining
+-- path to approval is `approveWorkflowStep` in src/actions/workflow.ts, a
+-- Server Action that runs inside the human's own authenticated browser
+-- session. This migration:
+--
+--   1. Adds provenance columns so an approval can be attributed to a real
+--      human, method, and time — today only 'web_ui' exists, but the column
+--      is a free CHECK-constrained text (not an enum) so a future approval
+--      surface doesn't need a schema migration to add itself.
+--   2. Adds a BEFORE UPDATE trigger as defence in depth: even if the
+--      application-level stub above regresses (a future PR reintroduces a
+--      working approve_step, a new code path forgets the provenance write,
+--      etc.), the database itself refuses to move a step from
+--      awaiting_approval to completed unless approved_by AND
+--      approval_method are both set on the very same UPDATE.
+--
+-- AUDITED every path that transitions a task_workflow_steps row OUT OF
+-- awaiting_approval (full list in the PR description) — the trigger only
+-- constrains awaiting_approval -> completed, so it does not touch any of
+-- them: MCP fail_step (now rejects awaiting_approval outright, never
+-- reaches an UPDATE), MCP/UI cascade reset and resetWorkflow (-> pending),
+-- MCP/UI removeWorkflow (DELETE, not UPDATE), propagateTemplateEdits/
+-- resync_workflow_template (touches pending steps only). The single
+-- legitimate awaiting_approval -> completed writer is approveWorkflowStep,
+-- updated in this PR to stamp all three columns in the same UPDATE.
+
+ALTER TABLE task_workflow_steps
+  ADD COLUMN approved_by uuid REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN approved_at timestamptz,
+  ADD COLUMN approval_method text CHECK (approval_method IN ('web_ui'));
+
+COMMENT ON COLUMN task_workflow_steps.approved_by IS 'Human who approved this step (awaiting_approval -> completed). Null for steps never gated or not yet approved.';
+COMMENT ON COLUMN task_workflow_steps.approved_at IS 'When approved_by approved this step.';
+COMMENT ON COLUMN task_workflow_steps.approval_method IS 'How the approval was made. Currently only ''web_ui'' (src/actions/workflow.ts approveWorkflowStep) — there is no MCP path.';
+
+-- Defence in depth: block the transition at the database layer regardless of
+-- which code path (or bug) attempts it.
+CREATE OR REPLACE FUNCTION enforce_workflow_step_approval_gate()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.approved_by IS NULL OR NEW.approval_method IS NULL THEN
+    RAISE EXCEPTION 'task_workflow_steps %: cannot move awaiting_approval -> completed without approved_by and approval_method (human-approval gate, board task d572c4d1)', NEW.id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SET search_path = public;
+
+CREATE TRIGGER workflow_step_approval_gate_trigger
+  BEFORE UPDATE ON task_workflow_steps
+  FOR EACH ROW
+  WHEN (OLD.status = 'awaiting_approval' AND NEW.status = 'completed')
+  EXECUTE FUNCTION enforce_workflow_step_approval_gate();


### PR DESCRIPTION
## What / Why

`human_check_required` workflow steps move to `awaiting_approval` and should only advance when a human genuinely approves. The MCP `approve_step` tool's only guard was a `users.is_bot` lookup on `ctx.userId` — but on the remote OAuth transport, `ctx.userId` is always the authenticated **human's own id**, so an orchestrating agent running under a connection authenticated as its human owner sailed straight through and could self-approve its own gated step. `fail_step`'s `awaiting_approval` rejection branch had no identity gate of any kind.

Building on the findings from **Reproduce & Investigate** (board task d572c4d1-bb45-468d-94b0-f3ac01855601): both bypasses were confirmed at `mcp-server/src/tools/workflows.ts` (`approveStep` ~1706-1787, `failStep`'s awaiting_approval branch ~1395-1427), stdio sessions were already safe (they run as a bot id, which the old check correctly blocked), and the only live exposure was the remote MCP transport where `ctx.userId` is the human's own id.

**Decision implemented: Option 1 — "approvals only via the web UI"** (the investigation's own recommendation). There is no reliable signal over MCP that distinguishes "a human clicked Approve" from "an agent called this tool", even on a human-authenticated connection — so both `approve_step` and `fail_step` (on an `awaiting_approval` step) are now hard-error stubs, modelled on `set_agent_identity`'s retirement. The only remaining path to approval/rejection is the web UI's own server actions, which run inside the human's authenticated browser session. A DB trigger enforces this as defence in depth.

## Acceptance criteria

- [x] An agent (stdio/local orchestrator, or remote MCP acting autonomously) calling `approve_step` on an `awaiting_approval` step is rejected — the ONLY path to approval is a genuine human action (web UI click).
- [x] The human sees the deliverable and explicitly approves/rejects before the workflow proceeds (unchanged web UI flow).
- [x] Approval provenance is recorded (human, method, timestamp) and visible on the step.
- [x] Existing legitimate human approvals (web UI) keep working unchanged — `approveWorkflowStep` behaviour is otherwise identical, now stamping provenance in the same UPDATE.

## Changes

**mcp-server**
- `approveStep` (`mcp-server/src/tools/workflows.ts`) is now a hard-error stub — never touches the DB except a best-effort read to build a deep link to the task's board for the error message. Removed the dead `users.is_bot` check.
- `failStep` rejects outright when the target step is `awaiting_approval`, with the same web-UI-only messaging. Its `in_progress` claim-token path is completely unchanged; the update's concurrency filter is narrowed from `["in_progress", "awaiting_approval"]` to `"in_progress"` so a step that races into `awaiting_approval` between the fetch and the update can't slip through the old filter either.
- `register-tools.ts`: `approve_step` and `fail_step` tool descriptions updated to state the new behaviour; `complete_step`'s "awaiting approval" message updated to stop telling agents `approve_step` might work with human instruction.

**Migration + types**
- `supabase/migrations/00159_workflow_step_approval_provenance.sql`: adds `approved_by uuid references users(id) on delete set null`, `approved_at timestamptz`, `approval_method text check (approval_method in ('web_ui'))` to `task_workflow_steps`. Adds a `BEFORE UPDATE` trigger that raises unless `approved_by`/`approval_method` are both set whenever a step moves `awaiting_approval -> completed`.
- `src/types/database.ts`: Row/Insert/Update + Relationships entry for the new columns/FK.

**Server action**
- `src/actions/workflow.ts` (`approveWorkflowStep`): stamps `approved_by`, `approved_at`, `approval_method: 'web_ui'` on the same UPDATE. Behaviour otherwise unchanged (optional output override, comment row, revalidation).

**UI**
- `src/types/index.ts`: `TaskWorkflowStep` carries an optional `approver` join field.
- `src/components/board/task-workflow-section.tsx`: steps query now joins `users!task_workflow_steps_approved_by_fkey(full_name)`.
- `src/components/board/step-detail-dialog.tsx`: shows "Approved by \<name\> via web UI · \<date\>" next to the existing Started/Completed timestamps once a step has been approved.

**Docs**
- `CLAUDE.md` and `src/app/guide/mcp-integration/page.tsx`: corrected statements that `approve_step` was a working, identity-gated approval path.

## Audited `awaiting_approval` transition paths (for the trigger)

| Path | Target status | Collides with trigger? |
|---|---|---|
| MCP `approveStep` | now a stub — never reaches an UPDATE | No |
| MCP `failStep` (awaiting_approval branch) | now rejects outright — never reaches an UPDATE | No |
| MCP `failStep` cascade reset (`reset_to_step_id`) | `pending` | No — not `completed` |
| MCP `resetWorkflow` | `pending` (all steps in run) | No |
| MCP `removeWorkflow` | row deleted (not UPDATEd) | No — DELETE, not UPDATE |
| `propagateTemplateEdits` / `resync_workflow_template` | only touches `pending` steps | No |
| Web UI `approveWorkflowStep` (`src/actions/workflow.ts`) | `completed` | **Yes — the one legitimate writer; updated to stamp `approved_by`/`approval_method` on the same UPDATE** |
| Web UI `failWorkflowStep` (reject, incl. cascade) | `failed` or `pending` | No |
| Web UI `resetWorkflow` / `removeWorkflow` | `pending` / row deleted | No |

## Test / lint / typecheck results

- `npx tsc --noEmit` (root): clean.
- `cd mcp-server && npx tsc --noEmit`: clean.
- `npm run test` (root, Vitest — covers both `src/` and `mcp-server/src/`): **175 files, 2864 tests passed**, 0 failed.
- `npm run lint`: **0 errors**, 76 warnings — all pre-existing (confirmed via `git stash` before/after comparison), none introduced by this change.
- Local Supabase (`supabase status`) was not running (Docker unavailable) — did not start it per instructions; migration SQL was re-read carefully instead, following the repo's existing FK/trigger/`SET search_path` conventions from recent migrations (00071, 00098, 00102).

Migration: yes — 00159 (adds `approved_by`/`approved_at`/`approval_method` columns + `workflow_step_approval_gate_trigger`).

## Left out / needs Nick's decision

- Historical design docs under `docs/*.html` (e.g. `docs/workflow-system.html`, `docs/claim-token-protocol-design.html`) still describe the old `is_bot`-check design. Per the repo's own convention (`set_agent_identity`'s retirement was "structural, not narrated" — these are append-only design records, not living docs), I left them as-is and only updated `CLAUDE.md` and the guide page, which are the living references.
- No `step-detail-dialog.test.tsx` / `task-workflow-section.test.tsx` exists in the repo, so the new "Approved by" UI line has no component test — didn't invent a new test harness per the task's own instruction not to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)