### PR TITLE
fix(launch): make the recorded project folder one store, keyed per machine

### DIFF
--- a/src/actions/launch-path.test.ts
+++ b/src/actions/launch-path.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Two independently-configurable outcomes: the row lookup (`select().eq().eq()`)
+// migrateLaunchPathPin makes first, and the `upsert(...).select(...).single()`
+// both actions share (the `.select().single()` tail is what lets
+// upsertProjectPath run its post-write ownership assertion — see
+// launch-path.ts). A real supabase-js query builder is thenable itself (no
+// `.single()` needed when the caller wants the raw {data, error} shape), so
+// the select-lookup builder exposes its own `then` rather than requiring a
+// terminal method call; the upsert builder terminates on `.single()` instead,
+// matching how the real client is actually called.
+let selectResult: { data: unknown; error: unknown } = { data: [], error: null };
+let upsertResult: { data: unknown; error: unknown } = { data: null, error: null };
+let userResult: { id: string } | null = { id: "user-1" };
+
+function makeSelectBuilder() {
+  const builder = {
+    eq: vi.fn(() => builder),
+    then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(selectResult).then(resolve, reject),
+  };
+  return builder;
+}
+
+function makeUpsertBuilder() {
+  const builder = {
+    select: vi.fn(() => builder),
+    single: vi.fn(() => Promise.resolve(upsertResult)),
+  };
+  return builder;
+}
+
+const mockUpsert = vi.fn(() => makeUpsertBuilder());
+const mockSelect = vi.fn(() => makeSelectBuilder());
+// Rest parameter (matching the real `.from(table)` call signature) rather than
+// a zero-arg function: the wrapper below forwards `from`'s args on to this mock
+// via a spread, which TS only allows into a function that declares a rest param.
+const mockFrom = vi.fn((..._args: unknown[]) => ({ select: mockSelect, upsert: mockUpsert }));
+const mockGetUser = vi.fn(() => Promise.resolve({ data: { user: userResult } }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: { getUser: () => mockGetUser() },
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { migrateLaunchPathPin, saveManualProjectPath } from "./launch-path";
+import { MANUAL_PIN_HOSTNAME } from "@/lib/launch-claude-code";
+
+const IDEA_ID = "idea-1";
+const PATH = "/Users/nick/projects/widget";
+const REAL_HOSTNAME = "Nicks-MacBook-Pro.local";
+
+/** The row the mocked upsert "returns" — owned by the caller unless a test overrides it. */
+function ownedRow(hostname: string, absolutePath: string, ownerUserId = "user-1") {
+  return { owner_user_id: ownerUserId, hostname, absolute_path: absolutePath };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectResult = { data: [], error: null };
+  upsertResult = { data: null, error: null };
+  userResult = { id: "user-1" };
+});
+
+describe("migrateLaunchPathPin", () => {
+  // pin-exists-and-migrates (0 rows, no known hostname)
+  it("0 existing rows, hostname unknown: inserts under MANUAL_PIN_HOSTNAME", async () => {
+    selectResult = { data: [], error: null };
+    upsertResult = { data: ownedRow(MANUAL_PIN_HOSTNAME, PATH), error: null };
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH);
+    expect(result).toEqual({
+      ok: true,
+      action: "insert",
+      recorded: { hostname: MANUAL_PIN_HOSTNAME, absolute_path: PATH },
+    });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idea_id: IDEA_ID,
+        owner_user_id: "user-1",
+        hostname: MANUAL_PIN_HOSTNAME,
+        absolute_path: PATH,
+      }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+  });
+
+  // Rework item 1 — the real hostname is now known (getMachineIdentity() on
+  // the client), so a fresh insert lands under IT, not the fake sentinel.
+  it("0 existing rows, real hostname known: inserts under the real hostname", async () => {
+    selectResult = { data: [], error: null };
+    upsertResult = { data: ownedRow(REAL_HOSTNAME, PATH), error: null };
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH, REAL_HOSTNAME);
+    expect(result).toEqual({
+      ok: true,
+      action: "insert",
+      recorded: { hostname: REAL_HOSTNAME, absolute_path: PATH },
+    });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: REAL_HOSTNAME, absolute_path: PATH }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+  });
+
+  // pin-and-record-disagree (exactly 1 row, different path, hostname unknown
+  // or not matching that row) — updates the lone row in place regardless.
+  it("exactly 1 existing row, hostname unknown: updates that row's own hostname in place", async () => {
+    selectResult = { data: [{ hostname: "Old-Machine.local" }], error: null };
+    upsertResult = { data: ownedRow("Old-Machine.local", PATH), error: null };
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH);
+    expect(result).toEqual({
+      ok: true,
+      action: "update",
+      recorded: { hostname: "Old-Machine.local", absolute_path: PATH },
+    });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: "Old-Machine.local", absolute_path: PATH }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+  });
+
+  // Precedence rule 1 — a row for the REAL hostname exists: that's the row to
+  // update, regardless of how many other rows exist (the >1-row "skip" rule
+  // existed only because the code couldn't tell which row was ours before).
+  it("real hostname known and a row for it exists: updates THAT row, even alongside other rows", async () => {
+    selectResult = {
+      data: [{ hostname: "other-machine" }, { hostname: REAL_HOSTNAME }],
+      error: null,
+    };
+    upsertResult = { data: ownedRow(REAL_HOSTNAME, PATH), error: null };
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH, REAL_HOSTNAME);
+    expect(result).toEqual({
+      ok: true,
+      action: "update",
+      recorded: { hostname: REAL_HOSTNAME, absolute_path: PATH },
+    });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: REAL_HOSTNAME, absolute_path: PATH }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+    // The other machine's row is never touched — only one upsert, keyed on ours.
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+  });
+
+  // >1 rows, none matching, but we KNOW our hostname: insert our own row. This
+  // used to skip, stranding the pin forever; the read (chooseLaunchCwd) now
+  // prefers the row keyed to this machine, so the inserted row is the one it
+  // picks — see decidePinMigration rule 4.
+  it(">1 existing rows, none matching, real hostname known: inserts OUR row", async () => {
+    selectResult = {
+      data: [{ hostname: "mac" }, { hostname: "linux" }],
+      error: null,
+    };
+    upsertResult = { data: ownedRow(REAL_HOSTNAME, PATH), error: null };
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH, REAL_HOSTNAME);
+    expect(result).toEqual({
+      ok: true,
+      action: "insert",
+      recorded: { hostname: REAL_HOSTNAME, absolute_path: PATH },
+    });
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: REAL_HOSTNAME, absolute_path: PATH }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+  });
+
+  it(">1 existing rows, hostname unknown: skips — writes nothing", async () => {
+    selectResult = {
+      data: [{ hostname: "mac" }, { hostname: "linux" }],
+      error: null,
+    };
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH);
+    expect(result).toEqual({ ok: true, action: "skip" });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  // migration run twice is a no-op (unknown hostname branch)
+  it("running twice converges to the same row state (idempotent, hostname unknown)", async () => {
+    // First run: 0 rows on file.
+    selectResult = { data: [], error: null };
+    upsertResult = { data: ownedRow(MANUAL_PIN_HOSTNAME, PATH), error: null };
+    const first = await migrateLaunchPathPin(IDEA_ID, PATH);
+    expect(first.action).toBe("insert");
+
+    // Second run: the row from the first run is now on file (same hostname).
+    selectResult = { data: [{ hostname: MANUAL_PIN_HOSTNAME }], error: null };
+    const second = await migrateLaunchPathPin(IDEA_ID, PATH);
+    expect(second).toEqual({
+      ok: true,
+      action: "update",
+      recorded: { hostname: MANUAL_PIN_HOSTNAME, absolute_path: PATH },
+    });
+    // Both calls converge on the identical (idea, hostname) upsert key — no
+    // duplicate/second row is ever created.
+    expect(mockUpsert).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ hostname: MANUAL_PIN_HOSTNAME, absolute_path: PATH }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+    expect(mockUpsert).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ hostname: MANUAL_PIN_HOSTNAME, absolute_path: PATH }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+  });
+
+  // The scenario the card explicitly calls out: migration writes under a real
+  // hostname, then a later agent launch re-records that SAME hostname with
+  // the same path (record_project_path's own upsert, mirrored here by a
+  // second migrateLaunchPathPin call now that a row for our hostname is on
+  // file) — must converge to ONE distinct row/path, never two.
+  it("migrating then a later same-machine re-record converges to one row, not two", async () => {
+    selectResult = { data: [], error: null };
+    upsertResult = { data: ownedRow(REAL_HOSTNAME, PATH), error: null };
+    const migrated = await migrateLaunchPathPin(IDEA_ID, PATH, REAL_HOSTNAME);
+    expect(migrated).toEqual({
+      ok: true,
+      action: "insert",
+      recorded: { hostname: REAL_HOSTNAME, absolute_path: PATH },
+    });
+
+    // The agent's own record_project_path self-heal call now sees that row.
+    selectResult = { data: [{ hostname: REAL_HOSTNAME }], error: null };
+    const relaunched = await migrateLaunchPathPin(IDEA_ID, PATH, REAL_HOSTNAME);
+    expect(relaunched).toEqual({
+      ok: true,
+      action: "update",
+      recorded: { hostname: REAL_HOSTNAME, absolute_path: PATH },
+    });
+
+    // Both writes target the SAME (idea, owner, hostname) conflict key — the
+    // upsert can only ever converge on one row, never fork into two.
+    expect(mockUpsert).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ hostname: REAL_HOSTNAME }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+    expect(mockUpsert).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ hostname: REAL_HOSTNAME }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+  });
+
+  it("rejects a non-absolute pin path without touching the database", async () => {
+    const result = await migrateLaunchPathPin(IDEA_ID, "~/relative/path");
+    expect(result).toEqual({ ok: false, action: "invalid" });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns unauthenticated when there's no session, and writes nothing", async () => {
+    userResult = null;
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH);
+    expect(result).toEqual({ ok: false, action: "unauthenticated" });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a row-lookup failure as action 'error' without throwing", async () => {
+    selectResult = { data: null, error: { message: "db unavailable" } };
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH);
+    expect(result).toEqual({ ok: false, action: "error" });
+  });
+
+  it("surfaces an upsert failure as action 'error' without throwing", async () => {
+    selectResult = { data: [], error: null };
+    upsertResult = { data: null, error: { message: "db unavailable" } };
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH);
+    expect(result).toEqual({ ok: false, action: "error" });
+  });
+
+  // A blank/whitespace-only hostname reads exactly like "not known" — falls
+  // back to MANUAL_PIN_HOSTNAME on insert, same as omitting it entirely.
+  it("treats a blank hostname the same as an unknown one", async () => {
+    selectResult = { data: [], error: null };
+    upsertResult = { data: ownedRow(MANUAL_PIN_HOSTNAME, PATH), error: null };
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH, "   ");
+    expect(result.action).toBe("insert");
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: MANUAL_PIN_HOSTNAME }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+  });
+
+  // Belt-and-braces ownership assertion: the written row must belong to the
+  // caller. If it doesn't (a future RLS-widening regression), fail loudly
+  // rather than silently reporting success on someone else's row.
+  it("fails when the upserted row comes back owned by someone else", async () => {
+    selectResult = { data: [], error: null };
+    upsertResult = { data: ownedRow(MANUAL_PIN_HOSTNAME, PATH, "someone-else"), error: null };
+    const result = await migrateLaunchPathPin(IDEA_ID, PATH);
+    expect(result).toEqual({ ok: false, action: "error" });
+  });
+});
+
+describe("saveManualProjectPath (the 'Set exact folder' dialog's server-side Save)", () => {
+  it("hostname unknown: upserts onto MANUAL_PIN_HOSTNAME regardless of existing rows (no row-count gating)", async () => {
+    upsertResult = { data: ownedRow(MANUAL_PIN_HOSTNAME, PATH), error: null };
+    const result = await saveManualProjectPath(IDEA_ID, `  ${PATH}  `);
+    expect(result).toEqual({ ok: true, recorded: { hostname: MANUAL_PIN_HOSTNAME, absolute_path: PATH } });
+    // Trimmed before it reaches the DB.
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: MANUAL_PIN_HOSTNAME, absolute_path: PATH }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+    // Unlike migrateLaunchPathPin, no row lookup happens first — this is a
+    // deliberate human write, not a migration decision.
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  // Rework item 1 — the dialog's Save now also prefers the real hostname.
+  it("real hostname known: upserts onto that hostname's row instead of the fallback", async () => {
+    upsertResult = { data: ownedRow(REAL_HOSTNAME, PATH), error: null };
+    const result = await saveManualProjectPath(IDEA_ID, PATH, REAL_HOSTNAME);
+    expect(result).toEqual({ ok: true, recorded: { hostname: REAL_HOSTNAME, absolute_path: PATH } });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: REAL_HOSTNAME, absolute_path: PATH }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+  });
+
+  it("a null hostname (getMachineIdentity() never set) falls back to MANUAL_PIN_HOSTNAME", async () => {
+    upsertResult = { data: ownedRow(MANUAL_PIN_HOSTNAME, PATH), error: null };
+    const result = await saveManualProjectPath(IDEA_ID, PATH, null);
+    expect(result).toEqual({ ok: true, recorded: { hostname: MANUAL_PIN_HOSTNAME, absolute_path: PATH } });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: MANUAL_PIN_HOSTNAME }),
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    );
+  });
+
+  it("rejects a non-absolute path", async () => {
+    const result = await saveManualProjectPath(IDEA_ID, "not/absolute");
+    expect(result).toEqual({ ok: false });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when unauthenticated", async () => {
+    userResult = null;
+    const result = await saveManualProjectPath(IDEA_ID, PATH);
+    expect(result).toEqual({ ok: false });
+  });
+
+  it("fails when the upserted row comes back owned by someone else", async () => {
+    upsertResult = { data: ownedRow(MANUAL_PIN_HOSTNAME, PATH, "someone-else"), error: null };
+    const result = await saveManualProjectPath(IDEA_ID, PATH);
+    expect(result).toEqual({ ok: false });
+  });
+});

