### PR TITLE
fix(terminal): ended screen's "View my other sessions" opens the chooser, not the running-only panel

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -70,13 +70,31 @@ const { sessionViewMountSpy, sessionViewUnmountSpy } = vi.hoisted(() => ({
 // MANY tabs actually got minted, and with what payload — the real component
 // (and the hook underneath it) is exercised elsewhere.
 vi.mock("./terminal-session-view", () => ({
-  TerminalSessionView: ({ entry }: { entry: { key: string; taskId?: string } }) => {
+  TerminalSessionView: ({
+    entry,
+    onBrowseSessions,
+  }: {
+    entry: { key: string; taskId?: string };
+    onBrowseSessions?: () => void;
+  }) => {
     useEffect(() => {
       sessionViewMountSpy(entry.key);
       return () => sessionViewUnmountSpy(entry.key);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-    return <div data-testid="session-view" data-key={entry.key} data-task-id={entry.taskId ?? ""} />;
+    return (
+      <div data-testid="session-view" data-key={entry.key} data-task-id={entry.taskId ?? ""}>
+        {/* Stands in for the ended panel's "View my other sessions" link —
+            the real panel only renders it on the session-ended view, which
+            needs the whole xterm/socket machinery this stub deliberately
+            omits. What matters here is WHERE the dock points the callback. */}
+        {onBrowseSessions && (
+          <button data-testid="view-my-other-sessions" onClick={onBrowseSessions}>
+            View my other sessions
+          </button>
+        )}
+      </div>
+    );
   },
   dockStatusMeta: () => ({ label: "Terminal", Icon: () => null, className: "" }),
 }));
@@ -746,5 +764,103 @@ describe("TerminalDock — another-session-here badge (card eaa55290)", () => {
     fireEvent.click(screen.getByTestId("chooser-reconnect-here-own-sid"));
 
     await waitFor(() => expect(screen.getByText("Another tab is open here")).toBeInTheDocument());
+  });
+});
+
+// Nick's field report, 2026-08-19. From an ENDED session he clicked "View my
+// other sessions" and got the "My sessions" popup — which filters to
+// `status === "active"` by construction (terminal-my-sessions-panel.tsx's
+// `running` memo), so it can never contain the ended/resumable rows the
+// link's own wording promises. The list he wanted — "Recent — ended in the
+// last 48h", with a per-row Resume — lives in the CHOOSER, and until now the
+// only way to reach it was the toolbar's Launch Claude Code.
+//
+// `onCapExceeded` keeps pointing at the My sessions panel on purpose: a cap
+// refusal genuinely IS about what's running, so that list is the right one
+// there. Only the ended panel's browse link moved.
+describe("TerminalDock — ended panel's 'View my other sessions' opens the chooser, not the running-only panel (Nick's field report 2026-08-19)", () => {
+  async function openFirstTabViaChooser() {
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("chooser-start-new"));
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+  }
+
+  it("opens the chooser overlay — the list that actually has resumable ended sessions in it", async () => {
+    // A recent ENDED row is exactly what the old wiring could never show.
+    stubFetch(Promise.resolve([recentRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await openFirstTabViaChooser();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("view-my-other-sessions"));
+
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    // The whole point: the ended row is present and offers Resume.
+    expect(screen.getByTestId("chooser-resume-sid-recent-task-9")).toBeInTheDocument();
+  });
+
+  it("never mints a session just for looking", async () => {
+    stubFetch(Promise.resolve([recentRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await openFirstTabViaChooser();
+    fireEvent.click(screen.getByTestId("view-my-other-sessions"));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+    expect(sessionViewUnmountSpy).not.toHaveBeenCalled();
+  });
+
+  it("is dismissible — browsing has no pending launch to resolve, so Escape closes it", async () => {
+    stubFetch(Promise.resolve([recentRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await openFirstTabViaChooser();
+    fireEvent.click(screen.getByTestId("view-my-other-sessions"));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape", code: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    // Backed out of, not acted on — no new tab, and the open one is intact.
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+    expect(sessionViewUnmountSpy).not.toHaveBeenCalled();
+  });
+
+  it("still traps a LAUNCH-opened overlay (forced choice, unchanged) — the dismissal relaxation is scoped to browsing", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await openFirstTabViaChooser();
+    act(() => {
+      requestBrowserLaunch();
+    });
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape", code: "Escape" });
+
+    // A fired launch must resolve to exactly one outcome — Escape must not
+    // silently swallow it.
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("resuming an ended session from the browse overlay closes it and launches with that row's own folder and conversation", async () => {
+    const ended = { ...recentRowForTask("task-9"), claudeSessionId: "claude-conv-xyz" };
+    stubFetch(Promise.resolve([ended]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await openFirstTabViaChooser();
+    fireEvent.click(screen.getByTestId("view-my-other-sessions"));
+    await waitFor(() => expect(screen.getByTestId("chooser-resume-sid-recent-task-9")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("chooser-resume-sid-recent-task-9"));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(2));
+    // Carries the ended row's task through, so the resumed tab is the same
+    // piece of work — not a blank session in the same folder.
+    const taskIds = screen.getAllByTestId("session-view").map((el) => el.dataset.taskId);
+    expect(taskIds).toContain("task-9");
   });
 });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -223,7 +223,20 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // a tab is already open (possibly actively connected) — the tab strip and
   // that tab's live `TerminalSessionView` stay mounted, connected, and
   // visible underneath; only clicking an action inside the overlay closes it.
-  const [chooserOpen, setChooserOpen] = useState(false);
+  //
+  // `chooserMode` records WHY it opened, because the two reasons want
+  // different dismissal rules (Nick's field report 2026-08-19):
+  //  - "launch": a launch fired and must resolve to exactly one outcome, so
+  //    the overlay is a forced choice — no close button, Escape and
+  //    outside-click both suppressed. Unchanged behaviour.
+  //  - "browse": the user followed the ended panel's "View my other sessions"
+  //    link purely to LOOK. Nothing is pending, so trapping them until they
+  //    start or reconnect something would be worse than the dead end the link
+  //    was added to fix — this mode is freely dismissible.
+  // Kept as one state rather than a second boolean so "open" and "why" can
+  // never drift out of sync; `chooserOpen` stays derived for every read site.
+  const [chooserMode, setChooserMode] = useState<"launch" | "browse" | null>(null);
+  const chooserOpen = chooserMode !== null;
   // Task-launch-skip-chooser (Nick's explicit product decision, 2026-08-16):
   // a per-task launch (payload carries `taskId`) never opens the full
   // chooser above — it either mints immediately (no existing session for
@@ -832,7 +845,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         // visible underneath.
         setExpanded(true);
         setPendingLaunch(payload);
-        if (sessionsRef.current.length > 0) setChooserOpen(true);
+        if (sessionsRef.current.length > 0) setChooserMode("launch");
         return;
       }
       mintAndDeliver(payload);
@@ -981,7 +994,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         // open, `deliverLaunch` couldn't know the resolved kind yet at queue
         // time, so the overlay hasn't been shown — open it now,
         // non-destructively.
-        if (sessions.length > 0) setChooserOpen(true);
+        if (sessions.length > 0) setChooserMode("launch");
         return;
       }
       const payload = pendingLaunch;
@@ -1021,7 +1034,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
 
   // ── chooser action handlers ─────────────────────────────────────────────────
   // Shared by BOTH the sessions.length === 0 body-swap chooser and the
-  // sessions.length > 0 overlay (rework 11) — the `setChooserOpen(false)` in
+  // sessions.length > 0 overlay (rework 11) — the `setChooserMode(null)` in
   // each is a no-op when it was never opened (the body-swap case), and the
   // one thing that's allowed to close the overlay per the design's
   // non-disruption guarantee: only an explicit action in here, never an
@@ -1030,14 +1043,14 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   const handleChooserStartNew = useCallback(() => {
     const payload = pendingLaunch;
     setPendingLaunch(null);
-    setChooserOpen(false);
+    setChooserMode(null);
     mintAndDeliver(payload);
   }, [pendingLaunch, mintAndDeliver]);
 
   const handleChooserReconnectHere = useCallback(
     (row: ChooserLiveRow) => {
       setPendingLaunch(null);
-      setChooserOpen(false);
+      setChooserMode(null);
       void performReattach(row.sid, { focus: true });
     },
     [performReattach],
@@ -1045,7 +1058,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
 
   const handleChooserOpenBoardAndReconnect = useCallback(
     (row: ChooserLiveRow) => {
-      setChooserOpen(false);
+      setChooserMode(null);
       router.push(`/ideas/${row.ideaId}/board?reconnect=${encodeURIComponent(row.sid)}`);
     },
     [router],
@@ -1054,7 +1067,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   const handleChooserResume = useCallback(
     (row: ChooserRecentRow) => {
       setPendingLaunch(null);
-      setChooserOpen(false);
+      setChooserMode(null);
       // F4's Resume: the EXISTING (capped) launch flow, carrying the ended
       // row's own recorded folder instead of a bootstrap prompt — see
       // BrowserLaunchPayload's doc and use-terminal-session.ts's
@@ -1073,6 +1086,24 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     },
     [mintAndDeliver],
   );
+
+  // The ended panel's "View my other sessions" link (Nick's field report
+  // 2026-08-19). It used to call `openMySessions`, which opens a panel that
+  // filters to `status === "active"` by construction — so from an ended
+  // session it showed a list that could never contain the ended/resumable
+  // rows the wording promises. This opens the chooser instead: the same
+  // component the launch flow uses, which has the "Recent — ended in the last
+  // 48h" section with its per-row Resume.
+  //
+  // Refreshes first because the session the user just ended is very likely
+  // NOT in `registryRows` as ended yet — without this the chooser would open
+  // missing the very row they came looking for. `refreshRegistry` swallows
+  // and toasts its own failures, so a stale-but-present list still opens
+  // rather than the link doing nothing.
+  const openChooserToBrowse = useCallback(() => {
+    setChooserMode("browse");
+    void refreshRegistry();
+  }, [refreshRegistry]);
 
   // Task-launch-skip-chooser: the minimal task-scoped choice's two actions.
   // Re-derives the match from the CURRENT `chooserSections` (rather than
@@ -1475,7 +1506,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onRegisterActions={registerActions}
             onAnnounce={announce}
             onCapExceeded={openMySessions}
-            onOpenMySessions={openMySessions}
+            onBrowseSessions={openChooserToBrowse}
             poppedOut={poppedOutKeys.has(entry.key)}
             onPopOut={() => handlePopOut(entry.key)}
             onBringBack={() => bringBackToDock(entry.key)}
@@ -1492,17 +1523,32 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           open (possibly actively connected). The tab strip and every
           `TerminalSessionView` render in the (untouched) block above this
           one, so opening this Dialog neither unmounts nor re-renders them —
-          it's a Portal-rendered overlay layered on top, nothing more. Forced
-          choice (matches onboarding-dialog.tsx's pattern): no close button,
-          outside-click and Escape are both suppressed — only an action
-          inside the chooser (wired to also call `setChooserOpen(false)`)
-          closes it. */}
-      <Dialog open={chooserOpen && sessions.length > 0} onOpenChange={() => {}}>
+          it's a Portal-rendered overlay layered on top, nothing more.
+
+          Dismissal depends on WHY it opened (`chooserMode`). "launch" is a
+          forced choice (matches onboarding-dialog.tsx's pattern): no close
+          button, outside-click and Escape both suppressed — only an action
+          inside the chooser (wired to also call `setChooserMode(null)`)
+          closes it, because a fired launch must resolve to exactly one
+          outcome. "browse" — the ended panel's "View my other sessions" link
+          — has no pending launch to resolve, so it closes normally; trapping
+          someone who only wanted a look would be worse than the dead end that
+          link exists to fix. */}
+      <Dialog
+        open={chooserOpen && sessions.length > 0}
+        onOpenChange={(next) => {
+          if (!next && chooserMode === "browse") setChooserMode(null);
+        }}
+      >
         <DialogContent
-          showCloseButton={false}
+          showCloseButton={chooserMode === "browse"}
           className="max-w-lg gap-0 border-zinc-700 bg-[#141417] p-0 text-zinc-200 sm:max-w-xl"
-          onInteractOutside={(e) => e.preventDefault()}
-          onEscapeKeyDown={(e) => e.preventDefault()}
+          onInteractOutside={(e) => {
+            if (chooserMode !== "browse") e.preventDefault();
+          }}
+          onEscapeKeyDown={(e) => {
+            if (chooserMode !== "browse") e.preventDefault();
+          }}
         >
           <DialogTitle className="sr-only">Choose a terminal session</DialogTitle>
           <DialogDescription className="sr-only">

--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -253,7 +253,7 @@ function renderErrorView(onReconnectTakenOver: (sid: string) => void = vi.fn()) 
 
 function renderEndedView(
   onResumeEndedSession: (payload: unknown) => void = vi.fn(),
-  onOpenMySessions?: () => void,
+  onBrowseSessions?: () => void,
 ) {
   return render(
     <TerminalSessionView
@@ -268,7 +268,7 @@ function renderEndedView(
       onRegisterActions={vi.fn()}
       onAnnounce={vi.fn()}
       onResumeEndedSession={onResumeEndedSession}
-      onOpenMySessions={onOpenMySessions}
+      onBrowseSessions={onBrowseSessions}
     />,
   );
 }
@@ -496,31 +496,34 @@ describe("TerminalSessionView — session-ended resume (Bug A)", () => {
 
   // Bug cbe60db5-followup-2 (low-medium): the ended panel had no path to a
   // user's other live/recent sessions in either button configuration
-  // (Resume+Start-fresh, or Launch-again-alone) — this reuses the same
-  // openMySessions trigger onCapExceeded already wires (E1, design §7b).
-  it("renders a 'View my other sessions' link that calls onOpenMySessions, alongside the Resume+Start-fresh buttons", () => {
-    const onOpenMySessions = vi.fn();
+  // (Resume+Start-fresh, or Launch-again-alone). The callback it fires is
+  // deliberately NOT onCapExceeded's "My sessions" trigger any more (Nick's
+  // field report 2026-08-19) — that panel is running-only, so it could never
+  // show the ended sessions this link's wording promises. The dock now points
+  // it at the chooser; see terminal-dock.test.tsx for that half.
+  it("renders a 'View my other sessions' link that calls onBrowseSessions, alongside the Resume+Start-fresh buttons", () => {
+    const onBrowseSessions = vi.fn();
     installMockEndedSession({
       endedReason: "idle",
       cwd: "/Users/nick/projects/vibe-coding-ideas",
       claudeSessionId: "claude-conv-abc",
     });
-    renderEndedView(vi.fn(), onOpenMySessions);
+    renderEndedView(vi.fn(), onBrowseSessions);
 
     const link = screen.getByRole("button", { name: /View my other sessions/ });
     fireEvent.click(link);
-    expect(onOpenMySessions).toHaveBeenCalledTimes(1);
+    expect(onBrowseSessions).toHaveBeenCalledTimes(1);
   });
 
   it("also renders the link alongside the plain 'Launch again' button (no cwd known)", () => {
-    const onOpenMySessions = vi.fn();
+    const onBrowseSessions = vi.fn();
     installMockEndedSession({ endedReason: "idle", cwd: null, claudeSessionId: null });
-    renderEndedView(vi.fn(), onOpenMySessions);
+    renderEndedView(vi.fn(), onBrowseSessions);
 
     expect(screen.getByRole("button", { name: /View my other sessions/ })).toBeInTheDocument();
   });
 
-  it("omits the link entirely when onOpenMySessions isn't wired (matches the optional-callback-gated-UI pattern used elsewhere in this file)", () => {
+  it("omits the link entirely when onBrowseSessions isn't wired (matches the optional-callback-gated-UI pattern used elsewhere in this file)", () => {
     installMockEndedSession({
       endedReason: "idle",
       cwd: "/Users/nick/projects/vibe-coding-ideas",

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -178,15 +178,23 @@ interface TerminalSessionViewProps {
    */
   onResumeEndedSession?: (payload: BrowserLaunchPayload) => void;
   /**
-   * Opens the dock's "My sessions" panel — the SAME trigger `onCapExceeded`
-   * already uses (E1, design §7b). Rendered as a small tertiary link under
-   * the ended-panel's button row: a user staring at one ended session had no
-   * way to see their other live/recent ones without hunting for the
-   * collapsed-bar trigger. Omitted hides the link entirely (defensive, the
-   * same optional-callback-gated-UI pattern `onPopOut`/`onResumeEndedSession`
+   * Opens the dock's full session CHOOSER — live sessions AND the "Recent —
+   * ended in the last 48h" rows you can resume. Rendered as a small tertiary
+   * link under the ended-panel's button row: a user staring at one ended
+   * session had no way to see their other live/recent ones.
+   *
+   * Deliberately NOT `onCapExceeded`'s "My sessions" panel, which this link
+   * originally shared (Nick's field report 2026-08-19): that panel filters to
+   * `status === "active"` by construction, so from an ended session it could
+   * never show the one thing the link's own wording promises — the ended
+   * sessions you might want to resume. Cap-exceeded still uses it correctly,
+   * because a cap is about what's *running*.
+   *
+   * Omitted hides the link entirely (defensive, the same
+   * optional-callback-gated-UI pattern `onPopOut`/`onResumeEndedSession`
    * already use in this file).
    */
-  onOpenMySessions?: () => void;
+  onBrowseSessions?: () => void;
 }
 
 export function TerminalSessionView({
@@ -207,7 +215,7 @@ export function TerminalSessionView({
   onReconnectTakenOver,
   onRetryReconnect,
   onResumeEndedSession,
-  onOpenMySessions,
+  onBrowseSessions,
 }: TerminalSessionViewProps) {
   const session = useTerminalSession(descriptor, {
     enabled: true,
@@ -562,7 +570,7 @@ export function TerminalSessionView({
               onReconnectTakenOver={() => {
                 if (pair) onReconnectTakenOver?.(pair.sessionId);
               }}
-              onOpenMySessions={onOpenMySessions}
+              onBrowseSessions={onBrowseSessions}
             />
           )}
           {state.status === "disconnected" && (
@@ -675,7 +683,7 @@ function StateOverlay({
   onResume,
   onCopyBridge,
   onReconnectTakenOver,
-  onOpenMySessions,
+  onBrowseSessions,
 }: {
   view: DockView;
   state: TerminalConnectionState;
@@ -704,7 +712,7 @@ function StateOverlay({
   onCopyBridge: () => void;
   onReconnectTakenOver: () => void;
   /** See TerminalSessionViewProps' same-named prop. */
-  onOpenMySessions?: () => void;
+  onBrowseSessions?: () => void;
 }) {
   return (
     <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 overflow-y-auto bg-[#0c0c0e]/95 px-6 py-6 text-center">
@@ -791,16 +799,16 @@ function StateOverlay({
             </Button>
           )}
           {/* Bug cbe60db5-followup-2 (low-medium): the ended panel used to be
-              a dead end for anyone who forgot where the collapsed bar's "My
-              sessions" trigger lives — this reuses the exact same
-              openMySessions callback onCapExceeded already wires (E1, design
-              §7b), just from a second entry point. Tertiary, so it never
-              competes with the primary Resume/Launch-again action above. */}
-          {onOpenMySessions && (
+              a dead end for anyone wanting their other sessions. Tertiary, so
+              it never competes with the primary Resume/Launch-again action
+              above. Opens the CHOOSER (live + resumable recent), not the
+              running-only "My sessions" panel it originally shared with
+              onCapExceeded — see onBrowseSessions' doc. */}
+          {onBrowseSessions && (
             <button
               type="button"
               className="text-[11px] text-zinc-500 underline hover:text-zinc-300"
-              onClick={onOpenMySessions}
+              onClick={onBrowseSessions}
             >
               View my other sessions
             </button>


### PR DESCRIPTION
Nick's field report, 19 Aug 2026.

## The bug

End a session, click **"View my other sessions"** on the ended screen, and you get the **"My sessions"** popup — live runs with Reconnect/End.

That panel filters to `status === "active"` by construction (`terminal-my-sessions-panel.tsx`'s `running` memo). It fetches the recently-ended rows and deliberately throws them away. So from an ended session the link opens a list that **cannot contain what its own wording promises**.

The list you actually want — **"Recent — ended in the last 48h"** with a per-row Resume — lives in `TerminalSessionChooser`, and until now the toolbar's "Launch Claude Code" was the only way to reach it.

## Why it was wired that way

Not accidental. Card `cea7e23b`'s follow-up added the link as a shortcut for people who couldn't find the collapsed bar's trigger, and reused `onCapExceeded`'s `openMySessions` callback. The "see my past sessions" reading was never the design. The wording and the destination simply disagree.

## The fix

- **Split the two entry points** rather than repointing one: `onOpenMySessions` → `onBrowseSessions`. `onCapExceeded` still opens the My sessions panel — a cap refusal genuinely *is* about what's running, so that list is right there.
- **Refresh the registry before opening.** The session just ended is very likely not recorded as ended yet; without this the chooser opens missing the exact row the user came for. `refreshRegistry` toasts its own failures, so a stale-but-present list still opens rather than the link doing nothing.
- **`chooserOpen` → `chooserMode: "launch" | "browse" | null`.** The two reasons want different dismissal rules:
  - `"launch"` — unchanged forced choice (no close button, Escape and outside-click suppressed). A fired launch must resolve to exactly one outcome.
  - `"browse"` — freely dismissible. Nothing is pending; trapping someone who only wanted a look would be worse than the dead end this link exists to fix.

  One state rather than a second boolean, so "open" and "why" can't drift apart. `chooserOpen` stays derived, so every read site is untouched.

## Tests

Five new cases in `terminal-dock.test.tsx` covering: the link opens the chooser with the ended row's Resume present; browsing never mints; Escape closes a browse overlay; Escape still **doesn't** close a launch overlay; and Resume from the browse overlay carries the ended row's task through.

The last two are mutually exclusive under any single uniform rule, so together they pin the mode distinction rather than just asserting current behaviour.

`npx tsc --noEmit` clean · eslint clean · 808 board + terminal tests pass.

## Not fixed here

Nick's ended panel offered only "Launch again", not "Resume this conversation" — that's `canResume === false`, i.e. no folder recorded for the session. Same family as `1b9895f5`, `40aace41`, `6f5d35e4`, which own it.

Board card: `26d9c28c-96ce-4468-a690-e5685f870a72`

🤖 Generated with [Claude Code](https://claude.com/claude-code)