### PR TITLE
fix(terminal): resuming another board's session no longer re-homes it

### DIFF
--- a/src/app/api/terminal/session/route.test.ts
+++ b/src/app/api/terminal/session/route.test.ts
@@ -1,0 +1,172 @@
+// Cross-board resume fix (bug 62e57071, Sentinel's investigation): the mint
+// route is the SERVER backstop for the same bug the client-side chooser/
+// task-choice fixes close — `terminal_sessions.task_id` carries no FK to
+// `idea_id` (see the 00141_terminal_sessions migration), so nothing at the
+// DB layer stops a client from minting a session that claims a task from one
+// board while registering it under a different idea_id. These tests cover
+// only the NEW task/idea guard this card adds — the route's pre-existing
+// auth/cap/rate-limit/budget behaviour is unchanged and untested here.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// BodySchema requires ideaId/taskId to be real (RFC4122-variant) UUIDs
+// (z.string().uuid()) — plain slugs like "idea-1", or an all-same-digit
+// string, fail validation before the guard under test ever runs.
+const { NOW_ISO, IDEA_1, IDEA_OTHER, TASK_ID } = vi.hoisted(() => ({
+  NOW_ISO: "2026-08-19T12:00:00.000Z",
+  IDEA_1: "faed9703-f223-4a32-8f3b-1aee2f2ddefd",
+  IDEA_OTHER: "2100fcf5-6d9b-4d4f-a53d-7fcf9f70d16a",
+  TASK_ID: "3d75a431-bc13-4f03-ae38-f90bb759e56b",
+}));
+
+// One configurable chain per table name — every chain method returns the
+// SAME chain object, which is itself thenable (resolves to that table's
+// configured `result` no matter which method the route happened to call
+// last), mirroring oauth.test.ts's makeChain pattern in this repo.
+function makeChain(result: { data?: unknown; error?: unknown; count?: number | null } = { data: null, error: null }) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {};
+  const methods = ["select", "insert", "eq", "gte", "order", "limit", "maybeSingle"];
+  for (const m of methods) chain[m] = vi.fn().mockReturnValue(chain);
+  chain.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject);
+  return chain;
+}
+
+const { mockFrom, mockGetUser, tableResults, insertSpy } = vi.hoisted(() => {
+  const mockFrom = vi.fn();
+  const mockGetUser = vi.fn();
+  const tableResults: Record<string, { data?: unknown; error?: unknown; count?: number | null }> = {};
+  const insertSpy = vi.fn();
+  return { mockFrom, mockGetUser, tableResults, insertSpy };
+});
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: { getUser: () => mockGetUser() },
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Reap is exercised elsewhere (session-reap.test.ts) — stub it to "nothing to
+// reap" so the cap/rate-limit reads below see a clean 0 active count.
+vi.mock("@/lib/terminal/session-reap", () => ({
+  reapExpiredSessions: vi.fn().mockResolvedValue({ activeBefore: 0, reapedIds: [] }),
+}));
+
+vi.mock("../../../../../terminal/shared/session-token.mjs", () => ({
+  mintSessionTokens: vi.fn().mockResolvedValue({
+    sid: "sid-minted-1",
+    idea: IDEA_1,
+    exp: Date.parse(NOW_ISO) + 60_000,
+    browser: "browser-tok",
+    bridge: "bridge-tok",
+  }),
+  mintHelperToken: vi.fn().mockResolvedValue("helper-tok"),
+}));
+
+import { POST } from "./route";
+import { logger } from "@/lib/logger";
+
+function req(body: unknown) {
+  return new Request("http://localhost/api/terminal/session", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.stubEnv("TERMINAL_SESSION_SECRET", "test-secret");
+  vi.setSystemTime(new Date(NOW_ISO));
+  mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  for (const key of Object.keys(tableResults)) delete tableResults[key];
+  tableResults.ideas = { data: { id: IDEA_1, author_id: "user-1" }, error: null };
+  tableResults.collaborators = { data: null, error: null };
+  tableResults.board_tasks = { data: null, error: null }; // "no such task" by default
+  // terminal_sessions backs the daily-budget read, the rate-limit read, AND
+  // the final insert — all three only ever read `.count`/`.error`, so one
+  // shared shape (0 rows so far, insert succeeds) covers every call.
+  tableResults.terminal_sessions = { data: null, error: null, count: 0 };
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "terminal_sessions") {
+      // Distinguish the insert (asserted on separately) from the read-only
+      // count queries, without changing what either resolves to.
+      const chain = makeChain(tableResults.terminal_sessions);
+      const realInsert = chain.insert;
+      chain.insert = (...args: unknown[]) => {
+        insertSpy(...args);
+        return realInsert(...args);
+      };
+      return chain;
+    }
+    return makeChain(tableResults[table] ?? { data: null, error: null });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("POST /api/terminal/session — task/idea correctness guard (bug 62e57071)", () => {
+  it("rejects a task_id that resolves to a DIFFERENT idea_id than the mint is targeting", async () => {
+    tableResults.board_tasks = { data: { id: "task-1", idea_id: IDEA_OTHER }, error: null };
+
+    const res = await POST(req({ ideaId: IDEA_1, taskId: TASK_ID }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/doesn't belong to this board/);
+    expect(insertSpy).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Terminal session mint refused: task belongs to a different board",
+      expect.objectContaining({ ideaId: IDEA_1, taskIdeaId: IDEA_OTHER }),
+    );
+  });
+
+  it("accepts a task_id that resolves to the SAME idea_id as the mint", async () => {
+    tableResults.board_tasks = { data: { id: "task-1", idea_id: IDEA_1 }, error: null };
+
+    const res = await POST(req({ ideaId: IDEA_1, taskId: TASK_ID }));
+
+    expect(res.status).toBe(200);
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ idea_id: IDEA_1, task_id: TASK_ID }),
+    );
+  });
+
+  it("accepts a task_id that resolves to NO row at all — no FK exists, so a task deleted between page load and this click is a benign race, not a boundary this guard polices", async () => {
+    tableResults.board_tasks = { data: null, error: null };
+
+    const res = await POST(req({ ideaId: IDEA_1, taskId: TASK_ID }));
+
+    expect(res.status).toBe(200);
+    expect(insertSpy).toHaveBeenCalled();
+  });
+
+  it("accepts a board-level launch with NO task_id at all — the guard only ever runs when a task_id is present", async () => {
+    const res = await POST(req({ ideaId: IDEA_1 }));
+
+    expect(res.status).toBe(200);
+    expect(insertSpy).toHaveBeenCalledWith(expect.objectContaining({ idea_id: IDEA_1, task_id: null }));
+  });
+
+  it("fails open (mints anyway, logs an error) when the task lookup read itself errors — a transient read failure must never block a legitimate mint", async () => {
+    tableResults.board_tasks = { data: null, error: { message: "connection reset" } };
+
+    const res = await POST(req({ ideaId: IDEA_1, taskId: TASK_ID }));
+
+    expect(res.status).toBe(200);
+    expect(insertSpy).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      "Terminal session mint: task lookup failed",
+      expect.objectContaining({ error: "connection reset" }),
+    );
+  });
+});