--- a/src/actions/launch-path.ts
+++ b/src/actions/launch-path.ts
@@ -1,0 +1,190 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import {
+  decidePinMigration,
+  isValidAbsolutePath,
+  MANUAL_PIN_HOSTNAME,
+  type RecordedProjectPath,
+} from "@/lib/launch-claude-code";
+
+/**
+ * Server-side writes into `idea_project_paths` for the two human-initiated
+ * (non-agent) paths — see docs on `decidePinMigration` / `MANUAL_PIN_HOSTNAME`
+ * in src/lib/launch-claude-code.ts for the design this implements:
+ *
+ *  - `migrateLaunchPathPin` — the one-time fold-in of a pre-existing
+ *    localStorage "Set exact folder" pin into the server record, so the pin
+ *    can be retired as a read source without silently changing anyone's
+ *    launch folder.
+ *  - `saveManualProjectPath` — what the "Set exact folder" dialog now calls
+ *    on Save (existing-mode only), replacing the old direct-to-localStorage
+ *    write. Server-side means the pin now persists across browsers.
+ *
+ * Both take an optional `hostname` — this browser's real machine identity
+ * from `getMachineIdentity()` (`src/lib/terminal/machine-identity.ts`),
+ * read on the CLIENT (it's a localStorage read; these are server actions
+ * and can't read it themselves) and passed in. Falls back to
+ * `MANUAL_PIN_HOSTNAME` when null (a browser that has never had a terminal
+ * session, so it genuinely doesn't know its own hostname yet) — see
+ * `MANUAL_PIN_HOSTNAME`'s doc for why preferring the real hostname matters:
+ * a fake, account-wide sentinel row is what let one browser's manual pin
+ * silently become what every other browser/machine on the account resolves.
+ *
+ * Both run through the authenticated (RLS-scoped) client — `owner_user_id`
+ * always comes from the session, never a client-supplied value, matching the
+ * owner-only RLS policy on idea_project_paths (see migration 00123).
+ */
+
+export interface SavePinResult {
+  ok: boolean;
+  /** Present on success; omitted on auth/validation/db failure. */
+  recorded?: RecordedProjectPath;
+}
+
+/** Trim a caller-supplied hostname; empty/whitespace-only reads as "not known". */
+function normalizeHostname(hostname: string | null | undefined): string | null {
+  const trimmed = hostname?.trim();
+  return trimmed ? trimmed : null;
+}
+
+async function upsertProjectPath(
+  ideaId: string,
+  hostname: string,
+  absolutePath: string
+): Promise<SavePinResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false };
+
+  const { data, error } = await supabase
+    .from("idea_project_paths")
+    .upsert(
+      {
+        idea_id: ideaId,
+        owner_user_id: user.id,
+        hostname,
+        absolute_path: absolutePath,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "idea_id,owner_user_id,hostname" }
+    )
+    .select("owner_user_id, hostname, absolute_path")
+    .single();
+
+  if (error) {
+    logger.warn("launch-path upsert failed", { ideaId, hostname, error: error.message });
+    return { ok: false };
+  }
+
+  // Belt-and-braces ownership assertion (adopted from an earlier prototype of
+  // this action, mcp-server's `record_project_path` sibling): the row we just
+  // wrote must belong to the caller. Structurally this can't happen today —
+  // `owner_user_id` above always comes from the session, never client input,
+  // and the table's RLS policy independently enforces `auth.uid() =
+  // owner_user_id` (migration 00123) — but if either of those is ever
+  // weakened by a future refactor, this turns a silent misdirected write into
+  // a loud, logged failure instead of a leaked one.
+  if (data.owner_user_id !== user.id) {
+    logger.error("launch-path upsert returned a row owned by someone else", {
+      ideaId,
+      hostname,
+      callerId: user.id,
+      rowOwnerId: data.owner_user_id,
+    });
+    return { ok: false };
+  }
+
+  return { ok: true, recorded: { hostname: data.hostname, absolute_path: data.absolute_path } };
+}
+
+/**
+ * The "Set exact folder" dialog's Save, for existing-mode paths. Always
+ * upserts onto ONE dedicated row — `hostname` (this machine's real identity)
+ * when known, else `MANUAL_PIN_HOSTNAME` — rather than being routed through
+ * the 0/1/>1-row migration logic (that logic exists to avoid disturbing
+ * agent-recorded rows on a ONE-TIME, no-user-action migration; an explicit
+ * Save is a deliberate write from a known machine and should always land
+ * there).
+ *
+ * Known consequence (flagged, not solved here — no reconciliation UI per the
+ * card): if a DIFFERENT hostname's row already exists for this idea with a
+ * different path, this creates a second distinct path, and
+ * chooseLaunchCwd's contract makes the resolution ambiguous (source "none")
+ * rather than picking one. That's an honest reflection of a genuine
+ * multi-machine divergence (this machine really does use a different
+ * folder), not new ambiguity manufactured by this change.
+ */
+export async function saveManualProjectPath(
+  ideaId: string,
+  absolutePath: string,
+  hostname?: string | null
+): Promise<SavePinResult> {
+  const trimmed = absolutePath.trim();
+  if (!isValidAbsolutePath(trimmed)) return { ok: false };
+  return upsertProjectPath(ideaId, normalizeHostname(hostname) ?? MANUAL_PIN_HOSTNAME, trimmed);
+}
+
+export interface MigratePinResult extends SavePinResult {
+  action: "insert" | "update" | "skip" | "invalid" | "unauthenticated" | "error";
+}
+
+/**
+ * One-time migration of a pre-existing browser pin into `idea_project_paths`.
+ * Called by `useLaunchPathPinMigration` on first board load per idea, ONLY
+ * when a localStorage existing-mode pin is still present (the hook clears it
+ * on success, so this naturally stops running once migrated — no separate
+ * "migrated" flag needed).
+ *
+ * Decision delegated to `decidePinMigration` (pure, unit-tested) against the
+ * CURRENT rows for (idea, user) AND `hostname` — this machine's real identity
+ * from `getMachineIdentity()`, passed in from the client (see this module's
+ * top-of-file doc) — see `decidePinMigration`'s doc for the full precedence
+ * table (a row for the real hostname wins outright; otherwise falls back to
+ * the original 0/1/>1-row logic, using the real hostname instead of
+ * `MANUAL_PIN_HOSTNAME` for a fresh insert when it's known).
+ *
+ * Idempotent: re-running with the same pin path converges to the same row
+ * state in every branch (upsert on the decided hostname, or no write at all).
+ */
+export async function migrateLaunchPathPin(
+  ideaId: string,
+  pinPath: string,
+  hostname?: string | null
+): Promise<MigratePinResult> {
+  const trimmed = pinPath.trim();
+  if (!isValidAbsolutePath(trimmed)) return { ok: false, action: "invalid" };
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, action: "unauthenticated" };
+
+  const { data: rows, error: selectError } = await supabase
+    .from("idea_project_paths")
+    .select("hostname")
+    .eq("idea_id", ideaId)
+    .eq("owner_user_id", user.id);
+
+  if (selectError) {
+    logger.warn("migrateLaunchPathPin: row lookup failed", {
+      ideaId,
+      error: selectError.message,
+    });
+    return { ok: false, action: "error" };
+  }
+
+  const decision = decidePinMigration(rows ?? [], normalizeHostname(hostname));
+  if (decision.action === "skip") {
+    logger.debug("migrateLaunchPathPin: skipped (ambiguous — >1 recorded rows)", { ideaId });
+    return { ok: true, action: "skip" };
+  }
+
+  const result = await upsertProjectPath(ideaId, decision.hostname!, trimmed);
+  if (!result.ok) return { ok: false, action: "error" };
+  return { ok: true, action: decision.action, recorded: result.recorded };
+}

--- a/src/components/board/board-launch-context.tsx
+++ b/src/components/board/board-launch-context.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext } from "react";
 import type { RecordedProjectPath } from "@/lib/launch-claude-code";
+import { useLaunchPathPinMigration } from "@/hooks/use-launch-path-pin-migration";
 
 /**
  * Idea-level context for the "Launch Claude Code" feature so per-task surfaces
@@ -32,6 +33,9 @@ export function BoardLaunchProvider({
   value: BoardLaunchContextValue;
   children: React.ReactNode;
 }) {
+  // Mounted once per board load (unlike LaunchClaudeCodeButton, which renders
+  // once per task) — the right place for the one-time browser-pin migration.
+  useLaunchPathPinMigration(value.ideaId);
   return <BoardLaunchContext.Provider value={value}>{children}</BoardLaunchContext.Provider>;
 }
 

--- a/src/components/board/launch-claude-code-button.tsx
+++ b/src/components/board/launch-claude-code-button.tsx
@@ -25,6 +25,7 @@ import {
   buildBoardBootstrapPrompt,
   buildTaskBootstrapPrompt,
   buildCompactPromptEssentials,
+  mergeRecordedPath,
   readLaunchPath,
   resolveAppUrl,
   resolveDefaultLaunchState,
@@ -33,6 +34,7 @@ import {
 } from "@/lib/launch-claude-code";
 import { LaunchPathDialog } from "./launch-path-dialog";
 import { isTerminalEnabled } from "@/lib/terminal/connection";
+import { getMachineIdentity } from "@/lib/terminal/machine-identity";
 import { isBrowserLaunchAvailable, requestBrowserLaunch } from "@/lib/terminal/launch-mode";
 
 const APP_URL = resolveAppUrl();
@@ -71,31 +73,53 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
   const { ideaId, ideaTitle, ideaGithubUrl, recordedProjectPaths } = props;
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
-  // The user's saved localStorage config, mirrored into state so a save in the
-  // dialog (or an open from another tab) re-renders the dropdown immediately.
-  // Lazily initialised — readLaunchPath is SSR-safe (returns null on the server).
+  // The user's saved localStorage config — CREATE-NEW mode only now (an
+  // existing-mode pin is retired as a read source; see resolveDefaultLaunchState).
+  // Mirrored into state so a save in the dialog (or an open from another tab)
+  // re-renders the dropdown immediately. Lazily initialised — readLaunchPath is
+  // SSR-safe (returns null on the server).
   const [savedState, setSavedState] = useState<LaunchPathState | null>(() =>
     readLaunchPath(ideaId)
   );
 
+  // An existing-mode path just saved through the dialog (server write — see
+  // saveManualProjectPath) or migrated from a pre-existing pin, mirrored here so
+  // the dropdown/launch reflect it immediately without waiting for the next SSR
+  // load of `recordedProjectPaths`. Merged into the recorded set below.
+  const [manualPin, setManualPin] = useState<RecordedProjectPath | null>(null);
+
+  // This browser's real machine hostname, as announced by a bridge on a previous
+  // terminal session. Lets the resolver below pick the recorded folder keyed to
+  // THIS machine when several are on file with different paths — without it,
+  // that case resolves to nothing and the user is asked every launch. Lazily
+  // initialised like savedState above; getMachineIdentity is SSR-safe (null on
+  // the server) and no product flow ever clears it, so it never needs
+  // refreshing mid-session — a first-ever bridge announcement lands before the
+  // next page load, which is when a recorded path would first exist anyway.
+  const [realHostname] = useState<string | null>(() => getMachineIdentity());
+
   // Re-read localStorage (call after a dialog save or when the dropdown opens, so
-  // we never show a stale path).
+  // we never show a stale new-mode path).
   const refreshSaved = useCallback(() => {
     setSavedState(readLaunchPath(ideaId));
   }, [ideaId]);
 
-  // Single source of truth for DISPLAY + LAUNCH cwd. The saved existing-mode path
-  // (localStorage — what "Set exact folder" writes) takes precedence over the
-  // agent-recorded DB path, so the dropdown's path line and the launched cwd can
-  // never diverge. Repo-backed ideas resolve via the `repo` slug → no cwd.
+  const effectiveRecordedPaths = useMemo(
+    () => mergeRecordedPath(recordedProjectPaths, manualPin),
+    [recordedProjectPaths, manualPin]
+  );
+
+  // Single source of truth for DISPLAY + LAUNCH cwd — server-recorded paths
+  // only (idea_project_paths, including any manual pin above). Repo-backed
+  // ideas resolve via the `repo` slug when nothing is known → no cwd.
   const effectiveTarget = useMemo(
     () =>
       resolveEffectiveLaunchTarget({
         hasRepo: !!ideaGithubUrl,
-        saved: savedState,
-        recordedPaths: recordedProjectPaths,
+        recordedPaths: effectiveRecordedPaths,
+        realHostname,
       }),
-    [ideaGithubUrl, savedState, recordedProjectPaths]
+    [ideaGithubUrl, effectiveRecordedPaths, realHostname]
   );
 
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -383,10 +407,18 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
   }, []);
 
   const handleSaved = useCallback(
-    (state: LaunchPathState) => {
-      // Mirror the freshly-saved state so the dropdown's path line + launch cwd
-      // update immediately (both read from effectiveTarget ← savedState).
-      setSavedState(state);
+    (state: LaunchPathState, recordedPath?: RecordedProjectPath) => {
+      // New-mode saves still mirror into the localStorage-backed state (the
+      // browser store's one surviving job). Existing-mode saves now write to
+      // the server (see LaunchPathDialog); `recordedPath` is that write's
+      // optimistic echo, merged into `effectiveRecordedPaths` so the dropdown's
+      // path line + launch cwd update immediately, without waiting on a fresh
+      // SSR load of `recordedProjectPaths`.
+      if (state.mode === "new") {
+        setSavedState(state);
+      } else if (recordedPath) {
+        setManualPin(recordedPath);
+      }
       if (pendingLaunch) {
         setPendingLaunch(false);
         openInClaudeCode(state);
@@ -395,13 +427,26 @@ export function LaunchClaudeCodeButton(props: LaunchClaudeCodeButtonProps) {
     [pendingLaunch, openInClaudeCode]
   );
 
+  // The dialog's prefill: a create-new draft still comes from localStorage
+  // (savedState); an existing-folder prefill now comes from the server-derived
+  // effectiveTarget instead of the retired localStorage pin, so editing "Set
+  // exact folder" always starts from the CURRENT authoritative path, not a
+  // stale browser value.
+  const initialForDialog: LaunchPathState | null = useMemo(() => {
+    if (savedState && savedState.mode === "new") return savedState;
+    if (effectiveTarget.source !== "none" && effectiveTarget.displayPath) {
+      return { mode: "existing", path: effectiveTarget.displayPath };
+    }
+    return null;
+  }, [savedState, effectiveTarget]);
+
   const dialog = (
     <LaunchPathDialog
       open={dialogOpen}
       onOpenChange={setDialogOpen}
       ideaId={ideaId}
       ideaGithubUrl={ideaGithubUrl}
-      initial={savedState}
+      initial={initialForDialog}
       initialMode={dialogMode}
       launchOnSave={pendingLaunch}
       onSaved={handleSaved}

--- a/src/components/board/launch-path-dialog.test.tsx
+++ b/src/components/board/launch-path-dialog.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+// Radix Dialog uses ResizeObserver, which jsdom lacks (same stub as
+// launch-claude-code-button.test.tsx / task-edit-dialog.test.tsx).
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (...a: unknown[]) => toastError(...a) },
+}));
+
+const mockSaveManualProjectPath = vi.fn();
+vi.mock("@/actions/launch-path", () => ({
+  saveManualProjectPath: (...args: unknown[]) => mockSaveManualProjectPath(...args),
+}));
+
+// The dialog's Save now reads the browser's real machine hostname (rework
+// item 1 — getMachineIdentity() was wrongly believed unavailable when this
+// feature was investigated) and passes it through to saveManualProjectPath.
+// Defaults to null (unknown) here; individual tests override it.
+let mockMachineIdentity: string | null = null;
+vi.mock("@/lib/terminal/machine-identity", () => ({
+  getMachineIdentity: () => mockMachineIdentity,
+}));
+
+import { LaunchPathDialog } from "./launch-path-dialog";
+import { MANUAL_PIN_HOSTNAME } from "@/lib/launch-claude-code";
+
+afterEach(cleanup);
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMachineIdentity = null;
+});
+
+describe("LaunchPathDialog — existing-mode Save writes to the server, not localStorage", () => {
+  it("saves through saveManualProjectPath and echoes the recorded row to onSaved", async () => {
+    mockSaveManualProjectPath.mockResolvedValue({
+      ok: true,
+      recorded: { hostname: MANUAL_PIN_HOSTNAME, absolute_path: "/Users/nick/projects/widget" },
+    });
+    const onSaved = vi.fn();
+
+    render(
+      <LaunchPathDialog
+        open
+        onOpenChange={() => {}}
+        ideaId="idea-1"
+        ideaGithubUrl={null}
+        initial={null}
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Absolute path on your computer"), {
+      target: { value: "/Users/nick/projects/widget" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mockSaveManualProjectPath).toHaveBeenCalledWith(
+        "idea-1",
+        "/Users/nick/projects/widget",
+        null
+      )
+    );
+    await waitFor(() =>
+      expect(onSaved).toHaveBeenCalledWith(
+        { mode: "existing", path: "/Users/nick/projects/widget" },
+        { hostname: MANUAL_PIN_HOSTNAME, absolute_path: "/Users/nick/projects/widget" }
+      )
+    );
+  });
+
+  // Rework item 1 — when this browser's real hostname IS known
+  // (getMachineIdentity() has a value), Save passes it through so the row
+  // lands under the real machine instead of the MANUAL_PIN_HOSTNAME fallback.
+  it("passes the real machine hostname through to saveManualProjectPath when known", async () => {
+    mockMachineIdentity = "Nicks-MacBook-Pro.local";
+    mockSaveManualProjectPath.mockResolvedValue({
+      ok: true,
+      recorded: { hostname: "Nicks-MacBook-Pro.local", absolute_path: "/Users/nick/projects/widget" },
+    });
+    const onSaved = vi.fn();
+
+    render(
+      <LaunchPathDialog
+        open
+        onOpenChange={() => {}}
+        ideaId="idea-1"
+        ideaGithubUrl={null}
+        initial={null}
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Absolute path on your computer"), {
+      target: { value: "/Users/nick/projects/widget" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mockSaveManualProjectPath).toHaveBeenCalledWith(
+        "idea-1",
+        "/Users/nick/projects/widget",
+        "Nicks-MacBook-Pro.local"
+      )
+    );
+    await waitFor(() =>
+      expect(onSaved).toHaveBeenCalledWith(
+        { mode: "existing", path: "/Users/nick/projects/widget" },
+        { hostname: "Nicks-MacBook-Pro.local", absolute_path: "/Users/nick/projects/widget" }
+      )
+    );
+  });
+
+  it("shows an error toast and does not call onSaved when the server write fails", async () => {
+    mockSaveManualProjectPath.mockResolvedValue({ ok: false });
+    const onSaved = vi.fn();
+
+    render(
+      <LaunchPathDialog
+        open
+        onOpenChange={() => {}}
+        ideaId="idea-1"
+        ideaGithubUrl={null}
+        initial={null}
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Absolute path on your computer"), {
+      target: { value: "/Users/nick/projects/widget" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("blocks Save (never calls the server) for a non-expanded path", () => {
+    render(
+      <LaunchPathDialog
+        open
+        onOpenChange={() => {}}
+        ideaId="idea-1"
+        ideaGithubUrl={null}
+        initial={null}
+        onSaved={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Absolute path on your computer"), {
+      target: { value: "~/projects/widget" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mockSaveManualProjectPath).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/fully-expanded absolute path/i);
+  });
+
+  // Create-new mode is untouched by this fix — still localStorage, never the server.
+  it("create-new mode never calls saveManualProjectPath", () => {
+    const onSaved = vi.fn();
+    render(
+      <LaunchPathDialog
+        open
+        onOpenChange={() => {}}
+        ideaId="idea-1"
+        ideaGithubUrl={null}
+        initial={null}
+        initialMode="new"
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("New folder name"), { target: { value: "my-idea" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(mockSaveManualProjectPath).not.toHaveBeenCalled();
+    expect(onSaved).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "new", name: "my-idea" }),
+      undefined
+    );
+  });
+});

--- a/src/components/board/launch-path-dialog.tsx
+++ b/src/components/board/launch-path-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { FolderOpen, FolderPlus, Lock, GitBranch, AlertTriangle } from "lucide-react";
 import {
   Dialog,
@@ -17,6 +18,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   type LaunchMode,
   type LaunchPathState,
+  type RecordedProjectPath,
   composeNewProjectPath,
   validateFolderName,
   looksAbsolutePath,
@@ -25,6 +27,8 @@ import {
   writeLaunchPath,
   DEFAULT_NEW_PROJECT_PARENT,
 } from "@/lib/launch-claude-code";
+import { saveManualProjectPath } from "@/actions/launch-path";
+import { getMachineIdentity } from "@/lib/terminal/machine-identity";
 
 interface LaunchPathDialogProps {
   open: boolean;
@@ -37,8 +41,13 @@ interface LaunchPathDialogProps {
   initialMode?: LaunchMode;
   /** When true the primary CTA continues the launch after saving. */
   launchOnSave?: boolean;
