### PR TITLE
fix(terminal): stop a failed auth check reading as "not authenticated", and log who gets refused

### DIFF
--- a/src/app/api/terminal/session/route.ts
+++ b/src/app/api/terminal/session/route.ts
@@ -12,6 +12,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
+import { isAuthCheckUnavailable } from "@/lib/supabase/auth-error";
 import { logger } from "@/lib/logger";
 // One shared implementation of the token scheme — also imported by the relay.
 import { mintSessionTokens, mintHelperToken } from "../../../../../terminal/shared/session-token.mjs";
@@ -70,10 +71,48 @@ export async function POST(req: Request) {
     }
 
     const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    // Card 42453a7d: a FAILED auth check is not the same as "no session".
+    // getUser() returns a null user for both, and answering 401 for the former
+    // tells a perfectly logged-in user they're logged out (and, client-side,
+    // surfaces "Couldn't start a terminal session — Not authenticated"). 503
+    // says "ask again", which is the truth. See auth-error.ts for the evidence.
+    if (!user && isAuthCheckUnavailable(authError)) {
+      logger.error("Terminal session mint: auth check unavailable", {
+        name: authError?.name,
+        status: authError?.status,
+        error: authError?.message,
+      });
+      return NextResponse.json(
+        { error: "Couldn't verify your login just now — please try again" },
+        { status: 503 },
+      );
+    }
     if (!user) {
+      // Card 42453a7d (2026-08-19): this refusal used to be completely silent,
+      // so when SOMETHING retried a mint every ~30 minutes all night (15
+      // unauthenticated attempts, 18-19 Aug, each one an isolated request with
+      // no page load or list poll around it) there was nothing in the logs to
+      // attribute it to. Log just enough to identify the caller next time —
+      // never cookie values or token material, and only the idea id from the
+      // body, which is the one field that tells us WHICH board's page is doing
+      // it. `hasAuthCookie` separates the two very different causes: absent =
+      // a client with no session at all, present = a session that expired or
+      // was rotated away under a long-lived page.
+      const probe = (await req.json().catch(() => null)) as { ideaId?: unknown } | null;
+      logger.warn("Terminal session mint refused: not authenticated", {
+        userAgent: req.headers.get("user-agent"),
+        referer: req.headers.get("referer"),
+        origin: req.headers.get("origin"),
+        hasAuthCookie: /(?:^|;\s*)sb-[^=;]*auth-token/.test(req.headers.get("cookie") ?? ""),
+        ideaId: typeof probe?.ideaId === "string" ? probe.ideaId : null,
+        // Answered-but-no: WHICH no. "Auth session missing" (no cookie at all)
+        // and "Invalid Refresh Token: Already Used" (a rotation race between
+        // this user's several open tabs) are different bugs with the same
+        // 401, and only this field tells them apart.
+        authError: authError?.message ?? null,
+        authErrorName: authError?.name ?? null,
+      });
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
 

--- a/src/lib/supabase/auth-error.test.ts
+++ b/src/lib/supabase/auth-error.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { isAuthCheckUnavailable } from "./auth-error";
+
+describe("isAuthCheckUnavailable", () => {
+  it("is false when there is no error at all (the question was answered: no session)", () => {
+    expect(isAuthCheckUnavailable(null)).toBe(false);
+    expect(isAuthCheckUnavailable(undefined)).toBe(false);
+  });
+
+  it("is false for a genuine missing session", () => {
+    expect(
+      isAuthCheckUnavailable({ name: "AuthSessionMissingError", status: 400, message: "Auth session missing!" }),
+    ).toBe(false);
+  });
+
+  it("is false for a rejected/expired token (4xx — answered, and the answer is no)", () => {
+    expect(isAuthCheckUnavailable({ name: "AuthApiError", status: 401, message: "invalid JWT" })).toBe(false);
+    expect(isAuthCheckUnavailable({ name: "AuthApiError", status: 403, message: "bad_jwt" })).toBe(false);
+    expect(
+      isAuthCheckUnavailable({ name: "AuthApiError", status: 400, message: "Invalid Refresh Token: Already Used" }),
+    ).toBe(false);
+  });
+
+  it("is true for a retryable fetch failure by name, whatever status it carries", () => {
+    expect(
+      isAuthCheckUnavailable({ name: "AuthRetryableFetchError", status: 0, message: "fetch failed" }),
+    ).toBe(true);
+    expect(
+      isAuthCheckUnavailable({ name: "AuthRetryableFetchError", status: 503, message: "unavailable" }),
+    ).toBe(true);
+  });
+
+  it("is true when the status is missing or zero (a thrown fetch never got a status)", () => {
+    expect(isAuthCheckUnavailable({ name: "TypeError", message: "fetch failed" })).toBe(true);
+    expect(isAuthCheckUnavailable({ name: "AuthUnknownError", status: 0, message: "write ETIMEDOUT" })).toBe(true);
+  });
+
+  it("is true for a 5xx from the auth service", () => {
+    expect(isAuthCheckUnavailable({ name: "AuthApiError", status: 500, message: "internal" })).toBe(true);
+    expect(isAuthCheckUnavailable({ name: "AuthApiError", status: 502, message: "bad gateway" })).toBe(true);
+  });
+});

--- a/src/lib/supabase/auth-error.ts
+++ b/src/lib/supabase/auth-error.ts
@@ -1,0 +1,42 @@
+// Telling "this person has no session" apart from "we couldn't ASK whether
+// they have a session" (card 42453a7d).
+//
+// `supabase.auth.getUser()` returns `{ data: { user: null }, error }` for BOTH
+// cases, and every call site in this codebase used to destructure only `data`
+// and treat a null user as "not authenticated". That is wrong — and provably
+// so: production logs for 18/19 Aug 2026 show outbound fetches from these
+// functions intermittently failing (`TypeError: fetch failed`, `write
+// ETIMEDOUT`) in the exact window where the terminal mint route was refusing
+// callers with 401 "Not authenticated" while the SAME browser's page requests
+// were being served 200 seconds either side. A transient auth-service blip
+// must not be reported to the user as "you're logged out".
+//
+// Shape-based on purpose (name + status), not `instanceof`: the error object
+// crosses a bundling boundary and there may be more than one copy of
+// @supabase/auth-js in the graph, which makes `instanceof` an unreliable
+// runtime test. See auth-error.test.ts for the full truth table.
+
+/** The subset of a Supabase AuthError this decision needs. */
+export interface AuthErrorLike {
+  name?: string;
+  status?: number;
+  message?: string;
+}
+
+/**
+ * True when the auth check itself could not be completed — network failure,
+ * timeout, or a 5xx from the auth service. The caller should answer 503 ("try
+ * again"), never 401 ("you're not logged in").
+ *
+ * False for a genuine, answered "no session" (AuthSessionMissingError, an
+ * expired/rotated token, a 4xx) and for `null`/`undefined` — those mean the
+ * question WAS answered and the answer was no.
+ */
+export function isAuthCheckUnavailable(error: AuthErrorLike | null | undefined): boolean {
+  if (!error) return false;
+  if (error.name === "AuthRetryableFetchError") return true;
+  // A missing/zero status is what a thrown-fetch failure surfaces as; a 5xx is
+  // the auth service failing to answer. Both are "ask again later".
+  if (typeof error.status !== "number" || error.status === 0) return true;
+  return error.status >= 500;
+}


### PR DESCRIPTION
## Why

Production runtime logs for 18/19 Aug 2026 show `POST /api/terminal/session` being refused with **401 "Not authenticated" roughly every 25–40 minutes all night** — 15 attempts between 19:22 and 05:04 BST — from a client that was demonstrably *not* logged out: unfiltered logs show four of Nick's board tabs plus the dashboard being served **200** five minutes either side of the 02:12 refusal.

Two gaps made that impossible to diagnose, and the second one is a real bug.

## What changed

**1. The refusal is no longer silent** (`src/app/api/terminal/session/route.ts`)

The 401 branch logged *nothing* — no user agent, no referer, no idea id, no indication whether an auth cookie even arrived. It now logs a `warn` with exactly that, plus the auth error's own name and message, so two very different failures stop sharing one indistinguishable 401:

- `Auth session missing` → no session cookie reached us at all
- `Invalid Refresh Token: Already Used` → a rotation race between this user's several open tabs

No cookie values, no token material, and only the `ideaId` is read out of the body (it identifies *which* board page is doing it).

**2. A failed auth check no longer masquerades as "you're logged out"**

`supabase.auth.getUser()` returns a null user for **both** "this person has no session" and "we could not ask whether they have a session", and this route destructured only `data`. So a transient auth-service or network failure — and this very log window carries `TypeError: fetch failed` / `write ETIMEDOUT` lines from these functions — told a perfectly logged-in user they were logged out, surfacing client-side as *"Couldn't start a terminal session — Not authenticated"*.

New `src/lib/supabase/auth-error.ts` splits the two on the error's **shape** (name + status, deliberately not `instanceof` — the error object crosses a bundling boundary and there may be more than one copy of `@supabase/auth-js` in the graph). An unavailable check now answers **503 "please try again"**; a genuine no-session still answers 401.

## Considered and rejected

Including `api/terminal` in the middleware matcher, so the terminal API gets the same session refresh every page request gets. On inspection it isn't the fix: `src/lib/supabase/server.ts` writes cookies through `cookies().set()`, which **is** permitted in a Route Handler, so this route already refreshes a session on its own. Adding middleware coverage would only add a duplicate auth round-trip to every relay callback (`/api/terminal/session/closed`). Left excluded.

## Still open (tracked on the card, not in this PR)

- What *triggers* an attempt every ~30 minutes with nobody at the keyboard. A failed mint leaves the state machine in `error` with `launchPhase: "opening"`, so auto-connect cannot re-fire in the same mounted hook — each attempt needs a fresh mount or trigger. Prime suspect: the periodic board-page server actions (three different boards refreshing within the same second) remounting the dock's session hook and re-arming auto-connect. **If that's confirmed, the same path on a tab with a healthy login would silently mint a *real* session — which would explain the surprise second terminal tab that started this investigation.**
- The sibling terminal routes (`/reattach`, `/list`, `/end`) still refuse silently and still conflate the two auth failures. Worth the same treatment once this one has proved itself in production.

## Verification

- `npx tsc --noEmit` clean
- `npm run lint` — 0 errors (76 pre-existing warnings untouched)
- `npx vitest run` — **176 files, 2879 tests, all passing**, including 6 new cases covering the auth-error truth table (missing session, expired/rotated token, retryable fetch failure, missing/zero status, 5xx)

Once this is live, watch for `Terminal session mint refused: not authenticated` in production logs — one line should identify the caller. Log retention only reaches back ~10 hours, so check within a day.

Card: 42453a7d

🤖 Generated with [Claude Code](https://claude.com/claude-code)