### PR TITLE
fix(terminal): show the session list in the panel when nothing is running, not as an overlay

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -592,6 +592,42 @@ describe("TerminalDock — task-launch-skip-chooser (Nick's explicit product dec
     expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
   });
 
+  // Card 79a0046c (Nick's field report, 2026-08-19): the ended session for
+  // this task had no recorded folder, so the choice dialog opened with Resume
+  // hidden and "Start fresh anyway" as its ONLY button — an interstitial in
+  // front of the exact mint it was gating. Nothing to choose between → don't
+  // ask; just start, same as if no session existed.
+  it("auto-starts when this task's only RECENT session has no recorded folder — no dead-end one-button dialog", async () => {
+    stubFetch(Promise.resolve([{ ...recentRowForTask("task-9"), cwd: null }]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    expect(screen.getByTestId("session-view").dataset.taskId).toBe("task-9");
+    expect(screen.queryByTestId("task-choice")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  // The skip is scoped to unresumable ENDED sessions. A RUNNING one still
+  // stops the launch even with no folder recorded — reattaching to a live
+  // session never needed one, so Reconnect is a genuine second option.
+  it("still shows the task choice when this task's LIVE session has no recorded folder", async () => {
+    stubFetch(Promise.resolve([{ ...liveHereRowForTask("task-9"), cwd: null }]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    act(() => {
+      requestBrowserLaunch({ taskId: "task-9", taskTitle: "Do the thing" });
+    });
+
+    await waitFor(() => expect(screen.getByTestId("task-choice")).toBeInTheDocument());
+    expect(screen.getByTestId("task-choice").dataset.matchKind).toBe("live-here");
+    expect(screen.queryByTestId("session-view")).not.toBeInTheDocument();
+  });
+
   it("auto-starts (no false-positive dedupe) when the only existing session belongs to a DIFFERENT task", async () => {
     stubFetch(Promise.resolve([liveHereRowForTask("task-OTHER")]));
     render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);

--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -73,9 +73,11 @@ vi.mock("./terminal-session-view", () => ({
   TerminalSessionView: ({
     entry,
     onBrowseSessions,
+    onReportSummary,
   }: {
     entry: { key: string; taskId?: string };
     onBrowseSessions?: () => void;
+    onReportSummary: (key: string, summary: Record<string, unknown>) => void;
   }) => {
     useEffect(() => {
       sessionViewMountSpy(entry.key);
@@ -93,6 +95,27 @@ vi.mock("./terminal-session-view", () => ({
             View my other sessions
           </button>
         )}
+        {/* Lets a test drive this tab to a real ENDED status. Without it every
+            stubbed tab reports nothing and the dock defaults it to "idle" —
+            which counts as live, so the panel-vs-overlay branch would never
+            be exercised. */}
+        <button
+          data-testid={`report-ended-${entry.key}`}
+          onClick={() =>
+            onReportSummary(entry.key, {
+              status: "session-ended",
+              sessionId: `sid-for-${entry.key}`,
+              errorKind: null,
+              launchPhase: "idle",
+              platformSupported: true,
+              paired: true,
+              browserToken: null,
+              readOnly: false,
+            })
+          }
+        >
+          report ended
+        </button>
       </div>
     );
   },
@@ -898,5 +921,117 @@ describe("TerminalDock — ended panel's 'View my other sessions' opens the choo
     // piece of work — not a blank session in the same folder.
     const taskIds = screen.getAllByTestId("session-view").map((el) => el.dataset.taskId);
     expect(taskIds).toContain("task-9");
+  });
+});
+
+// Nick's follow-up, 2026-08-19: "why do we have this brand new popup, rather
+// than it just switching to show all this in the terminal panel?" The
+// chooser already renders IN the panel — but the rule was `sessions.length
+// === 0`, i.e. "no tabs at all", so an ended tab was enough to force the
+// overlay. The overlay's actual purpose is protecting a LIVE terminal
+// underneath (swapping the body would tear down its xterm instance, socket
+// and scrollback); an ended tab has none of that to protect. The rule is now
+// liveness, not tab count.
+describe("TerminalDock — browsing renders IN the panel when nothing is running, overlay only when a live tab needs protecting (Nick's follow-up 2026-08-19)", () => {
+  async function openFirstTabViaChooser() {
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("chooser-start-new"));
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    return screen.getByTestId("session-view").dataset.key as string;
+  }
+
+  /** Drives the (stubbed) tab to a genuine "session-ended" status, the state
+   * Nick was actually in when he followed the link. Synchronous — fireEvent
+   * flushes the resulting setState — and it needs no assertion of its own:
+   * every caller then asserts on the panel-vs-overlay branch, which only
+   * takes the panel route if this actually landed. */
+  function endTab(key: string) {
+    fireEvent.click(screen.getByTestId(`report-ended-${key}`));
+  }
+
+  it("browsing from an ENDED tab renders the chooser in the panel — no dialog at all", async () => {
+    stubFetch(Promise.resolve([recentRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    const key = await openFirstTabViaChooser();
+    endTab(key);
+
+    fireEvent.click(screen.getByTestId("view-my-other-sessions"));
+
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    // Same list, same actions — it's the panel that changed, not the content.
+    expect(screen.getByTestId("chooser-resume-sid-recent-task-9")).toBeInTheDocument();
+  });
+
+  it("keeps the ended tab MOUNTED underneath so 'Back to terminal' returns to its scrollback, not an empty terminal", async () => {
+    stubFetch(Promise.resolve([recentRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    const key = await openFirstTabViaChooser();
+    endTab(key);
+    fireEvent.click(screen.getByTestId("view-my-other-sessions"));
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+
+    // Hidden by CSS, never torn down — the ended panel promises "The
+    // scrollback above is kept", and unmounting would break that promise the
+    // moment someone glanced at their session list.
+    expect(sessionViewUnmountSpy).not.toHaveBeenCalled();
+    expect(screen.getByTestId("session-view")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Back to terminal/ }));
+
+    await waitFor(() => expect(screen.queryByTestId("chooser")).not.toBeInTheDocument());
+    expect(sessionViewUnmountSpy).not.toHaveBeenCalled();
+    expect(screen.getByTestId("session-view").dataset.key).toBe(key);
+  });
+
+  it("still uses the OVERLAY while a tab is live — the panel must not be swapped out from under a running terminal", async () => {
+    stubFetch(Promise.resolve([recentRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    // Tab left at its default (never reported ended) — the dock reads that as
+    // live, exactly like a connected or still-connecting session.
+    await openFirstTabViaChooser();
+
+    fireEvent.click(screen.getByTestId("view-my-other-sessions"));
+
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /Back to terminal/ })).not.toBeInTheDocument();
+  });
+
+  it("a LAUNCH still overlays even with every tab ended — the forced choice outranks the panel swap", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    const key = await openFirstTabViaChooser();
+    endTab(key);
+
+    act(() => {
+      requestBrowserLaunch();
+    });
+
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    // And it stays a forced choice — Escape must not swallow a fired launch.
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape", code: "Escape" });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("resuming from the in-panel list works the same as from the overlay", async () => {
+    stubFetch(Promise.resolve([recentRowForTask("task-9")]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    const key = await openFirstTabViaChooser();
+    endTab(key);
+    fireEvent.click(screen.getByTestId("view-my-other-sessions"));
+    await waitFor(() => expect(screen.getByTestId("chooser-resume-sid-recent-task-9")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("chooser-resume-sid-recent-task-9"));
+
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(2));
+    const taskIds = screen.getAllByTestId("session-view").map((el) => el.dataset.taskId);
+    expect(taskIds).toContain("task-9");
+    // The list gave way to the terminal again once acted on.
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
   });
 });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -53,7 +53,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import { ChevronUp, ChevronDown, Circle, ListTree, Loader2, Plus, Terminal as TerminalIcon, X } from "lucide-react";
+import { ChevronUp, ChevronDown, ChevronLeft, Circle, ListTree, Loader2, Plus, Terminal as TerminalIcon, X } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -1200,6 +1200,30 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // that's actually allowed to show; the full chooser must never render
   // underneath/alongside it.
   const showingChooser = sessions.length === 0 && entryDecision?.kind === "chooser" && !taskChoiceOpen;
+  // Is ANY open tab still a running session? Drives whether a browse opens
+  // in the panel or as an overlay (below). Mirrors `requestClose`'s liveness
+  // test exactly, including its popped-out caveat: a popped tab's own
+  // reported status is usually mid-preemption ("error"/duplicate) while the
+  // session is very much alive in the other window, so it must never be read
+  // as finished here either. "idle"/"connecting" count as live — a tab
+  // mid-launch is about to be a real session, and swapping the panel out
+  // from under it would be exactly the disruption this is avoiding.
+  const anyTabLive = sessions.some(
+    (s) => poppedOutKeys.has(s.key) || isLiveTabStatus(summaries[s.key]?.status ?? "idle"),
+  );
+  // Nick's follow-up, 2026-08-19: "why a popup rather than just showing this
+  // in the terminal panel?" The overlay exists to protect a LIVE terminal
+  // underneath — swapping the panel's body would tear down its xterm
+  // instance, socket and scrollback. That reason evaporates when every open
+  // tab has ended: there's nothing running to disturb, so the list belongs
+  // in the panel like it already does when there are no tabs at all
+  // (`showingChooser`), rather than floating over a dimmed board for no gain.
+  //
+  // Browsing only — a launch keeps the overlay whatever the tab states are,
+  // because it also has to sit ON TOP of the forced-choice guarantee (and
+  // with no live tab it would be showing over a body that's about to be
+  // replaced anyway).
+  const inlineBrowse = chooserMode === "browse" && sessions.length > 0 && !anyTabLive;
   const pendingTask = pendingLaunch?.taskId
     ? { taskId: pendingLaunch.taskId, taskTitle: pendingLaunch.taskTitle ?? "" }
     : null;
@@ -1374,7 +1398,26 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           </div>
         )}
 
-        {showingChooser && (
+        {/* Inline browse needs a way back that `showingChooser` never did:
+            with no tabs there's nothing behind the chooser to return to, but
+            here an ended tab is sitting underneath with its scrollback
+            intact ("The scrollback above is kept" — the ended panel's own
+            promise), so backing out has to be possible without acting. */}
+        {inlineBrowse && (
+          <div className="flex items-center justify-between border-b border-zinc-800 bg-[#141417] px-3.5 py-1.5">
+            <span className="text-[11.5px] font-semibold text-zinc-400">Your sessions</span>
+            <Button
+              variant="ghost"
+              size="xs"
+              className="text-zinc-400 hover:text-zinc-100"
+              onClick={() => setChooserMode(null)}
+            >
+              <ChevronLeft className="h-3 w-3" /> Back to terminal
+            </Button>
+          </div>
+        )}
+
+        {(showingChooser || inlineBrowse) && (
           <TerminalSessionChooser
             sections={chooserSections}
             pendingTask={pendingTask}
@@ -1388,7 +1431,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           />
         )}
 
-        {multi && (
+        {multi && !inlineBrowse && (
           <div role="tablist" aria-label="Terminal sessions" className="flex items-stretch border-b border-zinc-800 bg-[#141417]">
             {/* Tabs shrink then scroll; "+" (below) stays pinned OUTSIDE this
                 scroll region so launch + oversight are never scrolled away
@@ -1488,6 +1531,13 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           </div>
         )}
 
+        {/* CSS-hidden, never unmounted, while an inline browse takes the
+            panel — the same rule the tab strip and the popped-out
+            placeholder already follow in this file and in
+            TerminalSessionView's own root. Unmounting would throw away the
+            ended tab's scrollback, so "Back to terminal" above would return
+            to an empty terminal instead of the conversation it promised. */}
+        <div className={cn(inlineBrowse && "hidden")}>
         {sessions.map((entry) => (
           <TerminalSessionView
             key={entry.key}
@@ -1515,6 +1565,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onResumeEndedSession={(payload) => mintAndDeliver(payload)}
           />
         ))}
+        </div>
       </div>
 
       {/* Chooser OVERLAY (card cbe60db5, rework 11): the same
@@ -1535,7 +1586,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           someone who only wanted a look would be worse than the dead end that
           link exists to fix. */}
       <Dialog
-        open={chooserOpen && sessions.length > 0}
+        open={chooserOpen && sessions.length > 0 && !inlineBrowse}
         onOpenChange={(next) => {
           if (!next && chooserMode === "browse") setChooserMode(null);
         }}

--- a/src/components/board/terminal-task-launch-choice.test.tsx
+++ b/src/components/board/terminal-task-launch-choice.test.tsx
@@ -88,13 +88,12 @@ describe("TerminalTaskLaunchChoice", () => {
     expect(onReconnect).toHaveBeenCalledOnce();
   });
 
-  // Bug 9fb9fced (2026-08-17): a "recent" match with no recorded cwd used to
-  // never reach this dialog at all — chooser-data.ts's old F4 rule excluded
-  // it from `sections.recent` entirely, so `findTaskSessionMatch` could never
-  // find it. It can now, but Resume has no folder to reopen — mirrors the
-  // cross-board chooser's RecentRow fix: the dialog still opens (so
-  // "start fresh anyway" is reachable) but hides Reconnect/Resume instead of
-  // offering an action that can't work.
+  // Defence in depth only. As of card 79a0046c (2026-08-19)
+  // `findTaskSessionMatch` no longer returns an unresumable ended row at all,
+  // so the dock can't route one here — a task launch in that state mints
+  // straight away instead of showing a dialog whose only button is the mint.
+  // The guard stays because this component takes a `match` prop from anyone:
+  // given one, hiding an action that cannot work still beats offering it.
   it("a recent match with no recorded cwd hides Resume, keeps Start fresh anyway", () => {
     const onReconnect = vi.fn();
     const noCwdMatch: TaskSessionMatch = {

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -559,19 +559,36 @@ describe("findTaskSessionMatch", () => {
     expect(findTaskSessionMatch(sections, "task-1")).toBeNull();
   });
 
-  // Card cbe60db5 follow-up (Nick, 2026-08-17): the general chooser's Recent
-  // list now hides no-folder rows via `visibleRecentRows` (a display-only
-  // filter applied by terminal-session-chooser.tsx). `findTaskSessionMatch`
-  // must NOT pick up that filter — a task-scoped launch still has to dedupe
-  // against its own no-folder recent session (routing to
-  // terminal-task-launch-choice.tsx's "already have a session" dialog
-  // instead of silently minting a second one for the same task).
-  it("still matches a Recent row with no recorded cwd — unaffected by the chooser's display-only filter", () => {
+  // Card 79a0046c (Nick's field report, 2026-08-19), reversing card d6ebd6e8's
+  // call: an ended no-folder session isn't resumable, so matching it only
+  // produced a one-button "start fresh anyway" dialog in front of the mint
+  // that would have happened anyway. No match → the launch mints immediately.
+  it("does not match an ended Recent row with no recorded cwd — nothing there to resume", () => {
     const rows = [row({ sid: "no-cwd-recent", status: "ended", cwd: null, taskId: "task-1", endedAt: new Date(NOW - 60_000).toISOString() })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(sections.recent.map((r) => r.sid)).toContain("no-cwd-recent"); // still IN the sections...
+    expect(findTaskSessionMatch(sections, "task-1")).toBeNull(); // ...just not a reason to interrupt a launch
+  });
+
+  // The skip above is scoped to unresumable ENDED rows only — a running
+  // session for this task still stops the launch, folder or no folder,
+  // because reattaching to it never needed one.
+  it("still matches a LIVE row for the task even with no recorded cwd", () => {
+    const rows = [row({ sid: "no-cwd-live", status: "active", cwd: null, taskId: "task-1" })];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    const match = findTaskSessionMatch(sections, "task-1");
+    expect(match?.kind).toBe("live-here");
+    expect(match?.row.sid).toBe("no-cwd-live");
+  });
+
+  // A resumable ended row is untouched by the skip — the dialog still earns
+  // its place there, because Resume is a real second option.
+  it("still matches an ended Recent row that has a recorded cwd", () => {
+    const rows = [row({ sid: "cwd-recent", status: "ended", cwd: "/repo", taskId: "task-1", endedAt: new Date(NOW - 60_000).toISOString() })];
     const sections = deriveChooserSections(rows, IDEA_A, NOW);
     const match = findTaskSessionMatch(sections, "task-1");
     expect(match?.kind).toBe("recent");
-    expect(match?.row.sid).toBe("no-cwd-recent");
+    expect(match?.row.sid).toBe("cwd-recent");
   });
 });
 

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -256,11 +256,10 @@ export function deriveChooserSections(
  *     not `ChooserSections`, so it's untouched by this helper either way, but
  *     the underlying data it depends on (a null-cwd row counting as "recent")
  *     is the same invariant this filter must not undermine at the source.
- *   - `findTaskSessionMatch` below — a task-scoped launch must still dedupe
- *     against its own no-folder recent session (routing to
- *     terminal-task-launch-choice.tsx's "already have a session" dialog
- *     instead of silently minting a second one), even though that session
- *     wouldn't be worth a row in the general chooser's list.
+ *   - `findTaskSessionMatch` below — it reads `sections.recent` directly and
+ *     applies its own equivalent no-folder skip inline (see the comment on
+ *     that function), which must stay a decision made THERE, on the full set,
+ *     rather than something it inherits from a display filter.
  *
  * Two callers apply this: `terminal-session-chooser.tsx` for its row list AND
  * its section show/hide check, and `chooserHeaderCounts` below for the header
@@ -337,7 +336,16 @@ export function findTaskSessionMatch(
   if (here) return { kind: "live-here", row: here };
   const elsewhere = sections.liveElsewhere.find((r) => r.taskId === taskId);
   if (elsewhere) return { kind: "live-elsewhere", row: elsewhere };
-  const recent = sections.recent.find((r) => r.taskId === taskId);
+  // Card 79a0046c (Nick's field report, 2026-08-19): an ENDED session with no
+  // recorded folder is not a match worth stopping for. Resume needs a folder
+  // to reopen, so the dialog it would route to can only offer "start fresh
+  // anyway" — a one-button interstitial in front of the exact thing that
+  // happens without it. Card d6ebd6e8 kept these rows matchable to avoid
+  // "silently minting a second session", but the matched session has already
+  // ended: there is no parallel session to avoid, only a click to waste.
+  // Live rows above are deliberately unaffected — reattaching to a running
+  // session needs no folder, so those still route to the choice dialog.
+  const recent = sections.recent.find((r) => r.taskId === taskId && r.cwd !== null);
   if (recent) return { kind: "recent", row: recent };
   return null;
 }


### PR DESCRIPTION
Nick's follow-up to #180: *"why do we have this brand new popup, rather than it just switching to show all this in the terminal panel?"*

## The answer, and the gap

The chooser **already** renders inside the dock — but only when `sessions.length === 0`, i.e. no tabs at all. An ended tab was enough to force the Dialog route.

The overlay's actual purpose is protecting a **live** terminal underneath: replacing the panel's body would tear down its xterm instance, socket and scrollback. An ended tab has none of that to protect, so the popup was floating over a dimmed board for no gain.

## The change

- **The rule is now liveness, not tab count.** `anyTabLive` mirrors `requestClose`'s existing test exactly — including its popped-out caveat, where a popped tab reports `error`/duplicate mid-preemption while the session is very much alive in the other window. `idle`/`connecting` count as live, so a tab mid-launch is never swapped out from under.
- **Scoped to browsing.** A launch keeps the overlay whatever the tab states are — it also carries the forced-choice guarantee, and with no live tab it would be overlaying a body that's about to be replaced anyway.
- **Inline browse gets "Back to terminal".** `showingChooser` never needed one (nothing behind it), but here an ended tab sits underneath with its scrollback intact.
- **Session views are CSS-hidden, not unmounted** — the same rule the tab strip and the popped-out placeholder already follow. The ended panel promises *"The scrollback above is kept"*; unmounting would make Back return to an empty terminal.

## Tests

Five new cases: browsing from an ended tab renders in-panel with **no dialog**; the ended tab stays mounted and Back returns to it; a **live** tab still gets the overlay and no Back control; a **launch** still overlays even with every tab ended, and still refuses Escape; and Resume from the in-panel list behaves identically to the overlay.

The dock's `TerminalSessionView` stub gained a way to report a real `session-ended` status — without it every stubbed tab defaults to `idle`, which counts as live, and the new branch would never be exercised.

`npx tsc --noEmit` clean · eslint clean · **817** board + terminal tests pass.

Board card: `26d9c28c-96ce-4468-a690-e5685f870a72`

🤖 Generated with [Claude Code](https://claude.com/claude-code)