--- a/src/app/api/terminal/session/route.ts
+++ b/src/app/api/terminal/session/route.ts
@@ -146,6 +146,44 @@ export async function POST(req: Request) {
       }
     }
 
+    // ── task/idea correctness guard (cross-board resume bug 62e57071) ───────
+    // `terminal_sessions.task_id` carries no FK to `idea_id` (see the
+    // 00141_terminal_sessions migration), so nothing at the DB layer stops a
+    // client from minting a session that claims a task from one board while
+    // registering it under a DIFFERENT idea_id — exactly the shape a
+    // mis-filed Recent-row resume produces client-side (see chooser-data.ts
+    // / terminal-dock.tsx for the client-side fix). This is the server-side
+    // backstop: reject only a task_id we can SEE and KNOW belongs to another
+    // idea. A task_id that resolves to no row at all is let through
+    // deliberately — with no FK, a task deleted between page load and this
+    // click is a benign race, not a boundary this guard exists to police;
+    // only a CONFIRMED cross-idea mismatch is rejected.
+    if (taskId) {
+      const { data: task, error: taskLookupErr } = await supabase
+        .from("board_tasks")
+        .select("id, idea_id")
+        .eq("id", taskId)
+        .maybeSingle();
+      if (taskLookupErr) {
+        // Best-effort, same fail-open posture as the budget/reap reads below
+        // — a transient read error must never itself block a legitimate
+        // mint.
+        logger.error("Terminal session mint: task lookup failed", {
+          error: taskLookupErr.message,
+          taskId,
+          ideaId,
+        });
+      } else if (task && task.idea_id !== ideaId) {
+        logger.warn("Terminal session mint refused: task belongs to a different board", {
+          userId: user.id,
+          ideaId,
+          taskId,
+          taskIdeaId: task.idea_id,
+        });
+        return NextResponse.json({ error: "That task doesn't belong to this board" }, { status: 400 });
+      }
+    }
+
     const nowMs = Date.now();
 
     // ── (a-1) MITIGATION 3 — ACCOUNT-WIDE daily relay budget breaker. Gated

--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -42,10 +42,18 @@ import type {
   TaskSessionMatch,
 } from "@/lib/terminal/chooser-data";
 
