### PR TITLE
fix(terminal): use the recorded project folder on repo-backed boards

### DIFF
--- a/src/components/board/board-launch-context.tsx
+++ b/src/components/board/board-launch-context.tsx
@@ -17,7 +17,8 @@ export interface BoardLaunchContextValue {
    * Absolute paths recorded by the agent for THIS user + idea, one per machine
    * (hostname). Read server-side from idea_project_paths (RLS-scoped to the
    * human). The launch button runs chooseLaunchCwd over these to decide whether
-   * to inject a cwd for no-repo launches. Undefined when none recorded.
+   * to inject a cwd — for repo-backed ideas as well as no-repo ones, whenever a
+   * single distinct path is known. Undefined when none recorded.
    */
   recordedProjectPaths?: RecordedProjectPath[];
 }

--- a/src/components/board/launch-claude-code-button.test.tsx
+++ b/src/components/board/launch-claude-code-button.test.tsx
@@ -147,3 +147,46 @@ describe("LaunchClaudeCodeButton — task-menu-item variant (browser launch item
     location.restore();
   });
 });
+
+/** Renders the "board" variant, which owns its own split-button + dropdown
+ * (unlike task-menu-item, it isn't hosted inside an external DropdownMenu). */
+function renderBoardButton(overrides: {
+  ideaGithubUrl?: string | null;
+  recordedProjectPaths?: import("@/lib/launch-claude-code").RecordedProjectPath[];
+} = {}) {
+  render(
+    <LaunchClaudeCodeButton
+      variant="board"
+      ideaId="idea-1"
+      ideaTitle="Idea One"
+      ideaGithubUrl={overrides.ideaGithubUrl ?? null}
+      recordedProjectPaths={overrides.recordedProjectPaths}
+    />
+  );
+}
+
+describe("LaunchClaudeCodeButton — board variant dropdown path line", () => {
+  it("shows the recorded path for a repo-backed idea (fix: cwd is no longer dropped just because a repo is attached)", () => {
+    renderBoardButton({
+      ideaGithubUrl: "https://github.com/acme/widgets",
+      recordedProjectPaths: [{ hostname: "nick-mbp", absolute_path: "/Users/nick/projects/widgets" }],
+    });
+
+    const trigger = screen.getByRole("button", { name: "Launch options" });
+    fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 });
+    fireEvent.click(trigger);
+
+    expect(screen.getByText("This machine — nick-mbp")).toBeInTheDocument();
+    expect(screen.getByText("/Users/nick/projects/widgets")).toBeInTheDocument();
+  });
+
+  it("shows no path line for a repo-backed idea with no recorded path (first-launch/clone flow)", () => {
+    renderBoardButton({ ideaGithubUrl: "https://github.com/acme/widgets" });
+
+    const trigger = screen.getByRole("button", { name: "Launch options" });
+    fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 });
+    fireEvent.click(trigger);
+
+    expect(screen.queryByText(/This machine/)).toBeNull();
+  });
+});

--- a/src/components/board/launch-claude-code-button.tsx
+++ b/src/components/board/launch-claude-code-button.tsx
@@ -46,8 +46,11 @@ interface BaseProps {
   ideaGithubUrl: string | null;
   /**
    * Absolute paths the agent recorded for this user + idea (one per machine).
-   * No-repo launches inject one as cwd via chooseLaunchCwd (option (a): only
-   * when exactly one is recorded). Empty/omitted → first-launch flow.
+   * Injected as cwd via chooseLaunchCwd — for repo-backed ideas too, not just
+   * no-repo — whenever the records dedupe to exactly one DISTINCT path (any
+   * number of records is fine as long as they all agree on that one path;
+   * more than one distinct path is genuinely ambiguous and falls back to no
+   * cwd). Empty/omitted, or ambiguous, → first-launch/clone flow.
    */
   recordedProjectPaths?: RecordedProjectPath[];
 }
@@ -225,12 +228,18 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
       });
 
       // cwd resolution — the SHARED rule (resolveLaunchCwd): pinned existing path
-      // → that path; new (no-repo) mode → the effective target's cwd (the saved
-      // path or the agent-recorded path for THIS machine — the SAME value the
-      // dropdown displays, so display and launch can't diverge); repo-backed →
-      // none (the `repo` slug resolves the working copy; effectiveTarget.cwd is
-      // undefined for repo ideas). The in-browser launch payload uses the same
-      // rule, so both destinations open in the same folder.
+      // → that path; new mode → the effective target's cwd (the saved path or
+      // the agent-recorded path for THIS machine — the SAME value the dropdown
+      // displays, so display and launch can't diverge). This now applies to
+      // repo-backed ideas too: a repo-backed idea with a known folder (pinned
+      // or recorded) injects that cwd exactly like a no-repo idea — the `repo`
+      // slug only resolves the working copy when NO folder is known yet
+      // (effectiveTarget.cwd is undefined in that case). Previously cwd was
+      // unconditionally dropped for any repo-backed idea, which reopened a
+      // fresh/wrong clone on every relaunch even when the real working copy's
+      // path was already known — that's the bug this fix corrects. The
+      // in-browser launch payload uses the same rule, so both destinations
+      // open in the same folder.
       const cwd = resolveLaunchCwd(state, effectiveTarget.cwd);
       const repo = ideaGithubUrl ?? undefined;
 