-  /** Called with the freshly-saved state so the caller can continue the launch. */
-  onSaved: (state: LaunchPathState) => void;
+  /**
+   * Called with the freshly-saved state so the caller can continue the launch.
+   * For an existing-mode save, `recordedPath` is the server row that was just
+   * written (see `saveManualProjectPath`) so the caller can reflect it
+   * immediately without waiting on a fresh server read.
+   */
+  onSaved: (state: LaunchPathState, recordedPath?: RecordedProjectPath) => void;
 }
 
 export function LaunchPathDialog({
@@ -56,6 +65,10 @@ export function LaunchPathDialog({
   const [parent, setParent] = useState(initial?.parent ?? DEFAULT_NEW_PROJECT_PARENT);
   const [name, setName] = useState(initial?.name ?? "");
   const [error, setError] = useState<string | null>(null);
+  // Existing-mode Save now round-trips to the server (idea_project_paths) —
+  // see saveManualProjectPath. Guards a double-submit and disables the CTA
+  // while the write is in flight.
+  const [saving, setSaving] = useState(false);
 
   const pathRef = useRef<HTMLInputElement>(null);
   const parentRef = useRef<HTMLInputElement>(null);
@@ -84,7 +97,7 @@ export function LaunchPathDialog({
     setError(null);
   }
 
-  function handleSave() {
+  async function handleSave() {
     if (mode === "existing") {
       const trimmed = path.trim();
       if (!trimmed) {
@@ -101,13 +114,27 @@ export function LaunchPathDialog({
         pathRef.current?.focus();
         return;
       }
+      // Existing-mode folders are now recorded server-side (idea_project_paths)
+      // instead of localStorage — this is what makes the pin persist across
+      // browsers, and what retires the two-independent-stores bug the pin used
+      // to cause (see resolveEffectiveLaunchTarget). Pass this browser's real
+      // machine hostname (if a terminal session has ever announced one) so the
+      // row lands under it rather than the MANUAL_PIN_HOSTNAME fallback — see
+      // saveManualProjectPath's doc.
       const state: LaunchPathState = { mode: "existing", path: trimmed };
-      writeLaunchPath(ideaId, state);
-      finish(state);
+      setSaving(true);
+      const result = await saveManualProjectPath(ideaId, trimmed, getMachineIdentity());
+      setSaving(false);
+      if (!result.ok) {
+        toast.error("Couldn't save the project folder — try again");
+        return;
+      }
+      finish(state, result.recorded);
       return;
     }
 
-    // Create-new mode
+    // Create-new mode — no server-side folder exists yet to record, so this
+    // still lives in localStorage (the one job the browser store keeps).
     const parentTrimmed = parent.trim();
     if (!parentTrimmed) {
       setError("Enter where to create the project (a parent folder).");
@@ -131,8 +158,8 @@ export function LaunchPathDialog({
     finish(state);
   }
 
-  function finish(state: LaunchPathState) {
-    onSaved(state);
+  function finish(state: LaunchPathState, recordedPath?: RecordedProjectPath) {
+    onSaved(state, recordedPath);
     onOpenChange(false);
   }
 
@@ -142,8 +169,9 @@ export function LaunchPathDialog({
   const existingNotAbsolute = mode === "existing" && path.trim() !== "" && !isValidAbsolutePath(path);
   const parentNotAbsolute = mode === "new" && parent.trim() !== "" && !looksAbsolutePath(parent);
 
-  const saveLabel =
-    mode === "new"
+  const saveLabel = saving
+    ? "Saving…"
+    : mode === "new"
       ? launchOnSave
         ? "Create & launch"
         : "Create"
@@ -320,7 +348,11 @@ export function LaunchPathDialog({
             <Lock className="h-3 w-3" />
             Private to you
           </span>
-          <span>Stored on this device only — never shown to other collaborators.</span>
+          <span>
+            {mode === "existing"
+              ? "Saved to your account — follows you between browsers, never shown to other collaborators."
+              : "Stored on this device only — never shown to other collaborators."}
+          </span>
         </div>
 
         {error && (
@@ -334,7 +366,9 @@ export function LaunchPathDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={handleSave}>{saveLabel}</Button>
+          <Button onClick={() => void handleSave()} disabled={saving}>
+            {saveLabel}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -87,7 +87,6 @@ import { type BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
 import {
   buildBoundedDeepLink,
   buildCompactPromptEssentials,
-  readLaunchPath,
   resolveAppUrl,
   resolveDefaultLaunchState,
   resolveEffectiveLaunchTarget,
@@ -100,7 +99,7 @@ import {
   resolveTerminalPlatform,
 } from "@/lib/terminal/platform";
 import { isBrowserPaired, markBrowserPaired, resolveFirstRunEntry } from "@/lib/terminal/paired-flag";
-import { setMachineIdentity } from "@/lib/terminal/machine-identity";
+import { getMachineIdentity, setMachineIdentity } from "@/lib/terminal/machine-identity";
 import { type LaunchPhase, nextLaunchPhaseOnTimeout } from "@/lib/terminal/first-run-flow";
 import { consumeRecentHelperIdleQuit } from "@/lib/terminal/helper-relaunch-signal";
 import {
@@ -954,8 +953,12 @@ export function useTerminalSession(
     if (carried) return carried;
     const effectiveTarget = resolveEffectiveLaunchTarget({
       hasRepo: !!ideaGithubUrl,
-      saved: readLaunchPath(ideaId),
       recordedPaths: recordedProjectPaths,
+      // Read fresh rather than captured: this runs at launch time, and a bridge
+      // may have announced this machine's hostname earlier in THIS session (see
+      // setMachineIdentity below) — the button's render-time snapshot can't see
+      // that, but a launch fired afterwards should.
+      realHostname: getMachineIdentity(),
     });
     const s = resolveDefaultLaunchState(ideaId, ideaTitle, ideaGithubUrl, effectiveTarget);
     const essentials = buildCompactPromptEssentials({

--- a/src/hooks/use-launch-path-pin-migration.test.ts
+++ b/src/hooks/use-launch-path-pin-migration.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+// jsdom in this project doesn't expose window.localStorage by default.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+Object.defineProperty(window, "localStorage", { value: localStorageMock, configurable: true });
+
+const mockMigrate = vi.fn();
+vi.mock("@/actions/launch-path", () => ({
+  migrateLaunchPathPin: (...args: unknown[]) => mockMigrate(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { useLaunchPathPinMigration } from "./use-launch-path-pin-migration";
+import { launchPathKey, readLaunchPath } from "@/lib/launch-claude-code";
+import { MACHINE_IDENTITY_KEY } from "@/lib/terminal/machine-identity";
+
+const IDEA_ID = "idea-1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe("useLaunchPathPinMigration", () => {
+  // no-pin-unchanged
+  it("no pin on file: never calls the migration action", async () => {
+    renderHook(() => useLaunchPathPinMigration(IDEA_ID));
+    // Give any stray microtask a chance to run, then assert nothing fired.
+    await Promise.resolve();
+    expect(mockMigrate).not.toHaveBeenCalled();
+  });
+
+  // create-new unchanged: a mode:"new" pin is never migrated (it stays local)
+  it("a create-new (mode: new) pin is left untouched — never migrated", async () => {
+    window.localStorage.setItem(
+      launchPathKey(IDEA_ID),
+      JSON.stringify({ mode: "new", path: "~/projects/x", parent: "~/projects", name: "x" })
+    );
+    renderHook(() => useLaunchPathPinMigration(IDEA_ID));
+    await Promise.resolve();
+    expect(mockMigrate).not.toHaveBeenCalled();
+    // Still there — nothing cleared it.
+    expect(readLaunchPath(IDEA_ID)).toMatchObject({ mode: "new" });
+  });
+
+  // pin-exists-and-migrates. getMachineIdentity() reads the SAME window.localStorage
+  // mock this suite stubs, and nothing has ever set MACHINE_IDENTITY_KEY here,
+  // so it's genuinely null (an honest "we don't know yet") — the migration call
+  // must reflect that rather than silently omitting the argument.
+  it("an existing-mode pin migrates (hostname unknown) and is then cleared from localStorage", async () => {
+    mockMigrate.mockResolvedValue({ ok: true, action: "insert" });
+    window.localStorage.setItem(
+      launchPathKey(IDEA_ID),
+      JSON.stringify({ mode: "existing", path: "/Users/nick/projects/widget" })
+    );
+
+    renderHook(() => useLaunchPathPinMigration(IDEA_ID));
+
+    expect(mockMigrate).toHaveBeenCalledWith(IDEA_ID, "/Users/nick/projects/widget", null);
+    await waitFor(() => expect(readLaunchPath(IDEA_ID)).toBeNull());
+  });
+
+  // Rework item 1 — when a terminal session has already announced this
+  // browser's real hostname (machine-identity.ts, set from the SAME
+  // window.localStorage this suite stubs), the migration passes it through
+  // instead of leaving the server action to fall back to MANUAL_PIN_HOSTNAME.
+  it("an existing-mode pin migrates WITH the real machine hostname when known", async () => {
+    mockMigrate.mockResolvedValue({ ok: true, action: "insert" });
+    window.localStorage.setItem(MACHINE_IDENTITY_KEY, "Nicks-MacBook-Pro.local");
+    window.localStorage.setItem(
+      launchPathKey(IDEA_ID),
+      JSON.stringify({ mode: "existing", path: "/Users/nick/projects/widget" })
+    );
+
+    renderHook(() => useLaunchPathPinMigration(IDEA_ID));
+
+    expect(mockMigrate).toHaveBeenCalledWith(
+      IDEA_ID,
+      "/Users/nick/projects/widget",
+      "Nicks-MacBook-Pro.local"
+    );
+    await waitFor(() => expect(readLaunchPath(IDEA_ID)).toBeNull());
+  });
+
+  it("leaves the pin in place on migration failure, so the next load retries", async () => {
+    mockMigrate.mockResolvedValue({ ok: false, action: "error" });
+    window.localStorage.setItem(
+      launchPathKey(IDEA_ID),
+      JSON.stringify({ mode: "existing", path: "/Users/nick/projects/widget" })
+    );
+
+    renderHook(() => useLaunchPathPinMigration(IDEA_ID));
+
+    await waitFor(() => expect(mockMigrate).toHaveBeenCalledTimes(1));
+    expect(readLaunchPath(IDEA_ID)).toMatchObject({ path: "/Users/nick/projects/widget" });
+  });
+
+  // Regression coverage for the data-loss defect this rework fixes: `skip`
+  // comes back `ok: true` (nothing "failed"), but decidePinMigration's >1-rows
+  // branch writes NOTHING server-side — so unlike every other `ok: true`
+  // action, the pin is the only surviving record of the folder and must NOT
+  // be cleared. Paired with the insert/update cases below so the "cleared vs
+  // kept" split can't silently regress in either direction.
+  it("skip action: nothing was written server-side, so the pin survives", async () => {
+    mockMigrate.mockResolvedValue({ ok: true, action: "skip" });
+    window.localStorage.setItem(
+      launchPathKey(IDEA_ID),
+      JSON.stringify({ mode: "existing", path: "/Users/nick/projects/widget" })
+    );
+
+    renderHook(() => useLaunchPathPinMigration(IDEA_ID));
+
+    await waitFor(() => expect(mockMigrate).toHaveBeenCalledTimes(1));
+    expect(readLaunchPath(IDEA_ID)).toMatchObject({ path: "/Users/nick/projects/widget" });
+  });
+
+  it("insert action: something was written server-side, so the pin is cleared", async () => {
+    mockMigrate.mockResolvedValue({ ok: true, action: "insert" });
+    window.localStorage.setItem(
+      launchPathKey(IDEA_ID),
+      JSON.stringify({ mode: "existing", path: "/Users/nick/projects/widget" })
+    );
+
+    renderHook(() => useLaunchPathPinMigration(IDEA_ID));
+
+    await waitFor(() => expect(readLaunchPath(IDEA_ID)).toBeNull());
+  });
+
+  it("update action: something was written server-side, so the pin is cleared", async () => {
+    mockMigrate.mockResolvedValue({ ok: true, action: "update" });
+    window.localStorage.setItem(
+      launchPathKey(IDEA_ID),
+      JSON.stringify({ mode: "existing", path: "/Users/nick/projects/widget" })
+    );
+
+    renderHook(() => useLaunchPathPinMigration(IDEA_ID));
+
+    await waitFor(() => expect(readLaunchPath(IDEA_ID)).toBeNull());
+  });
+
+  // Micro-fix: readLaunchPath doesn't validate what it reads back, so a
+  // corrupted/hand-edited pin (relative path here) would otherwise reach
+  // migrateLaunchPathPin, get rejected as action:"invalid" -> ok:false, and
+  // then — under the old "only clear on ok" logic — never be cleared, retrying
+  // and warn-logging on every board load forever. It must be dropped
+  // immediately instead, without even calling the migration action.
+  it("an invalid pin (fails isValidAbsolutePath) is discarded immediately, without calling migrate", async () => {
+    window.localStorage.setItem(
+      launchPathKey(IDEA_ID),
+      JSON.stringify({ mode: "existing", path: "not/an/absolute/path" })
+    );
+
+    renderHook(() => useLaunchPathPinMigration(IDEA_ID));
+    await waitFor(() => expect(readLaunchPath(IDEA_ID)).toBeNull());
+    expect(mockMigrate).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-launch-path-pin-migration.ts
+++ b/src/hooks/use-launch-path-pin-migration.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { migrateLaunchPathPin } from "@/actions/launch-path";
+import { clearLaunchPathPin, isValidAbsolutePath, readLaunchPath } from "@/lib/launch-claude-code";
+import { getMachineIdentity } from "@/lib/terminal/machine-identity";
+import { logger } from "@/lib/logger";
+
+/**
+ * One-time fold-in of a pre-existing "Set exact folder" localStorage pin into
+ * `idea_project_paths` (server) — see `migrateLaunchPathPin` /
+ * `decidePinMigration` for the full decision. Mounted once per idea (in
+ * `BoardLaunchProvider`, not per launch-button instance — a board can render
+ * several launch buttons for the same idea, and this must not fire once per
+ * button).
+ *
+ * Runs only when an EXISTING-mode pin is still in localStorage; the pin is
+ * cleared ONLY when something was actually written for it — `result.ok &&
+ * result.action !== "skip"` — so it a) stops being read anywhere (retired
+ * per the fix) once folded into the server record, and b) this effect
+ * naturally becomes a no-op on the next mount for that case — no separate
+ * "already migrated" flag needed. A failure (network/RLS/etc.), or a "skip"
+ * (decidePinMigration's >1-rows, none-matching case, which deliberately
+ * writes nothing server-side — see its doc), leaves the pin in place so the
+ * next page load retries — self-healing, matching the project's
+ * `record_project_path` self-heal pattern. Critically, "skip" must NOT clear
+ * the pin: nothing was saved server-side, so the pin is the only record of
+ * this folder that exists anywhere — deleting it here would be pure data
+ * loss, not a retry.
+ *
+ * A pin that fails `isValidAbsolutePath` is a separate, TERMINAL case: no
+ * retry can ever fix it (the server action rejects it the same way, every
+ * time), so it's cleared immediately, client-side, before even calling the
+ * server — otherwise it would silently retry-and-warn-log on every single
+ * board load, forever.
+ *
+ * Passes `getMachineIdentity()` — this browser's real machine hostname, if a
+ * terminal session has ever announced one — so the migration can land on
+ * this machine's own row instead of the `MANUAL_PIN_HOSTNAME` fallback (see
+ * `decidePinMigration`'s precedence table in launch-claude-code.ts).
+ */
+export function useLaunchPathPinMigration(ideaId: string): void {
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    // Guards a double-invoke within the SAME mount (e.g. React StrictMode) —
+    // NOT cross-mount persistence; that's what clearing the pin on success is
+    // for. A failed attempt intentionally resets nothing here, either: the
+    // next full mount (e.g. navigating back to the board) retries via the
+    // localStorage-presence check itself, no extra bookkeeping required.
+    if (attempted.current) return;
+
+    const pin = readLaunchPath(ideaId);
+    if (!pin || pin.mode !== "existing") return;
+
+    // readLaunchPath doesn't validate what it reads back, so a corrupted or
+    // hand-edited pin can reach here looking like a normal one. It would fail
+    // this same check server-side (migrateLaunchPathPin's own
+    // isValidAbsolutePath guard) on every retry forever — checking here first
+    // lets us drop it once, terminally, instead of round-tripping to the
+    // server and warn-logging on every board load.
+    if (!isValidAbsolutePath(pin.path)) {
+      clearLaunchPathPin(ideaId);
+      return;
+    }
+
+    attempted.current = true;
+    void migrateLaunchPathPin(ideaId, pin.path, getMachineIdentity()).then((result) => {
+      // "skip" is `ok: true` but writes nothing server-side (decidePinMigration's
+      // >1-rows, none-matching case) — the pin must survive it, or the only
+      // record of this folder is destroyed for nothing. Only clear once
+      // something was actually saved.
+      if (result.ok && result.action !== "skip") {
+        clearLaunchPathPin(ideaId);
+      } else if (result.action === "skip") {
+        logger.debug("launch path pin migration skipped (ambiguous rows), pin kept", { ideaId });
+      } else {
+        logger.warn("launch path pin migration failed, will retry next load", {
+          ideaId,
+          action: result.action,
+        });
+      }
+    });
+  }, [ideaId]);
+}

--- a/src/lib/launch-claude-code.test.ts
+++ b/src/lib/launch-claude-code.test.ts
@@ -46,10 +46,14 @@ import {
   buildLaunchCommand,
   readLaunchPath,
   writeLaunchPath,
+  clearLaunchPathPin,
   launchPathKey,
   slugifyIdeaTitle,
   DEFAULT_NEW_PROJECT_PARENT,
   buildWorktreeIsolationProtocol,
+  mergeRecordedPath,
+  decidePinMigration,
+  MANUAL_PIN_HOSTNAME,
 } from "./launch-claude-code";
 
 const APP_URL = "https://staging.vibecodes.co.uk";
@@ -562,6 +566,20 @@ describe("localStorage persistence", () => {
     window.localStorage.setItem(launchPathKey("idea-1"), JSON.stringify({ path: "/x" }));
     expect(readLaunchPath("idea-1")?.mode).toBe("existing");
   });
+
+  // clearLaunchPathPin: what useLaunchPathPinMigration calls after a successful
+  // migration so the pin stops being read (and re-migrated) on the next load.
+  it("clearLaunchPathPin removes the stored entry", () => {
+    writeLaunchPath("idea-1", { mode: "existing", path: "/Users/me/x" });
+    expect(readLaunchPath("idea-1")).not.toBeNull();
+    clearLaunchPathPin("idea-1");
+    expect(readLaunchPath("idea-1")).toBeNull();
+  });
+
+  it("clearLaunchPathPin is a safe no-op when nothing is stored", () => {
+    expect(() => clearLaunchPathPin("idea-with-nothing-stored")).not.toThrow();
+    expect(readLaunchPath("idea-with-nothing-stored")).toBeNull();
+  });
 });
 
 describe("slugifyIdeaTitle", () => {
@@ -733,66 +751,122 @@ describe("chooseLaunchCwd (hostname rule — Design Review option (a))", () => {
       ])
     ).toBeUndefined();
   });
+
+  // ── rule 1: this machine's own row wins ───────────────────────────────────
+  // idea_project_paths is keyed (idea_id, owner_user_id, hostname). A row under
+  // THIS browser's real hostname is this machine's folder by that key, so the
+  // read now uses the same three-part key the write does instead of only
+  // resolving when every machine happens to agree on one path.
+  describe("machine-aware read (realHostname)", () => {
+    const twoMachines = [
+      { absolute_path: "/Users/nick/projects/x", hostname: "Nicks-MacBook-Pro.local" },
+      { absolute_path: "/home/nick/code/x", hostname: "linux-box" },
+    ];
+
+    it("THE fix: >1 distinct paths but one row is ours → resolves to OUR path", () => {
+      expect(chooseLaunchCwd(twoMachines, "Nicks-MacBook-Pro.local")).toBe("/Users/nick/projects/x");
+      expect(chooseLaunchCwd(twoMachines, "linux-box")).toBe("/home/nick/code/x");
+    });
+
+    it("unchanged when the hostname is unknown — same rows still ambiguous", () => {
+      expect(chooseLaunchCwd(twoMachines, null)).toBeUndefined();
+      expect(chooseLaunchCwd(twoMachines)).toBeUndefined();
+    });
+
+    it("a hostname matching NO row falls through to the dedupe rule, never guesses", () => {
+      expect(chooseLaunchCwd(twoMachines, "some-third-machine")).toBeUndefined();
+      expect(
+        chooseLaunchCwd(
+          [
+            { absolute_path: "/Users/nick/x", hostname: "mac-a" },
+            { absolute_path: "/Users/nick/x", hostname: "mac-b" },
+          ],
+          "some-third-machine"
+        )
+      ).toBe("/Users/nick/x");
+    });
+
+    it("our row beats a manual-pin row recorded before the machine was known", () => {
+      expect(
+        chooseLaunchCwd(
+          [
+            { absolute_path: "/Users/nick/guessed", hostname: MANUAL_PIN_HOSTNAME },
+            { absolute_path: "/Users/nick/actual", hostname: "Nicks-MacBook-Pro.local" },
+          ],
+          "Nicks-MacBook-Pro.local"
+        )
+      ).toBe("/Users/nick/actual");
+    });
+
+    it("trims our row's path, like every other branch", () => {
+      expect(
+        chooseLaunchCwd([{ absolute_path: "  /Users/nick/x  ", hostname: "mine" }], "mine")
+      ).toBe("/Users/nick/x");
+    });
+
+    it("an INVALID path on our own row doesn't win, and doesn't block a good row", () => {
+      expect(
+        chooseLaunchCwd(
+          [
+            { absolute_path: "~/relative", hostname: "mine" },
+            { absolute_path: "/Users/nick/good", hostname: "other" },
+          ],
+          "mine"
+        )
+      ).toBe("/Users/nick/good");
+    });
+
+    it("hostname match is exact — a near-miss spelling is not our row", () => {
+      expect(chooseLaunchCwd(twoMachines, "Nicks-MacBook-Pro")).toBeUndefined();
+      expect(chooseLaunchCwd(twoMachines, "nicks-macbook-pro.local")).toBeUndefined();
+    });
+
+    it("no rows at all → undefined even with a known hostname", () => {
+      expect(chooseLaunchCwd([], "Nicks-MacBook-Pro.local")).toBeUndefined();
+      expect(chooseLaunchCwd(null, "Nicks-MacBook-Pro.local")).toBeUndefined();
+    });
+  });
 });
 
-describe("resolveEffectiveLaunchTarget (single source for DISPLAY + LAUNCH)", () => {
+describe("resolveEffectiveLaunchTarget (single source for DISPLAY + LAUNCH — server record only)", () => {
   const recorded = [
     { absolute_path: "/Users/nick/projects/from-db", hostname: "Nicks-MacBook" },
   ];
 
-  // ── Happy path: saved existing-mode path wins (THE BUG) ───────────────────
-  it("prefers a saved existing-mode absolute path over the DB recorded path", () => {
-    const t = resolveEffectiveLaunchTarget({
-      hasRepo: false,
-      saved: { mode: "existing", path: "/Users/nick/projects/from-dialog" },
-      recordedPaths: recorded,
-    });
-    // Same value drives BOTH the cwd (launch) and displayPath (dropdown) — so a
-    // path saved in the dialog is what the dropdown shows AND what launch uses.
-    expect(t.cwd).toBe("/Users/nick/projects/from-dialog");
-    expect(t.displayPath).toBe("/Users/nick/projects/from-dialog");
-    expect(t.source).toBe("saved");
-    expect(t.displayLabel).toBe("This machine — set manually");
-    expect(t.host).toBeNull();
-  });
-
-  it("regression: cwd and displayPath are ALWAYS the same value", () => {
-    for (const saved of [
-      null,
-      { mode: "existing" as const, path: "/Users/nick/x" },
-      { mode: "new" as const, path: "~/projects/x", parent: "~/projects", name: "x" },
-    ]) {
-      const t = resolveEffectiveLaunchTarget({ hasRepo: false, saved, recordedPaths: recorded });
-      expect(t.displayPath).toBe(t.cwd);
-    }
-  });
-
-  it("trims the saved path before using it", () => {
-    const t = resolveEffectiveLaunchTarget({
-      hasRepo: false,
-      saved: { mode: "existing", path: "  /Users/nick/x  " },
-      recordedPaths: null,
-    });
-    expect(t.cwd).toBe("/Users/nick/x");
-  });
-
-  // ── Falls back to the DB recorded path ────────────────────────────────────
-  it("falls back to the DB recorded path when no saved path exists", () => {
-    const t = resolveEffectiveLaunchTarget({
-      hasRepo: false,
-      saved: null,
-      recordedPaths: recorded,
-    });
+  // The card this rewrites for: resolveEffectiveLaunchTarget used to accept a
+  // `saved` (localStorage pin) arg and let it win over the DB record — two
+  // independent, never-compared stores for the same fact. The pin is now
+  // retired as a read source here entirely: `idea_project_paths` (surfaced as
+  // `recordedPaths` — this includes rows the "Set exact folder" dialog and the
+  // pin migration write, under MANUAL_PIN_HOSTNAME) is the only input.
+  it("resolves from the DB recorded path (no `saved` argument exists anymore)", () => {
+    const t = resolveEffectiveLaunchTarget({ hasRepo: false, recordedPaths: recorded });
     expect(t.cwd).toBe("/Users/nick/projects/from-db");
     expect(t.source).toBe("recorded");
     expect(t.displayLabel).toBe("This machine — Nicks-MacBook");
     expect(t.host).toBe("Nicks-MacBook");
   });
 
+  it("regression: cwd and displayPath are ALWAYS the same value", () => {
+    for (const paths of [null, [], recorded]) {
+      const t = resolveEffectiveLaunchTarget({ hasRepo: false, recordedPaths: paths });
+      expect(t.displayPath).toBe(t.cwd);
+    }
+  });
+
+  it("a manually-pinned row (MANUAL_PIN_HOSTNAME) resolves exactly like any other recorded hostname", () => {
+    const t = resolveEffectiveLaunchTarget({
+      hasRepo: false,
+      recordedPaths: [{ absolute_path: "/Users/nick/projects/pinned", hostname: MANUAL_PIN_HOSTNAME }],
+    });
+    expect(t.cwd).toBe("/Users/nick/projects/pinned");
+    expect(t.source).toBe("recorded");
+    expect(t.displayLabel).toBe(`This machine — ${MANUAL_PIN_HOSTNAME}`);
+  });
+
   it("honours chooseLaunchCwd's >1 → undefined contract (ambiguous machines)", () => {
     const t = resolveEffectiveLaunchTarget({
       hasRepo: false,
-      saved: null,
       recordedPaths: [
         { absolute_path: "/Users/nick/x", hostname: "mac" },
         { absolute_path: "/home/nick/x", hostname: "linux" },
@@ -802,64 +876,59 @@ describe("resolveEffectiveLaunchTarget (single source for DISPLAY + LAUNCH)", ()
     expect(t.source).toBe("none");
   });
 
-  // ── Negative paths: bad/irrelevant saved state must NOT surface ────────────
-  it("ignores new-mode saved state (composed ~/projects path is not a valid cwd)", () => {
+  it("…but resolves that same ambiguous set once realHostname names one of the rows", () => {
+    const ambiguous = [
+      { absolute_path: "/Users/nick/x", hostname: "mac" },
+      { absolute_path: "/home/nick/x", hostname: "linux" },
+    ];
     const t = resolveEffectiveLaunchTarget({
       hasRepo: false,
-      saved: { mode: "new", path: "~/projects/my-idea", parent: "~/projects", name: "my-idea" },
-      recordedPaths: recorded,
+      recordedPaths: ambiguous,
+      realHostname: "linux",
     });
-    // New-mode path is ignored → falls through to the DB recorded path.
-    expect(t.cwd).toBe("/Users/nick/projects/from-db");
+    expect(t.cwd).toBe("/home/nick/x");
     expect(t.source).toBe("recorded");
+    expect(t.host).toBe("linux");
+    expect(t.displayLabel).toBe("This machine — linux");
   });
 
-  it("ignores a saved existing-mode path that fails strict validation (~ / relative)", () => {
-    const t = resolveEffectiveLaunchTarget({
-      hasRepo: false,
-      saved: { mode: "existing", path: "~/projects/x" },
-      recordedPaths: recorded,
-    });
-    expect(t.cwd).toBe("/Users/nick/projects/from-db"); // falls back, not the ~ path
-    expect(t.source).toBe("recorded");
+  // The label must name the row we actually resolved FROM. With several rows
+  // sharing the resolved path, that's ours when we know which one is ours —
+  // showing another machine's hostname under "This machine" would be a lie.
+  it("labels with THIS machine's hostname when several rows share the resolved path", () => {
+    const sharedPath = [
+      { absolute_path: "/Users/nick/same", hostname: "old-laptop" },
+      { absolute_path: "/Users/nick/same", hostname: "Nicks-MacBook-Pro.local" },
+    ];
+    expect(
+      resolveEffectiveLaunchTarget({
+        hasRepo: false,
+        recordedPaths: sharedPath,
+        realHostname: "Nicks-MacBook-Pro.local",
+      }).displayLabel
+    ).toBe("This machine — Nicks-MacBook-Pro.local");
+    // Unknown identity keeps the old first-match label rather than degrading.
+    expect(
+      resolveEffectiveLaunchTarget({ hasRepo: false, recordedPaths: sharedPath }).displayLabel
+    ).toBe("This machine — old-laptop");
   });
 
-  // ── Repo-backed ideas: a known folder wins here too (regression) ──────────
-  // Previously `hasRepo` short-circuited to source "none" BEFORE the saved-pin
-  // check ran at all, so a repo-backed idea's explicit pin was silently
-  // dropped — the second defect QA found alongside the main resolver bug.
-  // Pin-beats-recorded precedence must hold the same way for repo-backed
-  // ideas as it does for no-repo ones.
-  it("repo-backed idea: a saved (pinned) path still wins, same as no-repo", () => {
-    const t = resolveEffectiveLaunchTarget({
-      hasRepo: true,
-      saved: { mode: "existing", path: "/Users/nick/projects/from-dialog" },
-      recordedPaths: recorded,
-    });
-    expect(t.cwd).toBe("/Users/nick/projects/from-dialog");
-    expect(t.displayPath).toBe("/Users/nick/projects/from-dialog");
-    expect(t.source).toBe("saved");
+  it("omitting realHostname is exactly the old behaviour (default off)", () => {
+    const rows = [
+      { absolute_path: "/Users/nick/x", hostname: "mac" },
+      { absolute_path: "/home/nick/x", hostname: "linux" },
+    ];
+    expect(resolveEffectiveLaunchTarget({ hasRepo: false, recordedPaths: rows })).toEqual(
+      resolveEffectiveLaunchTarget({ hasRepo: false, recordedPaths: rows, realHostname: null })
+    );
   });
 
-  it("repo-backed idea: a pinned path wins even with NO recorded path on file", () => {
-    const t = resolveEffectiveLaunchTarget({
-      hasRepo: true,
-      saved: { mode: "existing", path: "/Users/nick/projects/from-dialog" },
-      recordedPaths: [],
-    });
-    expect(t.cwd).toBe("/Users/nick/projects/from-dialog");
-    expect(t.source).toBe("saved");
-  });
-
-  // The main bug this card fixes: resolveEffectiveLaunchTarget used to return
-  // "none" unconditionally for hasRepo:true, so a recorded DB path (agent
-  // self-heal via record_project_path) was dead code for every repo-backed idea.
-  it("repo-backed idea: falls back to a recorded DB path when there's no pin", () => {
-    const t = resolveEffectiveLaunchTarget({
-      hasRepo: true,
-      saved: null,
-      recordedPaths: recorded,
-    });
+  // ── Repo-backed ideas: a known folder wins here too (regression, unchanged) ─
+  // A repo-backed idea with a known folder (recorded or manually pinned)
+  // resolves that folder exactly like a no-repo idea does — `hasRepo` doesn't
+  // gate this function.
+  it("repo-backed idea: a recorded path still resolves, same as no-repo", () => {
+    const t = resolveEffectiveLaunchTarget({ hasRepo: true, recordedPaths: recorded });
     expect(t.cwd).toBe("/Users/nick/projects/from-db");
     expect(t.source).toBe("recorded");
     expect(t.displayLabel).toBe("This machine — Nicks-MacBook");
@@ -868,19 +937,176 @@ describe("resolveEffectiveLaunchTarget (single source for DISPLAY + LAUNCH)", ()
   // Unchanged: repo-backed with nothing known at all → "none", so
   // resolveDefaultLaunchState still falls through to the empty-path
   // fresh-machine flow (repo slug / clone resolves the folder).
-  it("repo-backed idea: no pin and no recorded path → 'none' (fresh-machine flow, unchanged)", () => {
-    const t = resolveEffectiveLaunchTarget({ hasRepo: true, saved: null, recordedPaths: [] });
+  it("repo-backed idea: no recorded path → 'none' (fresh-machine flow, unchanged)", () => {
+    const t = resolveEffectiveLaunchTarget({ hasRepo: true, recordedPaths: [] });
     expect(t.cwd).toBeUndefined();
     expect(t.displayPath).toBeUndefined();
     expect(t.source).toBe("none");
   });
 
   it("returns source 'none' when nothing is usable (first-launch flow)", () => {
-    const t = resolveEffectiveLaunchTarget({ hasRepo: false, saved: null, recordedPaths: [] });
+    const t = resolveEffectiveLaunchTarget({ hasRepo: false, recordedPaths: [] });
     expect(t.cwd).toBeUndefined();
     expect(t.displayPath).toBeUndefined();
     expect(t.displayLabel).toBeUndefined();
     expect(t.source).toBe("none");
+  });
+});
+
+describe("mergeRecordedPath (optimistic merge of a just-saved manual pin)", () => {
+  const base = [{ absolute_path: "/Users/nick/projects/from-db", hostname: "Nicks-MacBook" }];
+
+  it("appends a new hostname", () => {
+    const merged = mergeRecordedPath(base, {
+      absolute_path: "/Users/nick/projects/manual",
+      hostname: MANUAL_PIN_HOSTNAME,
+    });
+    expect(merged).toHaveLength(2);
+    expect(merged).toContainEqual({ absolute_path: "/Users/nick/projects/manual", hostname: MANUAL_PIN_HOSTNAME });
+    expect(merged).toContainEqual(base[0]);
+  });
+
+  it("replaces an existing row with the same hostname rather than duplicating", () => {
+    const merged = mergeRecordedPath(base, {
+      absolute_path: "/Users/nick/projects/moved",
+      hostname: "Nicks-MacBook",
+    });
+    expect(merged).toEqual([{ absolute_path: "/Users/nick/projects/moved", hostname: "Nicks-MacBook" }]);
+  });
+
+  it("returns the base list unchanged (a copy) when there's no update", () => {
+    expect(mergeRecordedPath(base, null)).toEqual(base);
+    expect(mergeRecordedPath(base, undefined)).toEqual(base);
+    expect(mergeRecordedPath(null, null)).toEqual([]);
+  });
+});
+
+// ── decidePinMigration — the re-derived precedence table (this rework) ──
+// The investigation step this card was built from concluded "the browser
+// cannot know its hostname" — that's false (getMachineIdentity(), see
+// MANUAL_PIN_HOSTNAME's doc) — so decidePinMigration now takes the browser's
+// REAL hostname as a second argument, and a row for that exact hostname wins
+// outright regardless of row count. When it's null (never known), or doesn't
+// match any row, this falls through to the original 0/1/>1 row-count logic,
+// now inserting under the real hostname (when known) instead of the fake
+// MANUAL_PIN_HOSTNAME sentinel.
+describe("decidePinMigration (browser-pin → idea_project_paths migration decision)", () => {
+  describe("hostname unknown (realHostname omitted/null) — original row-count logic", () => {
+    it("0 rows → insert under MANUAL_PIN_HOSTNAME (preserve the only signal on file)", () => {
+      expect(decidePinMigration([])).toEqual({ action: "insert", hostname: MANUAL_PIN_HOSTNAME });
+      expect(decidePinMigration([], null)).toEqual({ action: "insert", hostname: MANUAL_PIN_HOSTNAME });
+    });
+
+    it("exactly 1 row → update THAT row's hostname in place (never a second row)", () => {
+      expect(decidePinMigration([{ hostname: "Nicks-MacBook-Pro.local" }])).toEqual({
+        action: "update",
+        hostname: "Nicks-MacBook-Pro.local",
+      });
+    });
+
+    // Still a skip with no real hostname — unlike rule 4 above, there is no
+    // hostname to insert under that would mean anything to a later read.
+    it("more than 1 row → skip (already ambiguous; not reconciled here)", () => {
+      expect(decidePinMigration([{ hostname: "mac" }, { hostname: "linux" }])).toEqual({ action: "skip" });
+      expect(
+        decidePinMigration([{ hostname: "mac" }, { hostname: "linux" }, { hostname: "win" }])
+      ).toEqual({ action: "skip" });
+    });
+  });
+
+  describe("real hostname known — rule 1: a row for it wins outright", () => {
+    it("a row for the real hostname exists, alone → update it", () => {
+      expect(decidePinMigration([{ hostname: "Nicks-MacBook-Pro.local" }], "Nicks-MacBook-Pro.local")).toEqual({
+        action: "update",
+        hostname: "Nicks-MacBook-Pro.local",
+      });
+    });
+
+    // The explicit case the card calls out: a row for the real hostname wins
+    // regardless of how many OTHER rows exist — the >1-row "skip" rule only
+    // ever existed because the code couldn't tell which row was ours; now it
+    // can, so it no longer needs to defer.
+    it("a row for the real hostname exists ALONGSIDE other rows → still updates only that one", () => {
+      expect(
+        decidePinMigration(
+          [{ hostname: "other-machine" }, { hostname: "Nicks-MacBook-Pro.local" }, { hostname: "third" }],
+          "Nicks-MacBook-Pro.local"
+        )
+      ).toEqual({ action: "update", hostname: "Nicks-MacBook-Pro.local" });
+    });
+  });
+
+  describe("real hostname known but no row matches it — falls through to row-count rules", () => {
+    it("0 rows → insert under the REAL hostname, not the sentinel", () => {
+      expect(decidePinMigration([], "Nicks-MacBook-Pro.local")).toEqual({
+        action: "insert",
+        hostname: "Nicks-MacBook-Pro.local",
+      });
+    });
+
+    it("exactly 1 row (a different hostname) → still updates that lone row in place", () => {
+      // Unchanged from the hostname-unknown case: the pin already wins over a
+      // lone recorded row (the card's standing "pin wins" decision), and
+      // updating in place is what keeps chooseLaunchCwd resolving to exactly
+      // one distinct path — narrowing this by hostname would only reintroduce
+      // the ambiguity the original 1-row rule was written to avoid.
+      expect(decidePinMigration([{ hostname: "Old-Machine.local" }], "Nicks-MacBook-Pro.local")).toEqual({
+        action: "update",
+        hostname: "Old-Machine.local",
+      });
+    });
+
+    // Rule 4, changed with the machine-aware READ: this used to skip, which
+    // left the pin permanently stranded (several machines on file, nothing ever
+    // lands, the user is re-asked every single launch). chooseLaunchCwd now
+    // prefers the row keyed to THIS machine over any amount of ambiguity, so
+    // the row inserted here is precisely the one the next read will pick.
+    it("more than 1 row, none matching, real hostname KNOWN → insert under it", () => {
+      expect(
+        decidePinMigration([{ hostname: "mac" }, { hostname: "linux" }], "Nicks-MacBook-Pro.local")
+      ).toEqual({ action: "insert", hostname: "Nicks-MacBook-Pro.local" });
+    });
+
+    it("inserts without disturbing the rows already there (decision names only OUR hostname)", () => {
+      const rows = [{ hostname: "mac" }, { hostname: "linux" }, { hostname: MANUAL_PIN_HOSTNAME }];
+      const decision = decidePinMigration(rows, "Nicks-MacBook-Pro.local");
+      expect(decision.action).toBe("insert");
+      expect(decision.action === "insert" && decision.hostname).toBe("Nicks-MacBook-Pro.local");
+      // The decision must never target another machine's row.
+      expect(rows.map((r) => r.hostname)).not.toContain("Nicks-MacBook-Pro.local");
+    });
+
+    // End-to-end of the pair: migrate into an ambiguous set, then read back.
+    // Before this change the read returned undefined here forever.
+    it("insert then read → the machine's own row resolves out of an ambiguous set", () => {
+      const existing = [
+        { absolute_path: "/Users/other/x", hostname: "mac" },
+        { absolute_path: "/home/other/x", hostname: "linux" },
+      ];
+      const decision = decidePinMigration(existing, "Nicks-MacBook-Pro.local");
+      expect(decision).toEqual({ action: "insert", hostname: "Nicks-MacBook-Pro.local" });
+      expect(chooseLaunchCwd(existing, "Nicks-MacBook-Pro.local")).toBeUndefined();
+      const after = [
+        ...existing,
+        { absolute_path: "/Users/nick/projects/mine", hostname: "Nicks-MacBook-Pro.local" },
+      ];
+      expect(chooseLaunchCwd(after, "Nicks-MacBook-Pro.local")).toBe("/Users/nick/projects/mine");
+    });
+  });
+
+  // The scenario the card explicitly requires: migrating under a real
+  // hostname, then a later decision against the resulting row (standing in
+  // for an agent's own record_project_path self-heal on the same machine)
+  // must target the SAME row, not a second one.
+  it("insert-under-real-hostname then a later decision against that same row converge on one hostname", () => {
+    const inserted = decidePinMigration([], "Nicks-MacBook-Pro.local");
+    expect(inserted).toEqual({ action: "insert", hostname: "Nicks-MacBook-Pro.local" });
+
+    const relaunched = decidePinMigration(
+      [{ hostname: inserted.hostname! }],
+      "Nicks-MacBook-Pro.local"
+    );
+    expect(relaunched).toEqual({ action: "update", hostname: "Nicks-MacBook-Pro.local" });
   });
 });
 
@@ -1221,14 +1447,30 @@ describe("resolveDefaultLaunchState (shared by launch button + terminal dock)", 
     window.localStorage.clear();
   });
 
-  it("prefers the user's saved localStorage config", () => {
-    writeLaunchPath("idea-1", { mode: "existing", path: "/Users/me/projects/x" });
-    expect(resolveDefaultLaunchState("idea-1", "My Idea", null)).toEqual({
-      mode: "existing",
-      path: "/Users/me/projects/x",
-      parent: undefined,
-      name: undefined,
+  it("prefers the user's saved NEW-mode localStorage config (the browser store's one surviving job)", () => {
+    writeLaunchPath("idea-1", {
+      mode: "new",
+      path: "~/projects/x",
+      parent: "~/projects",
+      name: "x",
     });
+    expect(resolveDefaultLaunchState("idea-1", "My Idea", null)).toEqual({
+      mode: "new",
+      path: "~/projects/x",
+      parent: "~/projects",
+      name: "x",
+    });
+  });
+
+  // Regression for the card: an EXISTING-mode localStorage pin used to win
+  // outright (returned verbatim, before `effectiveTarget` was even consulted).
+  // It's now retired as a read source here — `idea_project_paths`, via
+  // `effectiveTarget`, is the only thing that can resolve an existing folder.
+  it("ignores a saved EXISTING-mode localStorage pin — no known server folder falls through to the no-repo default", () => {
+    writeLaunchPath("idea-1", { mode: "existing", path: "/Users/me/projects/stale-pin" });
+    const state = resolveDefaultLaunchState("idea-1", "My First App", null);
+    expect(state.mode).toBe("new");
+    expect(state).not.toMatchObject({ path: "/Users/me/projects/stale-pin" });
   });
 
   it("repo-backed idea → existing mode with an empty path (repo slug resolves the folder)", () => {
@@ -1249,11 +1491,10 @@ describe("resolveDefaultLaunchState (shared by launch button + terminal dock)", 
   // ── Repo-backed idea + a known folder (effectiveTarget) ────────────────────
   // Second defect QA found: `resolveDefaultLaunchState`'s `if (ideaGithubUrl)`
   // branch used to fire BEFORE the effectiveTarget check, making a repo-backed
-  // idea's recorded/pinned folder dead code — the two resolvers disagreed.
-  it("repo-backed idea + a recorded DB path, no pin → existing mode at the recorded path", () => {
+  // idea's recorded folder dead code — the two resolvers disagreed.
+  it("repo-backed idea + a recorded DB path → existing mode at the recorded path", () => {
     const effectiveTarget = resolveEffectiveLaunchTarget({
       hasRepo: true,
-      saved: null,
       recordedPaths: [{ absolute_path: "/Users/nick/projects/widget", hostname: "Nicks-MacBook" }],
     });
     expect(
@@ -1261,22 +1502,13 @@ describe("resolveDefaultLaunchState (shared by launch button + terminal dock)", 
     ).toEqual({ mode: "existing", path: "/Users/nick/projects/widget" });
   });
 
-  it("repo-backed idea + a pinned path (with a recorded path too) → the pin wins", () => {
+  // A manually-pinned row (dialog Save / pin migration) is just another
+  // recordedPaths entry now — it resolves through the exact same path as an
+  // agent-recorded row, no separate "pin" concept in this resolver anymore.
+  it("repo-backed idea + a manually-pinned row (MANUAL_PIN_HOSTNAME) → existing mode at that path", () => {
     const effectiveTarget = resolveEffectiveLaunchTarget({
       hasRepo: true,
-      saved: { mode: "existing", path: "/Users/nick/projects/pinned-widget" },
-      recordedPaths: [{ absolute_path: "/Users/nick/projects/widget", hostname: "Nicks-MacBook" }],
-    });
-    expect(
-      resolveDefaultLaunchState("idea-1", "My Idea", "https://github.com/acme/widget", effectiveTarget)
-    ).toEqual({ mode: "existing", path: "/Users/nick/projects/pinned-widget" });
-  });
-
-  it("repo-backed idea + a pinned path, NO recorded path → the pin still wins", () => {
-    const effectiveTarget = resolveEffectiveLaunchTarget({
-      hasRepo: true,
-      saved: { mode: "existing", path: "/Users/nick/projects/pinned-widget" },
-      recordedPaths: [],
+      recordedPaths: [{ absolute_path: "/Users/nick/projects/pinned-widget", hostname: MANUAL_PIN_HOSTNAME }],
     });
     expect(
       resolveDefaultLaunchState("idea-1", "My Idea", "https://github.com/acme/widget", effectiveTarget)
@@ -1284,12 +1516,11 @@ describe("resolveDefaultLaunchState (shared by launch button + terminal dock)", 
   });
 
   // UNCHANGED / the fresh-machine flow that must not regress: repo-backed with
-  // NEITHER a pin NOR a recorded path still opens empty-path existing mode so
-  // the bootstrap prompt emits its clone/directory step.
+  // NO known folder still opens empty-path existing mode so the bootstrap
+  // prompt emits its clone/directory step.
   it("repo-backed idea + effectiveTarget but NO known folder → still the empty-path fresh-machine flow", () => {
     const effectiveTarget = resolveEffectiveLaunchTarget({
       hasRepo: true,
-      saved: null,
       recordedPaths: [],
     });
     expect(
@@ -1302,7 +1533,6 @@ describe("resolveDefaultLaunchState (shared by launch button + terminal dock)", 
   it("repo-backed idea + >1 distinct recorded paths (ambiguous) → still the empty-path flow", () => {
     const effectiveTarget = resolveEffectiveLaunchTarget({
       hasRepo: true,
-      saved: null,
       recordedPaths: [
         { absolute_path: "/Users/nick/widget", hostname: "mac" },
         { absolute_path: "/home/nick/widget", hostname: "linux" },
@@ -1337,7 +1567,6 @@ describe("recorded-path idea promotes to existing mode (prompt/cwd parity)", () 
   ): string {
     const effectiveTarget = resolveEffectiveLaunchTarget({
       hasRepo: false,
-      saved: null,
       recordedPaths,
     });
     const state = resolveDefaultLaunchState(IDEA_ID, "My Idea", null, effectiveTarget);
@@ -1359,7 +1588,6 @@ describe("recorded-path idea promotes to existing mode (prompt/cwd parity)", () 
   it("resolveDefaultLaunchState promotes a recorded no-repo idea to existing mode at that path", () => {
     const effectiveTarget = resolveEffectiveLaunchTarget({
       hasRepo: false,
-      saved: null,
       recordedPaths: [{ absolute_path: RECORDED, hostname: "Nicks-MacBook" }],
     });
     expect(resolveDefaultLaunchState(IDEA_ID, "My Idea", null, effectiveTarget)).toEqual({
@@ -1405,7 +1633,6 @@ describe("recorded-path idea promotes to existing mode (prompt/cwd parity)", () 
     // the clamp (as this test used to) is no longer representative.
     const effectiveTarget = resolveEffectiveLaunchTarget({
       hasRepo: false,
-      saved: null,
       recordedPaths: [{ absolute_path: RECORDED, hostname: "Nicks-MacBook" }],
     });
     const state = resolveDefaultLaunchState(IDEA_ID, "My Idea", null, effectiveTarget);
@@ -1425,19 +1652,34 @@ describe("recorded-path idea promotes to existing mode (prompt/cwd parity)", () 
     expect(link.length).toBeLessThanOrEqual(MAX_DEEP_LINK_URL_LENGTH);
   });
 
-  it("a saved localStorage path (no repo) is NOT clobbered by an absent recorded path", () => {
-    writeLaunchPath(IDEA_ID, { mode: "existing", path: "/Users/nick/pinned" });
+  it("a saved NEW-mode localStorage path (no repo) is NOT clobbered by an absent recorded path", () => {
+    writeLaunchPath(IDEA_ID, { mode: "new", path: "~/projects/x", parent: "~/projects", name: "x" });
+    const effectiveTarget = resolveEffectiveLaunchTarget({ hasRepo: false, recordedPaths: [] });
+    // resolveDefaultLaunchState still reads localStorage itself for new-mode —
+    // unaffected by effectiveTarget having nothing recorded.
+    expect(resolveDefaultLaunchState(IDEA_ID, "My Idea", null, effectiveTarget)).toEqual({
+      mode: "new",
+      path: "~/projects/x",
+      parent: "~/projects",
+      name: "x",
+    });
+  });
+
+  // Acceptance criterion "pin-and-record-disagree": before this fix, an
+  // EXISTING-mode localStorage pin always won over a disagreeing recorded DB
+  // path (the exact bug reported live: pin and server record pointed at two
+  // different clones, and every launch silently followed the pin). Now the
+  // server record is the only thing consulted — a leftover pin in
+  // localStorage (e.g. one that failed to migrate) has no effect at all.
+  it("pin-and-record-disagree: an EXISTING-mode pin no longer overrides a disagreeing recorded path", () => {
+    writeLaunchPath(IDEA_ID, { mode: "existing", path: "/Users/nick/projects/stale-pin-path" });
     const effectiveTarget = resolveEffectiveLaunchTarget({
       hasRepo: false,
-      saved: readLaunchPath(IDEA_ID),
-      recordedPaths: [],
+      recordedPaths: [{ absolute_path: RECORDED, hostname: "Nicks-MacBook" }],
     });
-    // Saved localStorage wins in resolveDefaultLaunchState (step 1), unchanged.
     expect(resolveDefaultLaunchState(IDEA_ID, "My Idea", null, effectiveTarget)).toEqual({
       mode: "existing",
-      path: "/Users/nick/pinned",
-      parent: undefined,
-      name: undefined,
+      path: RECORDED,
     });
   });
 });

--- a/src/lib/launch-claude-code.ts
+++ b/src/lib/launch-claude-code.ts
@@ -29,6 +29,36 @@ export const MAX_DEEP_LINK_URL_LENGTH = 1900;
 /** localStorage key namespace for the per-user-per-idea launch path. */
 export const LAUNCH_PATH_KEY_PREFIX = "vibecodes:launch-path:";
 
+/**
+ * FALLBACK `idea_project_paths.hostname` for a human-written row (the "Set
+ * exact folder" dialog's Save, and the one-time pin migration) when this
+ * browser's real machine hostname isn't known yet.
+ *
+ * CORRECTION (this rework): the investigation step that scoped this feature
+ * concluded "the browser cannot know the hostname" and this sentinel was
+ * built as the ONLY option for both writers. That premise is false —
+ * `getMachineIdentity()` (`src/lib/terminal/machine-identity.ts`) already
+ * gives the browser its real hostname, self-reported by the terminal bridge
+ * the same way an agent's `hostname`/`uname -n` self-report does (see the
+ * bridge's `bridge-version` control frame, `host` field). Both writers now
+ * prefer that real hostname and fall back to this sentinel only when
+ * `getMachineIdentity()` returns null (a browser that has never had a
+ * terminal session, so it genuinely doesn't know its own machine yet).
+ *
+ * Landing a write under this ACCOUNT-WIDE sentinel instead of a real,
+ * per-machine hostname is exactly the bug QA caught: every browser and
+ * machine on the account reads the same fake row, so one person's manual
+ * pin could become what a completely different machine resolves to. Using
+ * the real hostname whenever it's available is what fixes that — this
+ * sentinel is now the deliberately-narrow "we truly don't know" case, not
+ * the default.
+ *
+ * Still chosen to read naturally in the dropdown's "This machine — <hostname>"
+ * label when it IS used — it reproduces the exact copy ("This machine — set
+ * manually") the old localStorage-pin path used to show.
+ */
+export const MANUAL_PIN_HOSTNAME = "set manually";
+
 export type LaunchMode = "existing" | "new";
 
 /** Persisted per-idea launch config (machine-specific; localStorage only). */
@@ -286,36 +316,182 @@ export interface RecordedProjectPath {
 }
 
 /**
+ * Merge a single (optimistic) recorded row into a list, replacing any existing
+ * row with the same hostname rather than appending a duplicate. Used to fold a
+ * just-saved "Set exact folder" write (hostname `MANUAL_PIN_HOSTNAME`) into the
+ * board-loaded `recordedProjectPaths` immediately client-side — the SSR list
+ * won't see it until the next page load, but `resolveEffectiveLaunchTarget`
+ * only reads `recordedPaths`, so display + launch must be updated the same way
+ * the pin used to update instantly (this preserves that "just saved → the
+ * dropdown/launch reflect it right away" property now that the write goes to
+ * the server instead of localStorage).
+ */
+export function mergeRecordedPath(
+  records: ReadonlyArray<RecordedProjectPath> | null | undefined,
+  update: RecordedProjectPath | null | undefined
+): RecordedProjectPath[] {
+  const base = records ?? [];
+  if (!update) return [...base];
+  const withoutMatch = base.filter((r) => r.hostname !== update.hostname);
+  return [...withoutMatch, update];
+}
+
+export type PinMigrationAction = "insert" | "update" | "skip";
+
+export interface PinMigrationDecision {
+  action: PinMigrationAction;
+  /**
+   * The hostname to upsert onto. See `decidePinMigration`'s doc for the full
+   * precedence table this implements.
+   */
+  hostname?: string;
+}
+
+/**
+ * Pure decision for the one-time browser-pin → `idea_project_paths` migration
+ * (card: retire the localStorage pin for existing folders, with a migration
+ * that never regresses resolution — see `chooseLaunchCwd`'s dedupe-by-path
+ * contract). Takes the CURRENT server rows for (this idea, this user) plus
+ * `realHostname` — this browser's actual machine hostname from
+ * `getMachineIdentity()`, or null when it isn't known yet.
+ *
+ * CORRECTION (this rework): the original version of this function only ever
+ * saw row COUNT, because the investigation step it was built from concluded
+ * the browser can't know its own hostname. That conclusion was wrong —
+ * `getMachineIdentity()` already exists and gives the real answer (see
+ * `MANUAL_PIN_HOSTNAME`'s doc). Knowing the real hostname changes what
+ * "update in place" should mean: it can now target the row that is
+ * PROVABLY this machine's own, instead of guessing from "how many rows
+ * exist" — which is exactly what the old >1-rows "skip" rule was a
+ * stand-in for (it skipped not because >1 rows is inherently unfixable, but
+ * because the code had no way to tell which one, if any, was ours).
+ *
+ * Precedence, checked in this order:
+ *
+ *  1. `realHostname` is known AND a row with that exact hostname already
+ *     exists → **update** that row, regardless of how many OTHER rows exist.
+ *     This is no longer a guess: a row recorded under this exact machine's
+ *     real hostname (by a prior agent launch, or a prior real-hostname pin
+ *     save/migration) IS this machine's row, full stop. Overwriting it with
+ *     the pin's path can't corrupt anyone else's data — it never touches any
+ *     other row — and it's what makes the "pin wins over the server record"
+ *     decision (see the card) actually correct instead of a coincidence of
+ *     row count.
+ *  2. Otherwise, 0 existing rows → **insert** under `realHostname` when known,
+ *     else the `MANUAL_PIN_HOSTNAME` fallback. Nothing to collide with either
+ *     way; preferring the real hostname when we have it means a LATER agent
+ *     launch on this same machine (`record_project_path` with the same
+ *     self-reported hostname) upserts onto this same row instead of creating
+ *     a second one — the real hostname is exactly what
+ *     `idea_project_paths (idea_id, owner_user_id, hostname)` already keys
+ *     agent-recorded rows on, so using it here is just using the table's own
+ *     natural key instead of a synthetic one.
+ *  3. Otherwise, exactly 1 existing row (with a hostname that, per rule 1,
+ *     did NOT match `realHostname` — or `realHostname` is null) → **update**
+ *     THAT row's path in place, keeping its own hostname. Unchanged from the
+ *     original reasoning and deliberately NOT narrowed by hostname
+ *     awareness: the pin already won over a lone recorded row before any of
+ *     this hostname plumbing existed (the card's standing "pin wins"
+ *     decision), and overwriting the one row that exists is what keeps
+ *     `chooseLaunchCwd` resolving to exactly one distinct path afterwards —
+ *     inserting a second, differently-hostnamed row here would flip a
+ *     today-resolved idea to permanently ambiguous, strictly worse than the
+ *     bug being fixed.
+ *  4. Otherwise, >1 existing rows, none matching `realHostname`, but
+ *     `realHostname` IS known → **insert** under `realHostname`. This used to
+ *     be a skip, on the reasoning that adding a differently-hostnamed row to an
+ *     already-ambiguous set couldn't help — true only while `chooseLaunchCwd`
+ *     resolved purely by deduping paths, which made every extra row noise. It
+ *     now prefers the row keyed to this machine over any amount of ambiguity
+ *     (its rule 1), so the row we insert here is exactly the one the read will
+ *     pick: a machine we can positively identify, carrying a path this browser
+ *     was explicitly pinned to by the user. Nothing is overwritten — other
+ *     machines' rows are untouched — and the previously permanent dead end
+ *     (several machines on file, pin never lands anywhere, user re-asked every
+ *     launch forever) resolves on the next page load instead.
+ *  5. Otherwise, >1 existing rows and `realHostname` is UNKNOWN → **skip**.
+ *     Genuinely unattributable: no hostname to insert under that would mean
+ *     anything, and no basis to pick among existing rows. The SERVER rows are
+ *     left exactly as `chooseLaunchCwd` already treats them (source "none");
+ *     not reconciled here. That is only a claim about the rows this function
+ *     decides over — it says nothing about the caller's browser-local pin,
+ *     which is the one piece of state this function doesn't touch at all. A
+ *     caller that then deletes the pin on `skip` (as `ok: true` might tempt it
+ *     to, since nothing "failed") has destroyed the only surviving record of
+ *     the folder for no server-side benefit — this exact bug shipped once
+ *     already (see `useLaunchPathPinMigration`, which now keys clearing on
+ *     `action !== "skip"` specifically because of it). Treat `skip` as "wrote
+ *     nothing, pin must survive," not as "nothing happened."
+ *
+ * NOT keyed on `updated_at` — row identity (by hostname, or failing that by
+ * "does exactly one exist") is the only signal that can't be second-guessed
+ * by clock skew or an agent relaunch landing after the browser tab loads.
+ */
+export function decidePinMigration(
+  existingRows: ReadonlyArray<Pick<RecordedProjectPath, "hostname">>,
+  realHostname: string | null = null
+): PinMigrationDecision {
+  if (realHostname) {
+    const ownRow = existingRows.find((r) => r.hostname === realHostname);
+    if (ownRow) {
+      return { action: "update", hostname: realHostname };
+    }
+  }
+  if (existingRows.length === 0) {
+    return { action: "insert", hostname: realHostname ?? MANUAL_PIN_HOSTNAME };
+  }
+  if (existingRows.length === 1) {
+    return { action: "update", hostname: existingRows[0].hostname };
+  }
+  if (realHostname) {
+    return { action: "insert", hostname: realHostname };
+  }
+  return { action: "skip" };
+}
+
+/**
  * Choose the cwd to inject into a no-repo launch deep link from the paths
- * recorded for (this user, this idea) — Design Review hostname rule, option (a),
- * deduped by absolute path:
+ * recorded for (this user, this idea), given `realHostname` — this browser's
+ * actual machine hostname from `getMachineIdentity()`, or null when it isn't
+ * known yet (no bridge has ever announced one in this browser).
  *
- *  - 0 records          → undefined (first-launch / home flow; the agent creates + records)
- *  - 1 distinct path    → that path, whether it came from one record or several
- *                         (the common multi-machine case: the same idea launched
- *                         from two hosts whose project folder happens to live at
- *                         the same absolute path — e.g. two Macs both checking
- *                         out under /Users/nick/projects/<slug>). There is no
- *                         ambiguity to protect against here: whichever machine
- *                         the browser is actually on, the folder is at this path.
- *  - >1 distinct paths  → undefined (genuinely ambiguous across machines; the
- *                         browser can't know which host it's on, so never inject
- *                         a path we can't attribute to THIS machine — fall back
- *                         to the safe first-launch flow)
+ * `idea_project_paths` is keyed on (idea_id, owner_user_id, hostname), so a row
+ * carrying THIS machine's hostname is, by the table's own natural key, this
+ * machine's folder — there is nothing left to infer. Precedence:
  *
- * A record is only usable if its absolute_path passes strict validation; bad
- * rows are ignored so a single corrupt record can't poison the choice.
+ *  1. `realHostname` known AND a usable row exists under it → **that row's
+ *     path**, however many other rows exist and whatever they say. This is the
+ *     multi-machine case resolving correctly for the first time: two Macs with
+ *     the project checked out at different absolute paths each get their own
+ *     folder instead of both falling to "ask again" (rule 3). It also beats a
+ *     `MANUAL_PIN_HOSTNAME` row deliberately — that synthetic hostname only
+ *     ever exists because a save happened while the machine was unknown, so a
+ *     row we can positively attribute to this machine is strictly better
+ *     evidence than one we can't attribute at all.
+ *  2. Otherwise, 1 distinct path across all usable rows → that path, whether it
+ *     came from one row or several. The common same-path-across-machines case
+ *     (two hosts both checked out under /Users/nick/projects/<slug>): whichever
+ *     machine the browser is on, the folder is at this path. Kept BELOW rule 1
+ *     only for ordering tidiness — where both apply they agree by definition.
+ *     This is the rule that carries browsers with no known identity at all.
+ *  3. Otherwise (0 rows, or >1 distinct paths none of which we can attribute to
+ *     this machine) → undefined: the safe first-launch flow that asks. Never
+ *     inject a path we can't tie to the machine actually running the launch —
+ *     opening Claude Code in someone else's checkout is worse than asking.
  *
- * Deliberately does NOT match on hostname to narrow the record set before
- * deduping — the browser-side machine-identity plumbing for that
- * (`getMachineIdentity()` in `src/lib/terminal/machine-identity.ts`) exists but
- * wiring it in here is out of scope for this fix; same-path-across-machines is
- * the safe, hostname-independent case that doesn't need it.
+ * A row is only usable if its absolute_path passes strict validation; bad rows
+ * are ignored throughout, including under rule 1, so a single corrupt record
+ * can neither poison the choice nor block a good row from resolving.
  */
 export function chooseLaunchCwd(
-  records: ReadonlyArray<RecordedProjectPath> | null | undefined
+  records: ReadonlyArray<RecordedProjectPath> | null | undefined,
+  realHostname: string | null = null
 ): string | undefined {
   const usable = (records ?? []).filter((r) => isValidAbsolutePath(r.absolute_path));
+  if (realHostname) {
+    const own = usable.find((r) => r.hostname === realHostname);
+    if (own) return own.absolute_path.trim();
+  }
   const distinctPaths = new Set(usable.map((r) => r.absolute_path.trim()));
   if (distinctPaths.size === 1) return usable[0].absolute_path.trim();
   return undefined;
@@ -325,9 +501,21 @@ export function chooseLaunchCwd(
  * The single source of truth for "where will a launch open (if a folder is
  * already known), and what do we show the user?" — applies to repo-backed and
  * no-repo ideas alike. DISPLAY and LAUNCH must derive from this same result so
- * they can never diverge (the bug: the dialog saved to localStorage but the
- * dropdown read only the DB; and separately, a repo-backed idea's known folder
- * used to be discarded here entirely — see `resolveEffectiveLaunchTarget`).
+ * they can never diverge (the original bug: the dialog saved to localStorage
+ * but the dropdown read only the DB; a repo-backed idea's known folder used to
+ * be discarded here entirely).
+ *
+ * For an EXISTING folder, `idea_project_paths` (server, `recordedPaths`) is now
+ * the ONLY store this reads. The localStorage pin the "Set exact folder"
+ * dialog used to write is no longer consulted here — two independent,
+ * never-compared stores for the same fact (this machine's project folder) let
+ * a stale browser pin silently beat a correct, self-healing server record.
+ * The dialog now writes existing-mode saves to the server too (see
+ * `MANUAL_PIN_HOSTNAME`), and a one-time migration (`decidePinMigration`)
+ * folds any pre-existing pin in before this ships, so no launch folder changes
+ * as a result. `new`-mode pins are unaffected — see `resolveDefaultLaunchState`,
+ * the only place that still reads them (there's no server equivalent for a
+ * folder that doesn't exist yet).
  *
  * `cwd` is what gets injected into the deep link / copy command; `displayPath`
  * + `displayLabel` + `host` drive the dropdown's "This machine" line.
@@ -339,9 +527,15 @@ export interface EffectiveLaunchTarget {
   displayPath: string | undefined;
   /** Heading for the path line — names the source so it's honest. */
   displayLabel: string | undefined;
-  /** Hostname for the DB-sourced case (null for the localStorage/device case). */
+  /** Hostname for the DB-sourced case (null when nothing is usable). */
   host: string | null;
-  /** Where the path came from. "none" → show no path line. */
+  /**
+   * Where the path came from. "none" → show no path line. "saved" is kept
+   * only so callers that still pattern-match on it don't need a type change —
+   * this function no longer returns it; a resolved path is always "recorded"
+   * now (a manually-pinned row is just another `recordedPaths` entry, under
+   * `MANUAL_PIN_HOSTNAME`).
+   */
   source: "saved" | "recorded" | "none";
 }
 
@@ -349,65 +543,58 @@ export interface ResolveEffectiveLaunchTargetArgs {
   /**
    * Whether the idea has a GitHub repo. Kept for callers (they already track
    * it for the prompt builders) but no longer gates anything HERE: a
-   * repo-backed idea with a known folder (pinned or recorded for this
-   * machine) resolves that folder exactly like a no-repo idea does — see the
-   * precedence note below. `resolveDefaultLaunchState` is what still treats
-   * repo-backed differently when NO folder is known (empty-path existing
-   * mode instead of a fresh ~/projects/<slug>).
+   * repo-backed idea with a known folder (agent-recorded for this machine, or
+   * manually pinned via the dialog — both land in `recordedPaths`) resolves
+   * that folder exactly like a no-repo idea does. `resolveDefaultLaunchState`
+   * is what still treats repo-backed differently when NO folder is known
+   * (empty-path existing mode instead of a fresh ~/projects/<slug>).
    */
   hasRepo: boolean;
-  /** The user's saved localStorage launch config for this idea (or null). */
-  saved: LaunchPathState | null;
-  /** Paths the agent recorded in the DB for this user + idea. */
+  /**
+   * Paths recorded in the DB for this user + idea — both agent-self-reported
+   * rows (`record_project_path`, one per real hostname) and human-set rows
+   * (dialog Save / pin migration, hostname `MANUAL_PIN_HOSTNAME`). This is now
+   * the ONLY source an existing folder resolves from.
+   */
   recordedPaths: ReadonlyArray<RecordedProjectPath> | null | undefined;
+  /**
+   * This browser's real machine hostname (`getMachineIdentity()`), or null when
+   * no bridge has announced one yet. Lets `chooseLaunchCwd` pick the row keyed
+   * to THIS machine instead of only resolving when every machine agrees on the
+   * path — see its rule 1. Optional so non-browser callers (and tests written
+   * before this existed) keep the hostname-blind behaviour unchanged.
+   */
+  realHostname?: string | null;
 }
 
 /**
- * Resolve the effective launch target, preferring an explicitly-saved
- * existing-mode absolute path (localStorage — what the "Set exact folder" dialog
- * writes) over the agent-recorded DB path. This makes the dropdown reflect a
- * just-saved path immediately AND guarantees launch uses that same value.
+ * Resolve the effective launch target from the server-recorded paths alone, via
+ * `chooseLaunchCwd`: a row keyed to THIS machine's hostname wins outright;
+ * failing that, records agreeing on one path dedupe to it even across different
+ * hostnames (labelled "This machine — <host>"; a manually-pinned row is just
+ * another hostname, `MANUAL_PIN_HOSTNAME`, in that same set). Nothing usable →
+ * source "none" (first-launch / repo-slug-resolves-it flow; no path line).
  *
- * Precedence (applies identically whether or not the idea has a repo — a
- * pinned or recorded folder is just as real a "known folder" for a
- * repo-backed idea as for a no-repo one, and pin-beats-recorded must hold
- * consistently in both cases):
- *  1. Saved `existing`-mode path that passes strict validation → use it
- *     (labelled "This machine — set manually" — localStorage has no hostname).
- *  2. Otherwise the DB recorded path via `chooseLaunchCwd` (0 / 1-distinct-path
- *     / >1-distinct-paths contract — records that agree on the path dedupe to
- *     that one path, even from different hostnames),
- *     labelled "This machine — <host>". Both share the "This machine — <detail>"
- *     shape so they read as one box with two path sources, not two concepts.
- *  3. Nothing usable → source "none" (first-launch / repo-slug-resolves-it
- *     flow; no path line).
- *
- * `new`-mode saved state is intentionally ignored here: its composed
- * `~/projects/<slug>` path is not a validated absolute pwd and must not surface
- * as a recorded/launch path (it's created + recorded by the agent on launch).
+ * Callers in the browser MUST pass `realHostname` (`getMachineIdentity()`) —
+ * omitting it silently gives up rule 1 and reverts that caller to the old
+ * "every machine must agree" behaviour.
  */
 export function resolveEffectiveLaunchTarget({
-  saved,
   recordedPaths,
+  realHostname = null,
 }: ResolveEffectiveLaunchTargetArgs): EffectiveLaunchTarget {
-  // Saved existing-mode absolute path wins — it's the user's explicit choice and
-  // it's what the launch cwd resolution already used, so display now matches.
-  if (saved && saved.mode === "existing") {
-    const trimmed = saved.path.trim();
-    if (isValidAbsolutePath(trimmed)) {
-      return {
-        cwd: trimmed,
-        displayPath: trimmed,
-        displayLabel: "This machine — set manually",
-        host: null,
-        source: "saved",
-      };
-    }
-  }
-
-  const recordedCwd = chooseLaunchCwd(recordedPaths);
+  const recordedCwd = chooseLaunchCwd(recordedPaths, realHostname);
   if (recordedCwd) {
-    const match = (recordedPaths ?? []).find((r) => r.absolute_path.trim() === recordedCwd);
+    // Label from the row we actually resolved FROM where we can: with several
+    // rows sharing the resolved path (rule 2), the one under this machine's own
+    // hostname is the honest thing to name in "This machine — <host>". Falling
+    // back to the first path-match keeps the old label for unknown-identity
+    // browsers rather than dropping to the bare "This machine".
+    const pathMatches = (recordedPaths ?? []).filter(
+      (r) => r.absolute_path.trim() === recordedCwd
+    );
+    const match =
+      pathMatches.find((r) => r.hostname === realHostname) ?? pathMatches[0];
     return {
       cwd: recordedCwd,
       displayPath: recordedCwd,
@@ -1462,6 +1649,21 @@ export function writeLaunchPath(ideaId: string, state: LaunchPathState): void {
 }
 
 /**
+ * Remove the saved launch config for an idea. Used once a browser pin has been
+ * migrated into `idea_project_paths` (existing-mode pins only — see
+ * `decidePinMigration`) so it stops being read/re-migrated on every load. Also
+ * SSR-safe / no-op if storage is unavailable, matching `writeLaunchPath`.
+ */
+export function clearLaunchPathPin(ideaId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(launchPathKey(ideaId));
+  } catch {
+    // Storage disabled — nothing to clean up.
+  }
+}
+
+/**
  * The public app URL every bootstrap prompt points the MCP connector at.
  * NEXT_PUBLIC_APP_URL is inlined at build time; trailing-slash safe.
  */
@@ -1475,16 +1677,23 @@ export function resolveAppUrl(): string {
  * (paired auto-connect / Retry), so both build the compact prompt from the same
  * state and can never diverge (bootstrap-prompt parity, AC1/AC3):
  *
- *  - saved localStorage config for this idea → use it verbatim.
- *  - a known folder is on file (pinned localStorage path, or a recorded DB
- *    path for THIS machine — surfaced via `effectiveTarget`) → existing mode
- *    at that absolute path, so the bootstrap prompt SKIPS the create-folder/
+ *  - saved localStorage config for this idea, in CREATE-NEW mode → use it
+ *    verbatim. This is the ONLY case the browser store still drives: a
+ *    not-yet-created folder (parent + name) has no server equivalent, so
+ *    localStorage remains its home. A saved EXISTING-mode entry is no longer
+ *    read here — `idea_project_paths` (via `effectiveTarget`) is the single
+ *    source of truth for a folder that already exists (see
+ *    `resolveEffectiveLaunchTarget` for why: the pin and the server record
+ *    could silently disagree, and the pin always won, even when stale).
+ *  - a known folder is on file (recorded/manually-pinned DB path for THIS
+ *    machine — surfaced via `effectiveTarget`) → existing mode at that
+ *    absolute path, so the bootstrap prompt SKIPS the create-folder/
  *    mkdir/git-init block (the deep link's cwd already lands the session
  *    there). This applies WHETHER OR NOT the idea has a repo — a repo-backed
- *    idea with a recorded/pinned folder gets the same treatment as a no-repo
- *    one (this is the fix for the "repo-backed idea's recorded folder never
- *    surfaces" bug: `effectiveTarget` must be checked before the repo check
- *    below, or the repo branch always wins and the recorded path is dead code).
+ *    idea with a known folder gets the same treatment as a no-repo one (this
+ *    is the fix for the "repo-backed idea's recorded folder never surfaces"
+ *    bug: `effectiveTarget` must be checked before the repo check below, or
+ *    the repo branch always wins and the recorded path is dead code).
  *  - idea has a GitHub repo, no known folder → existing mode, empty path; the
  *    repo slug resolves the working copy locally (the fresh-machine flow).
  *  - no repo, no known folder → a brand-new project under ~/projects/<slug>;
@@ -1503,10 +1712,13 @@ export function resolveDefaultLaunchState(
   effectiveTarget?: EffectiveLaunchTarget
 ): LaunchPathState {
   const saved = readLaunchPath(ideaId);
-  if (saved) return saved;
-  // A known folder (recorded/pinned via resolveEffectiveLaunchTarget) opens
-  // THERE as existing mode so the prompt matches the cwd — checked BEFORE the
-  // repo fallback below so a repo-backed idea's recorded/pinned folder isn't
+  // Browser store survives ONLY for create-new-project mode — a folder that
+  // doesn't exist yet has no server-side row to be "the" record of. An
+  // existing-mode pin falls through to the server-only resolution below.
+  if (saved && saved.mode === "new") return saved;
+  // A known folder (recorded/manually-pinned via resolveEffectiveLaunchTarget)
+  // opens THERE as existing mode so the prompt matches the cwd — checked
+  // BEFORE the repo fallback below so a repo-backed idea's known folder isn't
   // shadowed by the empty-path repo default.
   if (effectiveTarget && effectiveTarget.source !== "none" && effectiveTarget.cwd) {
     return { mode: "existing", path: effectiveTarget.cwd };


### PR DESCRIPTION
## The bug

The folder a board opens Claude Code in was remembered in **two places at once** — a `localStorage` pin written by the "Set exact folder" dialog, and `idea_project_paths` on the server. Nothing ever compared them, and the pin won. So a stale browser value silently beat a correct, self-healing server record, and nothing followed the user to another browser or machine.

## The fix

**One store.** The server is now the only source an *existing* folder resolves from. `resolveEffectiveLaunchTarget` drops its `saved` argument entirely. The pin survives only for `mode: "new"`, where there is no server equivalent (the folder doesn't exist yet).

**The dialog writes to the server** (`saveManualProjectPath`) and surfaces failures instead of discarding the path silently.

**A one-time migration** (`useLaunchPathPinMigration`, mounted once per idea in `BoardLaunchProvider`) folds any pre-existing pin up to the server, then clears it — but only on a decision that actually wrote (`action !== "skip"`), never on a skip. An invalid pin is cleared outright, ending what would otherwise be an infinite retry loop.

## Reads now use the table's own key

`idea_project_paths` is keyed `(idea_id, owner_user_id, hostname)`, but `chooseLaunchCwd` only ever deduped by path — so two machines with the project checked out at *different* absolute paths resolved to nothing and re-asked on every launch.

It now takes `realHostname` (`getMachineIdentity()`, already populated from the bridge's announced host) and prefers the row keyed to **this** machine over any amount of cross-machine ambiguity. Both browser call sites thread it through. Unknown identity behaves exactly as before — the parameter defaults to `null`.

That in turn removes the migration's dead end: `decidePinMigration` rule 4 (>1 rows, none ours) used to skip, stranding the pin forever, because an extra row couldn't help a path-only dedupe. It now inserts under the real hostname — precisely the row the read will pick. Skip survives only when the hostname is genuinely unknown.

## Risk

- **No schema change.** The table already existed.
- **Every server write is an upsert, never a delete.** Other machines' rows are never touched.
- `owner_user_id` comes from the session, with a post-write ownership assertion.
- Worst credible failure: **a board asks for its folder once instead of knowing it.** One dialog save fixes it permanently, and cross-browser.
- Rollback is clean both ways: reverting leaves migrated rows in place (the goal), and already-cleared pins have their value preserved in those rows.

## Verification

- `npm run typecheck` — clean
- `npm run test` — 2982 passed, 180 files
- `npm run lint` — 0 errors (76 pre-existing warnings)
- `npm run build` — compiles
- **Mutation-checked**: deleting the machine-aware read rule fails 4 tests, so the new behaviour is genuinely locked rather than passing by accident.

Board task `40aace41`. Workflow run complete and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)