+// Shared spy (not a fresh vi.fn() per call) so cross-board resume/reconnect
+// tests can assert on WHERE the dock navigated, not just that it did.
+// `mockSearchParams` is mutable so a `?resume=<sid>` landing test can seed it
+// before render — defaults to empty (today's every-other-test behaviour).
+const { mockRouterPush, mockSearchParams } = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
+  mockSearchParams: { current: new URLSearchParams() },
+}));
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockRouterPush }),
   usePathname: () => "/ideas/idea-1/board",
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => mockSearchParams.current,
 }));
 
 vi.mock("posthog-js/react", () => ({
@@ -68,15 +76,42 @@ const { sessionViewMountSpy, sessionViewUnmountSpy } = vi.hoisted(() => ({
 
 // Renders just enough of a real TerminalSessionView for the test to see HOW
 // MANY tabs actually got minted, and with what payload — the real component
-// (and the hook underneath it) is exercised elsewhere.
+// (and the hook underneath it) is exercised elsewhere. The `resume-ended-*`
+// button stands in for the real component's ended-session "Resume this
+// conversation" action (terminal-session-view.tsx's `handleResume`) —
+// mirrors its exact payload shape (`ideaId: entry.ideaId`, see SessionEntry's
+// doc) so a click here exercises the DOCK's real `handleResumeEndedSession`
+// routing decision, not just the payload-building terminal-session-view.test.tsx
+// already covers (mutation-tested rework round 2: gutting that routing
+// decision must FAIL this file, not just terminal-session-view's own tests).
 vi.mock("./terminal-session-view", () => ({
-  TerminalSessionView: ({ entry }: { entry: { key: string; taskId?: string } }) => {
+  TerminalSessionView: ({
+    entry,
+    onResumeEndedSession,
+  }: {
+    entry: { key: string; taskId?: string; ideaId?: string };
+    onResumeEndedSession?: (payload: { cwd?: string; taskId?: string; ideaId?: string }, sid: string | null) => void;
+  }) => {
     useEffect(() => {
       sessionViewMountSpy(entry.key);
       return () => sessionViewUnmountSpy(entry.key);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-    return <div data-testid="session-view" data-key={entry.key} data-task-id={entry.taskId ?? ""} />;
+    return (
+      <div data-testid="session-view" data-key={entry.key} data-task-id={entry.taskId ?? ""} data-idea-id={entry.ideaId ?? ""}>
+        <button
+          data-testid={`resume-ended-${entry.key}`}
+          onClick={() =>
+            onResumeEndedSession?.(
+              { cwd: "/Users/nick/projects/here", taskId: entry.taskId, ideaId: entry.ideaId },
+              "sid-ended-own-tab",
+            )
+          }
+        >
+          Resume this conversation
+        </button>
+      </div>
+    );
   },
   dockStatusMeta: () => ({ label: "Terminal", Icon: () => null, className: "" }),
 }));
@@ -274,6 +309,37 @@ function recentRowForTask(taskId: string): ChooserRegistryRow {
   };
 }
 
+/** Same as `recentRowForTask`, but on a DIFFERENT board (`idea-OTHER`) —
+ * cross-board resume fix coverage: chooser-data.ts's Recent is never
+ * idea-scoped, so this row is still offered on `idea-1`'s dock even though
+ * it belongs elsewhere. */
+function recentRowForTaskElsewhere(taskId: string): ChooserRegistryRow {
+  return { ...recentRowForTask(taskId), sid: `sid-recent-elsewhere-${taskId}`, ideaId: "idea-OTHER" };
+}
+
+/** An ENDED, board-level (no taskId) session on THIS board — exercises the
+ * general chooser's Resume action (not the task-scoped choice). */
+function recentRowHere(): ChooserRegistryRow {
+  return {
+    sid: "sid-recent-here",
+    ideaId: "idea-1",
+    ideaTitle: "My Idea",
+    taskId: null,
+    taskTitle: null,
+    machineLabel: null,
+    cwd: "/Users/nick/projects/here",
+    claudeSessionId: null,
+    createdAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    status: "ended",
+    endedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+  };
+}
+
+/** Same as `recentRowHere`, but on a DIFFERENT board. */
+function recentRowElsewhere(): ChooserRegistryRow {
+  return { ...recentRowHere(), sid: "sid-recent-elsewhere", ideaId: "idea-OTHER" };
+}
+
 beforeEach(() => {
   vi.stubEnv("NEXT_PUBLIC_TERMINAL_ENABLED", "true");
 });
@@ -283,6 +349,7 @@ afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
   vi.clearAllMocks();
+  mockSearchParams.current = new URLSearchParams();
 });
 
 describe("TerminalDock — launch-bus race with the still-loading registry (Bug B)", () => {
@@ -746,5 +813,152 @@ describe("TerminalDock — another-session-here badge (card eaa55290)", () => {
     fireEvent.click(screen.getByTestId("chooser-reconnect-here-own-sid"));
 
     await waitFor(() => expect(screen.getByText("Another tab is open here")).toBeInTheDocument());
+  });
+});
+
+// Cross-board resume fix (bug 62e57071, Sentinel's investigation): resuming
+// a Recent row belonging to a DIFFERENT board used to mint a session under
+// WHICHEVER board's dock happened to be open, carrying the foreign row's
+// task/cwd along with it. These pin the fix at both origination points
+// (the general chooser's Resume, and the task-launch-skip-chooser's recent
+// arm) — same-board resumes must mint exactly as before (no navigation, no
+// extra click) — plus the `?resume=<sid>` pickup a cross-board navigation
+// lands on.
+describe("TerminalDock — cross-board resume (bug 62e57071)", () => {
+  it("chooser Resume on a SAME-board Recent row mints locally, unchanged — no navigation", async () => {
+    stubFetch(Promise.resolve([recentRowHere()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId(`chooser-resume-${recentRowHere().sid}`));
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it("chooser Resume on a CROSS-board Recent row navigates to that row's own board instead of minting here", async () => {
+    stubFetch(Promise.resolve([recentRowElsewhere()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId(`chooser-resume-${recentRowElsewhere().sid}`));
+
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      `/ideas/idea-OTHER/board?resume=${encodeURIComponent(recentRowElsewhere().sid)}`,
+    );
+    // Nothing minted locally under this (wrong) board.
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+  });
+
+  it("the task-choice recent arm mints locally for a SAME-board task match, unchanged", async () => {
+    stubFetch(Promise.resolve([recentRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+    await waitFor(() => expect(screen.getByTestId("task-choice")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("task-choice-reconnect"));
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it("the task-choice recent arm ALSO navigates for a cross-board task match, instead of minting here (propagation: closes the 2nd origination point)", async () => {
+    stubFetch(Promise.resolve([recentRowForTaskElsewhere("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+    await waitFor(() => expect(screen.getByTestId("task-choice")).toBeInTheDocument());
+    expect(screen.getByTestId("task-choice").dataset.matchKind).toBe("recent");
+
+    fireEvent.click(screen.getByTestId("task-choice-reconnect"));
+
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      `/ideas/idea-OTHER/board?resume=${encodeURIComponent(recentRowForTaskElsewhere("task-9").sid)}`,
+    );
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+  });
+
+  it("landing with ?resume=<sid> mints the matching Recent row from THIS board's own (idea-unscoped) registry fetch, with no chooser shown", async () => {
+    mockSearchParams.current = new URLSearchParams({ resume: recentRowHere().sid });
+    stubFetch(Promise.resolve([recentRowHere()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
+  });
+
+  it("landing with ?resume=<sid> for a row that's no longer in the registry surfaces a toast instead of silently doing nothing", async () => {
+    mockSearchParams.current = new URLSearchParams({ resume: "sid-long-gone" });
+    stubFetch(Promise.resolve([]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/expired/)));
+    // An empty registry is also "empty-launch" (F1's unchanged idle P1 slot)
+    // — that pristine tab is expected here (never a resume-mint carrying the
+    // vanished row's data), so only its shape is asserted, not its absence.
+    expect(screen.getByTestId("session-view").dataset.taskId).toBe("");
+  });
+
+  // Perpetuation fix (Sentinel's finding — "perpetuates a mis-file forever"):
+  // an already-mounted tab's OWN "Resume this conversation" button must
+  // obey the same board-correctness the chooser/task-choice Resume actions
+  // above do, or a session that was ever mis-filed onto the wrong board
+  // keeps re-minting under that same wrong board every time someone clicks
+  // Resume on it — this is the PERPETUATION point, not just the origination
+  // point the tests above cover. QA mutation-tested `handleResumeEndedSession`
+  // by gutting its routing decision to an unconditional mint; that mutation
+  // survived every other test in this suite untouched, so this test exists
+  // specifically to kill it.
+  it("an already-mounted tab's own Resume navigates to the entry's own board when it differs from the current one — never an in-place mint", async () => {
+    stubFetch(Promise.resolve([]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    // The dock auto-seeds one pristine tab for an empty registry (F1) — its
+    // `entry.ideaId` starts unset (createPristineEntry never sets it). A
+    // board-level launch carrying a FOREIGN `ideaId` reuses that pristine
+    // slot (mintAndDeliver's pristine-reuse path), giving this tab a
+    // recorded board that differs from the one currently open — exactly the
+    // "already mis-filed" precondition this fix exists for.
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    act(() => {
+      requestBrowserLaunch({ ideaId: "idea-OTHER" });
+    });
+    await waitFor(() => expect(screen.getByTestId("session-view").dataset.ideaId).toBe("idea-OTHER"));
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1); // reused the pristine slot, no 2nd tab
+
+    const key = screen.getByTestId("session-view").dataset.key;
+    fireEvent.click(screen.getByTestId(`resume-ended-${key}`));
+
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      `/ideas/idea-OTHER/board?resume=${encodeURIComponent("sid-ended-own-tab")}`,
+    );
+    // Never minted a 2nd tab in place under the wrong (currently open) board.
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+  });
+
+  it("an already-mounted tab's own Resume mints in place (no navigation) when its recorded board matches the current one", async () => {
+    stubFetch(Promise.resolve([]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    // Same setup as the cross-board test above, but the launch's `ideaId`
+    // matches the currently-open board this time.
+    act(() => {
+      requestBrowserLaunch({ ideaId: "idea-1" });
+    });
+    await waitFor(() => expect(screen.getByTestId("session-view").dataset.ideaId).toBe("idea-1"));
+
+    const key = screen.getByTestId("session-view").dataset.key;
+    fireEvent.click(screen.getByTestId(`resume-ended-${key}`));
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    // A genuine local mint happened (never a silent no-op) — this board's
+    // own dock delivered the resume itself instead of navigating away.
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(2));
   });
 });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -755,6 +755,10 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
                 origin: payload?.resume || payload?.resumeId ? "resume" : payload?.taskId ? "task" : "toolbar",
                 taskId: payload?.taskId,
                 taskTitle: payload?.taskTitle,
+                // Cross-board resume fix: resolves to a concrete idea even
+                // when the payload doesn't specify one (board/task launches
+                // always mean "here") — see SessionEntry.ideaId's doc.
+                ideaId: payload?.ideaId ?? ideaId,
                 launchSeq: s.launchSeq + 1,
                 launchPayload: payload ?? null,
               }
@@ -770,6 +774,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       origin: payload?.resume || payload?.resumeId ? "resume" : payload?.taskId ? "task" : "toolbar",
       taskId: payload?.taskId,
       taskTitle: payload?.taskTitle,
+      ideaId: payload?.ideaId ?? ideaId,
       createdAt: Date.now(),
       launchSeq: 1,
       launchPayload: payload ?? null,
@@ -780,7 +785,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     // 2nd+ tab (the pristine-slot reuse above is still the board's first tab,
     // same as P1, and isn't a "multi-session" event).
     posthogRef.current?.capture("terminal_tab_opened", { origin: entry.origin });
-  }, []);
+  }, [ideaId]);
 
   // Session entry chooser (card cbe60db5, F1; rework 11 fixes the gate below).
   // The actual entry point every launch source (toolbar bus event,
@@ -921,6 +926,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         origin: "reconnect",
         taskId: undefined,
         taskTitle: undefined,
+        // A reattach always runs already ON the row's own board — a
+        // cross-board live row goes through handleChooserOpenBoardAndReconnect
+        // (navigate first, `?reconnect=` picks it up here), never straight
+        // to performReattach — so the current board IS the correct one.
+        ideaId,
         createdAt: Date.now(),
         launchSeq: 0,
         launchPayload: null,
@@ -937,7 +947,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     } finally {
       setChooserBusy(false);
     }
-  }, [refreshRegistry]);
+  }, [refreshRegistry, ideaId]);
 
   // F1's empty-launch state ("today's open→launch behaviour remains") and
   // the instant-continue variant (design's veto note, Nick: yes) are both
@@ -1001,6 +1011,43 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     // "chooser": nothing to seed — the chooser renders in the body below.
   }, [entryDecision, sessions.length, performReattach, pendingLaunch, mintAndDeliver, chooserSections]);
 
+  // Cross-board resume fix (bug 62e57071, Sentinel's investigation): a
+  // Recent row can belong to ANY board — chooser-data.ts's Recent section is
+  // deliberately never idea-scoped, so the user can reach it from any board
+  // they're currently viewing (see deriveChooserSections' header comment and
+  // its own test coverage for "still offered"). Minting straight into
+  // `mintAndDeliver` from a click on such a row used to mint under
+  // WHICHEVER board's dock was mounted, carrying the row's foreign
+  // taskId/cwd along for the ride — the origination point of the bug.
+  // `handleChooserResume`/`handleTaskChoiceReconnect`'s recent arm below
+  // mirror `handleChooserOpenBoardAndReconnect`'s live-row pattern (defined
+  // further below): navigate to the row's OWN board first (`?resume=<sid>`,
+  // this file's sibling to
+  // `?reconnect=<sid>`, handled by the effect just below) and let THAT
+  // board's dock fire the mint once mounted there — never mint in place
+  // under the wrong one. Declared up here (ahead of the `?resume=` effect
+  // that also uses it) so both that effect and the click handlers below
+  // share one payload-building rule.
+  const buildResumePayload = useCallback(
+    (row: ChooserRecentRow): BrowserLaunchPayload => ({
+      // F4's Resume: the EXISTING (capped) launch flow, carrying the ended
+      // row's own recorded folder instead of a bootstrap prompt — see
+      // BrowserLaunchPayload's doc and use-terminal-session.ts's
+      // fireLaunchDeepLink. A row with a tracked `claudeSessionId` (rework 5,
+      // exact-conversation Resume) fires `claude --resume <id>` — the exact
+      // conversation the row described, never whatever else has run in that
+      // folder since; a row without one falls back to the legacy
+      // `claude --continue`.
+      resume: row.claudeSessionId ? undefined : true,
+      resumeId: row.claudeSessionId ?? undefined,
+      cwd: row.cwd ?? undefined,
+      taskId: row.taskId ?? undefined,
+      taskTitle: row.taskTitle ?? undefined,
+      ideaId: row.ideaId,
+    }),
+    [],
+  );
+
   // ── other-board Reconnect (`?reconnect=<sid>`, design item 2) ──────────────
   // "Open board & reconnect" navigates here with the target sid on the URL;
   // once the registry confirms it, reattach immediately (no second chooser —
@@ -1018,6 +1065,36 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     window.history.replaceState(null, "", `${pathname}${qs ? `?${qs}` : ""}`);
     void performReattach(reconnectParam, { focus: true });
   }, [reconnectParam, registryRows, pathname, performReattach]);
+
+  // ── cross-board Resume (`?resume=<sid>`, cross-board resume fix 62e57071) ──
+  // Sibling to the `?reconnect=<sid>` effect just above, for a Recent (ended)
+  // row instead of a live one: handleChooserResume /
+  // handleTaskChoiceReconnect's recent arm navigate here with the target
+  // row's sid rather than minting under whichever board was open when the
+  // user clicked. chooser-data.ts's Recent section is deliberately NOT
+  // idea-scoped (see its header comment + tests), so this board's own
+  // `chooserSections.recent` — built from the SAME idea-unscoped registry
+  // fetch every board's dock makes — already carries the identical row; look
+  // it up by sid and fire the exact mint `handleChooserResume` would have,
+  // now that we're actually on the row's own board. A row that's vanished
+  // by the time this runs (expired past 48h, machine-identity filtered,
+  // etc.) surfaces as a toast rather than silently doing nothing.
+  const resumeParam = searchParams.get("resume");
+  const resumeHandledRef = useRef(false);
+  useEffect(() => {
+    if (!resumeParam || resumeHandledRef.current || registryRows === null) return;
+    resumeHandledRef.current = true;
+    const params = new URLSearchParams(window.location.search);
+    params.delete("resume");
+    const qs = params.toString();
+    window.history.replaceState(null, "", `${pathname}${qs ? `?${qs}` : ""}`);
+    const row = chooserSectionsRef.current.recent.find((r) => r.sid === resumeParam);
+    if (!row) {
+      toast.error("Couldn't find that session to resume — it may have expired.");
+      return;
+    }
+    mintAndDeliver(buildResumePayload(row));
+  }, [resumeParam, registryRows, pathname, mintAndDeliver, buildResumePayload]);
 
   // ── chooser action handlers ─────────────────────────────────────────────────
   // Shared by BOTH the sessions.length === 0 body-swap chooser and the
@@ -1055,23 +1132,13 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     (row: ChooserRecentRow) => {
       setPendingLaunch(null);
       setChooserOpen(false);
-      // F4's Resume: the EXISTING (capped) launch flow, carrying the ended
-      // row's own recorded folder instead of a bootstrap prompt — see
-      // BrowserLaunchPayload's doc and use-terminal-session.ts's
-      // fireLaunchDeepLink. A row with a tracked `claudeSessionId` (rework 5,
-      // exact-conversation Resume) fires `claude --resume <id>` — the exact
-      // conversation the row described, never whatever else has run in that
-      // folder since; a row without one falls back to the legacy
-      // `claude --continue`.
-      mintAndDeliver({
-        resume: row.claudeSessionId ? undefined : true,
-        resumeId: row.claudeSessionId ?? undefined,
-        cwd: row.cwd ?? undefined,
-        taskId: row.taskId ?? undefined,
-        taskTitle: row.taskTitle ?? undefined,
-      });
+      if (row.ideaId !== ideaId) {
+        router.push(`/ideas/${row.ideaId}/board?resume=${encodeURIComponent(row.sid)}`);
+        return;
+      }
+      mintAndDeliver(buildResumePayload(row));
     },
-    [mintAndDeliver],
+    [mintAndDeliver, buildResumePayload, ideaId, router],
   );
 
   // Task-launch-skip-chooser: the minimal task-scoped choice's two actions.
@@ -1086,14 +1153,16 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     setTaskChoiceOpen(false);
     if (!match) return; // the match expired between render and click — nothing safe to reconnect to
     if (match.kind === "recent") {
+      // Same cross-board fix as handleChooserResume just above — a task's
+      // matched Recent row can belong to a different board than the one the
+      // task-launch button was clicked from (chooser-data.ts's Recent isn't
+      // idea-scoped), so this arm must navigate-then-mint too, not mint here.
       const row = match.row;
-      mintAndDeliver({
-        resume: row.claudeSessionId ? undefined : true,
-        resumeId: row.claudeSessionId ?? undefined,
-        cwd: row.cwd ?? undefined,
-        taskId: row.taskId ?? undefined,
-        taskTitle: row.taskTitle ?? undefined,
-      });
+      if (row.ideaId !== ideaId) {
+        router.push(`/ideas/${row.ideaId}/board?resume=${encodeURIComponent(row.sid)}`);
+        return;
+      }
+      mintAndDeliver(buildResumePayload(row));
       return;
     }
     if (match.kind === "live-here") {
@@ -1101,7 +1170,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     } else {
       router.push(`/ideas/${match.row.ideaId}/board?reconnect=${encodeURIComponent(match.row.sid)}`);
     }
-  }, [pendingLaunch, mintAndDeliver, performReattach, router]);
+  }, [pendingLaunch, mintAndDeliver, buildResumePayload, ideaId, performReattach, router]);
 
   const handleTaskChoiceStartFresh = useCallback(() => {
     const payload = pendingLaunch;
@@ -1109,6 +1178,32 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     setTaskChoiceOpen(false);
     mintAndDeliver(payload);
   }, [pendingLaunch, mintAndDeliver]);
+
+  // Propagation fix (Sentinel's finding — "perpetuates a mis-file forever"):
+  // an already-mounted tab's OWN "Resume this conversation" button
+  // (terminal-session-view.tsx's `handleResume`) must obey the same
+  // board-correctness the chooser/task-choice Resume actions above do, or a
+  // session that was ever mis-filed onto the wrong board keeps re-minting
+  // under that same wrong board every time someone clicks Resume on it —
+  // patching only the chooser closes the ORIGINATION point but leaves this
+  // one still capable of perpetuating an existing mis-file forever.
+  // `payload.ideaId` comes from `entry.ideaId` (see SessionEntry's doc) —
+  // undefined for a `reconnect`-origin entry or anything that predates this
+  // fix. Unknown honestly stays on the current board rather than guessing
+  // (same "only act on a disagreement we can actually see" spirit as
+  // chooser-data.ts's machine-identity filter) — there is no way to recover
+  // the TRUE board for a session that was mis-filed before this field
+  // existed; see this card's return value for that limitation.
+  const handleResumeEndedSession = useCallback(
+    (payload: BrowserLaunchPayload, sid: string | null) => {
+      if (payload.ideaId && payload.ideaId !== ideaId && sid) {
+        router.push(`/ideas/${payload.ideaId}/board?resume=${encodeURIComponent(sid)}`);
+        return;
+      }
+      mintAndDeliver(payload);
+    },
+    [ideaId, mintAndDeliver, router],
+  );
 
   // My sessions panel Reconnect (design item 9) — the SAME reattach flow;
   // "this board" attaches in place, any other board navigates + reconnects.
@@ -1481,7 +1576,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onBringBack={() => bringBackToDock(entry.key)}
             onReconnectTakenOver={(sid) => void performReattach(sid, { focus: true })}
             onRetryReconnect={(sid) => void performReattach(sid, { focus: true })}
-            onResumeEndedSession={(payload) => mintAndDeliver(payload)}
+            onResumeEndedSession={handleResumeEndedSession}
           />
         ))}
       </div>

--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -27,6 +27,7 @@ import type {
   TerminalSessionActions,
 } from "./use-terminal-session";
 import { RELAY_CLOSE, PREEMPTED_CLOSE_REASON, type TerminalConnectionState } from "@/lib/terminal/connection";
+import type { BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
 
 vi.mock("./use-terminal-session", () => ({
   useTerminalSession: vi.fn(),
@@ -209,8 +210,15 @@ function installMockEndedSession(
   });
 }
 
-function baseEntry(): SessionEntry {
-  return { key: "tab-1", origin: "toolbar", createdAt: Date.now(), launchSeq: 0, launchPayload: null };
+function baseEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    key: "tab-1",
+    origin: "toolbar",
+    createdAt: Date.now(),
+    launchSeq: 0,
+    launchPayload: null,
+    ...overrides,
+  };
 }
 
 function renderView(poppedOut: boolean, onRetryReconnect?: (sid: string) => void) {
@@ -252,12 +260,13 @@ function renderErrorView(onReconnectTakenOver: (sid: string) => void = vi.fn()) 
 }
 
 function renderEndedView(
-  onResumeEndedSession: (payload: unknown) => void = vi.fn(),
+  onResumeEndedSession: (payload: BrowserLaunchPayload, sid: string | null) => void = vi.fn(),
   onOpenMySessions?: () => void,
+  entryOverrides: Partial<SessionEntry> = {},
 ) {
   return render(
     <TerminalSessionView
-      entry={baseEntry()}
+      entry={baseEntry(entryOverrides)}
       descriptor={{ ideaId: "idea-1", ideaTitle: "My Idea", ideaGithubUrl: null }}
       label="Session 1"
       isActive
@@ -440,13 +449,17 @@ describe("TerminalSessionView — session-ended resume (Bug A)", () => {
 
     const resumeButton = screen.getByRole("button", { name: /Resume this conversation/ });
     fireEvent.click(resumeButton);
-    expect(onResumeEndedSession).toHaveBeenCalledWith({
-      resume: undefined,
-      resumeId: "claude-conv-abc",
-      cwd: "/Users/nick/projects/vibe-coding-ideas",
-      taskId: undefined,
-      taskTitle: undefined,
-    });
+    expect(onResumeEndedSession).toHaveBeenCalledWith(
+      {
+        resume: undefined,
+        resumeId: "claude-conv-abc",
+        cwd: "/Users/nick/projects/vibe-coding-ideas",
+        taskId: undefined,
+        taskTitle: undefined,
+        ideaId: undefined,
+      },
+      "sess-1",
+    );
 
     // The blind mint stays available too, but relabelled so it's never
     // confused with Resume.
@@ -464,13 +477,33 @@ describe("TerminalSessionView — session-ended resume (Bug A)", () => {
     renderEndedView(onResumeEndedSession);
 
     fireEvent.click(screen.getByRole("button", { name: /Resume this conversation/ }));
-    expect(onResumeEndedSession).toHaveBeenCalledWith({
-      resume: true,
-      resumeId: undefined,
+    expect(onResumeEndedSession).toHaveBeenCalledWith(
+      {
+        resume: true,
+        resumeId: undefined,
+        cwd: "/Users/nick/projects/vibe-coding-ideas",
+        taskId: undefined,
+        taskTitle: undefined,
+        ideaId: undefined,
+      },
+      "sess-1",
+    );
+  });
+
+  it("carries this tab's own recorded board (entry.ideaId) so the dock can route a resume of an already-mis-filed session back to its true board (propagation fix, bug 62e57071)", () => {
+    const onResumeEndedSession = vi.fn();
+    installMockEndedSession({
+      endedReason: "idle",
       cwd: "/Users/nick/projects/vibe-coding-ideas",
-      taskId: undefined,
-      taskTitle: undefined,
+      claudeSessionId: "claude-conv-abc",
     });
+    renderEndedView(onResumeEndedSession, undefined, { ideaId: "idea-other-board" });
+
+    fireEvent.click(screen.getByRole("button", { name: /Resume this conversation/ }));
+    expect(onResumeEndedSession).toHaveBeenCalledWith(
+      expect.objectContaining({ ideaId: "idea-other-board" }),
+      "sess-1",
+    );
   });
 
   it("hides Resume entirely and keeps the plain 'Launch again' button when no cwd is known (legacy pre-0.3.3 session)", () => {

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -175,8 +175,16 @@ interface TerminalSessionViewProps {
    * `onReconnectTakenOver` prop pattern above. Omitted hides the Resume
    * button entirely (defensive — the overlay itself already gates on
    * `session.cwd` being known before ever calling this).
+   *
+   * Cross-board resume fix (bug 62e57071): the payload now carries `ideaId:
+   * entry.ideaId` (this tab's own recorded board — see SessionEntry.ideaId's
+   * doc) and `sid` is passed alongside so the dock's handler
+   * (`handleResumeEndedSession`) can apply the SAME board-correctness the
+   * chooser's Resume does — a tab that was ever mis-filed onto the wrong
+   * board must not re-mint under that same wrong board forever just because
+   * the user clicked Resume from inside it.
    */
-  onResumeEndedSession?: (payload: BrowserLaunchPayload) => void;
+  onResumeEndedSession?: (payload: BrowserLaunchPayload, sid: string | null) => void;
   /**
    * Opens the dock's "My sessions" panel — the SAME trigger `onCapExceeded`
    * already uses (E1, design §7b). Rendered as a small tertiary link under
@@ -367,13 +375,19 @@ export function TerminalSessionView({
     view === "session-ended" && state.endedReason !== "user" && !!sessionCwd && !!onResumeEndedSession;
   const handleResume = () => {
     if (!sessionCwd) return;
-    onResumeEndedSession?.({
-      resume: claudeSessionId ? undefined : true,
-      resumeId: claudeSessionId ?? undefined,
-      cwd: sessionCwd,
-      taskId: entry.taskId,
-      taskTitle: entry.taskTitle,
-    });
+    onResumeEndedSession?.(
+      {
+        resume: claudeSessionId ? undefined : true,
+        resumeId: claudeSessionId ?? undefined,
+        cwd: sessionCwd,
+        taskId: entry.taskId,
+        taskTitle: entry.taskTitle,
+        // Cross-board resume fix: this tab's own recorded board, not
+        // necessarily the board currently open (see SessionEntry.ideaId).
+        ideaId: entry.ideaId,
+      },
+      pair?.sessionId ?? null,
+    );
   };
 
   return (

--- a/src/components/board/terminal-tabs.ts
+++ b/src/components/board/terminal-tabs.ts
@@ -39,6 +39,20 @@ export interface SessionEntry {
   origin: "toolbar" | "task" | "reconnect" | "resume";
   taskId?: string;
   taskTitle?: string;
+  /**
+   * Cross-board resume fix (bug 62e57071): the idea this entry's conversation
+   * actually belongs to, resolved once at creation (`payload?.ideaId ??
+   * <the dock's own ideaId prop>` — see terminal-dock.tsx's `mintAndDeliver`).
+   * Always resolves to a concrete value for anything minted after this fix
+   * shipped, so it's the one place terminal-session-view.tsx's ended-panel
+   * Resume can read "which board does clicking Resume on THIS tab actually
+   * belong to" without re-deriving it — see that file's `handleResume` and
+   * terminal-dock.tsx's `handleResumeEndedSession`. Undefined only for a
+   * `reconnect`-origin entry (reattach always happens already on the row's
+   * own board — see `performReattach` — so there's nothing to disambiguate)
+   * or an entry that predates this field.
+   */
+  ideaId?: string;
   createdAt: number;
   launchSeq: number;
   launchPayload: BrowserLaunchPayload | null;

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -43,6 +43,30 @@ describe("deriveChooserSections", () => {
     expect(sections.liveElsewhere.map((r) => r.sid)).toEqual(["live-elsewhere"]);
   });
 
+  // Cross-board resume fix (bug 62e57071): unlike liveHere/liveElsewhere just
+  // above, Recent is DELIBERATELY never filtered by `currentIdeaId` — a row
+  // from another board must still be OFFERED here so the user can reach it
+  // at all (terminal-dock.tsx's handleChooserResume/handleTaskChoiceReconnect
+  // are what enforce board-correctness, by navigating to the row's own board
+  // before minting, rather than this module silently hiding the row). Pinned
+  // explicitly so a future "tidy up Recent to match the live sections"
+  // change doesn't quietly reintroduce that filter without an actual
+  // decision to do so.
+  it("still offers a Recent row from a DIFFERENT board — Recent is deliberately never idea-scoped", () => {
+    const rows = [
+      row({
+        sid: "ended-elsewhere",
+        ideaId: IDEA_B,
+        status: "ended",
+        cwd: "~/projects/other-board",
+        endedAt: new Date(NOW - 60_000).toISOString(),
+      }),
+    ];
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent;
+    expect(recent.map((r) => r.sid)).toEqual(["ended-elsewhere"]);
+    expect(recent[0].ideaId).toBe(IDEA_B);
+  });
+
   it("includes a recently-ended row (with a recorded cwd) in Recent", () => {
     const rows = [
       row({

--- a/src/lib/terminal/launch-mode.ts
+++ b/src/lib/terminal/launch-mode.ts
@@ -111,6 +111,19 @@ export interface BrowserLaunchPayload {
   taskId?: string;
   /** The task's title, for the tab label (B3) when `taskId` is present. */
   taskTitle?: string;
+  /**
+   * Cross-board resume fix (bug 62e57071): the idea this launch's underlying
+   * conversation actually belongs to — set ONLY by a resume payload built
+   * from a `ChooserRecentRow`/ended-session record whose own `ideaId` is
+   * known (chooser Resume, task-choice Resume, the ended-panel's "Resume
+   * this conversation"). Undefined for every other payload (toolbar/"+"/
+   * task-launch), which never carries board ambiguity — those always target
+   * whichever board is currently open. terminal-dock.tsx's resume handlers
+   * compare this against the dock's own `ideaId` prop and navigate to the
+   * row's own board FIRST when they differ, rather than minting here under
+   * the wrong one — see handleChooserResume/handleResumeEndedSession.
+   */
+  ideaId?: string;
 }
 
 /** Ask the board's terminal dock to open + auto-launch in the browser. */


### PR DESCRIPTION
Follow-up to #179, from Nick's 19 Aug session-history investigation.

## The bug

The chooser's **Recent** list is deliberately board-agnostic — it shows ended sessions from every board, and a row displays task title / folder / age but **never which board it belongs to**. Resuming one of those rows minted a session filed under whichever board was currently open, while carrying the original row's task, folder and conversation.

The result is internally inconsistent: `idea_id` says one board, `task_id`/`cwd`/`claude_session_id` say another. The session then appears under the wrong board's lists and **never** under the one that actually owns the task.

**Worse than mislabelling:** `claude --resume <id>` appends to the same transcript file forever (`terminal/bridge/src/resume-cmd.js:12-18`). Because the same conversation could be resumed from two different boards, two live sessions can end up writing one transcript.

**Production evidence:** `sid 1b78264d` — `idea_id` = Balla Bot (the board open at the time), `task_id` = a **VibeCodes** task, `cwd` = the VibeCodes folder, sharing `claude_session_id` c462977a with the genuine VibeCodes row. A full-table query across all users found **exactly one** such row, so no cleanup campaign is needed.

## One defect, three call sites

No `ideaId` on `BrowserLaunchPayload`, and no server-side cross-check. Only the chooser could *originate* the corruption, but the other two would **perpetuate** it forever — an already-mis-filed tab re-minted under the wrong board on every subsequent Resume, never self-healing. All three are closed.

The live-row path already did this correctly (`handleChooserOpenBoardAndReconnect` navigates to `row.ideaId`'s board first). This makes resume match it.

## Changes

- `BrowserLaunchPayload` and `SessionEntry` carry `ideaId`.
- `handleChooserResume`, `handleTaskChoiceReconnect`'s recent arm, and the ended-panel's own Resume compare the row's board with the current one and navigate via a new `?resume=<sid>` param when they differ. **Same-board resumes are completely unchanged** — no navigation, no extra click.
- The `?resume=` landing effect reuses the `?reconnect=` idiom: ref-guarded against double-mint, gated on the registry having loaded (the cbe60db5 guard, so it can't fire early and silently mint a fresh session), URL stripped with `replaceState` so Back can't replay it, and it toasts rather than minting if the row has expired.
- The mint route rejects a `task_id` whose `idea_id` differs — **before** any token mint or insert. `task_id: null` (board launches) and an unknown task still pass, deliberately.

## Deliberately not here

**No foreign key / migration.** `terminal_sessions.task_id` has no FK, which is why the database couldn't catch this either. Worth adding — with `ON DELETE SET NULL` instead of today's silent unknown-task pass-through — but it is a schema change with its own risk profile and belongs on its own card.

## Verification

2909 tests passing (+15), `tsc --noEmit` clean, lint 0 errors.

**Every guard was mutation-tested** — deliberately broken and confirmed to fail:
- server cross-idea rejection → its test failed;
- server fail-open path → its test failed;
- chooser cross-board navigation → its test failed;
- ended-panel routing → **survived the first round**, which is why a test was added; re-mutated after, and it now fails;
- the real `terminal-session-view.tsx` payload construction (not just the mocked one) → its test failed, confirming the mock isn't hiding drift.

The adversarial pass also confirmed: a fabricated `?resume=` sid in the URL errors rather than silently minting; the effect can't double-fire or loop; and the server guard sits before the insert, not after.

## Known gaps

Verified in jsdom only — no live browser, and no real cross-board resume against a running relay. The one existing mis-filed row can't self-heal: `ideaId` was never persisted before this change, so there is nothing to recover from. One row, correctable by hand if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)