### PR TITLE
fix(terminal): start straight away when a task's last session has no folder

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -592,6 +592,42 @@ describe("TerminalDock — task-launch-skip-chooser (Nick's explicit product dec
     expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
   });
 
+  // Card 79a0046c (Nick's field report, 2026-08-19): the ended session for
+  // this task had no recorded folder, so the choice dialog opened with Resume
+  // hidden and "Start fresh anyway" as its ONLY button — an interstitial in
+  // front of the exact mint it was gating. Nothing to choose between → don't
+  // ask; just start, same as if no session existed.
+  it("auto-starts when this task's only RECENT session has no recorded folder — no dead-end one-button dialog", async () => {
+    stubFetch(Promise.resolve([{ ...recentRowForTask("task-9"), cwd: null }]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(screen.getByTestId("session-view").dataset.taskId).toBe("task-9");
+    expect(screen.queryByTestId("task-choice")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  // The skip is scoped to unresumable ENDED sessions. A RUNNING one still
+  // stops the launch even with no folder recorded — reattaching to a live
+  // session never needed one, so Reconnect is a genuine second option.
+  it("still shows the task choice when this task's LIVE session has no recorded folder", async () => {
+    stubFetch(Promise.resolve([{ ...liveHereRowForTask("task-9"), cwd: null }]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("task-choice")).toBeInTheDocument());
+    expect(screen.getByTestId("task-choice").dataset.matchKind).toBe("live-here");
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+  });
+
   it("auto-starts (no false-positive dedupe) when the only existing session belongs to a DIFFERENT task", async () => {
     stubFetch(Promise.resolve([liveHereRowForTask("task-OTHER")]));
     render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);

--- a/src/components/board/terminal-task-launch-choice.test.tsx
+++ b/src/components/board/terminal-task-launch-choice.test.tsx
@@ -88,13 +88,12 @@ describe("TerminalTaskLaunchChoice", () => {
     expect(onReconnect).toHaveBeenCalledOnce();
   });
 
-  // Bug 9fb9fced (2026-08-17): a "recent" match with no recorded cwd used to
-  // never reach this dialog at all — chooser-data.ts's old F4 rule excluded
-  // it from `sections.recent` entirely, so `findTaskSessionMatch` could never
-  // find it. It can now, but Resume has no folder to reopen — mirrors the
-  // cross-board chooser's RecentRow fix: the dialog still opens (so
-  // "start fresh anyway" is reachable) but hides Reconnect/Resume instead of
-  // offering an action that can't work.
+  // Defence in depth only. As of card 79a0046c (2026-08-19)
+  // `findTaskSessionMatch` no longer returns an unresumable ended row at all,
+  // so the dock can't route one here — a task launch in that state mints
+  // straight away instead of showing a dialog whose only button is the mint.
+  // The guard stays because this component takes a `match` prop from anyone:
+  // given one, hiding an action that cannot work still beats offering it.
   it("a recent match with no recorded cwd hides Resume, keeps Start fresh anyway", () => {
     const onReconnect = vi.fn();
     const noCwdMatch: TaskSessionMatch = {

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -559,19 +559,36 @@ describe("findTaskSessionMatch", () => {
     expect(findTaskSessionMatch(sections, "task-1")).toBeNull();
   });
 
-  // Card cbe60db5 follow-up (Nick, 2026-08-17): the general chooser's Recent
-  // list now hides no-folder rows via `visibleRecentRows` (a display-only
-  // filter applied by terminal-session-chooser.tsx). `findTaskSessionMatch`
-  // must NOT pick up that filter — a task-scoped launch still has to dedupe
-  // against its own no-folder recent session (routing to
-  // terminal-task-launch-choice.tsx's "already have a session" dialog
-  // instead of silently minting a second one for the same task).
-  it("still matches a Recent row with no recorded cwd — unaffected by the chooser's display-only filter", () => {
+  // Card 79a0046c (Nick's field report, 2026-08-19), reversing card d6ebd6e8's
+  // call: an ended no-folder session isn't resumable, so matching it only
+  // produced a one-button "start fresh anyway" dialog in front of the mint
+  // that would have happened anyway. No match → the launch mints immediately.
+  it("does not match an ended Recent row with no recorded cwd — nothing there to resume", () => {
     const rows = [row({ sid: "no-cwd-recent", status: "ended", cwd: null, taskId: "task-1", endedAt: new Date(NOW - 60_000).toISOString() })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(sections.recent.map((r) => r.sid)).toContain("no-cwd-recent"); // still IN the sections...
+    expect(findTaskSessionMatch(sections, "task-1")).toBeNull(); // ...just not a reason to interrupt a launch
+  });
+
+  // The skip above is scoped to unresumable ENDED rows only — a running
+  // session for this task still stops the launch, folder or no folder,
+  // because reattaching to it never needed one.
+  it("still matches a LIVE row for the task even with no recorded cwd", () => {
+    const rows = [row({ sid: "no-cwd-live", status: "active", cwd: null, taskId: "task-1" })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    const match = findTaskSessionMatch(sections, "task-1");
+    expect(match?.kind).toBe("live-here");
+    expect(match?.row.sid).toBe("no-cwd-live");
+  });
+
+  // A resumable ended row is untouched by the skip — the dialog still earns
+  // its place there, because Resume is a real second option.
+  it("still matches an ended Recent row that has a recorded cwd", () => {
+    const rows = [row({ sid: "cwd-recent", status: "ended", cwd: "/repo", taskId: "task-1", endedAt: new Date(NOW - 60_000).toISOString() })];
     const sections = deriveChooserSections(rows, IDEA_A, NOW);
     const match = findTaskSessionMatch(sections, "task-1");
     expect(match?.kind).toBe("recent");
-    expect(match?.row.sid).toBe("no-cwd-recent");
+    expect(match?.row.sid).toBe("cwd-recent");
   });
 });
 

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -256,11 +256,10 @@ export function deriveChooserSections(
  *     not `ChooserSections`, so it's untouched by this helper either way, but
  *     the underlying data it depends on (a null-cwd row counting as "recent")
  *     is the same invariant this filter must not undermine at the source.
- *   - `findTaskSessionMatch` below — a task-scoped launch must still dedupe
- *     against its own no-folder recent session (routing to
- *     terminal-task-launch-choice.tsx's "already have a session" dialog
- *     instead of silently minting a second one), even though that session
- *     wouldn't be worth a row in the general chooser's list.
+ *   - `findTaskSessionMatch` below — it reads `sections.recent` directly and
+ *     applies its own equivalent no-folder skip inline (see the comment on
+ *     that function), which must stay a decision made THERE, on the full set,
+ *     rather than something it inherits from a display filter.
  *
  * Two callers apply this: `terminal-session-chooser.tsx` for its row list AND
  * its section show/hide check, and `chooserHeaderCounts` below for the header
@@ -337,7 +336,16 @@ export function findTaskSessionMatch(
   if (here) return { kind: "live-here", row: here };
   const elsewhere = sections.liveElsewhere.find((r) => r.taskId === taskId);
   if (elsewhere) return { kind: "live-elsewhere", row: elsewhere };
-  const recent = sections.recent.find((r) => r.taskId === taskId);
+  // Card 79a0046c (Nick's field report, 2026-08-19): an ENDED session with no
+  // recorded folder is not a match worth stopping for. Resume needs a folder
+  // to reopen, so the dialog it would route to can only offer "start fresh
+  // anyway" — a one-button interstitial in front of the exact thing that
+  // happens without it. Card d6ebd6e8 kept these rows matchable to avoid
+  // "silently minting a second session", but the matched session has already
+  // ended: there is no parallel session to avoid, only a click to waste.
+  // Live rows above are deliberately unaffected — reattaching to a running
+  // session needs no folder, so those still route to the choice dialog.
+  const recent = sections.recent.find((r) => r.taskId === taskId && r.cwd !== null);
   if (recent) return { kind: "recent", row: recent };
   return null;
 }


### PR DESCRIPTION
Card `79a0046c` — Nick's field report, 19 Aug 2026.

## What Nick saw

Clicked **Launch in browser terminal** from a task's menu. Instead of a session starting, this appeared:

> **This task has a recent session**
> Add the finance app's hostname to the Cloudflare tunnel + Access policy (Google login, Nick only)
> Ended 4h 58m ago
> No folder was recorded for it — can't resume.
>
> `[ Start fresh anyway ]`

One button. The dialog says it can't do the thing it's asking about, then offers the only option left — which is exactly what should have happened with no dialog at all.

## Cause

`findTaskSessionMatch` returned a `recent` match for an ended session even when that session had no recorded folder. The dock treats any match as "show the choice dialog", and the dialog then hides Resume (no folder to reopen), leaving only the escape hatch.

Card `d6ebd6e8` deliberately kept these rows matchable so a task launch would "dedupe against its own no-folder recent session instead of silently minting a second one". That reasoning doesn't hold: the session has **ended**, so there is no second parallel session to avoid — only a click to waste.

## Change

`findTaskSessionMatch` skips ended rows with no folder. A task launch in that state mints immediately, same as if no session existed.

Live rows are deliberately untouched: reattaching to a running session never needed a folder, so those still route to the choice dialog, where Reconnect is a real second option.

`TerminalTaskLaunchChoice`'s own no-folder guard stays as defence in depth — the dock can no longer route such a match to it, but the component takes `match` from any caller, and hiding an action that cannot work still beats offering it.

## Tests

- Dock: a task whose only recent session has no folder auto-starts — no dialog, no chooser. **Verified failing without the fix.**
- Dock: a task whose *live* session has no folder still shows the choice.
- `chooser-data`: no-folder ended row stays in `sections.recent` but is no longer a match; live no-folder rows and resumable ended rows still match.
- Full suite: 2,903 passing. Typecheck and lint clean.

## Not fixed here

Why the folder is missing in the first place — cards `6f5d35e4`, `40aace41`, `1b9895f5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)