### PR TITLE
fix(terminal): make the session chooser closable — it had no way out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,14 @@
 
 - **Dev server**: `npm run dev` (http://localhost:3000)
 - **Build**: `npm run build`
-- **Lint**: `npm run lint`
-- **Test**: `npm run test` (Vitest) / `npm run test:watch` / `npm run test:e2e` (Playwright)
-- **Supabase**: `npm run supabase:start` / `npm run supabase:stop` / `npm run supabase:reset` / `npm run supabase:migrate`
+- **Lint**: `npm run lint` — **Typecheck**: `npm run typecheck`
+- **Test**: `npm run test` (Vitest) / `npm run test:watch` / `npm run test:e2e` (Playwright, also `:ui` / `:headed`)
+- **Supabase**: `npm run supabase:start` / `:stop` / `:reset` / `:migrate` / `:studio`
+- **Migration drift check**: `npm run check:migrations`
 
 ## Tech Stack
 
-Next.js 16 (App Router), TypeScript, Tailwind CSS v4, shadcn/ui (New York, Zinc), Supabase (Auth, Postgres, Realtime, RLS), Vercel AI SDK (`ai` + `@ai-sdk/anthropic`), mcp-handler (remote MCP + OAuth 2.1), Sentry, Resend, PostHog, Vitest + Playwright, zod v4, @dnd-kit, sonner, vaul, next-themes (dark default), cmdk (command palette), react-markdown + rehype-highlight + remark-gfm, date-fns, lucide-react, @marsidev/react-turnstile
+Next.js 16.1.6 (App Router), React 19.2, TypeScript, Tailwind CSS v4, shadcn/ui (New York, Zinc), Supabase (Auth, Postgres, Realtime, RLS), Vercel AI SDK v6 (`ai` + `@ai-sdk/anthropic` v3), mcp-handler (remote MCP + OAuth 2.1), xterm.js + node-pty (in-app terminal), Sentry, Resend, PostHog, Vitest v4 + Playwright, zod v4, @dnd-kit, sonner, vaul, next-themes (dark default), cmdk (command palette), react-markdown + rehype-highlight + remark-gfm, date-fns, lucide-react, @marsidev/react-turnstile
 
 ## Workflow Rules (MANDATORY)
 
@@ -59,15 +60,59 @@ Move to "Blocked/Requires User Input" with a comment explaining why.
 - `requireAiAccess()` for server actions (throws on failure), `getAiAccess()` for UI gating
 - AI API routes use `maxDuration = 300` for Vercel function timeout
 
-**Model update cadence**: to change the model, set `ANTHROPIC_MODEL` (or bump the default `AI_MODEL` in `src/lib/ai-helpers.ts:7`, which also drives `WORKFLOW_MATCHING_MODEL`). Before flipping, verify the resolved key(s) accept the new id via a real prod call that produces an `ai_usage_log` row — on the platform key AND a BYOK key (we were burned by a Haiku swap the account key rejected).
+**Model update cadence**: to change the model, set `ANTHROPIC_MODEL` (or bump the default `AI_MODEL` in `src/lib/ai-helpers.ts:12` — currently `claude-sonnet-5` — which also drives `WORKFLOW_MATCHING_MODEL`). Before flipping, verify the resolved key(s) accept the new id via a real prod call that produces an `ai_usage_log` row — on the platform key AND a BYOK key (we were burned by a Haiku swap the account key rejected).
+
+### In-App Terminal (largest active workstream — most current board cards)
+
+Runs Claude Code in the browser, against the user's **own machine**. Three
+processes, bytes forwarded verbatim end to end:
+
+```
+claude --[node-pty PTY]--> BRIDGE --ws--> RELAY (CF Worker + DO) --ws--> BROWSER (xterm.js)
+        (user's machine)   terminal/bridge   terminal/relay              terminal-dock.tsx
+```
+
+- **`terminal/`** (outside `src/`): `bridge/` (local Node + node-pty), `relay/`
+  (Cloudflare Worker, one Durable Object per session, pairs exactly one bridge
+  leg to one browser leg, enforces single-attach, never parses stream content),
+  `helper/` (the installable Mac app users download), `shared/`, `test/`, and
+  `RUN.md` — read RUN.md before touching any of it.
+- **`src/lib/terminal/`** — 26 modules. The pure logic lives here and is where
+  tests go: `entry-decision.ts` (reconnect vs chooser vs mint), `chooser-data.ts`
+  (dedupe, 48h recent window, per-task matching), `session-registry.ts`,
+  `session-cap.ts`, `session-reap.ts`, `helper-version.ts` / `helper-update-flow.ts`,
+  `relay-budget.ts`, `machine-identity.ts`, `deep-link.ts`.
+- **`src/components/board/terminal-*.tsx`** — 8 components. `terminal-dock.tsx`
+  is the orchestrator (tabs, chooser, overlays, pop-out) and is by far the most
+  intricate; `terminal-session-view.tsx` owns one xterm instance.
+- **API**: `src/app/api/terminal/` — `session` (mint), `session/[sid]`,
+  `session/list`, `session/end`, `session/closed`, `session/reattach`,
+  `helper/status`, `helper/command`. Excluded from middleware (does its own
+  `supabase.auth.getUser()`).
+- **Auth**: app and relay share `TERMINAL_SESSION_SECRET` (HMAC-SHA256) to sign
+  short-lived, owner-bound session tokens. Never in code.
+
+**Rules learned the hard way (each one is a fixed bug — don't regress them):**
+- **Never trap the user in a dialog.** Launch dialogs were built undismissable
+  on the theory that a fired launch must resolve to one outcome. Nothing is
+  minted until a click, so backing out is always free and must always be
+  possible — close button, Escape and outside-click, all modes.
+- Swapping the dock body tears down the xterm instance, socket and scrollback —
+  only use an overlay when a **live** tab genuinely needs protecting; otherwise
+  render in the panel.
+- A popped-out tab reports a misleading status (mid-preemption) while very much
+  alive elsewhere — never read it as ended or errored.
+- Sessions with no recorded folder can't be resumed; hide them from the chooser
+  but keep them in the internal reconnect check.
 
 ### Logging
 - Use `logger.*` from `src/lib/logger.ts`, NOT `console.*`
 - Structured JSON output; level via `LOG_LEVEL` env var (default: `warn` prod, `debug` dev)
 
 ### Auth & Middleware
-- Middleware protects `/dashboard`, `/ideas`, `/members`, `/profile`, `/admin`, `/agents`, `/feed`
-- Middleware excludes `.well-known`, `api/mcp`, `api/oauth`, `oauth`, `monitoring`, `sw.js`, `ingest`, `callback`
+- `middleware.ts` lives at the **repo root**, not in `src/`; the protected-path list it calls into is in `src/lib/supabase/middleware.ts`
+- Protected: `/dashboard`, `/ideas`, `/members`, `/profile`, `/admin`, `/agents` (**not** `/feed` — that is public)
+- Matcher excludes `.well-known`, `api/mcp`, `api/oauth`, `api/terminal`, `oauth`, `callback`, `monitoring`, `ingest`, `sw.js`, static assets
 - `useUser()` hook for client-side auth state
 
 ### Board
@@ -100,22 +145,32 @@ Move to "Blocked/Requires User Input" with a comment explaining why.
 
 ## Database
 
-42 tables with RLS (110 migrations in `supabase/migrations/`):
+**157 migrations** in `supabase/migrations/`. `src/types/database.ts` types **48** tables:
+
 - **Core**: users, ideas, comments, collaborators, votes, notifications, feedback, idea_attachments
-- **Board**: board_columns, board_tasks, board_labels, board_task_labels, board_checklist_items, board_task_activity, board_task_comments, board_task_attachments
-- **Workflows**: workflow_templates, workflow_auto_rules, workflow_runs, task_workflow_steps, workflow_step_comments, workflow_library_templates, user_workflow_templates
+- **Board**: board_columns, board_tasks, board_labels, board_task_labels, board_task_activity, board_task_comments, board_task_attachments
+- **Workflows**: workflow_templates, workflow_auto_rules, workflow_runs, task_workflow_steps, workflow_step_comments, workflow_library_templates, user_workflow_templates, workflow_suggestions
 - **Discussions**: idea_discussions, idea_discussion_replies, discussion_votes, discussion_attachments
-- **Agents**: bot_profiles, idea_agents, agent_votes, featured_teams, featured_team_agents
-- **Project Kits**: project_kits, kit_workflow_mappings
-- **AI**: ai_usage_log, ai_prompt_templates
-- **MCP**: mcp_oauth_clients, mcp_oauth_codes, mcp_tool_log, mcp_tool_stats
+- **Agents**: bot_profiles, idea_agents, agent_votes, agent_skills, featured_teams, featured_team_agents
+- **Terminal**: idea_project_paths (recorded project folder per idea + machine)
+- **AI**: ai_usage_log, ai_prompt_templates, idea_role_match_cache, platform_settings
+- **MCP**: mcp_oauth_clients, mcp_oauth_codes, mcp_tool_log, mcp_tool_stats, mcp_agent_sessions (retired with `set_agent_identity`; dropped in the pending Phase B task ec2bde45)
+- **User/integration**: user_api_keys, user_github_connections, github_oauth_states, pending_uploads
 - **Collaboration**: collaboration_requests
 
 Board tables use `is_idea_team_member()` RLS function. `is_super_admin` separates destructive ops from general admin access.
 
+### ⚠️ Tables that exist in the DB but are MISSING from `database.ts`
+
+`database.ts` is hand-maintained, and it has drifted. These are created by migrations but have no typed entry, so any query against them resolves to `never` — add the full `Row`/`Insert`/`Update`/`Relationships` block before using them:
+
+`terminal_sessions` (migrations 00141, 00157 — the in-app terminal's own session store), `project_kits`, `kit_workflow_mappings`, `bot_profile_prompt_backups`.
+
+(`board_checklist_items` also appears in migrations but was later dropped — it is correctly absent, don't re-add it.)
+
 ## MCP Server
 
-Two modes sharing 83 tools via `mcp-server/src/register-tools.ts`:
+Two modes sharing **85 tools** via `mcp-server/src/register-tools.ts` (21 tool files in `mcp-server/src/tools/`):
 - **Local (stdio)**: `mcp-server/src/index.ts` — service-role client, bypasses RLS
 - **Remote (HTTP)**: `src/app/api/mcp/[[...transport]]/route.ts` — OAuth 2.1 + PKCE, per-user RLS
 
@@ -141,9 +196,24 @@ NEXT_PUBLIC_POSTHOG_KEY
 # Logging
 LOG_LEVEL (default: warn prod, debug dev)
 
+# GitHub integration
+GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET
+
+# In-app terminal
+TERMINAL_SESSION_SECRET          # HMAC secret shared with the relay — never in code
+NEXT_PUBLIC_TERMINAL_ENABLED     # feature flag (removal tracked by card 139c633c)
+NEXT_PUBLIC_TERMINAL_RELAY_URL, NEXT_PUBLIC_TERMINAL_SESSION_CAP
+TERMINAL_SESSION_CAP, TERMINAL_MINT_RATE_LIMIT, TERMINAL_HELPER_VERSION
+TERMINAL_DAILY_BUDGET, TERMINAL_BUDGET_SOFT_PCT, TERMINAL_ASSUMED_REQUESTS_PER_SESSION
+
 # MCP (stdio mode)
-SUPABASE_URL, VIBECODES_BOT_ID, VIBECODES_OWNER_ID
+SUPABASE_URL, VIBECODES_BOT_ID, VIBECODES_BOT_USER_ID, VIBECODES_OWNER_ID
 ```
+
+**⚠️ Blank-env hazard**: Vercel "sensitive" env vars can silently store blank via
+the CLI — this caused a full AI outage. Any `process.env.X ?? default` passes `""`
+straight through; use `.trim() || default`. See `AI_MODEL` in `ai-helpers.ts:12`
+for the correct pattern.
 
 ## Deployment
 
@@ -191,38 +261,46 @@ Supabase Branching off prod)".
 - Scope locators to `page.getByRole("main")` to avoid strict mode violations
 - E2E auth uses API-based login (service-role client) to bypass Turnstile CAPTCHA — not browser login
 - CI matrix: Chrome + Mobile Chrome only (Firefox dropped)
-- 21 E2E spec files across admin, agents, auth, board, dashboard, discussions, ideas, members, mobile, onboarding, profile, and workflows
+- **22 E2E spec files**, in per-area subfolders (`e2e/board/`, `e2e/auth/`, `e2e/ideas/`, …) — not flat in `e2e/`
+- Current unit suite: **2,910 tests across 176 files** — run the full `npm run test` before pushing; it takes ~10s
 
 ## .vibecodes/ Config
 
 ```json
-{ "ideaId": "...", "ideaTitle": "...", "taskId": "...", "botId": "...", "defaultColumn": "..." }
+{ "ideaId": "...", "ideaTitle": "..." }
 ```
 
-Auto-injects `idea_id` into MCP tool calls from `.vibecodes/config.json`.
+Auto-injects `idea_id` into MCP tool calls. Optional extra keys (`taskId`,
+`botId`, `defaultColumn`) are supported but this repo's own config sets only the
+two above. This project's `ideaId` is `62e57071-3645-422f-96c0-b2042e39e6dd`.
 
 ## Project Structure
 
 ```
 src/
-├── actions/       # 22 server action files ("use server")
+├── actions/       # 30 server action files ("use server")
 ├── app/           # Next.js App Router
 │   ├── (auth)/    # Login, signup, password reset, callback
 │   ├── (main)/    # Admin, agents, dashboard, feed, ideas, members, profile
 │   ├── api/       # AI, health, MCP, notifications, OAuth
-│   ├── guide/     # 9 help/guide pages
+│   ├── guide/     # 12 help/guide pages (incl. launching-claude-code, project-kits)
 │   ├── changelog/ # Public changelog
 │   └── ...        # Privacy, terms, feed.xml, .well-known
-├── components/    # 20 directories, ~215 component files
+├── components/    # 20 directories, ~228 component files (board/ alone has 56)
 │   ├── ui/        # shadcn/ui primitives (don't edit except markdown.tsx)
 │   └── ...        # admin, agents, ai, auth, board, comments, dashboard,
 │                  # discussions, guide, ideas, kits, landing, layout,
 │                  # members, onboarding, posthog, profile, pwa, shared
 ├── data/          # Static data (changelog entries)
-├── hooks/         # Custom hooks (use-media-query, use-mentions,
-│                  # use-realtime, use-scroll-to-hash, use-user)
-├── lib/           # 25 utility/helper modules + supabase/ client setup
+├── hooks/         # 11 hooks (use-media-query, use-mentions, use-realtime,
+│                  # use-scroll-to-hash, use-user, use-debounced-save,
+│                  # use-keyboard-shortcut, use-now, use-platform-model-defaults,
+│                  # use-viewer-model-tier-map, use-launch-path-pin-migration)
+├── lib/           # 47 top-level modules + supabase/ client setup
+│                  # + terminal/ (26 modules — see In-App Terminal above)
 ├── test/          # Test utilities
 └── types/         # database.ts (manual), index.ts
-mcp-server/src/    # MCP server (shared tools, 22 tool files)
+mcp-server/src/    # MCP server (85 tools across 21 tool files)
+terminal/          # bridge / relay / helper / shared / test — see In-App Terminal
+middleware.ts      # at the REPO ROOT, not in src/
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,12 +152,25 @@ See `docs/release-process.md` for full details.
 | Environment | URL | Branch | Database |
 |---|---|---|---|
 | Local | http://localhost:3000 | any | Docker Supabase |
-| Staging | https://staging.vibecodes.co.uk | `develop` | Staging Supabase project |
 | Production | https://vibecodes.co.uk | `master` | Production Supabase project |
 
-- Feature branches → PR to `develop` → PR to `master`
-- Hotfixes branch directly from `master`
-- Migrations: auto-apply staging on merge, manual production trigger with approval gate
+**Branch from `master`, PR to `master`. There is no intermediate branch.**
+
+`develop` IS DEAD — do not target it, do not merge to it, do not "promote" through
+it. Its last commit was 18 March 2026; it now sits 751 commits behind `master`
+with 4 orphaned commits of its own. Every PR since March has gone feature branch
+→ `master` directly. `docs/release-process.md` still documents the old two-branch
+flow and is stale on this point (it half-admits it: "features are tested via PRs
+to master instead"). CI workflow files still *list* `develop` as a trigger — that
+is vestigial, not a signal that it's live.
+
+Staging (`staging.vibecodes.co.uk`) is not part of the flow either; its database
+is known-broken — see the board card "Recreate staging database properly (via
+Supabase Branching off prod)".
+
+- Migrations: manual production trigger with approval gate (the develop→staging
+  auto-apply path in `migrations.yml` no longer fires, since nothing lands on
+  `develop`)
 - Migrations cannot be rolled back — only corrective forward migrations
 - Monitoring: Sentry (source maps), Vercel Analytics + Speed Insights, PostHog (reverse-proxied via `/ingest`)
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,5 +1,21 @@
 # VibeCodes Release Process — Git Flow Lite (Option B)
 
+> ## ⚠️ STALE ON BRANCHING — `develop` IS DEAD
+>
+> The two-branch flow below (`feature → develop → master`) is **no longer how
+> this project ships**, and following it wastes time and targets a dead branch.
+>
+> **Current reality: branch from `master`, PR straight to `master`.**
+>
+> `develop`'s last commit was 18 March 2026. It is 751 commits behind `master`,
+> with 4 orphaned commits of its own. Every PR since March has gone directly to
+> `master`. Staging (`staging.vibecodes.co.uk`) is not in the flow either, and
+> its database is known-broken.
+>
+> Everything else here (local setup, migrations, Docker, env vars) is still
+> useful — it is specifically the branching strategy that is out of date.
+> `CLAUDE.md`'s Deployment section is the authority.
+
 This document explains the branching strategy, release workflow, and local development setup for VibeCodes. It's written for someone who uses Claude Code for all coding work and wants to understand how code gets from an idea to production.
 
 ---

--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -1094,7 +1094,7 @@ describe("TerminalDock — ended panel's 'View my other sessions' opens the choo
     expect(sessionViewUnmountSpy).not.toHaveBeenCalled();
   });
 
-  it("still traps a LAUNCH-opened overlay (forced choice, unchanged) — the dismissal relaxation is scoped to browsing", async () => {
+  it("a LAUNCH-opened overlay can be escaped too (Nick, 2026-08-19) — and abandoning it launches nothing", async () => {
     stubFetch(Promise.resolve([liveElsewhereRow()]));
     render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
 
@@ -1106,9 +1106,28 @@ describe("TerminalDock — ended panel's 'View my other sessions' opens the choo
 
     fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape", code: "Escape" });
 
-    // A fired launch must resolve to exactly one outcome — Escape must not
-    // silently swallow it.
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    // Nothing is minted until a click inside the chooser, so backing out of a
+    // fired launch is free — and a dialog with no exit is a trap, whatever
+    // the launch was supposed to resolve to.
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    // Backed out, not acted on: no new tab, and the open one is untouched.
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+  });
+
+  it("the launch overlay also offers an explicit Close, not just the corner X", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await openFirstTabViaChooser();
+    act(() => {
+      requestBrowserLaunch();
+    });
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /^Close$/ }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
   });
 
   it("resuming an ended session from the browse overlay closes it and launches with that row's own folder and conversation", async () => {
@@ -1207,7 +1226,7 @@ describe("TerminalDock — browsing renders IN the panel when nothing is running
     expect(screen.queryByRole("button", { name: /Back to terminal/ })).not.toBeInTheDocument();
   });
 
-  it("a LAUNCH still overlays even with every tab ended — the forced choice outranks the panel swap", async () => {
+  it("a LAUNCH still overlays even with every tab ended — but it can be escaped", async () => {
     stubFetch(Promise.resolve([liveElsewhereRow()]));
     render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
 
@@ -1218,10 +1237,11 @@ describe("TerminalDock — browsing renders IN the panel when nothing is running
       requestBrowserLaunch();
     });
 
+    // A launch still gets the overlay (it sits on top of a body that is about
+    // to be replaced anyway) — but it is no longer a dead end.
     await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
-    // And it stays a forced choice — Escape must not swallow a fired launch.
     fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape", code: "Escape" });
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
   });
 
   it("resuming from the in-panel list works the same as from the overlay", async () => {

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1112,11 +1112,9 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // ── chooser action handlers ─────────────────────────────────────────────────
   // Shared by BOTH the sessions.length === 0 body-swap chooser and the
   // sessions.length > 0 overlay (rework 11) — the `setChooserMode(null)` in
-  // each is a no-op when it was never opened (the body-swap case), and the
-  // one thing that's allowed to close the overlay per the design's
-  // non-disruption guarantee: only an explicit action in here, never an
-  // outside click/Escape (see the Dialog's `onInteractOutside`/
-  // `onEscapeKeyDown` below).
+  // each is a no-op when it was never opened (the body-swap case). These are
+  // the ways to close the overlay by ACTING; `handleChooserDismiss` below is
+  // the way to close it by walking away, and both are always available.
   const handleChooserStartNew = useCallback(() => {
     const payload = pendingLaunch;
     setPendingLaunch(null);

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1124,6 +1124,19 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     mintAndDeliver(payload);
   }, [pendingLaunch, mintAndDeliver]);
 
+  // Nick, 2026-08-19: "HOW THE HELL AM I GOING TO CLOSE THIS?" — the
+  // launch-mode overlay was a dead end by design (forced choice: no close
+  // button, Escape and outside-click both suppressed). That was wrong. A
+  // fired launch has minted NOTHING yet — the chooser's whole point is that
+  // no session exists until a click — so abandoning it costs nothing and
+  // leaves no orphan: dropping `pendingLaunch` returns the dock to exactly
+  // the state it was in before the launch event arrived. Every modal needs a
+  // way out.
+  const handleChooserDismiss = useCallback(() => {
+    setPendingLaunch(null);
+    setChooserMode(null);
+  }, []);
+
   const handleChooserReconnectHere = useCallback(
     (row: ChooserLiveRow) => {
       setPendingLaunch(null);
@@ -1245,6 +1258,14 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     },
     [ideaId, mintAndDeliver, router],
   );
+
+  // Back out of the task-scoped choice without launching anything — see the
+  // note in terminal-task-launch-choice.tsx. Drops the pending launch so the
+  // dialog can't reopen against a payload nobody asked for any more.
+  const handleTaskChoiceCancel = useCallback(() => {
+    setPendingLaunch(null);
+    setTaskChoiceOpen(false);
+  }, []);
 
   // My sessions panel Reconnect (design item 9) — the SAME reattach flow;
   // "this board" attaches in place, any other board navigates + reconnects.
@@ -1681,30 +1702,21 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           one, so opening this Dialog neither unmounts nor re-renders them —
           it's a Portal-rendered overlay layered on top, nothing more.
 
-          Dismissal depends on WHY it opened (`chooserMode`). "launch" is a
-          forced choice (matches onboarding-dialog.tsx's pattern): no close
-          button, outside-click and Escape both suppressed — only an action
-          inside the chooser (wired to also call `setChooserMode(null)`)
-          closes it, because a fired launch must resolve to exactly one
-          outcome. "browse" — the ended panel's "View my other sessions" link
-          — has no pending launch to resolve, so it closes normally; trapping
-          someone who only wanted a look would be worse than the dead end that
-          link exists to fix. */}
+          Dismissal is the SAME in both modes (`chooserMode`), and always
+          available: close button, Escape and outside-click all work. Launch
+          mode used to be a forced choice with all three suppressed, on the
+          theory that a fired launch must resolve to exactly one outcome —
+          but nothing is minted until a click inside here, so "no outcome" is
+          a perfectly valid one that costs nothing and leaves nothing behind.
+          A modal with no exit is a trap, not a guarantee. */}
       <Dialog
         open={chooserOpen && sessions.length > 0 && !inlineBrowse}
         onOpenChange={(next) => {
-          if (!next && chooserMode === "browse") setChooserMode(null);
+          if (!next) handleChooserDismiss();
         }}
       >
         <DialogContent
-          showCloseButton={chooserMode === "browse"}
           className="max-w-lg gap-0 border-zinc-700 bg-[#141417] p-0 text-zinc-200 sm:max-w-xl"
-          onInteractOutside={(e) => {
-            if (chooserMode !== "browse") e.preventDefault();
-          }}
-          onEscapeKeyDown={(e) => {
-            if (chooserMode !== "browse") e.preventDefault();
-          }}
         >
           <DialogTitle className="sr-only">Choose a terminal session</DialogTitle>
           <DialogDescription className="sr-only">
@@ -1720,6 +1732,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onStartNew={handleChooserStartNew}
             helperStatus={helperStatus}
             onHelperUpdateSettled={refreshAfterHelperUpdate}
+            onDismiss={handleChooserDismiss}
           />
         </DialogContent>
       </Dialog>
@@ -1740,6 +1753,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           busy={chooserBusy}
           onReconnect={handleTaskChoiceReconnect}
           onStartFresh={handleTaskChoiceStartFresh}
+          onCancel={handleTaskChoiceCancel}
         />
       )}
     </div>

--- a/src/components/board/terminal-session-chooser.tsx
+++ b/src/components/board/terminal-session-chooser.tsx
@@ -78,6 +78,14 @@ export interface TerminalSessionChooserProps {
    * (e.g. in tests) simply skips the refresh.
    */
   onHelperUpdateSettled?: () => void;
+  /**
+   * Back out without doing anything (Nick, 2026-08-19). When supplied, a
+   * plain "Close" sits at the FOOT of the list as well as in the dialog's
+   * corner — the corner X is easy to miss on a tall list you have to scroll,
+   * and the bottom is where you end up once you've read every row and
+   * decided none of them is what you wanted.
+   */
+  onDismiss?: () => void;
 }
 
 export function TerminalSessionChooser({
@@ -91,6 +99,7 @@ export function TerminalSessionChooser({
   cap,
   helperStatus = null,
   onHelperUpdateSettled,
+  onDismiss,
 }: TerminalSessionChooserProps) {
   const [confirmingResumeSid, setConfirmingResumeSid] = useState<string | null>(null);
   const firstFocusRef = useRef<HTMLButtonElement | null>(null);
@@ -299,6 +308,19 @@ export function TerminalSessionChooser({
             />
           ))}
         </ChooserSection>
+      )}
+
+      {onDismiss && (
+        <div className="flex justify-end border-t border-zinc-800 bg-[#111114] px-3.5 py-2">
+          <Button
+            variant="ghost"
+            size="xs"
+            className="text-zinc-400 hover:text-zinc-100"
+            onClick={onDismiss}
+          >
+            <X className="h-3 w-3" /> Close
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/src/components/board/terminal-task-launch-choice.test.tsx
+++ b/src/components/board/terminal-task-launch-choice.test.tsx
@@ -50,9 +50,45 @@ describe("TerminalTaskLaunchChoice", () => {
         match={LIVE_HERE_MATCH}
         onReconnect={vi.fn()}
         onStartFresh={vi.fn()}
+        onCancel={vi.fn()}
       />,
     );
     expect(screen.queryByTestId("terminal-task-launch-choice")).not.toBeInTheDocument();
+  });
+
+  it("can be cancelled — Cancel and Escape both back out without launching (Nick, 2026-08-19)", () => {
+    const onCancel = vi.fn();
+    const onStartFresh = vi.fn();
+    const onReconnect = vi.fn();
+    const { rerender } = render(
+      <TerminalTaskLaunchChoice
+        open
+        taskTitle="Fix login bug"
+        match={LIVE_HERE_MATCH}
+        onReconnect={onReconnect}
+        onStartFresh={onStartFresh}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Cancel$/ }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    // Backing out must never be mistaken for either real action.
+    expect(onStartFresh).not.toHaveBeenCalled();
+    expect(onReconnect).not.toHaveBeenCalled();
+
+    rerender(
+      <TerminalTaskLaunchChoice
+        open
+        taskTitle="Fix login bug"
+        match={LIVE_HERE_MATCH}
+        onReconnect={onReconnect}
+        onStartFresh={onStartFresh}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.keyDown(screen.getByTestId("terminal-task-launch-choice"), { key: "Escape", code: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(2);
   });
 
   it("labels a live match 'Reconnect' and fires onReconnect", () => {
@@ -64,6 +100,7 @@ describe("TerminalTaskLaunchChoice", () => {
         match={LIVE_HERE_MATCH}
         onReconnect={onReconnect}
         onStartFresh={vi.fn()}
+        onCancel={vi.fn()}
       />,
     );
     expect(screen.getByText(/already has a terminal running/i)).toBeInTheDocument();
@@ -81,6 +118,7 @@ describe("TerminalTaskLaunchChoice", () => {
         match={RECENT_MATCH}
         onReconnect={onReconnect}
         onStartFresh={vi.fn()}
+        onCancel={vi.fn()}
       />,
     );
     expect(screen.getByText(/recent session/i)).toBeInTheDocument();
@@ -107,6 +145,7 @@ describe("TerminalTaskLaunchChoice", () => {
         match={noCwdMatch}
         onReconnect={onReconnect}
         onStartFresh={vi.fn()}
+        onCancel={vi.fn()}
       />,
     );
     expect(screen.queryByRole("button", { name: "Resume" })).not.toBeInTheDocument();
@@ -123,6 +162,7 @@ describe("TerminalTaskLaunchChoice", () => {
         match={LIVE_HERE_MATCH}
         onReconnect={vi.fn()}
         onStartFresh={onStartFresh}
+        onCancel={vi.fn()}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /start fresh anyway/i }));
@@ -138,6 +178,7 @@ describe("TerminalTaskLaunchChoice", () => {
         match={LIVE_HERE_MATCH}
         onReconnect={vi.fn()}
         onStartFresh={vi.fn()}
+        onCancel={vi.fn()}
       />,
     );
     expect(screen.getByRole("button", { name: "Reconnect" })).toBeDisabled();

--- a/src/components/board/terminal-task-launch-choice.tsx
+++ b/src/components/board/terminal-task-launch-choice.tsx
@@ -27,6 +27,8 @@ export interface TerminalTaskLaunchChoiceProps {
   onReconnect: () => void;
   /** The "start fresh anyway" escape hatch — mints a brand-new session for this task, ignoring the match entirely. */
   onStartFresh: () => void;
+  /** Back out entirely — launches nothing. Close button, Escape and outside-click all route here. */
+  onCancel: () => void;
 }
 
 export function TerminalTaskLaunchChoice({
@@ -36,6 +38,7 @@ export function TerminalTaskLaunchChoice({
   busy = false,
   onReconnect,
   onStartFresh,
+  onCancel,
 }: TerminalTaskLaunchChoiceProps) {
   // Narrow on `match.kind` directly at each use (rather than a derived
   // boolean) — `ChooserLiveRow`/`ChooserRecentRow` don't share a `createdAt`/
@@ -53,12 +56,19 @@ export function TerminalTaskLaunchChoice({
   const canReconnect = match.kind !== "recent" || !!match.row.cwd;
 
   return (
-    <Dialog open={open} onOpenChange={() => {}}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      {/* Nick, 2026-08-19: this used to be undismissable (no close button,
+          Escape and outside-click both suppressed) so the launch had to
+          resolve to reconnect-or-fresh. But no session is minted until one
+          of those buttons is clicked, so backing out costs nothing and
+          leaves nothing behind — and a dialog you can't close is a trap. */}
       <DialogContent
-        showCloseButton={false}
         className="max-w-sm gap-0 border-zinc-700 bg-[#141417] p-0 text-zinc-200"
-        onInteractOutside={(e) => e.preventDefault()}
-        onEscapeKeyDown={(e) => e.preventDefault()}
         data-testid="terminal-task-launch-choice"
       >
         <div className="px-4 pt-4 pb-3">
@@ -72,6 +82,9 @@ export function TerminalTaskLaunchChoice({
           </DialogDescription>
         </div>
         <div className="flex items-center justify-end gap-2 border-t border-zinc-800 px-4 py-3">
+          <Button variant="ghost" size="xs" className="text-zinc-400 hover:text-zinc-100" disabled={busy} onClick={onCancel}>
+            Cancel
+          </Button>
           <Button variant="ghost" size="xs" disabled={busy} onClick={onStartFresh}>
             <TerminalIcon className="h-3 w-3" /> Start fresh anyway
           </Button>


### PR DESCRIPTION
## The problem

Nick, hitting the chooser overlay: *"HOW THE HELL AM I GOING TO CLOSE THIS?"*

Two terminal dialogs were deliberately built as dead ends:

- **`terminal-dock.tsx`** — the chooser overlay when opened by a *launch* (`chooserMode === "launch"`): `showCloseButton={false}`, with `onInteractOutside` and `onEscapeKeyDown` both `preventDefault()`ed. Only "browse" mode could be closed.
- **`terminal-task-launch-choice.tsx`** — the same three suppressions, plus `onOpenChange={() => {}}`.

The recorded reasoning was that "a fired launch must resolve to exactly one outcome". Once either was open there was no exit but Start new session / Reconnect / Resume / Start fresh anyway.

## Why that reasoning doesn't hold

The chooser mints **nothing** until a button inside it is clicked — that is the entry-chooser's design premise. Abandoning a launch costs nothing and leaves no orphan session: clearing `pendingLaunch` returns the dock to exactly the state it was in before the launch event arrived.

"No outcome" is a valid outcome. A modal with no exit is a trap, not a guarantee.

## Changes

- Shared `handleChooserDismiss` clears `pendingLaunch` + `chooserMode`; the overlay closes on X, Escape and outside-click in **both** modes.
- New optional `onDismiss` on `TerminalSessionChooser` renders an explicit **Close** at the *foot* of the list — the corner X is easy to miss on a tall list you scroll through before concluding no row is what you wanted.
- `TerminalTaskLaunchChoice` gains a required `onCancel`, a visible **Cancel** button, and normal Escape/outside-click dismissal.

The in-panel chooser is unchanged — it already had a way out (dock header Collapse, "Back to terminal").

## Swept for the same pattern

`ai-generate-dialog`, `import-dialog` and `enhance-dialog-shell` suppress dismissal only while `busy` — correct, untouched. `onboarding-dialog` is a genuine forced flow, out of scope.

## Docs (two commits)

- **Branching**: CLAUDE.md said "feature → `develop` → `master`". `develop`'s last commit is 18 March 2026, it is 751 commits behind, and every PR since has gone straight to `master`. Corrected, with a scoped staleness banner on `docs/release-process.md`.
- **Full CLAUDE.md audit**: every count re-derived from the repo — migrations 110→157, typed tables 42→48, MCP tools 83→85, actions 22→30, lib modules 25→47, guide pages 9→12, E2E specs 21→22. Fixed wrong facts (middleware is at the repo root and does **not** protect `/feed`; `AI_MODEL` is at `ai-helpers.ts:12`; `board_checklist_items` was dropped). Added the missing **In-App Terminal** section, a warning that 4 live tables (incl. `terminal_sessions`) are absent from the hand-maintained `database.ts`, and the blank-env hazard that caused the AI outage.

## Verification

Rebased onto current `master` (`4f4d0cd`), resolving one additive conflict against the `handleResumeEndedSession` added by #183 — both functions kept.

- `tsc --noEmit` — clean
- Full suite — **2925 passed, 177 files**
- Lint — 0 errors

Supersedes #185 (based on the pre-#183 tree, conflicted) and #184 (wrongly targeted `develop`).