--- a/src/lib/launch-claude-code.test.ts
+++ b/src/lib/launch-claude-code.test.ts
@@ -701,6 +701,38 @@ describe("chooseLaunchCwd (hostname rule — Design Review option (a))", () => {
       chooseLaunchCwd([{ absolute_path: "relative/path", hostname: "bad" }])
     ).toBeUndefined();
   });
+
+  // Regression: production data shows a user launching the same idea from two
+  // machines whose project folder happens to live at the identical absolute
+  // path (e.g. two Macs both under /Users/nick/projects/<slug>) — that's 2
+  // records but 0 ambiguity, since either machine opens the same place.
+  it("2 records, same absolute path, different hostnames → dedupes to that one path", () => {
+    expect(
+      chooseLaunchCwd([
+        { absolute_path: "/Users/nickball/projects/balla-bot", hostname: "Nicks-MacBook-Pro.local" },
+        { absolute_path: "/Users/nickball/projects/balla-bot", hostname: "Nicks-MBP.home.local" },
+      ])
+    ).toBe("/Users/nickball/projects/balla-bot");
+  });
+
+  it("2 records, same path after trimming whitespace → still dedupes", () => {
+    expect(
+      chooseLaunchCwd([
+        { absolute_path: "/Users/nick/x", hostname: "mac-a" },
+        { absolute_path: "  /Users/nick/x  ", hostname: "mac-b" },
+      ])
+    ).toBe("/Users/nick/x");
+  });
+
+  it("3 records, 2 sharing a path + 1 different → still >1 DISTINCT paths, undefined", () => {
+    expect(
+      chooseLaunchCwd([
+        { absolute_path: "/Users/nick/x", hostname: "mac-a" },
+        { absolute_path: "/Users/nick/x", hostname: "mac-b" },
+        { absolute_path: "/home/nick/x", hostname: "linux" },
+      ])
+    ).toBeUndefined();
+  });
 });
 
 describe("resolveEffectiveLaunchTarget (single source for DISPLAY + LAUNCH)", () => {
@@ -792,12 +824,52 @@ describe("resolveEffectiveLaunchTarget (single source for DISPLAY + LAUNCH)", ()
     expect(t.source).toBe("recorded");
   });
 
-  it("repo-backed ideas never inject a cwd or show a path line, even with a saved path", () => {
+  // ── Repo-backed ideas: a known folder wins here too (regression) ──────────
+  // Previously `hasRepo` short-circuited to source "none" BEFORE the saved-pin
+  // check ran at all, so a repo-backed idea's explicit pin was silently
+  // dropped — the second defect QA found alongside the main resolver bug.
+  // Pin-beats-recorded precedence must hold the same way for repo-backed
+  // ideas as it does for no-repo ones.
+  it("repo-backed idea: a saved (pinned) path still wins, same as no-repo", () => {
     const t = resolveEffectiveLaunchTarget({
       hasRepo: true,
       saved: { mode: "existing", path: "/Users/nick/projects/from-dialog" },
       recordedPaths: recorded,
     });
+    expect(t.cwd).toBe("/Users/nick/projects/from-dialog");
+    expect(t.displayPath).toBe("/Users/nick/projects/from-dialog");
+    expect(t.source).toBe("saved");
+  });
+
+  it("repo-backed idea: a pinned path wins even with NO recorded path on file", () => {
+    const t = resolveEffectiveLaunchTarget({
+      hasRepo: true,
+      saved: { mode: "existing", path: "/Users/nick/projects/from-dialog" },
+      recordedPaths: [],
+    });
+    expect(t.cwd).toBe("/Users/nick/projects/from-dialog");
+    expect(t.source).toBe("saved");
+  });
+
+  // The main bug this card fixes: resolveEffectiveLaunchTarget used to return
+  // "none" unconditionally for hasRepo:true, so a recorded DB path (agent
+  // self-heal via record_project_path) was dead code for every repo-backed idea.
+  it("repo-backed idea: falls back to a recorded DB path when there's no pin", () => {
+    const t = resolveEffectiveLaunchTarget({
+      hasRepo: true,
+      saved: null,
+      recordedPaths: recorded,
+    });
+    expect(t.cwd).toBe("/Users/nick/projects/from-db");
+    expect(t.source).toBe("recorded");
+    expect(t.displayLabel).toBe("This machine — Nicks-MacBook");
+  });
+
+  // Unchanged: repo-backed with nothing known at all → "none", so
+  // resolveDefaultLaunchState still falls through to the empty-path
+  // fresh-machine flow (repo slug / clone resolves the folder).
+  it("repo-backed idea: no pin and no recorded path → 'none' (fresh-machine flow, unchanged)", () => {
+    const t = resolveEffectiveLaunchTarget({ hasRepo: true, saved: null, recordedPaths: [] });
     expect(t.cwd).toBeUndefined();
     expect(t.displayPath).toBeUndefined();
     expect(t.source).toBe("none");
@@ -1173,6 +1245,73 @@ describe("resolveDefaultLaunchState (shared by launch button + terminal dock)", 
       name: "my-first-app",
     });
   });
+
+  // ── Repo-backed idea + a known folder (effectiveTarget) ────────────────────
+  // Second defect QA found: `resolveDefaultLaunchState`'s `if (ideaGithubUrl)`
+  // branch used to fire BEFORE the effectiveTarget check, making a repo-backed
+  // idea's recorded/pinned folder dead code — the two resolvers disagreed.
+  it("repo-backed idea + a recorded DB path, no pin → existing mode at the recorded path", () => {
+    const effectiveTarget = resolveEffectiveLaunchTarget({
+      hasRepo: true,
+      saved: null,
+      recordedPaths: [{ absolute_path: "/Users/nick/projects/widget", hostname: "Nicks-MacBook" }],
+    });
+    expect(
+      resolveDefaultLaunchState("idea-1", "My Idea", "https://github.com/acme/widget", effectiveTarget)
+    ).toEqual({ mode: "existing", path: "/Users/nick/projects/widget" });
+  });
+
+  it("repo-backed idea + a pinned path (with a recorded path too) → the pin wins", () => {
+    const effectiveTarget = resolveEffectiveLaunchTarget({
+      hasRepo: true,
+      saved: { mode: "existing", path: "/Users/nick/projects/pinned-widget" },
+      recordedPaths: [{ absolute_path: "/Users/nick/projects/widget", hostname: "Nicks-MacBook" }],
+    });
+    expect(
+      resolveDefaultLaunchState("idea-1", "My Idea", "https://github.com/acme/widget", effectiveTarget)
+    ).toEqual({ mode: "existing", path: "/Users/nick/projects/pinned-widget" });
+  });
+
+  it("repo-backed idea + a pinned path, NO recorded path → the pin still wins", () => {
+    const effectiveTarget = resolveEffectiveLaunchTarget({
+      hasRepo: true,
+      saved: { mode: "existing", path: "/Users/nick/projects/pinned-widget" },
+      recordedPaths: [],
+    });
+    expect(
+      resolveDefaultLaunchState("idea-1", "My Idea", "https://github.com/acme/widget", effectiveTarget)
+    ).toEqual({ mode: "existing", path: "/Users/nick/projects/pinned-widget" });
+  });
+
+  // UNCHANGED / the fresh-machine flow that must not regress: repo-backed with
+  // NEITHER a pin NOR a recorded path still opens empty-path existing mode so
+  // the bootstrap prompt emits its clone/directory step.
+  it("repo-backed idea + effectiveTarget but NO known folder → still the empty-path fresh-machine flow", () => {
+    const effectiveTarget = resolveEffectiveLaunchTarget({
+      hasRepo: true,
+      saved: null,
+      recordedPaths: [],
+    });
+    expect(
+      resolveDefaultLaunchState("idea-1", "My Idea", "https://github.com/acme/widget", effectiveTarget)
+    ).toEqual({ mode: "existing", path: "" });
+  });
+
+  // Ambiguous (>1 distinct recorded paths) must not promote a repo-backed idea
+  // either — same "don't guess which machine" contract as the no-repo case.
+  it("repo-backed idea + >1 distinct recorded paths (ambiguous) → still the empty-path flow", () => {
+    const effectiveTarget = resolveEffectiveLaunchTarget({
+      hasRepo: true,
+      saved: null,
+      recordedPaths: [
+        { absolute_path: "/Users/nick/widget", hostname: "mac" },
+        { absolute_path: "/home/nick/widget", hostname: "linux" },
+      ],
+    });
+    expect(
+      resolveDefaultLaunchState("idea-1", "My Idea", "https://github.com/acme/widget", effectiveTarget)
+    ).toEqual({ mode: "existing", path: "" });
+  });
 });
 
 // ── Recorded-path idea: prompt mode must MATCH the resolved cwd (the bug) ──────
