### PR TITLE
fix(launch): a new session offers the next task instead of just taking it

### DIFF
--- a/src/app/guide/launching-claude-code/page.tsx
+++ b/src/app/guide/launching-claude-code/page.tsx
@@ -40,12 +40,12 @@ export default function LaunchingClaudeCodePage() {
               claude-cli://
             </code>{" "}
             deep link that opens Claude Code, connects the VibeCodes MCP server,
-            and starts working the board.
+            and offers you the next task on the board.
           </p>
           <p className="text-muted-foreground">
             Instead of copying commands and explaining context by hand, one
             click hands Claude Code everything it needs: which project to open,
-            how to connect, and which task to pick up first.
+            how to connect, and what&apos;s waiting on your board.
           </p>
         </section>
 
@@ -233,15 +233,18 @@ export default function LaunchingClaudeCodePage() {
             </li>
           </ul>
           <p className="text-muted-foreground">
-            A board launch reads the board, takes the top unstarted task,
-            assigns it, moves it to{" "}
+            A board launch reads the board, tells you which unstarted task is
+            next up, and asks whether you want it — so you can say yes, or point
+            the session at something else entirely (a bug you just spotted, work
+            you left half-finished). Say yes and it assigns the task to you,
+            moves it to{" "}
             <strong className="text-foreground">In Progress</strong>, and if the
             task has a workflow it uses{" "}
             <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
               claim_next_step
             </code>
-            . Launching from a specific task targets that task instead of
-            picking the top one.
+            . Launching from a specific task skips the question and goes
+            straight to that task.
           </p>
         </section>
 

--- a/src/lib/launch-claude-code.test.ts
+++ b/src/lib/launch-claude-code.test.ts
@@ -345,6 +345,23 @@ describe("buildBoardBootstrapPrompt", () => {
     expect(p).toMatch(/Another live session may be actively working it right now/);
   });
 
+  // Card bd018a86: the verbose (copy-command) board prompt gets the same
+  // ask-first gate as the compact deep-link one — a fresh session must offer
+  // the next task and wait, not assign and start it unprompted.
+  it("board prompt asks before starting, and blocks any board write until answered", () => {
+    const p = buildBoardBootstrapPrompt({
+      appUrl: APP_URL,
+      ideaId: "idea-1",
+      ideaTitle: "My Idea",
+      mode: "existing",
+      repoUrl: "https://github.com/acme/widget",
+    });
+    expect(p).toMatch(/ASK me first, don't just start/);
+    expect(p).toMatch(/STOP and ask me/);
+    expect(p).toMatch(/Wait for my reply/);
+    expect(p).toMatch(/Do NOT call get_task, assign, move or start anything before I answer/);
+  });
+
   it("create-new mode injects mkdir and git clone when repo present", () => {
     const p = buildBoardBootstrapPrompt({
       appUrl: APP_URL,
@@ -1266,6 +1283,36 @@ describe("buildCompactBootstrapPrompt (deep-link prompt)", () => {
     expect(p).toContain("In Progress");
     // dir step comes before the MCP step
     expect(p.indexOf("mkdir -p")).toBeLessThan(p.indexOf("claude mcp add"));
+  });
+
+  // Card bd018a86: a board-level launch (no task chosen) must NOT silently
+  // start on the top of the queue — the session exists for whatever the user
+  // opened it for, and grabbing a task without asking forces them to interrupt
+  // it. It must name the next task, ask, and WAIT. A per-task launch is the
+  // opposite: the task was already chosen, so it goes straight in with no ask.
+  it("board-level launch asks before starting; per-task launch does not", () => {
+    const boardLevel = buildCompactBootstrapPrompt({
+      appUrl: APP_URL,
+      ideaId: "idea-1",
+      ideaTitle: "My Idea",
+      mode: "existing",
+      repoUrl: null,
+    });
+    expect(boardLevel).toMatch(/ASK first/);
+    expect(boardLevel).toMatch(/ask before starting it/);
+    expect(boardLevel).toMatch(/wait for my reply/);
+
+    const perTask = buildCompactBootstrapPrompt({
+      appUrl: APP_URL,
+      ideaId: "idea-1",
+      ideaTitle: "My Idea",
+      mode: "existing",
+      repoUrl: null,
+      taskId: "task-1",
+    });
+    expect(perTask).toContain("Work this task");
+    expect(perTask).not.toMatch(/ASK first/);
+    expect(perTask).not.toMatch(/wait for my reply/);
   });
 
   // Card 4cdcb33a: same hard exclusion as the full board bootstrap prompt, but

--- a/src/lib/launch-claude-code.ts
+++ b/src/lib/launch-claude-code.ts
@@ -836,11 +836,12 @@ export function buildBoardBootstrapPrompt({
 }: BoardBootstrapArgs): string {
   const dir = directoryBlock({ ideaId, mode, repoUrl, newProject });
   const mcp = mcpSetupHead(appUrl);
-  const work = `Then, pick up my work on the VibeCodes board for this idea:
+  const work = `Then, pick up my work on the VibeCodes board for this idea — but ASK me first, don't just start:
   • Idea: "${ideaTitle}"  (idea_id: ${ideaId})
   • Call get_board with idea_id ${ideaId} to see the columns and tasks. Do NOT use get_my_tasks here — it only returns tasks already ASSIGNED to you, and a freshly created board has none, so it would look (wrongly) like there's no work.
-  • Pick the top unstarted task (e.g. the first item in To Do, then Backlog), read it with get_task, assign it to yourself, and move it to In Progress. Only ever pick a task from To Do or Backlog — NEVER touch a task already in In Progress, Blocked, or Verify, even if it looks interrupted or interesting. Another live session may be actively working it right now.
-  • If that task has a workflow attached, use claim_next_step to claim its next step and follow the orchestration loop instead.
+  • Identify the top unstarted task (e.g. the first item in To Do, then Backlog). Only ever pick a task from To Do or Backlog — NEVER touch a task already in In Progress, Blocked, or Verify, even if it looks interrupted or interesting. Another live session may be actively working it right now.
+  • Then STOP and ask me: tell me which task is next up and ask whether you should pick it up, or whether I want something else (report a new bug, continue work in flight, a question, …). Wait for my reply. Do NOT call get_task, assign, move or start anything before I answer.
+  • If I say yes: read it with get_task, assign it to yourself, and move it to In Progress. If that task has a workflow attached, use claim_next_step to claim its next step and follow the orchestration loop instead.
 
 Use the MCP tools (get_board / get_task / claim_next_step / move_task / add_task_comment / …) to do the work. Move the task to In Progress and comment as you go.`;
 
@@ -1011,7 +1012,7 @@ function buildCompactStepPieces({
 
   const work = taskId
     ? `Work this task: get_task (task_id ${taskId}, idea_id ${ideaId}), move it to In Progress, then start. Comment as you go.`
-    : `Find work: call get_board (idea_id ${ideaId}) — NOT get_my_tasks, which only returns tasks already assigned to you (a new board has none). Only To Do/Backlog, never In Progress/Blocked/Verify (may be live). get_task it, assign it to yourself, move it to In Progress, then start. Comment as you go.`;
+    : `Find work, but ASK first: call get_board (idea_id ${ideaId}), NOT get_my_tasks. Only To Do/Backlog, never In Progress/Blocked/Verify (may be live). Name the top one, ask before starting it, and wait for my reply. Then get_task, assign to yourself, move to In Progress, start. Comment as you go.`;
 
   const header = taskId
     ? `Set up VibeCodes and work a board task for "${title}".`


### PR DESCRIPTION
## What

Starting a new session from the board button used to read the board, grab the top unstarted task, assign it, move it to In Progress and start working — with no pause. That's wrong whenever the session was opened for something else (report a bug you just spotted, resume work in flight, ask a question); the only recourse was interrupting it mid-flight.

The find-work step now **names the next task, asks, and waits**. Nothing is read, assigned, moved or started until the user answers. Say yes and it behaves exactly as before.

Per-task launches are deliberately untouched — the task was already chosen, so they go straight in with no question.

## The constraint worth reviewing

The compact prompt could not simply grow. It rides a `vibecodes://` URL capped at 2048 chars, and the `new-project` fixture in `deep-link.test.ts` already sat ~14 chars under the ceiling. Every appended variant overflowed and truncated the work step mid-sentence — the one step with no recovery path, since it carries the `idea_id`.

So the step was **rewritten rather than extended**: it now carries the ask and lands 7 encoded chars *shorter* than before. Every guard the earlier cards added survives verbatim — the To Do/Backlog-only exclusion (card 4cdcb33a) and the `NOT get_my_tasks` directive.

Headroom after the change, measured against the existing fixtures: board-level 391, task-selected 282, repo-backed 84, new-project 21.

## Also

`/guide/launching-claude-code` described the old take-it-without-asking behaviour; corrected.

## Tests

Full suite green. Two new cases pin the split — board-level asks and waits, per-task does not — alongside the existing URL-budget fixtures that would have caught the overflow.

Board card: `bd018a86-0824-46e7-8dff-f51f7560e17c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)