### PR TITLE
fix(terminal): hide unresumable (no-folder) sessions from the chooser's Recent list

### DIFF
--- a/src/components/board/terminal-session-chooser.test.tsx
+++ b/src/components/board/terminal-session-chooser.test.tsx
@@ -189,12 +189,17 @@ describe("TerminalSessionChooser", () => {
     expect(screen.queryByText(/Starts a new terminal/)).not.toBeInTheDocument();
   });
 
-  // Bug 9fb9fced (2026-08-17): a null-cwd Recent row used to never reach this
-  // component at all (chooser-data.ts hid it from `sections.recent`
-  // entirely). Now that it does, this proves the UI half of the fix: the row
-  // (sid, ended time) still renders, but Resume is omitted — not shown
-  // disabled — since there's no folder for it to reopen.
-  it("Recent row with no recorded cwd: renders the row but omits the Resume button", () => {
+  // Card cbe60db5 follow-up (Nick's field report, 2026-08-17): a null-cwd
+  // Recent row used to render here with Resume omitted and a "Can't resume —
+  // no folder recorded" note (bug 9fb9fced's fix, still true of the
+  // underlying ChooserSections — see chooser-data.test.ts). Nick's explicit
+  // ask this time: those rows are dead entries with nothing to click and
+  // shouldn't appear in the human-visible list AT ALL — only the Resume
+  // affordance was ever the problem, and now the whole row is gone from what
+  // renders. The data itself is untouched (proven separately in
+  // chooser-data.test.ts and entry-decision.test.ts) — this is purely about
+  // what this component puts on screen.
+  it("Recent row with no recorded cwd: the row itself is not rendered at all", () => {
     const onResume = vi.fn();
     const row = {
       sid: "sid-recent-no-cwd",
@@ -216,9 +221,79 @@ describe("TerminalSessionChooser", () => {
         onStartNew={vi.fn()}
       />,
     );
-    expect(screen.getByText(/no recorded folder/)).toBeInTheDocument();
+    expect(screen.queryByText(/no recorded folder/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Can.t resume/)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Resume" })).not.toBeInTheDocument();
-    expect(screen.getByText(/Can.t resume/)).toBeInTheDocument();
+    // No cwd-having rows either → the whole section is gone, header included.
+    expect(screen.queryByText("Recent — ended in the last 48h")).not.toBeInTheDocument();
+  });
+
+  it("Recent list: excludes a no-cwd row while still including one that DOES have a folder", () => {
+    const noCwdRow = {
+      sid: "sid-no-cwd",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      cwd: null,
+      machineLabel: null,
+      claudeSessionId: null,
+      endedAt: new Date().toISOString(),
+    };
+    const withCwdRow = {
+      sid: "sid-with-cwd",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      cwd: "~/projects/vibecodes",
+      machineLabel: null,
+      claudeSessionId: null,
+      endedAt: new Date().toISOString(),
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ recent: [noCwdRow, withCwdRow] })}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    // Section renders (at least one visible row) and shows only the
+    // cwd-having one.
+    expect(screen.getByText("Recent — ended in the last 48h")).toBeInTheDocument();
+    expect(screen.getByText(/~\/projects\/vibecodes/)).toBeInTheDocument();
+    expect(screen.queryByText(/no recorded folder/)).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Resume" })).toHaveLength(1);
+  });
+
+  // The section header's show/hide must key off the FILTERED count, not the
+  // raw `sections.recent.length` — a Recent section made up entirely of
+  // no-folder rows has nothing left to show, so the header disappears too,
+  // not just the (already-empty) row list beneath it.
+  it("Recent section header is hidden when every recent row is no-cwd, even though sections.recent is non-empty", () => {
+    const row = {
+      sid: "sid-no-cwd",
+      ideaId: "idea-1",
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      cwd: null,
+      machineLabel: null,
+      claudeSessionId: null,
+      endedAt: new Date().toISOString(),
+    };
+    render(
+      <TerminalSessionChooser
+        sections={sections({ recent: [row] })}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Recent — ended in the last 48h")).not.toBeInTheDocument();
   });
 
   it("Recent row with a tracked claudeSessionId: the confirm copy promises the EXACT conversation (rework 5)", () => {

--- a/src/components/board/terminal-session-chooser.tsx
+++ b/src/components/board/terminal-session-chooser.tsx
@@ -21,6 +21,7 @@ import { formatSessionAge } from "@/lib/terminal/session-registry";
 import { newSessionTooltip, getTerminalSessionCap, isNearSessionCap, terminalLimitLine } from "@/lib/terminal/session-cap";
 import {
   findLiveSessionForTask,
+  visibleRecentRows,
   type ChooserSections,
   type ChooserLiveRow,
   type ChooserRecentRow,
@@ -130,6 +131,14 @@ export function TerminalSessionChooser({
     // Only on mount — re-focusing on every prop change would steal focus
     // back from whatever the user is doing (e.g. mid-confirm on Resume).
   }, []);
+
+  // Display-only filter (Nick's field report, 2026-08-17): rows with no
+  // recorded folder ("Can't resume — no folder recorded") have nothing to
+  // click, so they're dropped from what's actually shown here — but
+  // `sections.recent` itself stays unfiltered (see visibleRecentRows's doc
+  // comment in chooser-data.ts): `findTaskSessionMatch` above this component
+  // and `entry-decision.ts`'s registry read both still need the full set.
+  const visibleRecent = visibleRecentRows(sections.recent);
 
   const taskMatch = pendingTask ? findLiveSessionForTask(sections, pendingTask.taskId) : null;
   const wasOpenSid =
@@ -272,9 +281,9 @@ export function TerminalSessionChooser({
         </ChooserSection>
       )}
 
-      {sections.recent.length > 0 && (
+      {visibleRecent.length > 0 && (
         <ChooserSection label="Recent — ended in the last 48h">
-          {sections.recent.map((row) => (
+          {visibleRecent.map((row) => (
             <RecentRow
               key={row.sid}
               row={row}
@@ -372,12 +381,13 @@ function RecentRow({
   onConfirm: () => void;
 }) {
   const label = row.taskTitle?.trim() || row.ideaTitle || row.sid.slice(0, 8);
-  // Null-cwd fix (bug 9fb9fced): the row itself is always shown (see
-  // chooser-data.ts's header comment) — Resume is the only thing that's
-  // unavailable when there's no recorded folder to reopen, since the launch
-  // flow Resume calls into (handleChooserResume) requires one. No disabled
-  // ghost button (original F4 intent) — the action is omitted entirely, with
-  // an honest inline note instead of silently doing nothing.
+  // Null-cwd handling: kept defensive even though the caller (this file's
+  // `visibleRecent`, via `visibleRecentRows`) now filters null-cwd rows out
+  // before they ever reach this component — see chooser-data.ts's
+  // `visibleRecentRows` doc comment for why the underlying `ChooserSections`
+  // itself is never filtered at the source. If `row.cwd` is ever null here,
+  // Resume is simply omitted (never a disabled ghost button) with an honest
+  // inline note instead of silently doing nothing.
   return (
     <div className={cn("border-t border-zinc-800 px-3.5 py-2.5", confirming && "bg-emerald-500/5")}>
       <div className="flex items-start gap-2.5">

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -7,7 +7,9 @@ import {
   findLiveSessionForTask,
   findTaskSessionMatch,
   liveSessionsElsewhereOnThisBoard,
+  visibleRecentRows,
   type ChooserRegistryRow,
+  type ChooserRecentRow,
 } from "./chooser-data";
 
 const NOW = Date.parse("2026-07-20T12:00:00.000Z");
@@ -529,6 +531,70 @@ describe("findTaskSessionMatch", () => {
     ];
     const sections = deriveChooserSections(rows, IDEA_A, NOW);
     expect(findTaskSessionMatch(sections, "task-1")).toBeNull();
+  });
+
+  // Card cbe60db5 follow-up (Nick, 2026-08-17): the general chooser's Recent
+  // list now hides no-folder rows via `visibleRecentRows` (a display-only
+  // filter applied by terminal-session-chooser.tsx). `findTaskSessionMatch`
+  // must NOT pick up that filter — a task-scoped launch still has to dedupe
+  // against its own no-folder recent session (routing to
+  // terminal-task-launch-choice.tsx's "already have a session" dialog
+  // instead of silently minting a second one for the same task).
+  it("still matches a Recent row with no recorded cwd — unaffected by the chooser's display-only filter", () => {
+    const rows = [row({ sid: "no-cwd-recent", status: "ended", cwd: null, taskId: "task-1", endedAt: new Date(NOW - 60_000).toISOString() })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    const match = findTaskSessionMatch(sections, "task-1");
+    expect(match?.kind).toBe("recent");
+    expect(match?.row.sid).toBe("no-cwd-recent");
+  });
+});
+
+// Card cbe60db5 follow-up (Nick's field report, 2026-08-17 — "Can't resume —
+// no folder recorded" rows are dead entries with nothing to click, they
+// shouldn't be in the human-visible list). `visibleRecentRows` is the
+// display-only filter `terminal-session-chooser.tsx` applies to
+// `ChooserSections.recent` for its row list AND its section show/hide check
+// — it must NEVER be baked into `deriveChooserSections` itself, since
+// `entry-decision.ts` (reads raw registry rows directly, see
+// entry-decision.test.ts) and `findTaskSessionMatch` (above) both still need
+// every recent row, folder or not.
+describe("visibleRecentRows", () => {
+  function recentRow(overrides: Partial<ChooserRecentRow> & { sid: string }): ChooserRecentRow {
+    return {
+      ideaId: IDEA_A,
+      ideaTitle: "VibeCodes",
+      taskId: null,
+      taskTitle: null,
+      cwd: null,
+      machineLabel: null,
+      claudeSessionId: null,
+      endedAt: new Date(NOW - 60_000).toISOString(),
+      ...overrides,
+    };
+  }
+
+  it("excludes rows with no recorded cwd", () => {
+    const recent = [recentRow({ sid: "no-cwd", cwd: null })];
+    expect(visibleRecentRows(recent)).toEqual([]);
+  });
+
+  it("keeps rows that DO have a recorded cwd", () => {
+    const recent = [recentRow({ sid: "with-cwd", cwd: "~/projects/a" })];
+    expect(visibleRecentRows(recent)).toEqual(recent);
+  });
+
+  it("keeps only the cwd-bearing rows out of a mixed set, preserving order", () => {
+    const recent = [
+      recentRow({ sid: "a", cwd: "~/projects/a" }),
+      recentRow({ sid: "no-cwd", cwd: null }),
+      recentRow({ sid: "b", cwd: "~/projects/b" }),
+    ];
+    expect(visibleRecentRows(recent).map((r) => r.sid)).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty array when every row is no-cwd", () => {
+    const recent = [recentRow({ sid: "a", cwd: null }), recentRow({ sid: "b", cwd: null })];
+    expect(visibleRecentRows(recent)).toEqual([]);
   });
 });
 

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -419,6 +419,32 @@ describe("chooserHeaderCounts", () => {
     );
     expect(chooserHeaderCounts(sections)).toEqual({ here: 1, elsewhere: 1, recent: 1 });
   });
+
+  // Card cbe60db5 follow-up: the "N recent" header pill (terminal-dock.tsx)
+  // must agree with the chooser's own filtered Recent list — a no-folder row
+  // isn't worth counting here any more than it's worth a row in the list.
+  it("does not count a no-cwd Recent row — the pill matches the filtered (visible) list, not the raw one", () => {
+    const sections = deriveChooserSections(
+      [row({ sid: "no-cwd", status: "ended", cwd: null, endedAt: new Date(NOW - 60_000).toISOString() })],
+      IDEA_A,
+      NOW,
+    );
+    expect(sections.recent).toHaveLength(1); // raw data layer still has it (bug 9fb9fced's fix)
+    expect(chooserHeaderCounts(sections).recent).toBe(0); // the pill does not
+  });
+
+  it("counts a mix of no-cwd and cwd-bearing Recent rows correctly (only the latter)", () => {
+    const sections = deriveChooserSections(
+      [
+        row({ sid: "no-cwd", status: "ended", cwd: null, endedAt: new Date(NOW - 60_000).toISOString() }),
+        row({ sid: "with-cwd", status: "ended", cwd: "~/projects/a", endedAt: new Date(NOW - 30_000).toISOString() }),
+      ],
+      IDEA_A,
+      NOW,
+    );
+    expect(sections.recent).toHaveLength(2);
+    expect(chooserHeaderCounts(sections).recent).toBe(1);
+  });
 });
 
 describe("findLiveSessionForTask", () => {

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -22,11 +22,20 @@
 // Resume button — so a session that force-closed before its cwd ever landed
 // vanished from history outright, and a refresh landing in that gap read as
 // "nothing to reconnect to" and silently launched a brand-new session (see
-// entry-decision.ts's matching fix). A null-cwd row is now KEPT in Recent —
-// it still has a sid, an ended time, and often a machine label worth
-// showing — with only its Resume affordance suppressed by the chooser UI
-// (terminal-session-chooser.tsx), since Resume genuinely has no folder to
-// reopen. `ChooserRecentRow.cwd` is `string | null` accordingly.
+// entry-decision.ts's matching fix). A null-cwd row is now KEPT in
+// `ChooserSections.recent` at THIS (data) layer — it still has a sid, an
+// ended time, and often a machine label, and `entry-decision.ts` /
+// `findTaskSessionMatch` below both need to see it to route correctly.
+// `ChooserRecentRow.cwd` is `string | null` accordingly.
+//
+// DISPLAY-ONLY FILTERING, card cbe60db5 follow-up (2026-08-17 — Nick's field
+// report: "Can't resume — no folder recorded" rows are dead entries with
+// nothing to click and shouldn't be in the human-visible list at all): the
+// general session chooser (terminal-session-chooser.tsx) now drops null-cwd
+// rows from what it actually renders, via `visibleRecentRows` below — but
+// that filter is applied AT THE COMPONENT, never here. This module's
+// `recent` output is intentionally still the full, unfiltered set described
+// in the paragraph above; see `visibleRecentRows`'s own doc comment for why.
 //
 // MACHINE IDENTITY (Nick's sign-off change 2 — "hide conversations that
 // aren't on the machine that you're running vibecodes on"): Recent rows also
@@ -244,6 +253,33 @@ export function chooserHeaderCounts(sections: ChooserSections): {
     elsewhere: sections.liveElsewhere.length,
     recent: sections.recent.length,
   };
+}
+
+/**
+ * Display-only filter for the session chooser's Recent list (Nick, field
+ * report 2026-08-17: "Can't resume — no folder recorded" rows have nothing a
+ * human can click and shouldn't be in the list at all).
+ *
+ * IMPORTANT — this must NEVER be applied to `ChooserSections.recent` itself,
+ * only to what a display consumer maps over. `sections.recent` stays exactly
+ * as `deriveChooserSections` produces it (including null-cwd rows, per the
+ * NULL-CWD ROWS fix above) because two other things read it directly and
+ * must keep seeing the full set:
+ *   - `entry-decision.ts`'s `decideEntryBehaviour` — takes raw registry rows,
+ *     not `ChooserSections`, so it's untouched by this helper either way, but
+ *     the underlying data it depends on (a null-cwd row counting as "recent")
+ *     is the same invariant this filter must not undermine at the source.
+ *   - `findTaskSessionMatch` below — a task-scoped launch must still dedupe
+ *     against its own no-folder recent session (routing to
+ *     terminal-task-launch-choice.tsx's "already have a session" dialog
+ *     instead of silently minting a second one), even though that session
+ *     wouldn't be worth a row in the general chooser's list.
+ *
+ * `terminal-session-chooser.tsx` is the one place that calls this — for its
+ * row list AND its section show/hide check — so those two can't drift apart.
+ */
+export function visibleRecentRows(recent: ChooserRecentRow[]): ChooserRecentRow[] {
+  return recent.filter((r) => r.cwd !== null);
 }
 
 /**

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -242,29 +242,16 @@ export function deriveChooserSections(
   return { liveHere, liveElsewhere, recent };
 }
 
-/** Header pill counts ("2 running here · 1 on another board · 2 recent") — a thin, testable view over the sections. */
-export function chooserHeaderCounts(sections: ChooserSections): {
-  here: number;
-  elsewhere: number;
-  recent: number;
-} {
-  return {
-    here: sections.liveHere.length,
-    elsewhere: sections.liveElsewhere.length,
-    recent: sections.recent.length,
-  };
-}
-
 /**
  * Display-only filter for the session chooser's Recent list (Nick, field
  * report 2026-08-17: "Can't resume — no folder recorded" rows have nothing a
  * human can click and shouldn't be in the list at all).
  *
  * IMPORTANT — this must NEVER be applied to `ChooserSections.recent` itself,
- * only to what a display consumer maps over. `sections.recent` stays exactly
- * as `deriveChooserSections` produces it (including null-cwd rows, per the
- * NULL-CWD ROWS fix above) because two other things read it directly and
- * must keep seeing the full set:
+ * only to what a display consumer maps over (or counts). `sections.recent`
+ * stays exactly as `deriveChooserSections` produces it (including null-cwd
+ * rows, per the NULL-CWD ROWS fix above) because two other things read it
+ * directly and must keep seeing the full set:
  *   - `entry-decision.ts`'s `decideEntryBehaviour` — takes raw registry rows,
  *     not `ChooserSections`, so it's untouched by this helper either way, but
  *     the underlying data it depends on (a null-cwd row counting as "recent")
@@ -275,11 +262,32 @@ export function chooserHeaderCounts(sections: ChooserSections): {
  *     instead of silently minting a second one), even though that session
  *     wouldn't be worth a row in the general chooser's list.
  *
- * `terminal-session-chooser.tsx` is the one place that calls this — for its
- * row list AND its section show/hide check — so those two can't drift apart.
+ * Two callers apply this: `terminal-session-chooser.tsx` for its row list AND
+ * its section show/hide check, and `chooserHeaderCounts` below for the header
+ * pill's "N recent" count — so none of those three can drift out of sync.
  */
 export function visibleRecentRows(recent: ChooserRecentRow[]): ChooserRecentRow[] {
   return recent.filter((r) => r.cwd !== null);
+}
+
+/**
+ * Header pill counts ("2 running here · 1 on another board · 2 recent") — a
+ * thin, testable view over the sections, consumed by terminal-dock.tsx's
+ * header bar. `recent` reports the FILTERED count (via `visibleRecentRows`,
+ * same as terminal-session-chooser.tsx's own list/header), not
+ * `sections.recent.length` — a no-folder row isn't worth counting in a pill
+ * any more than it's worth a row in the list underneath it.
+ */
+export function chooserHeaderCounts(sections: ChooserSections): {
+  here: number;
+  elsewhere: number;
+  recent: number;
+} {
+  return {
+    here: sections.liveHere.length,
+    elsewhere: sections.liveElsewhere.length,
+    recent: visibleRecentRows(sections.recent).length,
+  };
 }
 
 /**

--- a/src/lib/terminal/entry-decision.test.ts
+++ b/src/lib/terminal/entry-decision.test.ts
@@ -31,6 +31,16 @@ describe("decideEntryBehaviour", () => {
   // `cwd` is no longer part of `isRecentEnded`'s predicate; see
   // chooser-data.ts's matching fix for how the row renders once "chooser" is
   // reached (visible, but with Resume unavailable).
+  //
+  // Card cbe60db5 follow-up (2026-08-17): terminal-session-chooser.tsx now
+  // additionally hides no-folder rows from its human-visible Recent list
+  // (via chooser-data.ts's `visibleRecentRows` — a display-only filter, see
+  // its doc comment). This function is intentionally untouched by that
+  // change — it never imports `visibleRecentRows` or `ChooserSections`, only
+  // raw registry rows — so this test doubles as the regression guard that
+  // the 9fb9fced fix above still holds: a no-folder-only recent set must
+  // still route to "chooser", never silently fall through to
+  // "empty-launch" and mint a brand-new session.
   it("chooser (not empty-launch) when the only ended row has no recorded folder", () => {
     const rows = [row({ sid: "ended-1", status: "ended", cwd: null, endedAt: new Date(NOW - 60_000).toISOString() })];
     expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "chooser" });


### PR DESCRIPTION
## Summary
- Sessions with no recorded project folder are correctly kept in the underlying "recent sessions" data (fixed earlier today in 9fb9fced — this is what prevents a refresh from silently minting a brand-new session), but they were also rendering as dead "Can't resume — no folder recorded" rows in the session chooser's Recent list — nothing to click, just clutter.
- Nick's explicit ask: "why would you want to list these types of sessions though... what's the point of showing them?" Agreed direction: keep them in the internal reconnect-decision data, stop showing them to a human.
- Fix: a new pure filter (`visibleRecentRows` in `chooser-data.ts`) excludes no-folder rows from the chooser's Recent list and its header count/visibility — applied ONLY at display call sites, never inside `deriveChooserSections` itself, so `entry-decision.ts` and task-launch deduping keep seeing the full unfiltered set exactly as before.
- No changes to the "My sessions" popover (already never showed dead rows) or the single-task launch-choice dialog (intentionally keeps its own no-folder message, since it explains one specific session with a working "Start fresh anyway" button, not a list of many).

Board task: d6ebd6e8-2f3f-4f52-bb2a-ad208ae62c00

## Test plan
- [x] New tests for `visibleRecentRows`/`chooserHeaderCounts`, plus a `findTaskSessionMatch` test proving it still matches no-folder rows
- [x] `terminal-session-chooser.test.tsx` updated (dead-row test flipped, mixed-list + header-visibility cases added)
- [x] `entry-decision.test.ts`'s existing regression test annotated as the explicit guard that a no-folder-only "recent" set still routes to chooser, not a silent new session
- [x] 2873 tests pass
- [x] `npx tsc --noEmit` clean
- [x] eslint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)