@@ -1300,6 +1439,57 @@ describe("recorded-path idea promotes to existing mode (prompt/cwd parity)", () 
       parent: undefined,
       name: undefined,
     });
+  });
+});
+
+// ── Risk 2 (QA): repo-backed idea + a known folder must get verify-the-folder
+// wording, NOT the bare "cd your local clone, or git clone" fresh-machine
+// instruction — the compact prompt's directory branch is reachable for
+// repo-backed ideas for the first time once resolveDefaultLaunchState promotes
+// them to existing-mode-with-a-path (see the "recorded-path idea promotes"
+// block above). This exercises buildCompactBootstrapPrompt directly with
+// repoUrl + existingPath both set, mirroring what resolveDefaultLaunchState +
+// the callers in use-terminal-session.ts / launch-claude-code-button.tsx now
+// produce for that case.
+describe("repo-backed compact prompt with a known folder (Risk 2 — verify, don't re-clone)", () => {
+  const APP_URL = "https://vibecodes.co.uk";
+  const IDEA_ID = "idea-repo-recorded";
+  const REPO_URL = "https://github.com/acme/widget";
+  const KNOWN_PATH = "/Users/nick/projects/widget";
+
+  it("repo-backed + known folder → verify-the-folder wording, confirms the clone, no fresh clone instruction", () => {
+    const p = buildCompactBootstrapPrompt({
+      appUrl: APP_URL,
+      ideaId: IDEA_ID,
+      ideaTitle: "Widget",
+      mode: "existing",
+      repoUrl: REPO_URL,
+      existingPath: KNOWN_PATH,
+    });
+    expect(p).toContain(`already be in ${KNOWN_PATH}`);
+    expect(p).toMatch(/recorded from a previous session/i);
+    expect(p).toContain("clone of acme/widget");
+    expect(p).toContain("git remote -v");
+    expect(p).toMatch(/don't re-clone/i);
+    // The fresh-machine "get into the repo" clone instruction must NOT appear —
+    // we already know the folder, so don't tell the agent to (re-)clone it.
+    expect(p).not.toContain("Get into the repo");
+    expect(p).not.toContain("git clone https://github.com/acme/widget.git");
+  });
+
+  it("repo-backed + NO known folder → unchanged clone/cd instruction (fresh-machine flow)", () => {
+    const p = buildCompactBootstrapPrompt({
+      appUrl: APP_URL,
+      ideaId: IDEA_ID,
+      ideaTitle: "Widget",
+      mode: "existing",
+      repoUrl: REPO_URL,
+      // no existingPath — nothing recorded/pinned yet.
+    });
+    expect(p).toContain("Get into the repo acme/widget first");
+    expect(p).toContain(`git clone https://github.com/acme/widget.git ${DEFAULT_NEW_PROJECT_PARENT}/widget`);
+    expect(p).not.toContain("already be in");
+    expect(p).not.toContain("git remote -v");
   });
 });
 

--- a/src/lib/launch-claude-code.ts
+++ b/src/lib/launch-claude-code.ts
@@ -287,30 +287,47 @@ export interface RecordedProjectPath {
 
 /**
  * Choose the cwd to inject into a no-repo launch deep link from the paths
- * recorded for (this user, this idea) — Design Review hostname rule, option (a):
+ * recorded for (this user, this idea) — Design Review hostname rule, option (a),
+ * deduped by absolute path:
  *
- *  - 0 records  → undefined (first-launch / home flow; the agent creates + records)
- *  - exactly 1  → that record's absolute_path
- *  - >1 records → undefined (ambiguous across machines; the browser can't know
- *                 which host it's on, so never inject a path we can't attribute
- *                 to THIS machine — fall back to the safe first-launch flow)
+ *  - 0 records          → undefined (first-launch / home flow; the agent creates + records)
+ *  - 1 distinct path    → that path, whether it came from one record or several
+ *                         (the common multi-machine case: the same idea launched
+ *                         from two hosts whose project folder happens to live at
+ *                         the same absolute path — e.g. two Macs both checking
+ *                         out under /Users/nick/projects/<slug>). There is no
+ *                         ambiguity to protect against here: whichever machine
+ *                         the browser is actually on, the folder is at this path.
+ *  - >1 distinct paths  → undefined (genuinely ambiguous across machines; the
+ *                         browser can't know which host it's on, so never inject
+ *                         a path we can't attribute to THIS machine — fall back
+ *                         to the safe first-launch flow)
  *
  * A record is only usable if its absolute_path passes strict validation; bad
  * rows are ignored so a single corrupt record can't poison the choice.
+ *
+ * Deliberately does NOT match on hostname to narrow the record set before
+ * deduping — the browser-side machine-identity plumbing for that
+ * (`getMachineIdentity()` in `src/lib/terminal/machine-identity.ts`) exists but
+ * wiring it in here is out of scope for this fix; same-path-across-machines is
+ * the safe, hostname-independent case that doesn't need it.
  */
 export function chooseLaunchCwd(
   records: ReadonlyArray<RecordedProjectPath> | null | undefined
 ): string | undefined {
   const usable = (records ?? []).filter((r) => isValidAbsolutePath(r.absolute_path));
-  if (usable.length === 1) return usable[0].absolute_path.trim();
+  const distinctPaths = new Set(usable.map((r) => r.absolute_path.trim()));
+  if (distinctPaths.size === 1) return usable[0].absolute_path.trim();
   return undefined;
 }
 
 /**
- * The single source of truth for "where will a no-repo launch open, and what do
- * we show the user?". DISPLAY and LAUNCH must derive from this same result so
+ * The single source of truth for "where will a launch open (if a folder is
+ * already known), and what do we show the user?" — applies to repo-backed and
+ * no-repo ideas alike. DISPLAY and LAUNCH must derive from this same result so
  * they can never diverge (the bug: the dialog saved to localStorage but the
- * dropdown read only the DB).
+ * dropdown read only the DB; and separately, a repo-backed idea's known folder
+ * used to be discarded here entirely — see `resolveEffectiveLaunchTarget`).
  *
  * `cwd` is what gets injected into the deep link / copy command; `displayPath`
  * + `displayLabel` + `host` drive the dropdown's "This machine" line.
@@ -329,7 +346,15 @@ export interface EffectiveLaunchTarget {
 }
 
 export interface ResolveEffectiveLaunchTargetArgs {
-  /** Whether the idea has a GitHub repo (repo-backed ideas never inject a cwd). */
+  /**
+   * Whether the idea has a GitHub repo. Kept for callers (they already track
+   * it for the prompt builders) but no longer gates anything HERE: a
+   * repo-backed idea with a known folder (pinned or recorded for this
+   * machine) resolves that folder exactly like a no-repo idea does — see the
+   * precedence note below. `resolveDefaultLaunchState` is what still treats
+   * repo-backed differently when NO folder is known (empty-path existing
+   * mode instead of a fresh ~/projects/<slug>).
+   */
   hasRepo: boolean;
   /** The user's saved localStorage launch config for this idea (or null). */
   saved: LaunchPathState | null;
@@ -343,28 +368,28 @@ export interface ResolveEffectiveLaunchTargetArgs {
  * writes) over the agent-recorded DB path. This makes the dropdown reflect a
  * just-saved path immediately AND guarantees launch uses that same value.
  *
- * Precedence:
- *  1. Repo-backed idea → never inject a cwd (the `repo` slug resolves the folder).
- *  2. Saved `existing`-mode path that passes strict validation → use it
+ * Precedence (applies identically whether or not the idea has a repo — a
+ * pinned or recorded folder is just as real a "known folder" for a
+ * repo-backed idea as for a no-repo one, and pin-beats-recorded must hold
+ * consistently in both cases):
+ *  1. Saved `existing`-mode path that passes strict validation → use it
  *     (labelled "This machine — set manually" — localStorage has no hostname).
- *  3. Otherwise the DB recorded path via `chooseLaunchCwd` (0/1/>1 contract),
+ *  2. Otherwise the DB recorded path via `chooseLaunchCwd` (0 / 1-distinct-path
+ *     / >1-distinct-paths contract — records that agree on the path dedupe to
+ *     that one path, even from different hostnames),
  *     labelled "This machine — <host>". Both share the "This machine — <detail>"
  *     shape so they read as one box with two path sources, not two concepts.
- *  4. Nothing usable → source "none" (first-launch flow; no path line).
+ *  3. Nothing usable → source "none" (first-launch / repo-slug-resolves-it
+ *     flow; no path line).
  *
  * `new`-mode saved state is intentionally ignored here: its composed
  * `~/projects/<slug>` path is not a validated absolute pwd and must not surface
  * as a recorded/launch path (it's created + recorded by the agent on launch).
  */
 export function resolveEffectiveLaunchTarget({
-  hasRepo,
   saved,
   recordedPaths,
 }: ResolveEffectiveLaunchTargetArgs): EffectiveLaunchTarget {
-  if (hasRepo) {
-    return { cwd: undefined, displayPath: undefined, displayLabel: undefined, host: null, source: "none" };
-  }
-
   // Saved existing-mode absolute path wins — it's the user's explicit choice and
   // it's what the launch cwd resolution already used, so display now matches.
   if (saved && saved.mode === "existing") {
@@ -453,9 +478,17 @@ Do NOT debug or reconfigure other MCP servers, and do NOT improvise the OAuth fl
  *    hooks; a worktree session must never push to or merge the primary
  *    branch — only `vibe/wt-N`.
  *
- * Only used for existing-mode/no-repo launches (see directoryBlock and
- * buildCompactBootstrapPromptParts) — a repo-backed idea resolves its working
- * copy via the deep link's `repo` slug and is out of scope for this protocol.
+ * Used for existing-mode launches that already have a known folder (a
+ * recorded/pinned cwd) — repo-backed or not (see directoryBlock and
+ * buildCompactStepPieces). It used to be scoped to no-repo launches only, on
+ * the theory that a repo-backed idea's `repo` slug deterministically resolves
+ * the working copy so there is no concurrent-terminal ambiguity — but a
+ * repo-backed idea with a known folder ALSO opens a real local shell in that
+ * (possibly-shared) folder via the deep link's cwd, same as no-repo, so the
+ * ambiguity is identical and the fix widened this to cover it. Only a
+ * repo-backed idea with NO known folder yet (fresh clone) is genuinely out of
+ * scope, since that path is a brand-new/just-cloned folder, not a possibly-
+ * shared existing one.
  *
  * `variant: "compact"` returns a terse, budget-conscious rewrite of the same
  * steps for the URL-capped deep-link / in-browser-terminal prompt (see
@@ -667,12 +700,15 @@ export interface CompactBootstrapArgs extends CommonPromptArgs {
   /** Per-task launch: targets this task instead of the top of the queue. */
   taskId?: string;
   /**
-   * Existing-mode, no-repo launches: the absolute folder the deep-link cwd will
-   * open in (a recorded DB path for this machine, or a user-pinned localStorage
-   * path). When set, the compact prompt emits a "you're already here, just
-   * confirm" verify-folder step INSTEAD of the create-folder/mkdir block — the
-   * session already lands here via the deep link's cwd. Omitted → no directory
-   * step at all (repo-backed or first-launch flows resolve the folder elsewhere).
+   * Existing-mode launches with a known folder — no-repo OR repo-backed: the
+   * absolute folder the deep-link cwd will open in (a recorded DB path for
+   * this machine, or a user-pinned localStorage path). When set, the compact
+   * prompt emits a "you're already here, just confirm" verify-folder step
+   * INSTEAD of the create-folder/mkdir (no-repo) or clone (repo-backed) block
+   * — the session already lands here via the deep link's cwd; for a
+   * repo-backed idea the verify step also confirms it's the right clone
+   * rather than re-cloning. Omitted → no directory step (no-repo first-launch)
+   * or the clone/cd step (repo-backed with no known folder yet).
    */
   existingPath?: string;
 }
@@ -708,17 +744,18 @@ interface CompactStepPieces {
    * — out of BUG1's scope. Empty for existingPath / first-launch (no step). */
   leadingSteps: string[];
   /**
-   * Existing-mode/no-repo only: echoes the raw cwd. This DUPLICATES the deep
-   * link's `cwd` URL param, so a long recorded/pinned path grows both the
-   * fixed URL overhead AND (if this sat in the protected head) the head
-   * itself — the mechanism behind BUG1's overflow. Kept out of any
-   * `head`/essentials text; callers place it in the trimmable tail.
+   * Existing mode with a known folder ONLY (repo-backed or not): echoes the
+   * raw cwd. This DUPLICATES the deep link's `cwd` URL param, so a long
+   * recorded/pinned path grows both the fixed URL overhead AND (if this sat
+   * in the protected head) the head itself — the mechanism behind BUG1's
+   * overflow. Kept out of any `head`/essentials text; callers place it in the
+   * trimmable tail.
    */
   directoryEcho?: string;
   /**
-   * Compact worktree-isolation protocol candidate — same existing-mode/no-repo
-   * scope as directoryEcho, same reason it's kept separate: it must be
-   * included or omitted as one atomic block (BUG1 — see
+   * Compact worktree-isolation protocol candidate — same existing-mode/
+   * known-folder scope as directoryEcho, same reason it's kept separate: it
+   * must be included or omitted as one atomic block (BUG1 — see
    * fitCompactWorktreeProtocol), never embedded where a length guard could
    * half-truncate it.
    */
@@ -743,10 +780,13 @@ function buildCompactStepPieces({
   let directoryEcho: string | undefined;
   let protocol: string | undefined;
 
-  // Directory step. In create-new mode → mkdir/init the folder. Repo-backed →
-  // clone/cd. Existing-no-repo WITH a known folder (recorded/pinned path the deep
-  // link's cwd already opens in) → a "confirm you're already here" step, NOT a
-  // create step. Existing-no-repo with NO known folder → nothing (first-launch).
+  // Directory step. In create-new mode → mkdir/init the folder. Existing WITH a
+  // known folder (recorded/pinned path the deep link's cwd already opens in) →
+  // a "confirm you're already here" step, NOT a create/clone step — checked
+  // BEFORE the bare `repo` branch below so a repo-backed idea with a known
+  // folder gets verify-and-reuse wording (don't re-clone) instead of the
+  // fresh-machine clone instructions. Repo-backed with NO known folder → clone/
+  // cd. Existing-no-repo with NO known folder → nothing (first-launch).
   if (newProject) {
     const p = newProject.newProjectPath;
     const git = repo
@@ -755,20 +795,26 @@ function buildCompactStepPieces({
     leadingSteps.push(
       `Project folder FIRST, before anything else (even planning/research): if ${p} exists, cd in and reuse it as-is; else \`mkdir -p ${p} && cd ${p}\`. Never work in your home directory (${git}).`
     );
+  } else if (existingPath) {
+    // Repo-backed + known folder: verify it's the right clone, don't re-clone.
+    // No-repo + known folder: plain reuse-the-folder wording (unchanged).
+    const repoNote = repo
+      ? ` It should already be a clone of ${repo} — confirm with \`git remote -v\`; don't re-clone.`
+      : "";
+    directoryEcho = `You should already be in ${existingPath} (recorded from a previous session).${repoNote} Confirm with \`pwd\`; \`cd\` there if not. Don't re-init or re-clone — reuse the folder as-is.`;
+    // Concurrent-terminal isolation — the deep link's cwd is what puts this
+    // session in a possibly-shared folder, whether or not the idea is
+    // repo-backed (a repo-backed idea with NO known folder resolves via the
+    // `repo` slug in the branch below instead and never reaches here). The
+    // "compact" variant is a budget-conscious rewrite of the same steps
+    // buildWorktreeIsolationProtocol("full") gives the copy-command prompt —
+    // this one keeps every load-bearing invariant but drops the prose so the
+    // URL-capped deep link / in-browser terminal stay under their ceiling.
+    protocol = buildWorktreeIsolationProtocol("compact");
   } else if (repo) {
     leadingSteps.push(
       `Get into the repo ${repo} first: cd your local clone, or \`git clone https://github.com/${repo}.git ${DEFAULT_NEW_PROJECT_PARENT}/${repo.split("/")[1]}\` and cd in. Never work in your home directory.`
     );
-  } else if (existingPath) {
-    directoryEcho = `You should already be in ${existingPath} (recorded from a previous session). Confirm with \`pwd\`; \`cd\` there if not. Don't re-init or re-clone — reuse the folder as-is.`;
-    // Concurrent-terminal isolation (existing-mode/no-repo — the deep link's cwd
-    // is what puts this session in a possibly-shared folder; a repo-backed
-    // launch resolves via the `repo` slug instead and never reaches this
-    // branch). The "compact" variant is a budget-conscious rewrite of the same
-    // steps buildWorktreeIsolationProtocol("full") gives the copy-command
-    // prompt — this one keeps every load-bearing invariant but drops the prose
-    // so the URL-capped deep link / in-browser terminal stay under their ceiling.
-    protocol = buildWorktreeIsolationProtocol("compact");
   }
 
   const essentialSteps = [
@@ -847,9 +893,10 @@ export interface CompactPromptEssentials {
    */
   tail: string;
   /**
-   * Compact worktree-isolation protocol candidate (existing-mode/no-repo with
-   * a known cwd only); undefined when out of scope (repo-backed / new-project
-   * / first-launch). Best-effort on the URL-capped path — see
+   * Compact worktree-isolation protocol candidate (existing-mode with a known
+   * cwd only — repo-backed or not); undefined when out of scope (no known
+   * folder yet: new-project / first-launch, or repo-backed with nothing
+   * recorded). Best-effort on the URL-capped path — see
    * fitCompactWorktreeProtocol, which decides whether it rides the head.
    */
   protocol?: string;
@@ -1429,19 +1476,23 @@ export function resolveAppUrl(): string {
  * state and can never diverge (bootstrap-prompt parity, AC1/AC3):
  *
  *  - saved localStorage config for this idea → use it verbatim.
- *  - idea has a GitHub repo → existing mode, empty path; the repo slug resolves
- *    the working copy locally.
- *  - no repo BUT a real existing folder is known (a recorded DB path for THIS
- *    machine, surfaced via `effectiveTarget`) → existing mode at that absolute
- *    path, so the bootstrap prompt SKIPS the create-folder/mkdir/git-init block
- *    (the deep link's cwd already lands the session there — this is the fix for
- *    the "already-recorded idea still gets the first-run script" bug).
- *  - no repo, no known folder → a brand-new project under ~/projects/<slug>; the
- *    agent mkdir's it.
+ *  - a known folder is on file (pinned localStorage path, or a recorded DB
+ *    path for THIS machine — surfaced via `effectiveTarget`) → existing mode
+ *    at that absolute path, so the bootstrap prompt SKIPS the create-folder/
+ *    mkdir/git-init block (the deep link's cwd already lands the session
+ *    there). This applies WHETHER OR NOT the idea has a repo — a repo-backed
+ *    idea with a recorded/pinned folder gets the same treatment as a no-repo
+ *    one (this is the fix for the "repo-backed idea's recorded folder never
+ *    surfaces" bug: `effectiveTarget` must be checked before the repo check
+ *    below, or the repo branch always wins and the recorded path is dead code).
+ *  - idea has a GitHub repo, no known folder → existing mode, empty path; the
+ *    repo slug resolves the working copy locally (the fresh-machine flow).
+ *  - no repo, no known folder → a brand-new project under ~/projects/<slug>;
+ *    the agent mkdir's it.
  *
  * `effectiveTarget` is optional so callers without recorded paths (the terminal
  * dock's payload-less fallback) keep working unchanged — they pass nothing and
- * fall through to the create-new default exactly as before.
+ * fall through to the create-new/repo-empty-path default exactly as before.
  *
  * SSR-safe (readLaunchPath returns null on the server).
  */
@@ -1453,12 +1504,14 @@ export function resolveDefaultLaunchState(
 ): LaunchPathState {
   const saved = readLaunchPath(ideaId);
   if (saved) return saved;
-  if (ideaGithubUrl) return { mode: "existing", path: "" };
-  // A no-repo idea with a known folder (recorded/pinned via resolveEffective-
-  // LaunchTarget) opens THERE as existing mode so the prompt matches the cwd.
+  // A known folder (recorded/pinned via resolveEffectiveLaunchTarget) opens
+  // THERE as existing mode so the prompt matches the cwd — checked BEFORE the
+  // repo fallback below so a repo-backed idea's recorded/pinned folder isn't
+  // shadowed by the empty-path repo default.
   if (effectiveTarget && effectiveTarget.source !== "none" && effectiveTarget.cwd) {
     return { mode: "existing", path: effectiveTarget.cwd };
   }
+  if (ideaGithubUrl) return { mode: "existing", path: "" };
   const name = slugifyIdeaTitle(ideaTitle);
   return {
     mode: "new",
@@ -1473,14 +1526,18 @@ export function resolveDefaultLaunchState(
  * claude-cli:// deep link (launch button) and the in-browser vibecodes:// launch
  * (bus payload + terminal dock), so both destinations open in the same folder:
  *
- *  - existing mode with a user-pinned absolute path → use it.
+ *  - existing mode with a non-empty absolute path → use it. This covers a
+ *    user-pinned path AND a recorded/pinned folder that
+ *    `resolveDefaultLaunchState` promoted into existing mode for a
+ *    repo-backed idea (state carries no repo flag of its own — the path being
+ *    non-empty is what makes this branch fire either way).
  *  - new (no-repo) mode → the caller's effective cwd (the saved path or the
  *    agent-recorded path for THIS machine — resolveEffectiveLaunchTarget.cwd).
  *    Callers without the recorded paths (the dock's payload-less fallback) pass
  *    undefined, and the bootstrap prompt's directory step creates
  *    ~/projects/<slug> instead. (`~`-paths don't expand in the cwd param.)
- *  - repo-backed (existing mode, empty path) → no cwd; the repo slug / prompt
- *    directory step resolves the working copy.
+ *  - repo-backed, no known folder (existing mode, empty path) → no cwd; the
+ *    repo slug / prompt directory step resolves the working copy.
  */
 export function resolveLaunchCwd(
   state: LaunchPathState,


### PR DESCRIPTION
Fixes the bug Nick reported on 19 Aug: a Balla Bot terminal session died overnight, "Launch again" started a fresh session instead of resuming, and the session was missing from the Recent list entirely.

## Root cause

A board with a `github_url` never consulted `idea_project_paths`. Both resolvers short-circuited on the repo flag **before** reading the recorded path, so `resolveLaunchCwd` returned `undefined`, the post-connect PATCH was never sent, and `terminal_sessions.cwd` stayed `null` for the life of every session on that board.

Null `cwd` then cascades into both reported symptoms:
- `visibleRecentRows` filters out null-cwd rows → the session is invisible in the chooser.
- `canResume` requires a cwd → only the blind "Launch again" mint is offered.

Both of those consumers are correct and unchanged — they were faithfully acting on a bad `null`.

Production evidence: every Balla Bot session 17–19 Aug has `cwd: null`, board and task launches alike. VibeCodes escapes only because it has a browser-pinned path; Personal Spending escapes because it has no repo.

## Changes

- **`resolveEffectiveLaunchTarget`** — drop the `hasRepo` early return. Also fixes a second defect found during investigation: the two resolvers disagreed for repo + pinned path, so the *displayed* path and the *launch* cwd could diverge — the exact failure that function's own doc comment says it exists to prevent.
- **`resolveDefaultLaunchState`** — check `effectiveTarget` before the `github_url` fallback, which had made that branch dead code for every repo-backed idea.
- **`chooseLaunchCwd`** — dedupe by path before the 0/1/>1 rule. Two machines recording the **same** folder counted as ambiguous and returned `undefined`; five of the reporter's boards have 2 records but 1 distinct path, so the resolver fix alone would still have reproduced the bug on his own board. Genuinely divergent paths still return `undefined`.
- **`buildCompactStepPieces`** — check `existingPath` before the `repo` branch and make the message repo-aware (*"should already be a clone of X — confirm with `git remote -v`; don't re-clone"*). Without this, a repo-backed board with a known folder would newly have been told to clone it again. The worktree-isolation protocol now applies to that branch too.
- Four comments corrected that asserted the old repo-gated contract.

## Unchanged

- Repo-backed board with **no** recorded path → still the empty-path fresh-machine clone flow, byte-identical.
- No-repo boards → untouched.

## Verification

- 2894 tests passing (+2 dropdown guard tests, both **mutation-tested** — deliberately broken to confirm they fail when they should).
- `npx tsc --noEmit` clean; `npm run lint` 0 errors.
- Deep-link URL budget measured against the 1900 cap: 1716 realistic, 1898 for a pathological 610-char nested path — no overflow, and the degrade ladder is doing real work.

## Known gaps for the reviewer

Verified at the pure-function layer only. No live browser, no real `claude-cli://` launch end-to-end, and the URL cap is measured at representative points rather than proven. The reported symptom will only be *observably* fixed once a real repo-backed launch writes a non-null `cwd`.

## Follow-ups (not in this PR)

1. Nothing captures where a session **actually** ended up — the folder is decided at launch and never corrected, so this class of bug can't self-heal.
2. Two unreconciled stores for "where this project lives" (browser-pinned vs server-recorded). The browser copy silently wins and nothing compares them; on VibeCodes they currently disagree.
3. `chooseLaunchCwd` could match on hostname — the browser now records machine identity (`getMachineIdentity()`), which the "the browser can't know which host it's on" premise predates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)