### PR TITLE
feat(terminal): view two sessions side by side, with drag-to-dock

### DIFF
--- a/docs/design-terminal-split-view.html
+++ b/docs/design-terminal-split-view.html
@@ -1,0 +1,476 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Design — Terminal split view (two panes, one keyboard)</title>
+<style>
+:root{
+  --bg:#09090b; --panel:#0c0c0e; --panel2:#111114; --panel3:#141417; --panel-dim:#101012;
+  --border:#27272a; --border2:#3f3f46;
+  --txt:#e4e4e7; --bright:#f4f4f5; --dim:#a1a1aa; --faint:#71717a;
+  --emerald:#34d399; --emerald-bg:rgba(52,211,153,.09); --emerald-bd:rgba(52,211,153,.4);
+  --sky:#38bdf8; --sky3:#7dd3fc; --sky-bg:rgba(56,189,248,.09); --sky-bd:rgba(56,189,248,.4);
+  --amber:#fbbf24; --amber-bg:rgba(251,191,36,.09); --amber-bd:rgba(251,191,36,.4);
+  --rose:#fb7185; --rose-bg:rgba(251,113,133,.09); --rose-bd:rgba(251,113,133,.45);
+  --violet:#a78bfa;
+  --mono:ui-monospace,'SF Mono',Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:var(--bg);color:var(--txt);font:14px/1.6 -apple-system,'Segoe UI',Roboto,sans-serif;padding:40px 20px 80px}
+.wrap{max-width:1020px;margin:0 auto}
+h1{font-size:24px;margin-bottom:4px}
+h2{font-size:18px;margin:48px 0 12px;padding-bottom:6px;border-bottom:1px solid var(--border)}
+h3{font-size:14.5px;margin:24px 0 8px}
+h4{font-size:12.5px;margin:18px 0 6px;color:var(--dim);text-transform:uppercase;letter-spacing:.05em}
+p{margin:8px 0;color:var(--dim)}
+strong{color:var(--txt)}
+ul{margin:8px 0 8px 22px;color:var(--dim)} li{margin:4px 0}
+.sub{color:var(--faint);font-size:13px;margin-bottom:20px}
+.meta{display:flex;gap:8px;flex-wrap:wrap;margin:14px 0 6px}
+.chip{font-size:11px;padding:2px 9px;border-radius:999px;border:1px solid var(--border2);color:var(--dim)}
+.chip.em{border-color:var(--emerald-bd);color:var(--emerald);background:var(--emerald-bg)}
+.chip.sky{border-color:var(--sky-bd);color:var(--sky);background:var(--sky-bg)}
+code{font-family:var(--mono);font-size:12px;background:var(--panel2);border:1px solid var(--border);border-radius:4px;padding:1px 5px;color:var(--txt)}
+kbd{font-family:var(--mono);font-size:11.5px;background:var(--panel2);border:1px solid var(--border2);border-bottom-width:2px;border-radius:4px;padding:1px 6px;color:var(--txt)}
+.panel{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:16px 18px;margin:12px 0}
+.found{border-left:3px solid var(--emerald)}
+.found .ftitle{font-size:14px;font-weight:700;color:var(--emerald);margin-bottom:6px}
+.reject{border-left:3px solid var(--rose)}
+.reject .rtitle{font-size:14px;font-weight:700;color:var(--rose);margin-bottom:6px}
+.veto{border:1px dashed var(--amber-bd);background:var(--amber-bg);border-radius:8px;padding:10px 14px;margin:10px 0;font-size:12.5px;color:var(--amber)}
+.veto b{color:var(--amber)}
+table{width:100%;border-collapse:collapse;margin:12px 0;font-size:12.5px}
+th{text-align:left;padding:7px 10px;color:var(--faint);font-size:11px;text-transform:uppercase;letter-spacing:.05em;border-bottom:1px solid var(--border2);vertical-align:bottom}
+td{padding:8px 10px;border-bottom:1px solid var(--border);color:var(--dim);vertical-align:top}
+td:first-child{color:var(--txt);font-weight:600}
+.tblwrap{overflow-x:auto}
+td.mono, .mono{font-family:var(--mono);font-size:11.5px;color:var(--txt)}
+.pass{color:var(--emerald);font-weight:700}
+.pick{color:var(--emerald);font-weight:700}
+.no{color:var(--rose);font-weight:700}
+/* flows */
+.flow{display:flex;flex-wrap:wrap;align-items:center;gap:6px;margin:10px 0;padding:4px 0}
+.step{background:var(--panel2);border:1px solid var(--border2);border-radius:7px;padding:6px 11px;font-size:12px;color:var(--txt)}
+.step small{display:block;color:var(--faint);font-size:10.5px;max-width:230px}
+.step.sys{border-style:dashed;color:var(--dim)}
+.step.good{border-color:var(--emerald-bd);background:var(--emerald-bg)}
+.step.warn{border-color:var(--amber-bd);background:var(--amber-bg)}
+.step.act{border-color:var(--sky-bd);background:var(--sky-bg)}
+.arr{color:var(--faint);font-size:13px;flex:none}
+/* mockups */
+.mock{background:var(--panel);border:1px solid var(--border2);border-radius:10px;margin:14px 0;overflow:hidden;font-size:13px}
+.mock-cap{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);margin:20px 0 -6px}
+.caption{font-size:11.5px;color:var(--faint)}
+.tabstrip{display:flex;align-items:stretch;background:var(--panel3);border-bottom:1px solid var(--border)}
+.tabscroll{display:flex;align-items:stretch;min-width:0;flex:1;overflow-x:auto}
+.ttab{display:flex;align-items:center;gap:7px;padding:8px 12px;border-right:1px solid var(--border);border-top:2px solid transparent;font-size:12.5px;color:var(--dim);white-space:nowrap;min-width:0}
+.ttab.on{border-top-color:var(--sky);background:var(--panel);color:var(--txt);font-weight:600}
+.ttab .lbl{overflow:hidden;text-overflow:ellipsis;max-width:150px}
+.ttab .x{color:var(--faint);font-size:11px;margin-left:2px}
+.glyph{font-size:11px;flex:none}
+.g-ok{color:var(--emerald)} .g-mut{color:var(--faint)} .g-warn{color:var(--amber)} .g-err{color:var(--rose)} .g-popped{color:var(--violet)} .g-info{color:var(--sky)}
+.badge{font-size:10px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;border-radius:4px;padding:0 5px;flex:none}
+.badge.pane{background:var(--sky-bg);border:1px solid var(--sky-bd);color:var(--sky)}
+.badge.pane.dim{background:transparent;border-color:var(--border2);color:var(--dim)}
+.pinned{display:flex;align-items:stretch;margin-left:auto;flex:none}
+.iconbtn{display:flex;align-items:center;justify-content:center;width:38px;border-left:1px solid var(--border);color:var(--dim);font-size:15px}
+.iconbtn.on{color:var(--sky);background:var(--sky-bg)}
+/* panes */
+.splitbody{display:flex;align-items:stretch;background:var(--panel);gap:0}
+.pane{flex:1 1 0;min-width:0;border:1px solid var(--border);margin:3px;border-radius:6px;overflow:hidden}
+.pane.focus{border-color:var(--sky);box-shadow:0 0 0 1px rgba(56,189,248,.35),0 0 14px rgba(56,189,248,.12)}
+.phead{display:flex;align-items:center;gap:8px;padding:6px 10px;border-bottom:1px solid var(--border);background:var(--panel3);min-width:0}
+.pane:not(.focus) .phead{background:var(--panel-dim)}
+.fword{display:inline-flex;align-items:center;gap:5px;border-radius:6px;padding:2px 8px;font-size:11px;font-weight:700;flex:none}
+.fword.typing{color:var(--sky3);border:1px solid var(--sky-bd);background:var(--sky-bg)}
+.fword.watch{color:var(--dim);border:1px solid var(--border2);background:transparent;font-weight:600}
+.pill{display:inline-flex;align-items:center;gap:5px;border:1px solid var(--border2);border-radius:6px;padding:1px 8px;font-size:11px;font-weight:600;color:var(--dim);flex:none}
+.pill.em{border-color:var(--emerald-bd);color:var(--emerald);background:var(--emerald-bg)}
+.pname{min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:12px;font-weight:600;color:var(--bright)}
+.pane:not(.focus) .pname{color:var(--dim);font-weight:400}
+.pbtns{display:inline-flex;gap:4px;flex:none}
+.pbtn{display:inline-flex;align-items:center;justify-content:center;width:22px;height:20px;border:1px solid var(--border2);border-radius:5px;font-size:10.5px;color:var(--txt);background:rgba(63,63,70,.35)}
+.pane:not(.focus) .pbtn{color:var(--dim)}
+.pbtn.rose{border-color:var(--rose-bd);color:var(--rose);background:transparent}
+.pterm{background:var(--panel);padding:10px 12px;font-family:var(--mono);font-size:11.5px;line-height:1.55;color:var(--dim);min-height:120px}
+.pterm .cl{color:var(--txt)}
+.pterm .ac{color:var(--emerald)}
+.cur-solid{display:inline-block;width:7px;height:13px;background:var(--txt);vertical-align:-2px;animation:blink 1.1s steps(1) infinite}
+.cur-hollow{display:inline-block;width:7px;height:13px;border:1px solid var(--dim);vertical-align:-2px}
+@keyframes blink{50%{opacity:0}}
+.swatch{display:inline-block;width:11px;height:11px;border-radius:3px;border:1px solid var(--border2);vertical-align:-1px;margin-right:5px}
+@media (prefers-reduced-motion: reduce){.cur-solid{animation:none}}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Terminal split view — two panes, one keyboard</h1>
+<div class="sub">UX design for task <code>df7a0134</code> · workflow step 2 of 6 · builds directly on the approved <strong>Requirements</strong> step (ProdOwner, 2026-08-20)</div>
+<div class="meta">
+  <span class="chip sky">2-pane split · 50/50 · opt-in toggle</span>
+  <span class="chip em">Exactly one pane owns the keyboard</span>
+  <span class="chip">Tabs stay the default</span>
+  <span class="chip">Never unmount an xterm</span>
+</div>
+
+<p>The Requirements step already locked the shape of v1: an <strong>opt-in toggle</strong> (tabs stay the default), <strong>two panes only</strong>, a <strong>50/50 split</strong>, <strong>exactly one pane owning keyboard input</strong>, focus signalled by <strong>border + words + dimmed chrome + cursor shape</strong> (never colour alone), <strong>popped-out sessions never claim a pane</strong>, <strong>never unmount an xterm</strong>, and a <strong>width floor that falls back to tabs</strong>. This document does not relitigate any of that — it turns each decision into concrete pixels, tokens and flows, and answers the three questions Requirements left open (§7): pane assignment with 3+ sessions, whether a per-pane swap control is needed, and the exact px floor.</p>
+<p><strong>One genuine late addition from Nick (2026-08-20), received during this design step:</strong> split view must also be reachable by <em>direct manipulation</em> — drag a tab and dock it to the left or right half, the way panels dock in an IDE. That is designed in §6 as a second entry route; the toggle remains the primary, keyboard- and touch-accessible path. It supersedes any earlier assumption that the toggle is the only way in.</p>
+
+<h2>1 · Decisions at a glance</h2>
+<div class="tblwrap"><table>
+<tr><th>Decision</th><th>What this design specifies</th><th>Why</th></tr>
+<tr><td>Split toggle placement</td><td>An icon toggle pinned in the tab strip's non-scrolling right region, immediately left of the existing “+” button. <code>aria-pressed</code>, visible only when ≥2 eligible tabs exist.</td><td>Fitts: session management already lives at that pinned edge; the toggle can never be scrolled away, same rule as “+”.</td></tr>
+<tr><td>Second entry route: drag-to-dock</td><td>Drag a tab into the dock body and drop it on the left or right half — translucent sky drop zones, drag ghost, Escape cancels. Toggle stays the accessible equivalent.</td><td>Nick's late addition (§6); IDE panel-docking convention — Jakob's law.</td></tr>
+<tr><td>Focused-pane treatment</td><td>Sky perimeter border + soft glow, bright header, <strong>“⌨ Typing here”</strong> chip, solid blinking block cursor.</td><td>Requirements §4 verbatim, made concrete in §3 below.</td></tr>
+<tr><td>Unfocused-pane treatment</td><td>Zinc border, header background steps down one shade, <strong>“◇ Watching”</strong> chip, hollow cursor. <strong>Terminal output is never dimmed.</strong></td><td>Watching the second session run is the entire point (Requirements §4: “do not scrim content”).</td></tr>
+<tr><td>Dimming mechanism</td><td>Explicit colour tokens, <strong>never CSS opacity on text</strong>.</td><td>Opacity silently breaks contrast guarantees; tokens keep every state provably AA (§3 table).</td></tr>
+<tr><td>Focus-move shortcut</td><td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>←</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>→</kbd> — absolute (names the destination pane), intercepted before the PTY.</td><td>Collision audit in §5.4 — every closer chord is taken by the browser, Claude Code, readline or tmux.</td></tr>
+<tr><td>Pane assignment (3+ sessions)</td><td>Active tab + most-recently-active other eligible session; a tab click while split replaces the <em>unfocused</em> pane and takes focus.</td><td>§7 Q1 — never yank the session the user is typing into.</td></tr>
+<tr><td>Per-pane swap control</td><td><strong>None in v1.</strong> The tab strip is the single swap affordance.</td><td>§7 Q2 — Hick's law, and there is no room at the 480px floor anyway.</td></tr>
+<tr><td>Width floor</td><td><code>MIN_PANE_WIDTH_PX = 480</code>; split needs a dock body ≥ <code>961px</code>, restore with a 20px hysteresis band at ≥ <code>981px</code>.</td><td>§7 Q3 — derived from the shipped 12.5px mono metrics, not guessed.</td></tr>
+<tr><td>Tabs of paned sessions</td><td>Carry a small “L” / “R” badge; <code>aria-selected</code> follows the <em>focused</em> pane.</td><td>Keeps the tablist's “exactly one selected” invariant coherent with two visible panels (§8).</td></tr>
+</table></div>
+
+<h2>2 · Wireframes</h2>
+<p class="caption">Rendered at the real palette (zinc <code>#09090b/#0c0c0e/#141417</code>, sky accent <code>#38bdf8</code>, glyph vocabulary from <code>terminal-tabs.ts</code>). Three sessions are open throughout — one of them with a deliberately long task title — so truncation and the 3-session pane story are visible, not hypothetical.</p>
+
+<div class="mock-cap">A — Tabbed mode (today's default), with the new split toggle in the pinned region</div>
+<div class="mock">
+  <div class="tabstrip">
+    <div class="tabscroll">
+      <div class="ttab on"><span class="glyph g-ok">●</span><span class="lbl">Fix login redirect loop</span><span class="x">✕</span></div>
+      <div class="ttab"><span class="glyph g-ok">●</span><span class="lbl">Terminal: view multiple open sessions side by side, not just as tabs</span><span class="x">✕</span></div>
+      <div class="ttab"><span class="glyph g-mut">■</span><span class="lbl">vibecodes · a3f2</span><span class="x">✕</span></div>
+    </div>
+    <div class="pinned">
+      <div class="iconbtn" title="Split view: show two sessions side by side" aria-label="demo">◫</div>
+      <div class="iconbtn">＋</div>
+    </div>
+  </div>
+  <div class="pane focus" style="margin:3px;border-color:var(--border);box-shadow:none">
+    <div class="phead">
+      <span class="pill em">● Connected</span>
+      <span class="pname">Fix login redirect loop</span>
+      <span class="mono" style="color:var(--faint)">nicks-mbp · session 9f21ac04</span>
+      <span class="pbtns"><span class="pbtn" title="Pop out">⧉</span><span class="pbtn" title="Read-only">🔓</span><span class="pbtn rose" title="End">⏻</span></span>
+    </div>
+    <div class="pterm">
+      <span class="ac">⏺</span> I'll trace the redirect. Reading <span class="cl">middleware.ts</span>…<br>
+      <span class="cl">&gt; </span><span class="cur-solid" aria-hidden="true"></span>
+    </div>
+  </div>
+</div>
+<p class="caption">The toggle only renders with 2+ eligible tabs; with 0–1 tabs the strip is byte-identical to today. Everything else in this frame is the shipped UI.</p>
+
+<div class="mock-cap">B — Split mode, LEFT pane focused</div>
+<div class="mock">
+  <div class="tabstrip">
+    <div class="tabscroll">
+      <div class="ttab on"><span class="glyph g-ok">●</span><span class="lbl">Fix login redirect loop</span><span class="badge pane">L</span><span class="x">✕</span></div>
+      <div class="ttab"><span class="glyph g-ok">●</span><span class="lbl">Terminal: view multiple open sessions side by…</span><span class="badge pane dim">R</span><span class="x">✕</span></div>
+      <div class="ttab"><span class="glyph g-mut">■</span><span class="lbl">vibecodes · a3f2</span><span class="x">✕</span></div>
+    </div>
+    <div class="pinned">
+      <div class="iconbtn on" title="Back to tabs">◫</div>
+      <div class="iconbtn">＋</div>
+    </div>
+  </div>
+  <div class="splitbody">
+    <div class="pane focus">
+      <div class="phead">
+        <span class="fword typing">⌨ Typing here</span>
+        <span class="pill em">●</span>
+        <span class="pname">Fix login redirect loop</span>
+        <span class="pbtns"><span class="pbtn" title="Pop out">⧉</span><span class="pbtn" title="Read-only">🔓</span><span class="pbtn rose" title="End">⏻</span></span>
+      </div>
+      <div class="pterm">
+        <span class="ac">⏺</span> Found it — <span class="cl">callback</span> is on the protected list.<br>
+        <span class="ac">⏺</span> Editing <span class="cl">src/lib/supabase/middleware.ts</span>…<br>
+        <span class="cl">&gt; approve the plan when ready </span><span class="cur-solid" aria-hidden="true"></span>
+      </div>
+    </div>
+    <div class="pane">
+      <div class="phead">
+        <span class="fword watch">◇ Watching</span>
+        <span class="pill em">●</span>
+        <span class="pname" title="Terminal: view multiple open sessions side by side, not just as tabs">Terminal: view multiple open sessions side by side, not just…</span>
+        <span class="pbtns"><span class="pbtn" title="Pop out">⧉</span><span class="pbtn" title="Read-only">🔓</span><span class="pbtn rose" title="End">⏻</span></span>
+      </div>
+      <div class="pterm">
+        <span class="ac">⏺</span> Running <span class="cl">npm run test</span> — 176 files…<br>
+        <span class="cl">✓</span> 2,910 passed (9.8s)<br>
+        <span class="cl">&gt; </span><span class="cur-hollow" aria-hidden="true"></span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="mock-cap">C — Split mode, RIGHT pane focused (compare with B directly above)</div>
+<div class="mock">
+  <div class="tabstrip">
+    <div class="tabscroll">
+      <div class="ttab"><span class="glyph g-ok">●</span><span class="lbl">Fix login redirect loop</span><span class="badge pane dim">L</span><span class="x">✕</span></div>
+      <div class="ttab on"><span class="glyph g-ok">●</span><span class="lbl">Terminal: view multiple open sessions side by…</span><span class="badge pane">R</span><span class="x">✕</span></div>
+      <div class="ttab"><span class="glyph g-mut">■</span><span class="lbl">vibecodes · a3f2</span><span class="x">✕</span></div>
+    </div>
+    <div class="pinned">
+      <div class="iconbtn on" title="Back to tabs">◫</div>
+      <div class="iconbtn">＋</div>
+    </div>
+  </div>
+  <div class="splitbody">
+    <div class="pane">
+      <div class="phead">
+        <span class="fword watch">◇ Watching</span>
+        <span class="pill em">●</span>
+        <span class="pname">Fix login redirect loop</span>
+        <span class="pbtns"><span class="pbtn" title="Pop out">⧉</span><span class="pbtn" title="Read-only">🔓</span><span class="pbtn rose" title="End">⏻</span></span>
+      </div>
+      <div class="pterm">
+        <span class="ac">⏺</span> Found it — <span class="cl">callback</span> is on the protected list.<br>
+        <span class="ac">⏺</span> Editing <span class="cl">src/lib/supabase/middleware.ts</span>…<br>
+        <span class="cl">&gt; approve the plan when ready </span><span class="cur-hollow" aria-hidden="true"></span>
+      </div>
+    </div>
+    <div class="pane focus">
+      <div class="phead">
+        <span class="fword typing">⌨ Typing here</span>
+        <span class="pill em">●</span>
+        <span class="pname" title="Terminal: view multiple open sessions side by side, not just as tabs">Terminal: view multiple open sessions side by side, not just…</span>
+        <span class="pbtns"><span class="pbtn" title="Pop out">⧉</span><span class="pbtn" title="Read-only">🔓</span><span class="pbtn rose" title="End">⏻</span></span>
+      </div>
+      <div class="pterm">
+        <span class="ac">⏺</span> Running <span class="cl">npm run test</span> — 176 files…<br>
+        <span class="cl">✓</span> 2,910 passed (9.8s)<br>
+        <span class="cl">&gt; </span><span class="cur-solid" aria-hidden="true"></span>
+      </div>
+    </div>
+  </div>
+</div>
+<p class="caption">Four independent signals flip together between B and C: the sky border + glow, the header words (“⌨ Typing here” ⇄ “◇ Watching”), the header brightness (name <code>#f4f4f5</code> semibold ⇄ <code>#a1a1aa</code>), and the cursor (solid blinking block ⇄ hollow outline). The terminal output itself is identical in both panes — never dimmed. The “Typing here” prompt line in the Watching pane of frame C is exactly the wrong-pane accident this feature must prevent: the user can see at a glance their keystrokes will NOT approve that plan.</p>
+
+<div class="mock-cap">D — Below the width floor: tabs render, the preference is kept</div>
+<div class="mock" style="max-width:560px">
+  <div class="tabstrip">
+    <div class="tabscroll">
+      <div class="ttab on"><span class="glyph g-ok">●</span><span class="lbl">Fix login redirect loop</span><span class="x">✕</span></div>
+      <div class="ttab"><span class="glyph g-ok">●</span><span class="lbl">Terminal: view mult…</span><span class="x">✕</span></div>
+    </div>
+    <div class="pinned">
+      <div class="iconbtn" title="Split view (needs a wider window)">◫</div>
+      <div class="iconbtn">＋</div>
+    </div>
+  </div>
+  <div style="display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--amber-bd);background:var(--amber-bg);padding:5px 12px;font-size:11.5px;color:var(--amber)">
+    ⓘ Split view needs a wider window — it will come back automatically when there's room. <span style="margin-left:auto;color:var(--amber)">✕</span>
+  </div>
+  <div class="pterm" style="border-top:1px solid var(--border)"><span class="cl">&gt; </span><span class="cur-solid" aria-hidden="true"></span></div>
+</div>
+<p class="caption">The amber notice (existing dismissible-notice pattern from the session view) appears only on the <em>transition</em> into the floor, and when the user presses the toggle while too narrow. The toggle is never disabled — pressing it below the floor stores the preference, shows this notice, and announces it (§5.8). No hover-only explanation, no dead button.</p>
+
+<h2>3 · Focused vs unfocused pane — exact tokens</h2>
+<div class="tblwrap"><table>
+<tr><th>Element</th><th>Focused pane</th><th>Unfocused pane</th></tr>
+<tr><td>Pane border</td><td class="mono"><span class="swatch" style="background:#38bdf8"></span>1px solid #38bdf8 (sky-400) + box-shadow 0 0 0 1px rgba(56,189,248,.35), 0 0 14px rgba(56,189,248,.12)</td><td class="mono"><span class="swatch" style="background:#27272a"></span>1px solid #27272a (zinc-800), no shadow</td></tr>
+<tr><td>Header background</td><td class="mono"><span class="swatch" style="background:#141417"></span>#141417 (the shipped header bg)</td><td class="mono"><span class="swatch" style="background:#101012"></span>#101012 (one shade darker)</td></tr>
+<tr><td>Focus words</td><td class="mono">“⌨ Typing here” — #7dd3fc (sky-300) on sky chip (border rgba(56,189,248,.4), bg rgba(56,189,248,.09))</td><td class="mono">“◇ Watching” — #a1a1aa (zinc-400), border #3f3f46, transparent bg</td></tr>
+<tr><td>Session name</td><td class="mono">#f4f4f5 (zinc-100), font-weight 600, truncate + full name in <code>title</code></td><td class="mono">#a1a1aa (zinc-400), font-weight 400, same truncation</td></tr>
+<tr><td>Header icon buttons</td><td class="mono">#e4e4e7 (zinc-200)</td><td class="mono">#a1a1aa (zinc-400); hover/focus-visible restores #e4e4e7</td></tr>
+<tr><td>Status pill</td><td colspan="2"><strong>Identical in both panes</strong> — it is information, not chrome; its colour vocabulary must keep one meaning everywhere (same rule as the tab glyphs).</td></tr>
+<tr><td>Terminal output area</td><td colspan="2"><strong>Identical in both panes</strong> — <code>#0c0c0e</code> bg, full-brightness text, keeps streaming. The shipped <code>opacity-45</code> treatment stays reserved for <code>disconnected</code> only.</td></tr>
+<tr><td>Cursor</td><td class="mono">Solid blinking block (xterm with real DOM focus)</td><td class="mono">Hollow outline block (xterm's built-in blurred rendering — route real focus, don't fake this)</td></tr>
+<tr><td>Text opacity</td><td colspan="2"><strong>Never used.</strong> All dimming is explicit colour tokens so every state below is provably AA.</td></tr>
+</table></div>
+
+<h3>Contrast (WCAG 2.1 AA)</h3>
+<div class="tblwrap"><table>
+<tr><th>Text / component</th><th>Foreground</th><th>Background</th><th>Ratio</th><th>AA requirement</th></tr>
+<tr><td>“⌨ Typing here”</td><td class="mono">#7dd3fc</td><td class="mono">#141417</td><td class="mono">11.0 : 1</td><td class="pass">≥ 4.5 ✓</td></tr>
+<tr><td>“◇ Watching”</td><td class="mono">#a1a1aa</td><td class="mono">#101012</td><td class="mono">7.4 : 1</td><td class="pass">≥ 4.5 ✓</td></tr>
+<tr><td>Focused session name</td><td class="mono">#f4f4f5</td><td class="mono">#141417</td><td class="mono">16.7 : 1</td><td class="pass">≥ 4.5 ✓</td></tr>
+<tr><td>Unfocused session name</td><td class="mono">#a1a1aa</td><td class="mono">#101012</td><td class="mono">7.4 : 1</td><td class="pass">≥ 4.5 ✓</td></tr>
+<tr><td>Unfocused icon buttons</td><td class="mono">#a1a1aa</td><td class="mono">#101012</td><td class="mono">7.4 : 1</td><td class="pass">≥ 3 (component) ✓</td></tr>
+<tr><td>Focused pane border (indicator)</td><td class="mono">#38bdf8</td><td class="mono">#0c0c0e / #141417</td><td class="mono">9.1 / 8.6 : 1</td><td class="pass">≥ 3 (non-text) ✓</td></tr>
+</table></div>
+<p class="caption">The zinc-800 border on the unfocused pane is below 3:1 against the panel by design — it is <em>not</em> an indicator. The indicator is the <em>presence</em> of the sky border + glow on exactly one pane, backed by words and cursor shape; absence never has to pass a contrast gate.</p>
+
+<h2>4 · Pane header anatomy</h2>
+<p>Left→right, mirroring the shipped session header so nothing has to be relearned: <strong>focus-state chip</strong> (new, always first — it is the answer to “where will my keys go?”, so it sits where scanning starts) · <strong>status pill</strong> (existing component, compact glyph-only under 560px pane width) · <strong>session name</strong> (new in the header — with two panes visible each needs its own name; <code>deriveTabLabel()</code> output, CSS-truncated, full text in <code>title</code>) · <strong>controls</strong>: Pop out, Read-only, End (the existing three, icon-only below 560px pane width with their existing <code>aria-label</code>s; every target keeps ≥ 24×24px hit area with padding). The host / session-id mono text is dropped from pane headers entirely — it is already hidden below <code>sm</code> today and is the lowest-value item at 480px.</p>
+<p>The header is a click target for focus like everything else in the pane (§5.3) — with one carve-out: clicks on the three control buttons act <em>without</em> first moving focus (ending or popping out the Watching pane must not first steal the keyboard from the pane you're typing in).</p>
+<p>The <strong>3-session case</strong> is visible in wireframes B/C: the third session stays a plain tab, fully live, reachable by one click; the two paned tabs carry “L”/“R” badges so the strip answers “which two am I seeing?” without looking down.</p>
+
+<h2>5 · Interaction flows</h2>
+
+<h3>5.1 Entering split</h3>
+<p>Two routes reach the same state: the toggle (below — the deliberate, keyboard/touch-accessible route) and drag-to-dock (§6 — direct manipulation). Both end in identical pane state, refit, focus and persistence; only the announcement wording differs.</p>
+<div class="flow">
+  <span class="step act">Click ◫ toggle<small>or keyboard-activate it in the strip</small></span><span class="arr">→</span>
+  <span class="step sys">Panes assigned: active tab → left, most-recently-active other eligible → right</span><span class="arr">→</span>
+  <span class="step sys">Both xterms refit + PTY resize<small>same forced refit bring-back already uses</small></span><span class="arr">→</span>
+  <span class="step good">Focus stays with the previously active session<small>no surprise keyboard move</small></span><span class="arr">→</span>
+  <span class="step">Announce: “Split view on. Fix login redirect loop left, Terminal: view multiple… right. Typing goes to Fix login redirect loop.”</span>
+</div>
+<p>Leaving split (toggle again): the <em>focused</em> pane's session becomes the single active tab; one refit; announce “Split view off. Showing Fix login redirect loop.” Preference persists via localStorage using the dock-height contract (never-throw, validate on read).</p>
+
+<h3>5.2 Clicking a tab while split</h3>
+<ul>
+<li><strong>Tab of the focused pane</strong> — no-op (already selected); no announcement.</li>
+<li><strong>Tab of the unfocused pane</strong> — focus moves to that pane. Identical to clicking into it (§5.3).</li>
+<li><strong>Tab of a third session</strong> — its session replaces the <em>unfocused</em> pane's content and <strong>takes focus</strong> (a tab click has always meant “attend to this one”). The replaced session stays mounted and live as a plain tab. The pane you were typing in stays visible and demotes to “◇ Watching”. Both panes refit only if geometry changed (it didn't — 50/50 is stable), so this is a pure re-parent of already-mounted views, never a remount.</li>
+</ul>
+
+<h3>5.3 Clicking into the unfocused pane</h3>
+<div class="flow">
+  <span class="step act">Click anywhere in the pane<small>output, header, padding — control buttons excepted</small></span><span class="arr">→</span>
+  <span class="step sys">Real DOM focus routed to that pane's xterm</span><span class="arr">→</span>
+  <span class="step good">All four signals flip atomically<small>border+glow, words, brightness, cursor</small></span><span class="arr">→</span>
+  <span class="step sys">aria-selected moves to its tab</span><span class="arr">→</span>
+  <span class="step">Announce: “Typing now goes to Terminal: view multiple open sessions…”</span>
+</div>
+<p>The click that focuses a pane is swallowed — it must not also select text or reach the PTY as a stray event. Focus and visual state share one source of truth (the pure module's <code>focusedPaneKey</code>), verified against real <code>document.activeElement</code> — no split-brain.</p>
+
+<h3>5.4 Keyboard: moving focus between panes</h3>
+<p><strong>Chord: <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>←</kbd> focuses the left pane, <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>→</kbd> the right.</strong> Absolute, not cyclic — it names the destination, so it is idempotent (pressing “left” while left is a silent no-op; no announcement spam) and spatially honest. It is intercepted in <em>both</em> panes via xterm's <code>attachCustomKeyEventHandler</code> (returning <code>false</code> so it <strong>never reaches the PTY</strong>) and by a dock-level keydown for when DOM focus is on pane chrome. Works only while split; in tabbed mode the keys pass through untouched.</p>
+<div class="tblwrap"><table>
+<tr><th>Candidate</th><th>Already taken by</th><th>Verdict</th></tr>
+<tr><td class="mono">Alt+← / Alt+→</td><td>readline word-move (Alt+b/f equivalents many shells map arrows to); Windows Terminal pane focus — but it forwards to the shell here</td><td class="no">collides with shell editing</td></tr>
+<tr><td class="mono">Cmd/Ctrl+Alt+← / →</td><td>Chrome & Safari macOS: switch <em>browser</em> tabs</td><td class="no">browser steals it</td></tr>
+<tr><td class="mono">Ctrl+Tab, Ctrl+PgUp/PgDn</td><td>Browser tab switching; not reliably interceptable</td><td class="no">browser steals it</td></tr>
+<tr><td class="mono">Ctrl+← / → (bare)</td><td>macOS Mission Control space switching (OS level); readline word-move on Linux</td><td class="no">OS/shell steal it</td></tr>
+<tr><td class="mono">Ctrl+B–based prefix</td><td>tmux prefix; Claude Code “run in background”</td><td class="no">collides in-PTY</td></tr>
+<tr><td class="mono">Shift+Tab / Esc / Ctrl+O/R/T/V/_ </td><td>Claude Code's own UI keys (mode cycle, transcript, verbose, paste, undo…)</td><td class="no">collides with Claude Code</td></tr>
+<tr><td class="mono pick">Ctrl+Shift+← / →</td><td>Nothing in Chrome/Safari/Firefox/Edge, macOS or Windows defaults, bash/zsh readline defaults, tmux defaults, or Claude Code's documented keys. (Text-field word-selection exists only in editable fields the chord never fires from.)</td><td class="pick">chosen</td></tr>
+</table></div>
+<p class="caption">Belt and braces: even if some TUI did bind <code>CSI 1;6 D/C</code>, the handler intercepts the chord <em>before</em> encoding, so it never reaches the PTY at all. Discoverability: the toggle's tooltip reads “Split view · Ctrl+Shift+←/→ moves typing”, each focus chip's <code>title</code> names the chord, and the launching-claude-code guide page documents it — never announced repeatedly through the live region.</p>
+
+<h3>5.5 Pop-out while split</h3>
+<p>Pop out the <strong>unfocused</strong> pane: it leaves the dock (existing pop-out flow); if a third eligible session exists, the most-recently-active one fills the vacated pane (still unfocused); otherwise split suspends and the surviving session renders full-width — <em>the mode preference is kept</em>, and split resumes automatically when a second eligible session appears (launch, reconnect, or bring-back). Pop out the <strong>focused</strong> pane: same, plus focus moves to the surviving pane and is announced. A popped-out session never occupies a pane (shipped invariant): its tab shows the existing ⧉ violet treatment and is excluded from pane eligibility.</p>
+
+<h3>5.6 A session ends while split</h3>
+<p>The pane <strong>keeps its slot</strong> and renders the existing ended panel in place — scrollback intact, Resume available, ■ glyph in tab and status pill. Nothing collapses under the user mid-read. If the ended pane was focused, focus moves to the live pane (announced: “Session ended: vibecodes · a3f2. Typing now goes to Fix login redirect loop.”). Closing it via the tab ✕ follows the existing confirm flow; on close, a third eligible session back-fills the pane, else the survivor goes full-width as in §5.5.</p>
+
+<h3>5.7 Resize while split</h3>
+<p>Dock-height drag and window resize refit <strong>both</strong> panes (each pane's existing ResizeObserver sees its own container change — verify a PTY resize is sent per pane, per Requirements AC11–12).</p>
+
+<h3>5.8 Narrowing below the width floor</h3>
+<div class="flow">
+  <span class="step warn">Dock body &lt; 961px</span><span class="arr">→</span>
+  <span class="step sys">Tabs render; both sessions stay mounted; preference untouched</span><span class="arr">→</span>
+  <span class="step">Amber notice (once, dismissible) + announce: “Window too narrow for split view — showing tabs. Split returns when wider.”</span><span class="arr">→</span>
+  <span class="step good">Body ≥ 981px → split restores itself, refit, announce “Split view restored.”</span>
+</div>
+<p>The 20px hysteresis band (fall back &lt;961, restore ≥981) prevents mode-flapping while dragging a window edge across the boundary. Pressing the toggle while below the floor stores the preference and shows the same notice — the button is never disabled (mockup D).</p>
+
+<h2>6 · Second entry route: drag a tab to dock it</h2>
+<p>Nick's request, verbatim: <em>“can we have a drag and drop version as well, where i can drag a tab and it can latch onto the right or left — just like a panel behaves in something like an IDE.”</em> This is the VS Code / JetBrains panel-docking convention, so the design copies that grammar rather than inventing one (Jakob's law): a drag ghost of the tab, translucent drop zones over the halves of the dock body, the hovered half lights up, release docks, <kbd>Esc</kbd> or releasing anywhere else cancels.</p>
+
+<h3>6.1 Gesture grammar — how docking, reordering and clicking stay distinct</h3>
+<div class="tblwrap"><table>
+<tr><th>Gesture</th><th>Recognised as</th><th>How it's distinguished</th></tr>
+<tr><td>Press + release, movement &lt; 8px</td><td>Ordinary tab click (select / focus pane)</td><td>8px pointer-distance activation constraint — no drag state exists until the pointer has moved 8px, so a twitchy click can never start a drag, let alone a split.</td></tr>
+<tr><td>Drag that stays within the tab strip's band</td><td>Tab <strong>reorder</strong> — a drop indicator line between tabs, selection unchanged until release</td><td>Geometry, not modifiers: while the pointer's Y remains inside the strip (plus an 8px grace margin), only reorder targets are active and no dock zones render.</td></tr>
+<tr><td>Drag that crosses down into the dock body</td><td><strong>Docking drag</strong> — left/right drop zones appear (§6.2)</td><td>Crossing the strip's bottom edge swaps the target set: reorder indicators vanish, zones fade in (120ms). Dragging back up restores reorder mode — the gesture is undecided until release.</td></tr>
+<tr><td>Release over a zone</td><td>Dock the session to that half</td><td>—</td></tr>
+<tr><td>Release anywhere else · <kbd>Esc</kbd> mid-drag</td><td><strong>Cancel</strong> — ghost animates back to the strip, nothing changes, no announcement beyond dnd-kit's cancel</td><td>—</td></tr>
+<tr><td>Touch</td><td>Same drags via long-press (250ms + 5px tolerance)</td><td>Prevents scroll hijacking; but touch users are pointed at the toggle — the drag is a shortcut, never the only way in.</td></tr>
+</table></div>
+
+<div class="mock-cap">E — Mid-drag from tabbed mode: tab in hand, right drop zone active</div>
+<div class="mock">
+  <div class="tabstrip">
+    <div class="tabscroll">
+      <div class="ttab on"><span class="glyph g-ok">●</span><span class="lbl">Fix login redirect loop</span><span class="x">✕</span></div>
+      <div class="ttab" style="opacity:.35;border-style:dashed"><span class="glyph g-ok">●</span><span class="lbl">Terminal: view multiple open sessions side by…</span><span class="x">✕</span></div>
+      <div class="ttab"><span class="glyph g-mut">■</span><span class="lbl">vibecodes · a3f2</span><span class="x">✕</span></div>
+    </div>
+    <div class="pinned">
+      <div class="iconbtn" title="Split view">◫</div>
+      <div class="iconbtn">＋</div>
+    </div>
+  </div>
+  <div style="position:relative">
+    <div class="pterm" style="min-height:150px">
+      <span class="ac">⏺</span> Found it — <span class="cl">callback</span> is on the protected list.<br>
+      <span class="cl">&gt; </span><span class="cur-solid" aria-hidden="true"></span>
+    </div>
+    <div style="position:absolute;inset:0;display:flex;gap:0;pointer-events:none">
+      <div style="flex:1;margin:6px 3px 6px 6px;border:1px dashed var(--border2);border-radius:8px;background:rgba(63,63,70,.15);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:600;color:var(--dim)">Dock left</div>
+      <div style="flex:1;margin:6px 6px 6px 3px;border:1px solid var(--sky-bd);border-radius:8px;background:rgba(56,189,248,.14);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;color:var(--sky3)">Dock right</div>
+    </div>
+    <div style="position:absolute;right:14%;top:38%;display:flex;align-items:center;gap:7px;background:var(--panel3);border:1px solid var(--border2);border-radius:7px;padding:7px 12px;font-size:12.5px;color:var(--txt);opacity:.9;box-shadow:0 4px 16px rgba(0,0,0,.5)">
+      <span class="glyph g-ok">●</span> Terminal: view multiple open ses… <span style="color:var(--faint);font-size:11px">⤸ in hand</span>
+    </div>
+  </div>
+</div>
+<p class="caption">The dragged tab stays in the strip as a dashed 35%-opacity placeholder (it is never unmounted); the ghost is a portal-rendered clone following the pointer. The hovered zone shows its destination <em>in words</em> (“Dock right”), not colour alone.</p>
+
+<h3>6.2 Drop-zone tokens</h3>
+<div class="tblwrap"><table>
+<tr><th>Element</th><th>Spec</th></tr>
+<tr><td>Zone container</td><td class="mono">position:absolute; inset:0 over the dock body; pointer-events:none (hit-testing is done from pointer coordinates by the drag layer, never by DOM hover — the xterm canvas below must never see these elements)</td></tr>
+<tr><td>Zone, inactive</td><td class="mono">border:1px dashed #3f3f46; background:rgba(63,63,70,.15); border-radius:8px; label #a1a1aa 12px/600</td></tr>
+<tr><td>Zone, active (hovered)</td><td class="mono">border:1px solid rgba(56,189,248,.5); background:rgba(56,189,248,.14); label “Dock left/right” #7dd3fc 12px/700 (≈10.9:1 over the terminal's #0c0c0e — AA ✓)</td></tr>
+<tr><td>Z-order</td><td class="mono">zones z-index:30, drag ghost z-index:40, inside the dock's stacking context — above xterm's canvas/selection layers, below the chooser Dialog portal</td></tr>
+<tr><td>Drag ghost</td><td class="mono">clone of the tab, opacity:.9, box-shadow 0 4px 16px rgba(0,0,0,.5), cursor:grabbing; source tab: opacity:.35 + dashed border, never unmounted</td></tr>
+<tr><td>Transitions</td><td class="mono">zones fade/scale in 120ms ease-out; cancelled ghost animates back to the strip; all suppressed under prefers-reduced-motion</td></tr>
+</table></div>
+
+<h3>6.3 Drop outcomes</h3>
+<ul>
+<li><strong>From tabbed mode, drop on a half:</strong> split turns on with the dragged session in that half; the other half takes the previously active session (if the dragged one <em>was</em> active, the most-recently-active other eligible session — same MRA rule as §7 Q1). Preference stored, both panes refit + PTY resize — the toggle's exact pipeline (§5.1).</li>
+<li><strong>Already split, drop a third tab on a half:</strong> that half's session is replaced (it returns to being a plain live tab). Unlike the tab-click rule (§5.2), the user chose the side explicitly, so the drop may replace <em>either</em> pane — including the focused one.</li>
+<li><strong>Drag a paned tab back into the strip and release:</strong> split ends — the return path. The dragged session becomes the single active tab (it is the one in hand); the other pane's session returns to a plain tab; preference updates to tabs, one refit. Mid-drag the strip highlights as a drop target (“Back to tabs” indicator line) so the destination is legible before release.</li>
+<li><strong>Focus after any drag-dock lands:</strong> the just-dropped pane takes keyboard focus — direct manipulation is the strongest possible statement of attention — and every §3 signal applies to it instantly. Live region: <em>“Split view on. Terminal: view multiple… docked right. Typing goes to Terminal: view multiple…”</em> (or <em>“…docked left…”</em> / <em>“Split view off. Showing Fix login redirect loop.”</em> for the return path).</li>
+<li><strong>Popped-out tabs are not drag-docking sources:</strong> a popped-out session never claims a pane (shipped invariant), so its tab never activates a docking drag — press-and-move on it does nothing beyond the existing click behaviours. It may still be reordered along the strip.</li>
+<li><strong>Dragging a tab out of the browser window: out of scope.</strong> Pop-out already covers “this session in its own OS window”, with the relay's single-attach machinery behind it; a drag-out gesture would be a second, worse path to the same result. Explicitly not designed.</li>
+</ul>
+
+<h3>6.4 Accessibility and implementation notes</h3>
+<ul>
+<li><strong>The toggle is the accessible equivalent, stated plainly:</strong> drag-and-drop is pointer-only here. dnd-kit's keyboard sensor is deliberately <em>not</em> wired to tabs — arrow keys already navigate the tablist, and a keyboard drag mode would fight both that and the terminal's key handling. Keyboard and switch users reach the identical end state via the toggle + <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>←</kbd>/<kbd>→</kbd>; touch users via the toggle (long-press drag works but is not the recommended path).</li>
+<li><strong>Reuse <code>@dnd-kit</code>, don't hand-roll pointer events:</strong> it is already a project dependency doing drag-and-drop on the board, and it supplies exactly the pieces this gesture needs for free — the 8px distance and 250ms touch activation constraints, Escape-to-cancel, portal drag overlays, and collision detection for the zone/reorder target swap. A bespoke pointer-event layer would re-implement all of that and drift from the board's behaviour.</li>
+<li><strong>Hard invariant for the engineer:</strong> the drop handler mutates only the pure module's pane-assignment state; the panes are already-mounted xterm instances that get re-laid-out by CSS, exactly as the toggle does. A drag must never cause a remount — the “placeholder tab + portal ghost” pattern above exists precisely so the real tab (and its session view) never leaves the tree — and the drop must trigger the same forced refit + PTY resize that entering split via the toggle does.</li>
+</ul>
+
+<h2>7 · The three open questions, answered</h2>
+
+<div class="panel found"><div class="ftitle">Q1 — Pane assignment with 3+ sessions</div>
+<p><strong>Adopt Requirements' recommendation, with the focus rule made explicit.</strong> Panes hold the active tab + the most-recently-active other eligible session (eligible = mounted, not popped out; ended sessions remain eligible — they hold readable scrollback). Clicking a third tab replaces the <strong>unfocused</strong> pane and <strong>takes focus</strong>. Rationale: the unfocused pane is by definition the one the user is not typing in, so it is the only slot that can change without risking a mid-keystroke context switch; and a tab click has meant “make this the one I'm attending to” since tabs shipped — split view must not quietly change what a click means (recognition over recall). MRA beats list-order because it matches “the two things I was just working with”, the same recency logic the chooser already uses.</p></div>
+
+<div class="panel found"><div class="ftitle">Q2 — Per-pane “swap session” control</div>
+<p><strong>Not in v1.</strong> The tab strip is already a complete, visible, familiar switching surface one glance above the panes, and §5.2 makes it the swap mechanism for free. A per-pane dropdown would be a second, competing way to do the same thing (Hick's law), would cost header space that does not exist at the 480px floor, and would need its own keyboard/a11y surface. Revisit only if real usage shows people popping out sessions just to rearrange panes.</p></div>
+
+<div class="panel found"><div class="ftitle">Q3 — Exact px floor for a ~60-column pane</div>
+<p><strong><code>MIN_PANE_WIDTH_PX = 480</code>; split requires a dock body ≥ 961px; restore at ≥ 981px (20px hysteresis).</strong> Derivation from shipped values, not taste: xterm runs at <code>fontSize: 12.5</code> in SF&nbsp;Mono/Menlo-class faces (<code>use-terminal-session.ts:704–708</code>), whose advance width is ≈0.602em → ≈7.53px per cell; 60 columns ≈ 452px, plus the container's <code>px-3</code> padding (24px) and the 2px focus border ≈ 478px → rounded to 480. Two panes + 1px divider = 961px. The constants live in the new pure module beside the pane-assignment logic, with a comment tying them to the font metrics so a future font-size change knows to revisit them.</p></div>
+
+<h2>8 · Accessibility</h2>
+<ul>
+<li><strong>Tablist stays coherent:</strong> the strip keeps <code>role="tablist"</code> / <code>role="tab"</code>; <code>aria-selected="true"</code> tracks the <strong>focused pane's</strong> tab — exactly one selected at all times, in both modes. The other paned tab is plain <code>aria-selected="false"</code>; its visibility is conveyed by its pane's own semantics, not by inventing a second “selected”.</li>
+<li><strong>Panes:</strong> each pane wrapper keeps <code>role="tabpanel"</code> + <code>aria-labelledby</code> its tab, and both visible panels drop <code>hidden</code>/<code>aria-hidden</code>; non-pane sessions keep today's hidden treatment. Each pane additionally exposes focus state in its accessible name via a visually-rendered, programmatically-associated chip: accessible name resolves to e.g. <em>“Fix login redirect loop — typing here”</em> / <em>“Terminal: view multiple… — watching”</em>. The a11y tree can never report two typing panes because the name derives from the single <code>focusedPaneKey</code>.</li>
+<li><strong>“L”/“R” tab badges</strong> carry <code>aria-label="in left pane"</code> / <code>"in right pane"</code> — words, not position-by-colour.</li>
+<li><strong>Live region</strong> (the existing shared polite announcer, one message per event, never per re-render): split on/off (§5.1), drag-dock landings and the drag return path (§6.3), focus moves — click or chord — (“Typing now goes to …”), width-floor fallback and restore (§5.8), session-ended focus handoff (§5.6). Background-tab attention announcements (<code>shouldAnnounceAttention</code>) continue unchanged; a <em>paned</em> session counts as “active” for that rule (its state is on screen — announcing it would double-speak).</li>
+<li><strong>Keyboard reachability:</strong> the toggle is a real button in the strip's tab order with <code>aria-pressed</code>; <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>←</kbd>/<kbd>→</kbd> moves pane focus; the existing arrow-key tab navigation is untouched. Focus-visible rings on all pane controls at both dim levels (§3 contrast row).</li>
+<li><strong>Drag-to-dock is pointer-only by design</strong> (§6.4): every state it can produce is reachable via the toggle and the chord, so no keyboard drag mode is added — one that fought the tablist's arrow keys and the terminal's key handling would be worse than none.</li>
+<li><strong>Never colour alone:</strong> every focus signal has a non-colour twin — words (chip), shape (solid vs hollow cursor), weight (name), and the border is presence/absence, not hue-vs-hue.</li>
+</ul>
+
+<h2>9 · What the engineer must not break</h2>
+<ul>
+<li><strong>Never unmount an xterm.</strong> Mode switches, pane swaps, drag-docks, floor fallback and pop-out are all CSS/layout re-arrangements of the always-mounted <code>TerminalSessionView</code>s — scrollback, socket and connection state survive every transition in this document. The drag gesture in particular: source tab stays mounted as a placeholder, the ghost is a portal clone, and the drop mutates only pane-assignment state, then fires the same forced refit + PTY resize as the toggle (§6.4).</li>
+<li><strong>One keyboard owner, enforced not implied.</strong> <code>useTerminalSession</code>'s auto-focus on expand/refresh must be routed: exactly one pane gets the focus grab; the other gets refit <em>without</em> it. Visual focus state must derive from the same single source the DOM focus does.</li>
+<li><strong>Refit + PTY resize on every geometry change:</strong> enter/leave split, pane swap, back-fill, floor fallback/restore, dock-height drag, window resize.</li>
+<li><strong>Popped-out sessions never claim a pane</strong>, and their mid-preemption status is never read as ended/errored.</li>
+<li><strong>Chooser and overlay discipline untouched:</strong> inline browse still CSS-hides the whole session container (both panes); every dialog stays dismissable.</li>
+<li><strong>The chord never reaches the PTY</strong>, and no other key is newly intercepted — a terminal that eats keystrokes is broken.</li>
+<li><strong>Sessions with no recorded folder</strong> keep their existing chooser/reconnect behaviour — split view changes nothing about eligibility rules beyond pop-out exclusion.</li>
+<li><strong>Pure logic in <code>src/lib/terminal/</code></strong> (suggested: <code>split-view.ts</code> — pane assignment, eligibility, focus ownership, width floor + hysteresis, persistence read/write) with unit tests, mirroring <code>terminal-tabs.ts</code>; the dock stays event wiring. Everything behind <code>NEXT_PUBLIC_TERMINAL_ENABLED</code>.</li>
+<li><strong>Tab semantics:</strong> dedupe, per-tab close/confirm, cap refusal, task-launch choice and “+” behave identically in both modes; <code>aria-selected</code> stays singular.</li>
+</ul>
+
+<p class="caption" style="margin-top:36px">Compass · UX Design step for “Terminal: view multiple open sessions side by side, not just as tabs” · 2026-08-20. Palette, glyphs and header anatomy taken from <code>terminal-dock.tsx</code>, <code>terminal-session-view.tsx</code>, <code>terminal-tabs.ts</code>; width floor derived from <code>use-terminal-session.ts</code> font metrics; persistence contract from <code>dock-height.ts</code>.</p>
+
+</div>
+</body>
+</html>

--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -91,12 +91,24 @@ vi.mock("./terminal-session-view", () => ({
     onBrowseSessions,
     onReportSummary,
     onPopOut,
+    paneFocused,
+    grabFocus,
+    onPaneFocusChange,
   }: {
     entry: { key: string; taskId?: string; ideaId?: string };
     onResumeEndedSession?: (payload: { cwd?: string; taskId?: string; ideaId?: string }, sid: string | null) => void;
     onBrowseSessions?: () => void;
     onReportSummary: (key: string, summary: Record<string, unknown>) => void;
     onPopOut?: () => void;
+    // Split-view focus-sync defect fix (task df7a0134, QA rework): a real
+    // focusable element stands in for xterm's own hidden input, so a test
+    // can drive the SAME real focus/blur events the fix listens for (not
+    // just clicks) and assert `grabFocus`'s tabIndex consequence — the
+    // dock's own logic is what's under test here, the real xterm/hook
+    // wiring is covered by use-terminal-session.test.ts.
+    paneFocused?: boolean;
+    grabFocus?: boolean;
+    onPaneFocusChange?: (focused: boolean) => void;
   }) => {
     useEffect(() => {
       sessionViewMountSpy(entry.key);
@@ -172,6 +184,28 @@ vi.mock("./terminal-session-view", () => ({
           <button data-testid={`pop-out-${entry.key}`} onClick={onPopOut}>
             Pop out
           </button>
+        )}
+        {/* Split-view focus-sync defect fix (task df7a0134, QA rework):
+            `paneFocused` only renders (true or false) while this stub is one
+            of the split's two panes — mirrors the real component's `inPane`
+            gate. The indicator text is the SAME words a real user reads
+            (paneFocusWord); the input is a real focusable element wired to
+            `onPaneFocusChange` exactly like the real xterm textarea is
+            wired via use-terminal-session.ts, with `grabFocus` driving its
+            tabIndex the same way the real fix does — so a test here can
+            assert BOTH "the indicator never lies" and "Tab can't reach the
+            watching pane" without needing the real xterm/hook machinery. */}
+        {paneFocused !== undefined && (
+          <>
+            <span data-testid={`pane-indicator-${entry.key}`}>{paneFocused ? "Typing here" : "Watching"}</span>
+            <input
+              data-testid={`pane-input-${entry.key}`}
+              tabIndex={grabFocus ? 0 : -1}
+              onFocus={() => onPaneFocusChange?.(true)}
+              onBlur={() => onPaneFocusChange?.(false)}
+              readOnly
+            />
+          </>
         )}
       </div>
     );
@@ -1325,5 +1359,138 @@ describe("TerminalDock — resize handle hidden while the active tab is popped o
     // placeholder (terminal-session-view.tsx) — a live handle over it would
     // invite a drag with no terminal body underneath.
     expect(screen.queryByTestId("terminal-dock-resize-handle")).not.toBeInTheDocument();
+  });
+});
+
+// Split-view focus-sync defect fix (task df7a0134, QA rework — category-1,
+// blocks-release). QA's finding: real DOM keyboard focus could diverge from
+// the "Typing here"/"Watching" indicator — nothing in the previous
+// implementation listened for focus arriving anywhere OTHER than a click,
+// and native Tab order could walk straight into the "Watching" pane's real
+// input, since nothing constrained its tabIndex either. These tests render
+// BOTH panes (via the mock TerminalSessionView's `paneFocused`/`grabFocus`/
+// `onPaneFocusChange` stand-ins above — real xterm/focus wiring is covered
+// directly in use-terminal-session.test.ts) and assert the DOCK's own
+// state — `focusedSide` + the new `keyboardLive` ground truth — follows
+// SIMULATED real focus/blur events, not just clicks, including the exact
+// Tab-into-the-watching-pane path from QA's repro.
+describe("TerminalDock — split view keyboard-focus sync (defect fix, task df7a0134)", () => {
+  /** Mints a 2nd local tab via the chooser's "Start new" (mirrors
+   * `openFirstTabViaChooser` above, generalised to N tabs) — the only way to
+   * reach 2+ eligible sessions without relying on the bug that describe
+   * block covers. Returns every session's key, in mint order. */
+  async function mintTwoSessions(): Promise<[string, string]> {
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("chooser-start-new"));
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    const firstKey = screen.getByTestId("session-view").dataset.key as string;
+
+    act(() => {
+      requestBrowserLaunch();
+    });
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("chooser-start-new"));
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(2));
+
+    const keys = screen.getAllByTestId("session-view").map((el) => el.dataset.key as string);
+    const secondKey = keys.find((k) => k !== firstKey) as string;
+    return [firstKey, secondKey];
+  }
+
+  function enterSplitView() {
+    fireEvent.click(screen.getByRole("button", { name: "Split view: show two sessions side by side" }));
+  }
+
+  function indicatorTextFor(key: string): string {
+    return screen.getByTestId(`pane-indicator-${key}`).textContent ?? "";
+  }
+
+  function findFocused(keys: [string, string]): string {
+    const [a, b] = keys;
+    if (indicatorTextFor(a) === "Typing here") return a;
+    if (indicatorTextFor(b) === "Typing here") return b;
+    throw new Error("neither pane reports 'Typing here'");
+  }
+
+  it("entering split view marks exactly one pane 'Typing here' and removes the OTHER pane's input from native Tab order (tabIndex -1) — the fix for QA's exact repro", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+    const [keyA, keyB] = await mintTwoSessions();
+
+    enterSplitView();
+    await waitFor(() => expect(screen.getByTestId(`pane-indicator-${keyA}`)).toBeInTheDocument());
+
+    const focused = findFocused([keyA, keyB]);
+    const watching = focused === keyA ? keyB : keyA;
+    expect(indicatorTextFor(watching)).toBe("Watching");
+
+    // The invariant the defect broke: the pane the indicator calls "Typing
+    // here" must be the ONLY one a native Tab press can reach. `tabIndex=-1`
+    // excludes an element from sequential navigation entirely (it stays
+    // reachable by click/chord, which use `.focus()` directly).
+    expect((screen.getByTestId(`pane-input-${focused}`) as HTMLInputElement).tabIndex).toBe(0);
+    expect((screen.getByTestId(`pane-input-${watching}`) as HTMLInputElement).tabIndex).toBe(-1);
+  });
+
+  it("real focus landing on the 'Watching' pane's input — exactly what native Tab does now that it CAN reach it, or anything else that moves DOM focus there — flips the indicator instead of leaving it lying", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+    const [keyA, keyB] = await mintTwoSessions();
+
+    enterSplitView();
+    await waitFor(() => expect(screen.getByTestId(`pane-indicator-${keyA}`)).toBeInTheDocument());
+    const focused = findFocused([keyA, keyB]);
+    const watching = focused === keyA ? keyB : keyA;
+
+    // Simulates real DOM focus arriving on the watching pane's input with NO
+    // click involved — before this fix, nothing was listening for this at
+    // all, so `focusedSide` (and the indicator) would have kept claiming the
+    // OTHER pane was "Typing here" while this one genuinely held the
+    // keyboard. This is the class of bug QA reproduced with a real Tab press.
+    fireEvent.focus(screen.getByTestId(`pane-input-${watching}`));
+
+    await waitFor(() => expect(indicatorTextFor(watching)).toBe("Typing here"));
+    expect(indicatorTextFor(focused)).toBe("Watching");
+  });
+
+  it("focus leaving BOTH panes (a blur with no followup focus — click elsewhere on the page, window blur) clears 'Typing here' from both, never leaving a stale claim", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+    const [keyA, keyB] = await mintTwoSessions();
+
+    enterSplitView();
+    await waitFor(() => expect(screen.getByTestId(`pane-indicator-${keyA}`)).toBeInTheDocument());
+    const focused = findFocused([keyA, keyB]);
+
+    // No pane refocuses afterwards — mirrors clicking outside the dock
+    // entirely, or the browser window itself losing focus.
+    fireEvent.blur(screen.getByTestId(`pane-input-${focused}`));
+
+    await waitFor(() => {
+      expect(indicatorTextFor(keyA)).toBe("Watching");
+      expect(indicatorTextFor(keyB)).toBe("Watching");
+    });
+  });
+
+  it("a focus move BETWEEN the two panes (blur old, focus new — the same tick, exactly like the browser does it) never dips through a false 'neither focused' state", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+    const [keyA, keyB] = await mintTwoSessions();
+
+    enterSplitView();
+    await waitFor(() => expect(screen.getByTestId(`pane-indicator-${keyA}`)).toBeInTheDocument());
+    const focused = findFocused([keyA, keyB]);
+    const other = focused === keyA ? keyB : keyA;
+
+    // Native focus changes fire blur(old) then focus(new) synchronously in
+    // the same tick — mirrored here in one `act`, the same way the real
+    // browser (and jsdom's own focus() implementation) would deliver them.
+    act(() => {
+      fireEvent.blur(screen.getByTestId(`pane-input-${focused}`));
+      fireEvent.focus(screen.getByTestId(`pane-input-${other}`));
+    });
+
+    expect(indicatorTextFor(other)).toBe("Typing here");
+    expect(indicatorTextFor(focused)).toBe("Watching");
   });
 });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -780,7 +780,9 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   }, [splitPreferred]);
   useEffect(() => {
     const el = splitBodyRef.current;
-    if (!el) return;
+    // Guarded for jsdom and any environment without ResizeObserver — same
+    // pattern as terminal-dock-inset.ts's own measurement effect.
+    if (!el || typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver((entries) => {
       const width = entries[0]?.contentRect.width ?? el.getBoundingClientRect().width;
       setBelowWidthFloor((prev) => {
@@ -808,6 +810,13 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       setFloorNoticeDismissed(false);
       if (assignment.left && assignment.right) {
         announce(formatSplitOnAnnouncement(labelFor(assignment.left), labelFor(assignment.right), labelFor(assignment.left)));
+        // Belt and braces for the hard requirement: the LEFT pane's
+        // `grabFocus`/`expanded` props may both already have been `true`
+        // (it was the tab the user was just on), so the effect that reacts
+        // to THEIR transition wouldn't re-fire on its own — force the
+        // keyboard there explicitly rather than trust it was already real
+        // DOM focus (it might have been on the toggle button itself).
+        actionsMapRef.current.get(assignment.left)?.refreshView({ focus: true });
       }
     } else {
       const remaining = splitAssignment[focusedSide] ?? activeKey;
@@ -947,6 +956,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       writeSplitViewPreference(true);
       setExpanded(true);
       announce(formatDockAnnouncement(labelFor(draggedKey), outcome.side));
+      // Same belt-and-braces as the toggle above — direct manipulation is
+      // the strongest possible statement of attention (design §6.3), so the
+      // dropped pane must genuinely hold real DOM focus, not just the props
+      // that would eventually produce it.
+      actionsMapRef.current.get(draggedKey)?.refreshView({ focus: true });
     },
     [dropZone, splitAssignment, eligible, announce, labelFor],
   );

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -445,6 +445,30 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   const [splitAssignment, setSplitAssignment] = useState<PaneAssignment>({ left: null, right: null });
   // Exactly ONE pane owns the keyboard at all times (the hard requirement).
   const [focusedSide, setFocusedSide] = useState<PaneSide>("left");
+  // Split-view focus-sync defect fix (task df7a0134, QA rework): `focusedSide`
+  // above is the APP's declared intent — which pane a click/chord/forced move
+  // targeted. It says nothing about whether the keyboard is ACTUALLY there
+  // right now. `keyboardLive` is that ground truth: true only while real DOM
+  // focus genuinely sits inside one of the two panes' xterm inputs — false
+  // the instant it leaves both (click elsewhere on the page, window blur), so
+  // neither pane's "Typing here" chip can ever be shown while nothing
+  // actually holds the keyboard. Fed into `paneFocused` below alongside
+  // `focusedSide`; kept true by every explicit "grab the keyboard" call site
+  // (`movePaneFocus`, entering split, drag-to-dock) via `markPaneFocusLive`,
+  // and corrected by real focus/blur events via `handlePaneFocusChange` —
+  // see both below.
+  const [keyboardLive, setKeyboardLive] = useState(false);
+  // Which pane's textarea most recently reported real focus — read by the
+  // deferred blur check in `handlePaneFocusChange` so a focus move BETWEEN
+  // the two panes (blur old, focus new — both synchronous, same tick) never
+  // flickers `keyboardLive` false in between.
+  const liveFocusKeyRef = useRef<string | null>(null);
+  const blurCheckTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (blurCheckTimeoutRef.current) clearTimeout(blurCheckTimeoutRef.current);
+    };
+  }, []);
   // Width-floor hysteresis state (design §7 Q3 / §5.8) — measured off the
   // same element the two panes actually share (see `splitBodyRef` below).
   const [belowWidthFloor, setBelowWidthFloor] = useState(false);
@@ -798,6 +822,27 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     return () => ro.disconnect();
   }, [announce]);
 
+  // Split-view focus-sync defect fix: the one place `keyboardLive` is set
+  // TRUE — every call site below that deliberately grabs the keyboard
+  // (entering split, the chord/click move, a drag-drop dock) calls this
+  // alongside its existing `refreshView({ focus: true })`, rather than
+  // relying solely on the resulting native focus event. That event can be a
+  // no-op when the target already genuinely had DOM focus before the
+  // transition (the exact "belt and braces" gap the toggle's own comment
+  // below already called out for `grabFocus`/`expanded`) — `.focus()` on an
+  // already-focused element fires no new focus event, so nothing would
+  // otherwise update `keyboardLive`. `handlePaneFocusChange` (below) is the
+  // complementary correction for focus arriving somewhere the app DIDN'T
+  // ask it to.
+  const markPaneFocusLive = useCallback((key: string) => {
+    liveFocusKeyRef.current = key;
+    if (blurCheckTimeoutRef.current) {
+      clearTimeout(blurCheckTimeoutRef.current);
+      blurCheckTimeoutRef.current = null;
+    }
+    setKeyboardLive(true);
+  }, []);
+
   // Toggle (design §5.1): the deliberate, keyboard/touch-accessible entry
   // route — drag-to-dock (below) is a shortcut, never the only way in.
   const toggleSplitView = useCallback(() => {
@@ -817,6 +862,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         // keyboard there explicitly rather than trust it was already real
         // DOM focus (it might have been on the toggle button itself).
         actionsMapRef.current.get(assignment.left)?.refreshView({ focus: true });
+        markPaneFocusLive(assignment.left);
       }
     } else {
       const remaining = splitAssignment[focusedSide] ?? activeKey;
@@ -828,7 +874,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     }
     setSplitPreferred(turningOn);
     writeSplitViewPreference(turningOn);
-  }, [splitPreferred, activeKey, eligible, splitAssignment, focusedSide, announce, labelFor]);
+  }, [splitPreferred, activeKey, eligible, splitAssignment, focusedSide, announce, labelFor, markPaneFocusLive]);
 
   // Moving focus between panes (design §5.3/§5.4): click-into-a-pane and the
   // Ctrl+Shift+←/→ chord both land here — one source of truth for "which
@@ -841,9 +887,10 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       setFocusedSide(side);
       setActiveKey(key);
       actionsMapRef.current.get(key)?.refreshView({ focus: true });
+      markPaneFocusLive(key);
       announce(formatFocusMoveAnnouncement(labelFor(key)));
     },
-    [splitAssignment, focusedSide, announce, labelFor],
+    [splitAssignment, focusedSide, announce, labelFor, markPaneFocusLive],
   );
   const focusPaneByKey = useCallback(
     (key: string) => {
@@ -851,6 +898,41 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       if (side) movePaneFocus(side);
     },
     [splitAssignment, movePaneFocus],
+  );
+
+  // Split-view focus-sync defect fix: the other half of the invariant —
+  // real focus ARRIVING somewhere the app didn't send it (native Tab order
+  // in particular, since xterm's hidden input defaults to `tabIndex=0`; also
+  // covers a stray click that lands on the terminal viewport itself rather
+  // than the pane wrapper `onFocusPane` is bound to). Wired to each pane's
+  // `onPaneFocusChange` (terminal-session-view.tsx → use-terminal-session.ts's
+  // real textarea focus/blur listener — see its doc). A `focused: true`
+  // routes through the SAME `focusPaneByKey` a click already uses, so
+  // `focusedSide` can never point at a pane the keyboard isn't really in. A
+  // `focused: false` is deferred one tick before declaring the keyboard has
+  // left BOTH panes: a focus move FROM one pane TO the other fires blur(old)
+  // then focus(new) synchronously in the same tick, so `liveFocusKeyRef`
+  // already reflects the new pane by the time this timeout runs — only a
+  // blur with no followup focus (click elsewhere on the page, window blur)
+  // survives to flip `keyboardLive` false.
+  const handlePaneFocusChange = useCallback(
+    (key: string, focused: boolean) => {
+      if (focused) {
+        focusPaneByKey(key);
+        markPaneFocusLive(key);
+        return;
+      }
+      if (liveFocusKeyRef.current !== key) return;
+      if (blurCheckTimeoutRef.current) clearTimeout(blurCheckTimeoutRef.current);
+      blurCheckTimeoutRef.current = setTimeout(() => {
+        blurCheckTimeoutRef.current = null;
+        if (liveFocusKeyRef.current === key) {
+          liveFocusKeyRef.current = null;
+          setKeyboardLive(false);
+        }
+      }, 0);
+    },
+    [focusPaneByKey, markPaneFocusLive],
   );
 
   useEffect(() => {
@@ -961,8 +1043,9 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       // dropped pane must genuinely hold real DOM focus, not just the props
       // that would eventually produce it.
       actionsMapRef.current.get(draggedKey)?.refreshView({ focus: true });
+      markPaneFocusLive(draggedKey);
     },
-    [dropZone, splitAssignment, eligible, announce, labelFor],
+    [dropZone, splitAssignment, eligible, announce, labelFor, markPaneFocusLive],
   );
 
   const handleDragCancel = useCallback(() => {
@@ -2428,8 +2511,9 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             isActive={isEntryVisible}
             expanded={expanded && isEntryVisible}
             grabFocus={splitActive ? paneSide === focusedSide : true}
-            paneFocused={paneSide !== null ? paneSide === focusedSide : undefined}
+            paneFocused={paneSide !== null ? paneSide === focusedSide && keyboardLive : undefined}
             onFocusPane={paneSide !== null ? () => focusPaneByKey(entry.key) : undefined}
+            onPaneFocusChange={paneSide !== null ? (focused: boolean) => handlePaneFocusChange(entry.key, focused) : undefined}
             dragActiveRef={dragActiveRef}
             onRequestExpand={requestExpand}
             autoConnectWhenExpanded={entry.launchSeq === 0 && !entry.attach}

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -51,11 +51,23 @@
 // exactly "true" (checked here AND at the board page mount) — B9: flag off means
 // zero new UI anywhere, including the tab strip and "+".
 
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { ChevronUp, ChevronDown, ChevronLeft, Circle, ListTree, Loader2, Pencil, Plus, Terminal as TerminalIcon, X } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { toast } from "sonner";
+import {
+  DndContext,
+  DragOverlay,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  useDraggable,
+  type DragStartEvent,
+  type DragMoveEvent,
+  type DragEndEvent,
+} from "@dnd-kit/core";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
@@ -90,6 +102,31 @@ import {
 import { decideEntryBehaviour, type EntryDecision } from "@/lib/terminal/entry-decision";
 import { loadSessionSnapshot, readLastTabSid, toReconnectBuffer } from "@/lib/terminal/session-snapshot";
 import { readDockOpen, writeDockOpen } from "@/lib/terminal/dock-open-persistence";
+import {
+  type PaneAssignment,
+  type PaneSide,
+  type DropZone,
+  eligiblePaneKeys,
+  enterSplitAssignment,
+  reconcileSplitAssignment,
+  applyTabClickToSplit,
+  applyDropToSplit,
+  resolveWidthFloor,
+  isMobileViewport,
+  isSplitRenderable,
+  readSplitViewPreference,
+  writeSplitViewPreference,
+  matchFocusMoveChord,
+  classifyDropZone,
+  resolveDragOutcome,
+  formatFocusMoveAnnouncement,
+  formatSplitOnAnnouncement,
+  formatSplitOffAnnouncement,
+  formatWidthFloorAnnouncement,
+  formatDockAnnouncement,
+  formatLeaveSplitAnnouncement,
+  DRAG_ACTIVATION_DISTANCE_PX,
+} from "@/lib/terminal/split-view";
 import { useDockInset } from "./terminal-dock-inset";
 import { useDockHeight, TerminalDockResizeHandle } from "./terminal-dock-resize";
 import { getMachineIdentity } from "@/lib/terminal/machine-identity";
@@ -180,6 +217,45 @@ function dotClass(status: TerminalStatus): string {
 // Bug A retry schedule (card cbe60db5) — immediate attempt, then two backoff
 // retries, before `refreshRegistry` gives up and surfaces the failure.
 const REGISTRY_RETRY_DELAYS_MS = [0, 400, 1200];
+
+// Drag-to-dock (design §6): the pointer position at drag START — dnd-kit's
+// DragMoveEvent gives a DELTA from that point, not an absolute pointer
+// position, so the raw geometry `classifyDropZone` needs is
+// `startPoint + delta`. Reads whichever event shape actually fired
+// (Pointer/Mouse/Touch — MouseSensor/TouchSensor each dispatch their own).
+function getEventPoint(evt: Event | null | undefined): { x: number; y: number } | null {
+  if (!evt) return null;
+  if (typeof PointerEvent !== "undefined" && evt instanceof PointerEvent) return { x: evt.clientX, y: evt.clientY };
+  if (typeof MouseEvent !== "undefined" && evt instanceof MouseEvent) return { x: evt.clientX, y: evt.clientY };
+  if (typeof TouchEvent !== "undefined" && evt instanceof TouchEvent) {
+    const touch = evt.touches[0] ?? evt.changedTouches[0];
+    return touch ? { x: touch.clientX, y: touch.clientY } : null;
+  }
+  return null;
+}
+
+/**
+ * Split view drag-to-dock (design §6.4: "reuse @dnd-kit, don't hand-roll
+ * pointer events"). A tiny render-prop wrapper so `useDraggable` — a HOOK —
+ * can be called once per tab from inside the tab strip's `.map()` (Rules of
+ * Hooks forbid calling it directly inside the callback). Deliberately spreads
+ * only `listeners` (the pointer/touch handlers), never dnd-kit's own
+ * `attributes` — those carry a `role`/`tabIndex` meant for its OWN keyboard
+ * sensor, which this feature deliberately doesn't wire up (design §6.4); the
+ * tab keeps its existing `role="tab"`/tablist semantics untouched.
+ */
+function DraggableTab({
+  id,
+  disabled,
+  children,
+}: {
+  id: string;
+  disabled: boolean;
+  children: (args: { setNodeRef: (el: HTMLElement | null) => void; listeners: ReturnType<typeof useDraggable>["listeners"] }) => ReactNode;
+}) {
+  const { setNodeRef, listeners } = useDraggable({ id, disabled });
+  return children({ setNodeRef, listeners });
+}
 
 export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProjectPaths }: TerminalDockProps) {
   // Defence-in-depth: also gated at the page mount. When off, render nothing —
@@ -348,6 +424,63 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // Reserve the dock's footprint at the bottom of the page, so board
   // columns can scroll past it instead of ending underneath it (card 534d2049).
   const dockInsetRef = useDockInset();
+
+  // ── split view (task df7a0134) ──────────────────────────────────────────────
+  // A view-mode toggle: two sessions side by side in the SAME dock body,
+  // instead of one-at-a-time tabs. Tabs stay the default (Requirements
+  // §"default recommendation") — `splitPreferred` is `null` until the
+  // localStorage preference hydrates on mount (SSR/first-paint stays tabs,
+  // same install-first correction pattern as `readDockOpen` above), then
+  // tracks the user's OWN choice; entering/leaving the width floor or losing
+  // a pane to pop-out never touches it (design §5.5/§5.8 — the preference is
+  // "kept" through a suspension, not cleared).
+  const [splitPreferred, setSplitPreferred] = useState<boolean | null>(null);
+  useEffect(() => {
+    setSplitPreferred(readSplitViewPreference());
+  }, []);
+  // Which session occupies which half. Reconciled below whenever the
+  // eligible set changes (a pane's session popped out/closed, or a 3rd
+  // eligible session appears to backfill an empty half — design §5.5/§5.6,
+  // AC16 "resumes automatically").
+  const [splitAssignment, setSplitAssignment] = useState<PaneAssignment>({ left: null, right: null });
+  // Exactly ONE pane owns the keyboard at all times (the hard requirement).
+  const [focusedSide, setFocusedSide] = useState<PaneSide>("left");
+  // Width-floor hysteresis state (design §7 Q3 / §5.8) — measured off the
+  // same element the two panes actually share (see `splitBodyRef` below).
+  const [belowWidthFloor, setBelowWidthFloor] = useState(false);
+  const [floorNoticeDismissed, setFloorNoticeDismissed] = useState(false);
+  // Mobile always renders tabs regardless of stored preference (Design
+  // Review required change 3 / AC14) — tracked as an explicit gate, not left
+  // as an accident of the width floor.
+  const [viewportWidth, setViewportWidth] = useState(0);
+  const splitBodyRef = useRef<HTMLDivElement | null>(null);
+  // Most-recently-active session keys, most-recent-first — the recency
+  // signal `enterSplitAssignment`/`reconcileSplitAssignment` need for
+  // "the most-recently-active OTHER eligible session" (design §7 Q1),
+  // without threading a bump through every existing `setActiveKey` call
+  // site. Purely additive bookkeeping — never itself drives a render.
+  const activeHistoryRef = useRef<string[]>([]);
+  useEffect(() => {
+    if (!activeKey) return;
+    activeHistoryRef.current = [activeKey, ...activeHistoryRef.current.filter((k) => k !== activeKey)];
+  }, [activeKey]);
+  // Drag-to-dock (design §6, Design Review required change 2): true for the
+  // whole lifetime of any tab drag — forwarded to EVERY mounted session's
+  // xterm instance so Escape is consumed regardless of which pane had DOM
+  // focus when the drag began (see use-terminal-session.ts's doc). A ref, not
+  // state, so it never forces a render on its own.
+  const dragActiveRef = useRef(false);
+  const [draggingKey, setDraggingKey] = useState<string | null>(null);
+  const [dropZone, setDropZone] = useState<DropZone | null>(null);
+  const dragStartPointRef = useRef<{ x: number; y: number } | null>(null);
+  const tabStripRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const onResize = () => setViewportWidth(window.innerWidth);
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
 
   // ── session entry chooser (card cbe60db5) — registry fetch + entry decision ──
   //
@@ -576,6 +709,253 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   }, []);
 
   const announce = useCallback((text: string) => setAnnouncement(text), []);
+
+  // ── split view (task df7a0134) — pane assignment, width floor, focus ───────
+  // A session's own resolved name — the SAME string the tab shows
+  // (`deriveTabLabel`, which delegates to `resolveSessionName`) — for
+  // announcements and the pane header (design's binding note: never
+  // re-derive it). Reads the refs (not `sessions`/`summaries` state) so it's
+  // callable from event handlers without becoming a dependency that forces
+  // them to rebind on every session/summary change.
+  const labelFor = useCallback(
+    (key: string | null): string => {
+      if (!key) return "";
+      const entry = sessionsRef.current.find((s) => s.key === key);
+      return deriveTabLabel({
+        displayName: entry?.displayName,
+        taskTitle: entry?.taskTitle,
+        ideaTitle,
+        sessionId: summariesRef.current[key]?.sessionId ?? null,
+      });
+    },
+    [ideaTitle],
+  );
+
+  // Popped-out sessions never claim a pane (shipped invariant); ended
+  // sessions stay eligible — only pop-out excludes.
+  const eligible = useMemo(
+    () => eligiblePaneKeys(sessions.map((s) => ({ key: s.key, poppedOut: poppedOutKeys.has(s.key) }))),
+    [sessions, poppedOutKeys],
+  );
+  const mobileViewport = isMobileViewport(viewportWidth);
+  const splitActive =
+    isSplitRenderable({
+      preferred: splitPreferred === true,
+      eligibleCount: eligible.length,
+      belowWidthFloor,
+      mobileViewport,
+    }) && !!splitAssignment.left && !!splitAssignment.right;
+
+  // Keep the assignment valid as sessions/pop-out state changes — a pane's
+  // session popping out or closing gets backfilled from the most-recently-
+  // active other eligible session; split resumes automatically the moment a
+  // 2nd eligible session is available again (design §5.5/§5.6, AC16), with
+  // no user action. Gated on the PREFERENCE (not `splitActive`) so it also
+  // keeps the assignment fresh while merely suspended by the width floor —
+  // the gate lifting must restore split immediately, not with stale panes.
+  useEffect(() => {
+    if (splitPreferred !== true) return;
+    setSplitAssignment((prev) => reconcileSplitAssignment(prev, eligible, activeHistoryRef.current));
+  }, [eligible, splitPreferred]);
+
+  // Keep `activeKey` (and so `aria-selected`) pointed at the right session
+  // while split is the standing preference: the focused pane's session when
+  // the assignment is complete (even if not currently RENDERED as split —
+  // width floor / mobile, §5.8), or whichever single session survived when
+  // a pane genuinely has nothing left to backfill it with (§5.5/§5.6).
+  useEffect(() => {
+    if (splitPreferred !== true) return;
+    const bothFilled = !!splitAssignment.left && !!splitAssignment.right;
+    const target = bothFilled ? splitAssignment[focusedSide] : (splitAssignment.left ?? splitAssignment.right);
+    if (target && target !== activeKey) setActiveKey(target);
+  }, [splitPreferred, splitAssignment, focusedSide, activeKey]);
+
+  // Width floor (design §7 Q3 / §5.8): measured off `splitBodyRef`, the SAME
+  // element the two panes actually share — not the whole dock — so the
+  // 480px/pane arithmetic means what it says. `splitPreferredRef` avoids
+  // re-subscribing the ResizeObserver on every toggle.
+  const splitPreferredRef = useRef(splitPreferred);
+  useEffect(() => {
+    splitPreferredRef.current = splitPreferred;
+  }, [splitPreferred]);
+  useEffect(() => {
+    const el = splitBodyRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? el.getBoundingClientRect().width;
+      setBelowWidthFloor((prev) => {
+        const next = resolveWidthFloor(width, prev);
+        if (next !== prev && splitPreferredRef.current) {
+          announce(formatWidthFloorAnnouncement(next ? "fallback" : "restored"));
+          if (next) setFloorNoticeDismissed(false);
+        }
+        return next;
+      });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [announce]);
+
+  // Toggle (design §5.1): the deliberate, keyboard/touch-accessible entry
+  // route — drag-to-dock (below) is a shortcut, never the only way in.
+  const toggleSplitView = useCallback(() => {
+    const turningOn = splitPreferred !== true;
+    if (turningOn) {
+      const recency = activeHistoryRef.current.filter((k) => k !== activeKey);
+      const assignment = enterSplitAssignment(activeKey, eligible, recency);
+      setSplitAssignment(assignment);
+      setFocusedSide("left");
+      setFloorNoticeDismissed(false);
+      if (assignment.left && assignment.right) {
+        announce(formatSplitOnAnnouncement(labelFor(assignment.left), labelFor(assignment.right), labelFor(assignment.left)));
+      }
+    } else {
+      const remaining = splitAssignment[focusedSide] ?? activeKey;
+      if (remaining) {
+        setActiveKey(remaining);
+        announce(formatSplitOffAnnouncement(labelFor(remaining)));
+      }
+      setSplitAssignment({ left: null, right: null });
+    }
+    setSplitPreferred(turningOn);
+    writeSplitViewPreference(turningOn);
+  }, [splitPreferred, activeKey, eligible, splitAssignment, focusedSide, announce, labelFor]);
+
+  // Moving focus between panes (design §5.3/§5.4): click-into-a-pane and the
+  // Ctrl+Shift+←/→ chord both land here — one source of truth for "which
+  // pane owns the keyboard", so visual state (border/glow/words/cursor) and
+  // real DOM focus can never split-brain.
+  const movePaneFocus = useCallback(
+    (side: PaneSide) => {
+      const key = splitAssignment[side];
+      if (!key || side === focusedSide) return;
+      setFocusedSide(side);
+      setActiveKey(key);
+      actionsMapRef.current.get(key)?.refreshView({ focus: true });
+      announce(formatFocusMoveAnnouncement(labelFor(key)));
+    },
+    [splitAssignment, focusedSide, announce, labelFor],
+  );
+  const focusPaneByKey = useCallback(
+    (key: string) => {
+      const side: PaneSide | null = splitAssignment.left === key ? "left" : splitAssignment.right === key ? "right" : null;
+      if (side) movePaneFocus(side);
+    },
+    [splitAssignment, movePaneFocus],
+  );
+
+  useEffect(() => {
+    if (!splitActive) return;
+    const handler = (e: KeyboardEvent) => {
+      const dir = matchFocusMoveChord(e);
+      if (!dir) return;
+      e.preventDefault();
+      movePaneFocus(dir);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [splitActive, movePaneFocus]);
+
+  // A tab click while split (design §5.2): the focused pane's own tab is a
+  // no-op, the unfocused pane's tab just moves focus, a 3rd session's tab
+  // replaces the UNFOCUSED pane and takes focus there.
+  const handleSplitTabClick = useCallback(
+    (key: string) => {
+      const result = applyTabClickToSplit(splitAssignment, focusedSide, key);
+      const changed = result.assignment !== splitAssignment;
+      setSplitAssignment(result.assignment);
+      const focusChanged = result.focusedSide !== focusedSide;
+      setFocusedSide(result.focusedSide);
+      const targetKey = result.assignment[result.focusedSide];
+      if (targetKey) {
+        setActiveKey(targetKey);
+        if (changed || focusChanged) announce(formatFocusMoveAnnouncement(labelFor(targetKey)));
+      }
+    },
+    [splitAssignment, focusedSide, announce, labelFor],
+  );
+
+  // ── drag-to-dock (design §6, Design Review required changes 1 + 2) ─────────
+  // 8px activation distance + the touch delay/tolerance the design specifies
+  // — @dnd-kit's MouseSensor/TouchSensor supply both for free (no bespoke
+  // pointer-event layer to drift from the board's own drag behaviour).
+  // Deliberately NO KeyboardSensor (design §6.4): the toggle above is the
+  // full keyboard-equivalent route, and a keyboard drag mode would fight
+  // both the tablist's own arrow-key navigation and the terminal's key
+  // handling.
+  const dragMouseSensor = useSensor(MouseSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE_PX } });
+  const dragTouchSensor = useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } });
+  const dragSensors = useSensors(dragMouseSensor, dragTouchSensor);
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    dragStartPointRef.current = getEventPoint(event.activatorEvent);
+    dragActiveRef.current = true;
+    setDraggingKey(String(event.active.id));
+    setDropZone(null);
+  }, []);
+
+  const handleDragMove = useCallback((event: DragMoveEvent) => {
+    const start = dragStartPointRef.current;
+    const stripEl = tabStripRef.current;
+    const bodyEl = splitBodyRef.current;
+    if (!start || !stripEl || !bodyEl) return;
+    const stripRect = stripEl.getBoundingClientRect();
+    const bodyRect = bodyEl.getBoundingClientRect();
+    setDropZone(
+      classifyDropZone({
+        pointerX: start.x + event.delta.x,
+        pointerY: start.y + event.delta.y,
+        stripBottom: stripRect.bottom,
+        bodyLeft: bodyRect.left,
+        bodyWidth: bodyRect.width,
+      }),
+    );
+  }, []);
+
+  // Design Review required change 1: NO tab reordering — a drag that begins
+  // and ends within the strip cancels, changing nothing, UNLESS the dragged
+  // tab was already paned, which keeps its designed "leave split" meaning
+  // (`resolveDragOutcome` owns this decision, pure/tested).
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      dragActiveRef.current = false;
+      const draggedKey = String(event.active.id);
+      const zone = dropZone ?? "none";
+      setDraggingKey(null);
+      setDropZone(null);
+      const isPaned = splitAssignment.left === draggedKey || splitAssignment.right === draggedKey;
+      const outcome = resolveDragOutcome(zone, isPaned);
+      if (outcome.kind === "cancel") return;
+      if (outcome.kind === "leave-split") {
+        setActiveKey(draggedKey);
+        setSplitAssignment({ left: null, right: null });
+        setSplitPreferred(false);
+        writeSplitViewPreference(false);
+        announce(formatLeaveSplitAnnouncement(labelFor(draggedKey)));
+        return;
+      }
+      // outcome.kind === "dock" — the user chose the side explicitly, so this
+      // may replace EITHER pane, including the focused one (design §6.3).
+      const recency = activeHistoryRef.current.filter((k) => k !== draggedKey);
+      const fallbackOther = recency.find((k) => k !== draggedKey) ?? eligible.find((k) => k !== draggedKey) ?? null;
+      const result = applyDropToSplit(splitAssignment, outcome.side, draggedKey, fallbackOther);
+      setSplitAssignment(result.assignment);
+      setFocusedSide(result.focusedSide);
+      setActiveKey(draggedKey);
+      setFloorNoticeDismissed(false);
+      setSplitPreferred(true);
+      writeSplitViewPreference(true);
+      setExpanded(true);
+      announce(formatDockAnnouncement(labelFor(draggedKey), outcome.side));
+    },
+    [dropZone, splitAssignment, eligible, announce, labelFor],
+  );
+
+  const handleDragCancel = useCallback(() => {
+    dragActiveRef.current = false;
+    setDraggingKey(null);
+    setDropZone(null);
+  }, []);
 
   // ── pop-out (D1-D7, design §10 + §13 Flow 3) ────────────────────────────────
   // Tears down THIS tab's pop-out bookkeeping — the BroadcastChannel and the
@@ -1401,7 +1781,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   );
 
   const handleTabKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLDivElement>, index: number, key: string) => {
+    (e: ReactKeyboardEvent<HTMLDivElement>, index: number, key: string) => {
       if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
         e.preventDefault();
         const dir = e.key === "ArrowRight" ? 1 : -1;
@@ -1693,12 +2073,59 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           />
         )}
 
-        {multi && !inlineBrowse && (
-          <div role="tablist" aria-label="Terminal sessions" className="flex items-stretch border-b border-zinc-800 bg-[#141417]">
-            {/* Tabs shrink then scroll; "+" (below) stays pinned OUTSIDE this
-                scroll region so launch + oversight are never scrolled away
-                (design §4a: "never wrap, never hide the '+'"). */}
-            <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto">
+        {/* Split view (design §6.4): both the tab strip (drag SOURCE) and the
+            session body (drop TARGET, further below) live inside ONE
+            DndContext so a drag can travel from one into the other —
+            unconditional (not gated on `multi`/`inlineBrowse`) so the
+            always-mounted session body underneath is never pulled in/out of
+            it; nothing inside is actually draggable without 2+ tabs anyway. */}
+        <DndContext
+          sensors={dragSensors}
+          onDragStart={handleDragStart}
+          onDragMove={handleDragMove}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
+          {multi && !inlineBrowse && (
+            <>
+            {/* Below-floor notice (design §5.8, mockup D) — only while split
+                is the standing preference but the window's too narrow to
+                render it; dismissible, never blocks the toggle from being
+                pressed again. */}
+            {splitPreferred === true && belowWidthFloor && !mobileViewport && !floorNoticeDismissed && (
+              <div className="flex items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-[11.5px] text-amber-300">
+                <span aria-hidden="true">ⓘ</span>
+                <span className="flex-1">
+                  Split view needs a wider window — it will come back automatically when there&apos;s room.
+                </span>
+                <button
+                  type="button"
+                  aria-label="Dismiss"
+                  className="text-amber-400 hover:text-amber-200"
+                  onClick={() => setFloorNoticeDismissed(true)}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            )}
+            <div
+              ref={tabStripRef}
+              role="tablist"
+              aria-label="Terminal sessions"
+              className={cn(
+                "flex items-stretch border-b bg-[#141417]",
+                // Drag-to-dock (design §6.3 "Back to tabs" indicator): a
+                // PANED tab dragged back up over the strip highlights it as
+                // the un-split target, distinct from the ordinary border.
+                dropZone === "strip" && draggingKey && (splitAssignment.left === draggingKey || splitAssignment.right === draggingKey)
+                  ? "border-sky-500/60"
+                  : "border-zinc-800",
+              )}
+            >
+              {/* Tabs shrink then scroll; "+"/toggle (below) stay pinned
+                  OUTSIDE this scroll region so launch + oversight are never
+                  scrolled away (design §4a: "never wrap, never hide the '+'"). */}
+              <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto">
               {sessions.map((entry, index) => {
                 const summary = summaries[entry.key];
                 const status = summary?.status ?? "idle";
@@ -1715,9 +2142,23 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
                 const confirming = confirmingKey === entry.key;
                 const renaming = renamingKey === entry.key;
                 const renameLength = codePointLength(renameDraft);
+                // Split view: which half (if any) this tab currently
+                // occupies — an "L"/"R" badge (words, not colour alone —
+                // aria-label carries the same fact for screen readers).
+                const paneSide: PaneSide | null = !splitActive
+                  ? null
+                  : splitAssignment.left === entry.key
+                    ? "left"
+                    : splitAssignment.right === entry.key
+                      ? "right"
+                      : null;
+                const paneSideFocused = paneSide !== null && paneSide === focusedSide;
                 return (
+                  <DraggableTab key={entry.key} id={entry.key} disabled={poppedOut || renaming || confirming}>
+                    {({ setNodeRef, listeners }) => (
                   <div
-                    key={entry.key}
+                    ref={setNodeRef}
+                    {...listeners}
                     id={`terminal-tab-${entry.key}`}
                     role="tab"
                     aria-selected={isActive}
@@ -1725,8 +2166,9 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
                     title={label}
                     onKeyDown={(e) => handleTabKeyDown(e, index, entry.key)}
                     onClick={() => {
-                      setActiveKey(entry.key);
                       setExpanded(true);
+                      if (splitActive) handleSplitTabClick(entry.key);
+                      else setActiveKey(entry.key);
                     }}
                     className={cn(
                       "flex min-w-[110px] max-w-[190px] flex-none cursor-pointer items-center gap-1.5 border-r border-t-2 border-zinc-800 border-t-transparent px-2.5 py-0 text-[12.5px] text-zinc-400",
@@ -1738,6 +2180,17 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
                       (renaming || confirming) && "max-w-none flex-1",
                     )}
                   >
+                    {paneSide && (
+                      <span
+                        aria-label={`in ${paneSide} pane`}
+                        className={cn(
+                          "flex-none rounded border px-1 text-[9px] font-bold leading-[14px]",
+                          paneSideFocused ? "border-sky-500/50 bg-sky-500/10 text-sky-300" : "border-zinc-700 text-zinc-500",
+                        )}
+                      >
+                        {paneSide === "left" ? "L" : "R"}
+                      </span>
+                    )}
                     {renaming ? (
                       // Contents-swap (design §3a mid-edit) — same shape as
                       // the "End session?" confirm below, reusing the tab's
@@ -1880,29 +2333,69 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
                       </>
                     )}
                   </div>
+                    )}
+                  </DraggableTab>
                 );
               })}
+              </div>
+              {/* Split view toggle (design §1 "immediately left of the
+                  existing '+'"): visible whenever tabs themselves are —
+                  never a disabled dead button (no trapping dialogs — the
+                  toggle always does something, even below the width floor,
+                  where pressing it stores the preference and shows the
+                  amber notice instead of silently failing). */}
+              <button
+                type="button"
+                aria-pressed={splitPreferred === true}
+                aria-label={splitPreferred === true ? "Split view — back to tabs" : "Split view: show two sessions side by side"}
+                title={
+                  mobileViewport
+                    ? "Split view (needs a wider window)"
+                    : "Split view · Ctrl+Shift+←/→ moves typing"
+                }
+                onClick={toggleSplitView}
+                className={cn(
+                  "flex h-[38px] w-[38px] flex-none items-center justify-center border-l border-zinc-800 text-base text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-100",
+                  splitPreferred === true && "bg-sky-500/10 text-sky-300",
+                )}
+              >
+                <span aria-hidden="true">◫</span>
+              </button>
+              <button
+                type="button"
+                aria-label="New terminal session"
+                title={newSessionTooltip()}
+                onClick={handlePlus}
+                className="flex h-[38px] w-[38px] flex-none items-center justify-center border-l border-zinc-800 text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-100"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
             </div>
-            <button
-              type="button"
-              aria-label="New terminal session"
-              title={newSessionTooltip()}
-              onClick={handlePlus}
-              className="flex h-[38px] w-[38px] flex-none items-center justify-center border-l border-zinc-800 text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-100"
-            >
-              <Plus className="h-4 w-4" />
-            </button>
-          </div>
-        )}
+            </>
+          )}
 
-        {/* CSS-hidden, never unmounted, while an inline browse takes the
-            panel — the same rule the tab strip and the popped-out
-            placeholder already follow in this file and in
-            TerminalSessionView's own root. Unmounting would throw away the
-            ended tab's scrollback, so "Back to terminal" above would return
-            to an empty terminal instead of the conversation it promised. */}
-        <div className={cn(inlineBrowse && "hidden")}>
-        {sessions.map((entry) => (
+          {/* CSS-hidden, never unmounted, while an inline browse takes the
+              panel — the same rule the tab strip and the popped-out
+              placeholder already follow in this file and in
+              TerminalSessionView's own root. Unmounting would throw away the
+              ended tab's scrollback, so "Back to terminal" above would return
+              to an empty terminal instead of the conversation it promised.
+              Split view (design §2 "splitbody"): `flex items-stretch` only
+              while actually rendering the split — `splitBodyRef` measures
+              THIS element for the width floor either way, since it's the
+              space the two panes would share. `relative` hosts the drop-zone
+              overlay below. */}
+          <div ref={splitBodyRef} className={cn("relative", inlineBrowse && "hidden", splitActive && "flex items-stretch")}>
+        {sessions.map((entry) => {
+          const paneSide: PaneSide | null = !splitActive
+            ? null
+            : splitAssignment.left === entry.key
+              ? "left"
+              : splitAssignment.right === entry.key
+                ? "right"
+                : null;
+          const isEntryVisible = splitActive ? paneSide !== null : entry.key === activeKey;
+          return (
           <TerminalSessionView
             key={entry.key}
             entry={entry}
@@ -1913,8 +2406,12 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
               ideaTitle,
               sessionId: summaries[entry.key]?.sessionId ?? null,
             })}
-            isActive={entry.key === activeKey}
-            expanded={expanded && entry.key === activeKey}
+            isActive={isEntryVisible}
+            expanded={expanded && isEntryVisible}
+            grabFocus={splitActive ? paneSide === focusedSide : true}
+            paneFocused={paneSide !== null ? paneSide === focusedSide : undefined}
+            onFocusPane={paneSide !== null ? () => focusPaneByKey(entry.key) : undefined}
+            dragActiveRef={dragActiveRef}
             onRequestExpand={requestExpand}
             autoConnectWhenExpanded={entry.launchSeq === 0 && !entry.attach}
             onReportSummary={reportSummary}
@@ -1929,8 +2426,69 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onRetryReconnect={(sid) => void performReattach(sid, { focus: true })}
             onResumeEndedSession={handleResumeEndedSession}
           />
-        ))}
+          );
+        })}
+          {/* Drag-to-dock drop zones (design §6.2) — a pure geometry read
+              (`pointer-events: none`; the drag layer hit-tests from raw
+              coordinates, never DOM hover, so the xterm canvas underneath
+              never sees these). Only rendered for a drag that's actually
+              capable of docking somewhere: a popped-out session was never
+              made draggable in the first place (DraggableTab above), so
+              nothing further to exclude here. */}
+          {draggingKey && (
+            <div className="pointer-events-none absolute inset-0 z-30 flex gap-0">
+              <div
+                className={cn(
+                  "m-1.5 ml-1.5 mr-[3px] flex flex-1 items-center justify-center rounded-lg border text-[12px] font-semibold",
+                  dropZone === "left"
+                    ? "border-sky-500/50 bg-sky-500/15 text-sky-300 font-bold"
+                    : "border-dashed border-zinc-600 bg-zinc-700/15 text-zinc-400",
+                )}
+              >
+                Dock left
+              </div>
+              <div
+                className={cn(
+                  "m-1.5 ml-[3px] mr-1.5 flex flex-1 items-center justify-center rounded-lg border text-[12px] font-semibold",
+                  dropZone === "right"
+                    ? "border-sky-500/50 bg-sky-500/15 text-sky-300 font-bold"
+                    : "border-dashed border-zinc-600 bg-zinc-700/15 text-zinc-400",
+                )}
+              >
+                Dock right
+              </div>
+            </div>
+          )}
         </div>
+          {/* Drag ghost (design §6.2) — a portal overlay, so it renders above
+              everything (including the drop zones) without the source tab
+              ever leaving the strip (DraggableTab's `disabled` aside, dnd-kit
+              itself never removes/moves the source node). */}
+          <DragOverlay dropAnimation={null}>
+            {draggingKey
+              ? (() => {
+                  const entry = sessionsRef.current.find((s) => s.key === draggingKey);
+                  const summary = summariesRef.current[draggingKey];
+                  const dragLabel = deriveTabLabel({
+                    displayName: entry?.displayName,
+                    taskTitle: entry?.taskTitle,
+                    ideaTitle,
+                    sessionId: summary?.sessionId ?? null,
+                  });
+                  const dragMeta = tabStatusMeta(displayStatusFor(draggingKey));
+                  return (
+                    <div className="flex max-w-[220px] items-center gap-1.5 rounded-md border border-zinc-700 bg-[#141417] px-3 py-1.5 text-[12.5px] font-semibold text-zinc-100 opacity-90 shadow-[0_4px_16px_rgba(0,0,0,0.5)]">
+                      <span aria-hidden="true" style={toneStyle(dragMeta.tone)}>
+                        {dragMeta.glyph}
+                      </span>
+                      <span className="truncate">{dragLabel}</span>
+                      <span className="flex-none text-[11px] font-normal text-zinc-500">in hand</span>
+                    </div>
+                  );
+                })()
+              : null}
+          </DragOverlay>
+        </DndContext>
       </div>
 
       {/* Chooser OVERLAY (card cbe60db5, rework 11): the same

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1809,8 +1809,13 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         document.getElementById(`terminal-tab-${sessions[sessions.length - 1].key}`)?.focus();
       } else if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
-        setActiveKey(key);
         setExpanded(true);
+        // Split view: keyboard activation must reach the SAME pane-aware
+        // decision the click handler does (§8 "keyboard reachability") — a
+        // blind setActiveKey here would desync `activeKey` from whichever
+        // pane is actually focused, and skip the focus-move announcement.
+        if (splitActive) handleSplitTabClick(key);
+        else setActiveKey(key);
       } else if (e.key === "Delete") {
         e.preventDefault();
         requestClose(key);
@@ -1825,7 +1830,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         openTabRename(key);
       }
     },
-    [sessions, requestClose, confirmingKey, cancelClose, activeKey, openTabRename],
+    [sessions, requestClose, confirmingKey, cancelClose, activeKey, openTabRename, splitActive, handleSplitTabClick],
   );
 
   if (!enabled) return null;

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -228,6 +228,15 @@ interface TerminalSessionViewProps {
    */
   grabFocus?: boolean;
   /**
+   * Split-view focus-sync defect fix (task df7a0134, QA rework): forwarded
+   * straight to `useTerminalSession`'s `onKeyboardFocusChange` option — see
+   * its doc there. Fires whenever xterm's real hidden input genuinely
+   * gains/loses DOM focus, so the dock can keep `paneFocused` truthful no
+   * matter how focus got there (not just `onFocusPane`'s click route).
+   * Omitted whenever `paneFocused` is undefined, same as `onFocusPane`.
+   */
+  onPaneFocusChange?: (focused: boolean) => void;
+  /**
    * Split view drag-to-dock (design §6.1, Design Review required change 2):
    * true for the whole lifetime of ANY tab being dragged toward a dock
    * zone — Escape must be consumed by the terminal (never sent to the PTY)
@@ -262,6 +271,7 @@ export function TerminalSessionView({
   onFocusPane,
   grabFocus = true,
   dragActiveRef,
+  onPaneFocusChange,
 }: TerminalSessionViewProps) {
   const session = useTerminalSession(descriptor, {
     enabled: true,
@@ -279,6 +289,7 @@ export function TerminalSessionView({
     attachExisting: entry.attach ?? null,
     grabFocus,
     dragActiveRef,
+    onKeyboardFocusChange: onPaneFocusChange,
   });
   const {
     state,

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -74,6 +74,7 @@ import {
   type TerminalSessionActions,
   type TerminalSessionDescriptor,
 } from "./use-terminal-session";
+import { paneAccessibleName, paneFocusWord } from "@/lib/terminal/split-view";
 
 /**
  * Everything the dock needs about ONE tab's session without lifting the whole
@@ -203,6 +204,39 @@ interface TerminalSessionViewProps {
    * already use in this file).
    */
   onBrowseSessions?: () => void;
+  /**
+   * Split view (task df7a0134, design §3/§9): set (to `true` or `false`)
+   * exactly while this view is rendered as one of the split's two panes —
+   * `undefined` (the default) means "tabbed mode", rendered exactly as
+   * before. `true` = this is the pane that owns the keyboard: every
+   * focus-clarity signal (border+glow, "⌨ Typing here", bright header,
+   * solid cursor) renders. `false` = the other pane ("◇ Watching" — its
+   * OUTPUT stays full-brightness; only chrome dims, via explicit colour
+   * tokens, never opacity — Requirements §4 / Design Review §2).
+   */
+  paneFocused?: boolean;
+  /**
+   * Split view: clicking anywhere in this pane (header included; the three
+   * control buttons opt out via their own `stopPropagation`) moves focus to
+   * it. Omitted whenever `paneFocused` is undefined.
+   */
+  onFocusPane?: () => void;
+  /**
+   * Split view (design §9, "one keyboard owner, enforced not implied"):
+   * forwarded straight to `useTerminalSession`'s same-named option — see
+   * its doc there. Defaults to `true` (unchanged single-pane behaviour).
+   */
+  grabFocus?: boolean;
+  /**
+   * Split view drag-to-dock (design §6.1, Design Review required change 2):
+   * true for the whole lifetime of ANY tab being dragged toward a dock
+   * zone — Escape must be consumed by the terminal (never sent to the PTY)
+   * for every mounted session while a drag is live, since DOM focus could
+   * still be sitting in whichever pane's xterm was focused before the drag
+   * began. A ref, not a prop, so flipping it never forces a re-render or a
+   * hook-effect re-subscription — see use-terminal-session.ts's doc.
+   */
+  dragActiveRef?: { current: boolean };
 }
 
 export function TerminalSessionView({
@@ -224,6 +258,10 @@ export function TerminalSessionView({
   onRetryReconnect,
   onResumeEndedSession,
   onBrowseSessions,
+  paneFocused,
+  onFocusPane,
+  grabFocus = true,
+  dragActiveRef,
 }: TerminalSessionViewProps) {
   const session = useTerminalSession(descriptor, {
     enabled: true,
@@ -239,6 +277,8 @@ export function TerminalSessionView({
     // deliver — the hook's own attach-once-per-sid effect handles it below,
     // independent of `launchSeq`/`launchPayload` (see SessionEntry's doc).
     attachExisting: entry.attach ?? null,
+    grabFocus,
+    dragActiveRef,
   });
   const {
     state,
@@ -403,8 +443,34 @@ export function TerminalSessionView({
     );
   };
 
+  // Split view (task df7a0134): `paneFocused` is only ever set (true OR
+  // false) while this view is one of the split's two panes — `undefined`
+  // means tabbed mode, unchanged from before this feature. `inPane` gates
+  // every bit of pane-only chrome below (border/glow wrapper, the header's
+  // extra focus chip, the click-to-focus handler, tabpanel labelling).
+  const inPane = paneFocused !== undefined;
+  const handlePaneClick = () => {
+    if (inPane && !paneFocused) onFocusPane?.();
+  };
+
   return (
-    <div className={cn(!isActive && "hidden")} aria-hidden={!isActive}>
+    <div
+      className={cn(
+        !isActive && "hidden",
+        // Design §2 tokens: flex-1 so two panes share the dock body 50/50 in
+        // the parent's flex row (terminal-dock.tsx); the focused pane gets a
+        // sky perimeter border + soft glow, the unfocused a plain zinc one —
+        // PRESENCE of the glow is the indicator, never a hue-vs-hue contrast
+        // (design §3's contrast table treats it that way deliberately).
+        inPane && "m-[3px] flex min-w-0 flex-1 flex-col overflow-hidden rounded-md border",
+        inPane && paneFocused && "border-sky-400 shadow-[0_0_0_1px_rgba(56,189,248,0.35),0_0_14px_rgba(56,189,248,0.12)]",
+        inPane && !paneFocused && "border-zinc-800",
+      )}
+      aria-hidden={!isActive}
+      role={inPane ? "tabpanel" : undefined}
+      aria-label={inPane ? paneAccessibleName(label, !!paneFocused) : undefined}
+      onClick={inPane ? handlePaneClick : undefined}
+    >
       {/* Multi-session stage 4 (D2/D3, design §10b): once this tab has been
           popped out, show the placeholder INSTEAD OF the normal
           header/body/input. Both faces stay mounted here — only CSS `hidden`
@@ -447,9 +513,48 @@ export function TerminalSessionView({
         </div>
       </div>
 
-      <div className={cn(poppedOut && "hidden")} aria-hidden={poppedOut}>
-        {/* Header: state · identity · controls (safest → most destructive) */}
-        <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 bg-[#141417] px-3 py-2">
+      <div
+        className={cn(poppedOut && "hidden", inPane && "flex min-h-0 flex-1 flex-col")}
+        aria-hidden={poppedOut}
+      >
+        {/* Header: state · identity · controls (safest → most destructive).
+            Split view (design §4 "pane header anatomy"): the focus-state chip
+            renders FIRST — it's the answer to "where will my keys go?", so it
+            sits where scanning starts — followed by the session's own name
+            (the SAME string `deriveTabLabel` gave the tab, via this view's
+            existing `label` prop; never re-derived, per the design's binding
+            note). Header background steps one shade darker on the unfocused
+            pane via an explicit token swap (never opacity — Requirements §4). */}
+        <div
+          className={cn(
+            "flex flex-wrap items-center gap-2 border-b border-zinc-800 px-3 py-2",
+            inPane && !paneFocused ? "bg-[#101012]" : "bg-[#141417]",
+          )}
+        >
+          {inPane && (
+            <>
+              <span
+                className={cn(
+                  "inline-flex flex-none items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-bold",
+                  paneFocused
+                    ? "border-sky-500/40 bg-sky-500/10 text-sky-300"
+                    : "border-zinc-700 bg-transparent font-semibold text-zinc-400",
+                )}
+              >
+                <span aria-hidden="true">{paneFocused ? "⌨" : "◇"}</span>
+                {paneFocusWord(!!paneFocused)}
+              </span>
+              <span
+                className={cn(
+                  "min-w-0 max-w-[180px] truncate text-[12px]",
+                  paneFocused ? "font-semibold text-zinc-100" : "font-normal text-zinc-400",
+                )}
+                title={label}
+              >
+                {label}
+              </span>
+            </>
+          )}
           <span className={cn("inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold", meta.className)}>
             <meta.Icon className={cn("h-3 w-3", meta.spin && "animate-spin")} />
             {meta.label}
@@ -471,12 +576,20 @@ export function TerminalSessionView({
                 there's a live/reconnecting stream to move into another window;
                 `onPopOut` itself is dock-only (the popped window's own view
                 never renders this component with a handler wired). */}
+            {/* Split view (design §4): these three controls act WITHOUT
+                first moving pane focus — ending or popping out the WATCHING
+                pane must not steal the keyboard from the pane the user is
+                actually typing in. `stopPropagation` is a no-op outside a
+                pane (no `onClick` on the wrapper to reach). */}
             {showStream && onPopOut && (
               <Button
                 variant="outline"
                 size="xs"
                 className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
-                onClick={onPopOut}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onPopOut();
+                }}
                 aria-label="Pop this session out into its own window"
               >
                 <ExternalLink className="h-3 w-3" /> Pop out
@@ -487,7 +600,10 @@ export function TerminalSessionView({
                 variant="outline"
                 size="xs"
                 className="border-zinc-700 bg-zinc-800/60 text-zinc-200 hover:bg-zinc-700"
-                onClick={() => actions.setReadOnly((r) => !r)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  actions.setReadOnly((r) => !r);
+                }}
                 aria-pressed={readOnly}
                 aria-label={readOnly ? "Read-only is on — click to allow input" : "Switch to read-only"}
               >
@@ -500,7 +616,10 @@ export function TerminalSessionView({
                 variant="outline"
                 size="xs"
                 className="border-rose-500/45 bg-transparent text-rose-400 hover:bg-rose-500/10"
-                onClick={actions.end}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  actions.end();
+                }}
                 aria-label="End session"
               >
                 <Power className="h-3 w-3" /> End

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -47,6 +47,12 @@ vi.mock("@xterm/xterm", () => ({
     }
     focus() {}
     dispose() {}
+    // Split view (task df7a0134): the hook registers a custom key handler at
+    // init to swallow the pane-focus chord / a drag-cancelling Escape before
+    // they reach the PTY — see use-terminal-session.ts's xterm-init effect.
+    // Real xterm.js always has this method; the mock needs it too or the
+    // hook's init effect throws and never reaches `setXtermReady(true)`.
+    attachCustomKeyEventHandler() {}
   },
 }));
 vi.mock("@xterm/addon-fit", () => ({

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -53,6 +53,11 @@ vi.mock("@xterm/xterm", () => ({
     // Real xterm.js always has this method; the mock needs it too or the
     // hook's init effect throws and never reaches `setXtermReady(true)`.
     attachCustomKeyEventHandler() {}
+    // Split-view focus-sync defect fix (task df7a0134, QA rework): a real
+    // DOM node so the hook can attach its focus/blur listeners to it (and a
+    // test can dispatch real FocusEvents against it) exactly like real
+    // xterm.js's own `term.textarea`.
+    textarea = document.createElement("textarea");
   },
 }));
 vi.mock("@xterm/addon-fit", () => ({
@@ -1760,6 +1765,100 @@ describe("useTerminalSession", () => {
         vi.advanceTimersByTime(RECONNECT_GRACE_MS + 1000);
       });
       expect(result.current.pairingTimedOut).toBe(true);
+    });
+  });
+
+  // Split-view focus-sync defect fix (task df7a0134, QA rework — category-1,
+  // blocks-release): the accepted repro was real DOM keyboard focus
+  // diverging from the "Typing here"/"Watching" indicator with NO listener
+  // anywhere catching it, and native Tab order walking straight into the
+  // "Watching" pane's real xterm input. These tests exercise the hook's two
+  // halves of the fix directly against xterm's own hidden input (the
+  // `textarea` the mock Terminal above now exposes, same as real xterm.js):
+  // `grabFocus` drives its `tabIndex` (so native Tab can't reach an
+  // unfocused pane's input at all), and its real focus/blur events drive
+  // `onKeyboardFocusChange` (so anything ELSE that moves DOM focus there —
+  // Tab, assistive tech, a stray click — still gets caught). The dock-level
+  // consequence (state actually following these signals, including the
+  // exact Tab-into-the-watching-pane path) is covered in terminal-dock.test.tsx.
+  describe("split-view keyboard-focus ground truth (task df7a0134, QA rework)", () => {
+    function mountContainer(result: { current: { containerRef: { current: HTMLDivElement | null } } }) {
+      result.current.containerRef.current = document.createElement("div");
+    }
+
+    it("leaves the xterm textarea's tabIndex at the native default (0) when grabFocus is true — every single-pane caller (tabs, pop-out) is unaffected", async () => {
+      const requestExpand = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, { enabled: true, expanded: true, requestExpand }),
+      );
+      mountContainer(result);
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+      const term = mockTerminals[mockTerminals.length - 1] as unknown as { textarea: HTMLTextAreaElement };
+      await waitFor(() => expect(term.textarea.tabIndex).toBe(0));
+    });
+
+    it("removes the unfocused split pane's terminal from native Tab order (tabIndex -1), and restores it once grabFocus returns — the exact QA repro: Tab must never be able to reach the 'Watching' pane's real input", async () => {
+      const requestExpand = vi.fn();
+      const { result, rerender } = renderHook(
+        ({ grabFocus }: { grabFocus: boolean }) =>
+          useTerminalSession(descriptor, { enabled: true, expanded: true, requestExpand, grabFocus }),
+        { initialProps: { grabFocus: true } },
+      );
+      mountContainer(result);
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+      const term = mockTerminals[mockTerminals.length - 1] as unknown as { textarea: HTMLTextAreaElement };
+      await waitFor(() => expect(term.textarea.tabIndex).toBe(0));
+
+      // The dock flips `grabFocus` false for the pane that just lost the
+      // keyboard (terminal-dock.tsx: `grabFocus={splitActive ? paneSide ===
+      // focusedSide : true}`) — this mirrors the "Watching" pane's own
+      // props transition. Sequential Tab navigation skips a tabIndex=-1
+      // element entirely; it stays reachable by click/chord (programmatic
+      // `.focus()` still works at tabIndex=-1).
+      rerender({ grabFocus: false });
+      await waitFor(() => expect(term.textarea.tabIndex).toBe(-1));
+
+      // Reversible: a later chord/click move makes this pane the focused
+      // one again — tabIndex must come back, not get stuck excluded.
+      rerender({ grabFocus: true });
+      await waitFor(() => expect(term.textarea.tabIndex).toBe(0));
+    });
+
+    it("calls onKeyboardFocusChange(true)/(false) on the xterm textarea's OWN real focus/blur — the ground truth path independent of any click handler", async () => {
+      const requestExpand = vi.fn();
+      const onKeyboardFocusChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTerminalSession(descriptor, { enabled: true, expanded: true, requestExpand, onKeyboardFocusChange }),
+      );
+      mountContainer(result);
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+      const term = mockTerminals[mockTerminals.length - 1] as unknown as { textarea: HTMLTextAreaElement };
+
+      // Simulates exactly what a native Tab keypress does to a tabIndex=0
+      // element — real DOM focus landing on the terminal's input with no
+      // click involved. Before this fix nothing listened for this at all,
+      // so the app never found out and the indicator kept lying.
+      act(() => term.textarea.dispatchEvent(new FocusEvent("focus")));
+      expect(onKeyboardFocusChange).toHaveBeenLastCalledWith(true);
+
+      act(() => term.textarea.dispatchEvent(new FocusEvent("blur")));
+      expect(onKeyboardFocusChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it("stops calling onKeyboardFocusChange once the hook unmounts (listener cleanup, no stale-closure leak)", async () => {
+      const requestExpand = vi.fn();
+      const onKeyboardFocusChange = vi.fn();
+      const { result, unmount } = renderHook(() =>
+        useTerminalSession(descriptor, { enabled: true, expanded: true, requestExpand, onKeyboardFocusChange }),
+      );
+      mountContainer(result);
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+      const term = mockTerminals[mockTerminals.length - 1] as unknown as { textarea: HTMLTextAreaElement };
+
+      unmount();
+      onKeyboardFocusChange.mockClear();
+      term.textarea.dispatchEvent(new FocusEvent("focus"));
+      expect(onKeyboardFocusChange).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -301,6 +301,21 @@ export interface UseTerminalSessionOptions {
    * prop this hook would need to re-subscribe effects on.
    */
   dragActiveRef?: { current: boolean };
+  /**
+   * Split-view focus-sync defect fix (task df7a0134, QA rework): fires
+   * `true`/`false` whenever xterm's own hidden input textarea — the actual
+   * keystroke target — genuinely gains or loses DOM focus, via a native
+   * focus/blur listener attached directly to it (see the xterm-init effect
+   * below). `grabFocus` above only covers focus THIS hook explicitly grabs
+   * (a click, the chord, a forced toggle/dock); it says nothing about focus
+   * arriving some OTHER way — native Tab order in particular, since xterm
+   * unconditionally sets `textarea.tabIndex = 0`. The caller (terminal-dock.tsx,
+   * via TerminalSessionView) routes this through the SAME movePaneFocus path
+   * a click already uses, so the split "Typing here"/"Watching" indicator can
+   * never diverge from where the keyboard actually is, no matter how focus
+   * got there. Omitted outside split view (paneFocused undefined) — no-op.
+   */
+  onKeyboardFocusChange?: (focused: boolean) => void;
 }
 
 /** The minimum a popped-out window needs to attach to an existing session — see `attachExisting` above. */
@@ -505,12 +520,19 @@ export function useTerminalSession(
     attachExisting = null,
     grabFocus = true,
     dragActiveRef,
+    onKeyboardFocusChange,
   } = options;
   const posthog = usePostHog();
   const posthogRef = useRef(posthog);
   const onCapExceededRef = useRef(onCapExceeded);
   posthogRef.current = posthog;
   onCapExceededRef.current = onCapExceeded;
+  // Split-view focus-sync defect fix: read fresh inside the stable
+  // focus/blur listeners the xterm-init effect attaches below, so a new
+  // `onKeyboardFocusChange` identity every render never forces that
+  // mount-once effect to re-run (same idiom as `posthogRef` above).
+  const onKeyboardFocusChangeRef = useRef(onKeyboardFocusChange);
+  onKeyboardFocusChangeRef.current = onKeyboardFocusChange;
 
   const [state, dispatch] = useReducer(terminalReducer, initialConnectionState);
   const [readOnly, setReadOnly] = useState(false);
@@ -730,6 +752,13 @@ export function useTerminalSession(
     if (!enabled) return;
     let disposed = false;
     let term: XTerm | null = null;
+    // Split-view focus-sync defect fix: the textarea + listener pair get
+    // captured here (not just declared inside the async IIFE below) so the
+    // effect's cleanup can remove them — see the attachment site further
+    // down for why this is the one thing that can never lie about focus.
+    let focusedTextarea: HTMLTextAreaElement | null = null;
+    const handleTextareaFocus = () => onKeyboardFocusChangeRef.current?.(true);
+    const handleTextareaBlur = () => onKeyboardFocusChangeRef.current?.(false);
 
     (async () => {
       const [{ Terminal }, { FitAddon }] = await Promise.all([
@@ -785,6 +814,18 @@ export function useTerminalSession(
 
       termRef.current = term;
       fitRef.current = fit;
+      // Split view keyboard-focus ground truth (defect fix, task df7a0134 QA
+      // rework): xterm's hidden input textarea is the ACTUAL keystroke
+      // target — a native focus/blur listener on it is the one source of
+      // truth that can never lie about which pane really holds the
+      // keyboard, regardless of how focus got there (a click, native Tab
+      // order, assistive tech, or anything else `grabFocus`'s own explicit
+      // `.focus()` calls don't cover). See `onKeyboardFocusChange`'s doc.
+      if (term.textarea) {
+        focusedTextarea = term.textarea;
+        term.textarea.addEventListener("focus", handleTextareaFocus);
+        term.textarea.addEventListener("blur", handleTextareaBlur);
+      }
       // A buffer arrived (attachToExisting ran) before the terminal itself
       // was ready to receive it — apply it now that it is (see
       // pendingInitialBufferRef's doc).
@@ -812,6 +853,8 @@ export function useTerminalSession(
 
     return () => {
       disposed = true;
+      focusedTextarea?.removeEventListener("focus", handleTextareaFocus);
+      focusedTextarea?.removeEventListener("blur", handleTextareaBlur);
       term?.dispose();
       termRef.current = null;
       fitRef.current = null;
@@ -917,6 +960,24 @@ export function useTerminalSession(
   useEffect(() => {
     if (state.status === "connected") sendResize();
   }, [state.status, sendResize]);
+
+  // Split view keyboard-focus ground truth, part 2 (defect fix): xterm
+  // unconditionally sets its hidden input's `tabIndex` to 0, so with both
+  // panes visible and non-hidden, native Tab traversal walks straight into
+  // the "Watching" pane's real input — the exact QA repro. `grabFocus`
+  // already means "this instance owns the keyboard" everywhere else in this
+  // hook (see the focus effects below), so reusing it here keeps tabIndex
+  // and the rest of the focus story from ever disagreeing: only the pane
+  // that owns the keyboard is reachable by sequential Tab; the other stays
+  // reachable by click and by the documented Ctrl+Shift+←/→ chord (both
+  // still work on a `tabIndex=-1` element — that only removes it from
+  // SEQUENTIAL navigation, not from programmatic `.focus()`). No-op outside
+  // split view — every other caller passes the default `true`, so this only
+  // ever (re)asserts 0, the native default.
+  useEffect(() => {
+    const ta = termRef.current?.textarea;
+    if (ta) ta.tabIndex = grabFocus ? 0 : -1;
+  }, [grabFocus, xtermReady]);
 
   // ── launch focus (fix/terminal-dock-launch-defects, Defect 2) ──────────────
   // Nothing previously called termRef.current.focus() — a freshly connected

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -114,6 +114,7 @@ import {
   rememberLastTabSid,
   SNAPSHOT_SAVE_INTERVAL_MS,
 } from "@/lib/terminal/session-snapshot";
+import { matchFocusMoveChord } from "@/lib/terminal/split-view";
 
 // How long we wait for the helper to attach after firing the deep link before
 // dropping to the calm fallback (~8s, per the approved UX). This is the safety net
@@ -279,6 +280,27 @@ export interface UseTerminalSessionOptions {
    * don't need to memoize beyond keeping the sessionId stable).
    */
   attachExisting?: AttachExistingPair | null;
+  /**
+   * Split view (task df7a0134, design §9 "one keyboard owner, enforced not
+   * implied"): with two panes visible at once, `expanded` alone can no
+   * longer mean "this is the one instance that should grab the keyboard" —
+   * BOTH panes are visible (and so both need the resize/refit effects below,
+   * which stay keyed on `expanded`), but only ONE may steal focus. Defaults
+   * to `true` — every existing single-pane caller (tabbed mode, the
+   * pop-out window) is unaffected, since there `expanded` already implied
+   * "the one visible instance". The dock passes `false` for the pane that
+   * ISN'T the split's `focusedPaneKey`; that pane still refits on every
+   * geometry change, it just never calls `termRef.current?.focus()`.
+   */
+  grabFocus?: boolean;
+  /**
+   * Split view drag-to-dock (design §6.1, Design Review required change 2):
+   * while `.current` is true, Escape is swallowed from reaching the PTY —
+   * see `dragActiveRef`'s doc on TerminalSessionViewProps for why this is a
+   * ref (read fresh inside the xterm custom-key handler below) rather than a
+   * prop this hook would need to re-subscribe effects on.
+   */
+  dragActiveRef?: { current: boolean };
 }
 
 /** The minimum a popped-out window needs to attach to an existing session — see `attachExisting` above. */
@@ -383,8 +405,12 @@ export interface TerminalSessionActions {
    * was hidden that way, so the `expanded`-keyed resize/focus effects above
    * never re-fire for it; this is the same recovery those effects already do
    * on a dock re-expand, just triggered on demand instead of by `expanded`.
+   * Split view: pass `{ focus: false }` for a pane the caller does NOT want
+   * to steal the keyboard for (the unfocused pane in a 2-up layout) — the
+   * refit still happens either way. Omitted/`{}` keeps the original
+   * always-focus behaviour every pre-existing caller relies on.
    */
-  refreshView: () => void;
+  refreshView: (opts?: { focus?: boolean }) => void;
   /**
    * Scrollback transfer (card 35cffc10, design §7): serialize THIS
    * session's live terminal right now, capped at 1 MiB — the dock calls this
@@ -477,6 +503,8 @@ export function useTerminalSession(
     displayName,
     onCapExceeded,
     attachExisting = null,
+    grabFocus = true,
+    dragActiveRef,
   } = options;
   const posthog = usePostHog();
   const posthogRef = useRef(posthog);
@@ -727,6 +755,24 @@ export function useTerminalSession(
         /* container may be 0-size while collapsed — refit on expand */
       }
 
+      // Split view (task df7a0134, design §5.4 + §6.1, Design Review required
+      // change 2): intercept BEFORE xterm processes the keydown, so neither
+      // the pane-focus chord nor a drag-cancelling Escape ever reaches the
+      // PTY as input — `false` stops xterm's own handling (no data sent,
+      // cursor untouched) but does NOT call preventDefault/stopPropagation on
+      // the native event, so it still bubbles normally to the dock's own
+      // window-level listener, which performs the actual pane-focus move (or
+      // lets dnd-kit's own Escape-cancel run — see terminal-dock.tsx).
+      // Unconditional on the chord (harmless outside split view — nothing
+      // else claims Ctrl+Shift+←/→); Escape is gated on `dragActiveRef` so a
+      // NON-drag Escape keeps its ordinary terminal meaning.
+      term.attachCustomKeyEventHandler((event) => {
+        if (event.type !== "keydown") return true;
+        if (matchFocusMoveChord(event)) return false;
+        if (event.key === "Escape" && dragActiveRef?.current) return false;
+        return true;
+      });
+
       // Keystrokes → relay (binary). Guarded by the pure input-enabled predicate so
       // read-only / non-connected states never reach the PTY.
       term.onData((data) => {
@@ -770,6 +816,12 @@ export function useTerminalSession(
       termRef.current = null;
       fitRef.current = null;
     };
+    // `dragActiveRef` is a ref (stable identity, read fresh via `.current`
+    // inside the customKeyEventHandler at call time, not captured by value)
+    // — including it here would only force a pointless re-init of xterm
+    // itself whenever the dock passes a differently-identified ref object,
+    // which it never does (one ref, created once, shared by every session).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled]);
 
   // Correct the install-first gate inputs on mount (navigator is only reliable
@@ -876,35 +928,41 @@ export function useTerminalSession(
   // the first time" transition (prior status connecting/waiting-to-pair), never on
   // a grace-window reattach (prior status disconnected) — a user typing mid-drop
   // must not have their cursor/scroll position hijacked by an automatic reattach.
+  // Split view: also gated on `grabFocus` — the pane that ISN'T the split's
+  // focused one refits (see the resize effects above, keyed on `expanded`
+  // alone) but must never steal the keyboard out from under the pane the
+  // user is actually typing in (design §9).
   useEffect(() => {
     const prev = prevStatusRef.current;
     if (
       state.status === "connected" &&
       (prev === "connecting" || prev === "waiting-to-pair") &&
-      expanded
+      expanded &&
+      grabFocus
     ) {
       termRef.current?.focus();
     }
     prevStatusRef.current = state.status;
-  }, [state.status, expanded]);
+  }, [state.status, expanded, grabFocus]);
 
   // Expand focus: a user-initiated expand of an already-live session (e.g.
   // collapse then re-expand while connected) should also land focus in the
   // terminal. Keyed ONLY on `expanded` (not state.status) so a background status
   // change — e.g. a reattach completing while the dock is already expanded —
   // never re-triggers this and steals focus; it reads the current status from
-  // closure at the moment `expanded` itself transitions.
+  // closure at the moment `expanded` itself transitions. Also gated on
+  // `grabFocus` — see the first-connect effect above for why.
   useEffect(() => {
-    if (!expanded || state.status !== "connected") return;
+    if (!expanded || !grabFocus || state.status !== "connected") return;
     // Next paint, mirroring the expand-rAF resize above — the container must be
     // un-hidden before focus() can land.
     const id = window.requestAnimationFrame(() => termRef.current?.focus());
     return () => window.cancelAnimationFrame(id);
     // Deliberately excludes state.status: see comment above (must only re-run on
-    // `expanded` transitions, not on every status change, or a background
-    // reattach while already expanded would steal focus).
+    // `expanded`/`grabFocus` transitions, not on every status change, or a
+    // background reattach while already expanded would steal focus).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [expanded]);
+  }, [expanded, grabFocus]);
 
   const clearConnectTimer = useCallback(() => {
     if (connectTimerRef.current) {
@@ -2031,13 +2089,22 @@ export function useTerminalSession(
   // See `refreshView`'s doc on TerminalSessionActions. Mirrors the expand-rAF
   // resize + expand-focus effects above (next paint, so the container has
   // already been un-hidden before fit()/focus() land) — just callable
-  // directly rather than gated on `expanded`.
-  const refreshView = useCallback(() => {
-    window.requestAnimationFrame(() => {
-      sendResize();
-      termRef.current?.focus();
-    });
-  }, [sendResize]);
+  // directly rather than gated on `expanded`. Split view (task df7a0134,
+  // design §9): a pane transitioning hidden→visible needs the SAME forced
+  // refit bring-back already uses, but only the split's focused pane should
+  // also grab the keyboard — `focus` defaults to `true` so every pre-existing
+  // caller (pop-out bring-back) is unchanged; the dock passes `focus: false`
+  // when forcing a refit on the UNFOCUSED pane.
+  const refreshView = useCallback(
+    (opts?: { focus?: boolean }) => {
+      const focus = opts?.focus ?? true;
+      window.requestAnimationFrame(() => {
+        sendResize();
+        if (focus) termRef.current?.focus();
+      });
+    },
+    [sendResize],
+  );
 
   // Scrollback transfer (card 35cffc10, design §7). See TerminalSessionActions'
   // doc on both for the full contract — these are thin, stable-identity

--- a/src/lib/terminal/split-view.test.ts
+++ b/src/lib/terminal/split-view.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  eligiblePaneKeys,
+  enterSplitAssignment,
+  reconcileSplitAssignment,
+  applyTabClickToSplit,
+  applyDropToSplit,
+  resolveWidthFloor,
+  isMobileViewport,
+  isSplitRenderable,
+  readSplitViewPreference,
+  writeSplitViewPreference,
+  matchFocusMoveChord,
+  classifyDropZone,
+  resolveDragOutcome,
+  paneFocusWord,
+  paneAccessibleName,
+  formatFocusMoveAnnouncement,
+  formatSplitOnAnnouncement,
+  formatSplitOffAnnouncement,
+  formatWidthFloorAnnouncement,
+  formatDockAnnouncement,
+  formatLeaveSplitAnnouncement,
+  MIN_PANE_WIDTH_PX,
+  SPLIT_FALLBACK_BODY_PX,
+  SPLIT_RESTORE_BODY_PX,
+  MOBILE_VIEWPORT_MAX_PX,
+} from "./split-view";
+
+describe("eligiblePaneKeys", () => {
+  it("excludes popped-out sessions", () => {
+    expect(
+      eligiblePaneKeys([
+        { key: "a", poppedOut: false },
+        { key: "b", poppedOut: true },
+        { key: "c", poppedOut: false },
+      ]),
+    ).toEqual(["a", "c"]);
+  });
+
+  it("keeps ended sessions eligible — only pop-out excludes", () => {
+    // "ended" isn't a field this module tracks; the point is nothing besides
+    // poppedOut filters a candidate out.
+    expect(eligiblePaneKeys([{ key: "a", poppedOut: false }])).toEqual(["a"]);
+  });
+});
+
+describe("enterSplitAssignment", () => {
+  it("left = active tab, right = most-recently-active other eligible", () => {
+    const result = enterSplitAssignment("active", ["active", "b", "c"], ["c", "b", "active"]);
+    expect(result).toEqual({ left: "active", right: "c" });
+  });
+
+  it("falls back to strip order when nothing is in recency", () => {
+    const result = enterSplitAssignment("active", ["active", "b"], []);
+    expect(result).toEqual({ left: "active", right: "b" });
+  });
+
+  it("picks a left replacement when the active key isn't eligible (e.g. popped out)", () => {
+    const result = enterSplitAssignment("popped", ["a", "b"], ["b", "a"]);
+    expect(result).toEqual({ left: "b", right: "a" });
+  });
+
+  it("right is null when only one eligible session exists", () => {
+    expect(enterSplitAssignment("active", ["active"], [])).toEqual({ left: "active", right: null });
+  });
+});
+
+describe("reconcileSplitAssignment", () => {
+  it("leaves a still-valid assignment untouched", () => {
+    const current = { left: "a", right: "b" };
+    expect(reconcileSplitAssignment(current, ["a", "b", "c"], ["c", "b", "a"])).toEqual(current);
+  });
+
+  it("backfills a slot that's no longer eligible (popped out) from recency", () => {
+    const result = reconcileSplitAssignment({ left: "a", right: "b" }, ["a", "c"], ["c", "a"]);
+    expect(result).toEqual({ left: "a", right: "c" });
+  });
+
+  it("collapses to a single filled slot when only one eligible session remains", () => {
+    const result = reconcileSplitAssignment({ left: "a", right: "b" }, ["a"], []);
+    expect(result).toEqual({ left: "a", right: null });
+  });
+
+  it("never assigns the same key to both sides", () => {
+    const result = reconcileSplitAssignment({ left: "a", right: "a" }, ["a", "b"], ["b"]);
+    expect(result.left).not.toBe(result.right);
+    expect(result).toEqual({ left: "a", right: "b" });
+  });
+
+  it("resumes split automatically when a 2nd eligible session reappears (AC16)", () => {
+    // Right went empty (pop-out); a bring-back / new tab makes "c" eligible again.
+    const afterPopout = reconcileSplitAssignment({ left: "a", right: null }, ["a"], []);
+    expect(afterPopout).toEqual({ left: "a", right: null });
+    const afterBringBack = reconcileSplitAssignment(afterPopout, ["a", "c"], ["c"]);
+    expect(afterBringBack).toEqual({ left: "a", right: "c" });
+  });
+});
+
+describe("applyTabClickToSplit", () => {
+  const assignment = { left: "a", right: "b" };
+
+  it("clicking the focused pane's own tab is a no-op", () => {
+    expect(applyTabClickToSplit(assignment, "left", "a")).toEqual({ assignment, focusedSide: "left" });
+  });
+
+  it("clicking the unfocused pane's tab moves focus to it without reassigning", () => {
+    expect(applyTabClickToSplit(assignment, "left", "b")).toEqual({ assignment, focusedSide: "right" });
+  });
+
+  it("a 3rd tab click replaces the UNFOCUSED pane and takes focus", () => {
+    const result = applyTabClickToSplit(assignment, "left", "c");
+    expect(result).toEqual({ assignment: { left: "a", right: "c" }, focusedSide: "right" });
+  });
+
+  it("never touches the currently-focused pane on a 3rd tab click", () => {
+    const result = applyTabClickToSplit(assignment, "right", "c");
+    expect(result).toEqual({ assignment: { left: "c", right: "b" }, focusedSide: "left" });
+  });
+});
+
+describe("applyDropToSplit", () => {
+  it("docks a tab from tabbed mode, seeding the other side from the fallback", () => {
+    const result = applyDropToSplit({ left: null, right: null }, "right", "b", "a");
+    expect(result).toEqual({ assignment: { left: "a", right: "b" }, focusedSide: "right" });
+  });
+
+  it("may replace the FOCUSED pane — the user chose the side explicitly", () => {
+    const result = applyDropToSplit({ left: "a", right: "b" }, "left", "c", null);
+    expect(result).toEqual({ assignment: { left: "c", right: "b" }, focusedSide: "left" });
+  });
+
+  it("never leaves the same session in both slots", () => {
+    const result = applyDropToSplit({ left: "a", right: "b" }, "left", "b", null);
+    expect(result.assignment.right).not.toBe("b");
+    expect(result.assignment).toEqual({ left: "b", right: null });
+  });
+});
+
+describe("resolveWidthFloor (hysteresis)", () => {
+  it("falls back below the fallback threshold", () => {
+    expect(resolveWidthFloor(SPLIT_FALLBACK_BODY_PX - 1, false)).toBe(true);
+  });
+
+  it("does not fall back at or above the fallback threshold", () => {
+    expect(resolveWidthFloor(SPLIT_FALLBACK_BODY_PX, false)).toBe(false);
+  });
+
+  it("does not restore in the hysteresis band (961-980) once below", () => {
+    expect(resolveWidthFloor(SPLIT_FALLBACK_BODY_PX + 5, true)).toBe(true);
+  });
+
+  it("restores at the restore threshold", () => {
+    expect(resolveWidthFloor(SPLIT_RESTORE_BODY_PX, true)).toBe(false);
+  });
+
+  it("keeps the prior state for an unmeasured (0/NaN) width", () => {
+    expect(resolveWidthFloor(0, true)).toBe(true);
+    expect(resolveWidthFloor(NaN, false)).toBe(false);
+  });
+
+  it("two panes at the floor plus a divider matches the documented body threshold", () => {
+    expect(SPLIT_FALLBACK_BODY_PX).toBeGreaterThanOrEqual(MIN_PANE_WIDTH_PX * 2);
+  });
+});
+
+describe("isMobileViewport", () => {
+  it("is true at and below the mobile max", () => {
+    expect(isMobileViewport(MOBILE_VIEWPORT_MAX_PX)).toBe(true);
+    expect(isMobileViewport(320)).toBe(true);
+  });
+
+  it("is false above the mobile max", () => {
+    expect(isMobileViewport(MOBILE_VIEWPORT_MAX_PX + 1)).toBe(false);
+  });
+
+  it("is false for an invalid width rather than throwing", () => {
+    expect(isMobileViewport(0)).toBe(false);
+    expect(isMobileViewport(NaN)).toBe(false);
+  });
+});
+
+describe("isSplitRenderable", () => {
+  it("requires the preference, 2+ eligible, above the floor and non-mobile all at once", () => {
+    expect(
+      isSplitRenderable({ preferred: true, eligibleCount: 2, belowWidthFloor: false, mobileViewport: false }),
+    ).toBe(true);
+    expect(
+      isSplitRenderable({ preferred: false, eligibleCount: 2, belowWidthFloor: false, mobileViewport: false }),
+    ).toBe(false);
+    expect(
+      isSplitRenderable({ preferred: true, eligibleCount: 1, belowWidthFloor: false, mobileViewport: false }),
+    ).toBe(false);
+    expect(
+      isSplitRenderable({ preferred: true, eligibleCount: 2, belowWidthFloor: true, mobileViewport: false }),
+    ).toBe(false);
+    // AC14: mobile always renders tabs, regardless of stored preference.
+    expect(
+      isSplitRenderable({ preferred: true, eligibleCount: 2, belowWidthFloor: false, mobileViewport: true }),
+    ).toBe(false);
+  });
+});
+
+describe("split-view preference persistence", () => {
+  function fakeStorage(): Storage {
+    const map = new Map<string, string>();
+    return {
+      getItem: (k: string) => map.get(k) ?? null,
+      setItem: (k: string, v: string) => void map.set(k, v),
+      removeItem: (k: string) => void map.delete(k),
+      clear: () => map.clear(),
+      key: () => null,
+      get length() {
+        return map.size;
+      },
+    } as Storage;
+  }
+
+  it("defaults to false (tabs) when nothing was ever written", () => {
+    expect(readSplitViewPreference(fakeStorage())).toBe(false);
+  });
+
+  it("round-trips true", () => {
+    const storage = fakeStorage();
+    writeSplitViewPreference(true, storage);
+    expect(readSplitViewPreference(storage)).toBe(true);
+  });
+
+  it("writing false clears the key rather than storing a falsy marker", () => {
+    const storage = fakeStorage();
+    writeSplitViewPreference(true, storage);
+    writeSplitViewPreference(false, storage);
+    expect(readSplitViewPreference(storage)).toBe(false);
+    expect(storage.getItem(SPLIT_VIEW_PREFERENCE_KEY_FOR_TEST())).toBeNull();
+  });
+
+  function SPLIT_VIEW_PREFERENCE_KEY_FOR_TEST() {
+    return "vc:term:split-view";
+  }
+
+  it("never throws when storage is unavailable", () => {
+    expect(() => readSplitViewPreference(null)).not.toThrow();
+    expect(() => writeSplitViewPreference(true, null)).not.toThrow();
+  });
+
+  it("never throws when storage itself throws (privacy mode / quota)", () => {
+    const throwing = {
+      getItem: () => {
+        throw new Error("nope");
+      },
+      setItem: () => {
+        throw new Error("nope");
+      },
+      removeItem: () => {
+        throw new Error("nope");
+      },
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } as unknown as Storage;
+    expect(readSplitViewPreference(throwing)).toBe(false);
+    expect(() => writeSplitViewPreference(true, throwing)).not.toThrow();
+  });
+});
+
+describe("matchFocusMoveChord", () => {
+  const base = { key: "ArrowLeft", ctrlKey: true, shiftKey: true, altKey: false, metaKey: false };
+
+  it("matches Ctrl+Shift+Left/Right", () => {
+    expect(matchFocusMoveChord(base)).toBe("left");
+    expect(matchFocusMoveChord({ ...base, key: "ArrowRight" })).toBe("right");
+  });
+
+  it("requires both Ctrl and Shift", () => {
+    expect(matchFocusMoveChord({ ...base, ctrlKey: false })).toBeNull();
+    expect(matchFocusMoveChord({ ...base, shiftKey: false })).toBeNull();
+  });
+
+  it("rejects Alt/Meta so it never collides with an OS chord that also holds one of those", () => {
+    expect(matchFocusMoveChord({ ...base, altKey: true })).toBeNull();
+    expect(matchFocusMoveChord({ ...base, metaKey: true })).toBeNull();
+  });
+
+  it("ignores unrelated keys", () => {
+    expect(matchFocusMoveChord({ ...base, key: "a" })).toBeNull();
+  });
+});
+
+describe("classifyDropZone", () => {
+  const geometry = { stripBottom: 100, bodyLeft: 0, bodyWidth: 1000 };
+
+  it("is 'strip' at and just below the strip's bottom edge (grace margin)", () => {
+    expect(classifyDropZone({ ...geometry, pointerX: 500, pointerY: 100 })).toBe("strip");
+    expect(classifyDropZone({ ...geometry, pointerX: 500, pointerY: 108 })).toBe("strip");
+  });
+
+  it("is 'left'/'right' once past the strip + grace margin, split at the body midpoint", () => {
+    expect(classifyDropZone({ ...geometry, pointerX: 200, pointerY: 200 })).toBe("left");
+    expect(classifyDropZone({ ...geometry, pointerX: 800, pointerY: 200 })).toBe("right");
+  });
+
+  it("is 'none' outside the body's horizontal bounds", () => {
+    expect(classifyDropZone({ ...geometry, pointerX: -10, pointerY: 200 })).toBe("none");
+    expect(classifyDropZone({ ...geometry, pointerX: 1200, pointerY: 200 })).toBe("none");
+  });
+
+  it("is 'none' for a zero-width body rather than dividing by zero", () => {
+    expect(classifyDropZone({ ...geometry, bodyWidth: 0, pointerX: 5, pointerY: 200 })).toBe("none");
+  });
+});
+
+describe("resolveDragOutcome", () => {
+  it("docks left/right", () => {
+    expect(resolveDragOutcome("left", false)).toEqual({ kind: "dock", side: "left" });
+    expect(resolveDragOutcome("right", true)).toEqual({ kind: "dock", side: "right" });
+  });
+
+  it("cancels a release outside the dock", () => {
+    expect(resolveDragOutcome("none", false)).toEqual({ kind: "cancel" });
+  });
+
+  it("cancels a strip release for a tab that wasn't paned — no reordering (Design Review required change 1)", () => {
+    expect(resolveDragOutcome("strip", false)).toEqual({ kind: "cancel" });
+  });
+
+  it("a PANED tab's strip release leaves split — its designed un-split meaning survives the cut", () => {
+    expect(resolveDragOutcome("strip", true)).toEqual({ kind: "leave-split" });
+  });
+});
+
+describe("accessible names + announcements", () => {
+  it("paneFocusWord / paneAccessibleName never say 'typing' for both panes at once", () => {
+    expect(paneFocusWord(true)).toBe("Typing here");
+    expect(paneFocusWord(false)).toBe("Watching");
+    expect(paneAccessibleName("Fix login", true)).toBe("Fix login — typing here");
+    expect(paneAccessibleName("Fix login", false)).toBe("Fix login — watching");
+  });
+
+  it("formats every announcement string the design specifies", () => {
+    expect(formatFocusMoveAnnouncement("Fix login")).toBe("Typing now goes to Fix login");
+    expect(formatSplitOnAnnouncement("A", "B", "A")).toBe("Split view on. A left, B right. Typing goes to A.");
+    expect(formatSplitOffAnnouncement("A")).toBe("Split view off. Showing A.");
+    expect(formatWidthFloorAnnouncement("fallback")).toMatch(/too narrow/);
+    expect(formatWidthFloorAnnouncement("restored")).toBe("Split view restored.");
+    expect(formatDockAnnouncement("A", "right")).toBe("Split view on. A docked right. Typing goes to A.");
+    expect(formatLeaveSplitAnnouncement("A")).toBe("Split view off. Showing A.");
+  });
+});
+
+// Keep vi/beforeEach imports meaningful even though most of this module needs
+// no mocking — a couple of persistence tests build ad hoc fakes above instead.
+describe("module sanity", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  it("exports the documented width-floor constants in a sane order", () => {
+    expect(MIN_PANE_WIDTH_PX).toBeLessThan(SPLIT_FALLBACK_BODY_PX);
+    expect(SPLIT_FALLBACK_BODY_PX).toBeLessThan(SPLIT_RESTORE_BODY_PX);
+  });
+});

--- a/src/lib/terminal/split-view.ts
+++ b/src/lib/terminal/split-view.ts
@@ -1,0 +1,321 @@
+// In-app terminal — split view PURE logic (task df7a0134,
+// docs/design-terminal-split-view.html). Builds on the Requirements/UX
+// Design/Design Review workflow steps: an opt-in 2-pane horizontal split of
+// the dock body, tabs remaining the default. Every DECISION this feature
+// needs that can be expressed as a pure function over plain data lives here
+// — mirroring how terminal-tabs.ts keeps label/dedupe/status-glyph decisions
+// out of terminal-dock.tsx. Covers:
+//
+//   - pane eligibility (a popped-out session can never claim a pane — shipped
+//     invariant) and pane ASSIGNMENT (active tab + most-recently-active other
+//     eligible session; a 3rd tab click replaces the UNFOCUSED pane and takes
+//     focus — design §7 Q1)
+//   - width-floor fallback with hysteresis (design §7 Q3: 480px/pane, split
+//     needs a dock body ≥961px, restores at ≥981px) and an explicit mobile-
+//     viewport gate (Design Review required change 3 — AC14 must not rely only
+//     on the width floor being incidentally true on a phone)
+//   - the drag-to-dock gesture's zone/threshold decisions (design §6): an 8px
+//     activation distance, and — per the Design Review's required change 1 —
+//     NO tab reordering: a drag that begins and ends within the tab strip
+//     cancels, except a PANED tab's drag-to-strip, which keeps its designed
+//     "leave split" meaning
+//   - the focus-move keyboard chord (design §5.4: Ctrl+Shift+←/→, absolute)
+//   - persistence of the split-on/off preference (dock-height.ts's
+//     never-throw, localStorage contract)
+//   - accessible-name / live-region announcement strings (design §8)
+//
+// Font metrics the 480px floor is derived from live in
+// src/components/board/use-terminal-session.ts (Design Review required
+// change 4 — the design doc's own citation was wrong).
+
+// ── pane assignment ─────────────────────────────────────────────────────────
+
+export type PaneSide = "left" | "right";
+
+export interface PaneAssignment {
+  left: string | null;
+  right: string | null;
+}
+
+/** A session as far as pane eligibility is concerned. */
+export interface EligibleCandidate {
+  key: string;
+  /** Popped-out sessions never claim a pane (shipped invariant) — excluded. */
+  poppedOut: boolean;
+}
+
+/** Keys eligible for a pane, in their given (tab-strip) order. Ended sessions stay eligible — only pop-out excludes. */
+export function eligiblePaneKeys(sessions: EligibleCandidate[]): string[] {
+  return sessions.filter((s) => !s.poppedOut).map((s) => s.key);
+}
+
+/**
+ * Pick a replacement session for an empty pane slot: most-recently-active
+ * eligible key first (excluding whatever's already in the OTHER slot),
+ * falling back to the first eligible key in strip order. `recency` is
+ * most-recent-first. Returns `null` when nothing is left to offer.
+ */
+function pickReplacement(eligibleKeys: string[], recency: string[], exclude: string | null): string | null {
+  const recentPick = recency.find((k) => k !== exclude && eligibleKeys.includes(k));
+  if (recentPick) return recentPick;
+  return eligibleKeys.find((k) => k !== exclude) ?? null;
+}
+
+/**
+ * The assignment split view enters WITH (toggle-on, or a fresh docking drag
+ * from tabbed mode): left = the active tab (if still eligible), right = the
+ * most-recently-active OTHER eligible session (design §7 Q1 / §5.1).
+ */
+export function enterSplitAssignment(activeKey: string, eligibleKeys: string[], recency: string[]): PaneAssignment {
+  const left = eligibleKeys.includes(activeKey) ? activeKey : pickReplacement(eligibleKeys, recency, null);
+  const right = pickReplacement(eligibleKeys, recency, left);
+  return { left, right };
+}
+
+/**
+ * Keep an existing assignment valid as `sessions`/pop-out state change (a
+ * pane's session popped out, closed, or a 3rd eligible session appeared to
+ * backfill an empty slot) — design §5.5/§5.6/AC16: split auto-resumes when a
+ * 2nd eligible session becomes available again, without the user acting.
+ * Never reassigns a slot that's still valid, so it never steals focus from a
+ * pane that's still showing the same session.
+ */
+export function reconcileSplitAssignment(
+  current: PaneAssignment,
+  eligibleKeys: string[],
+  recency: string[],
+): PaneAssignment {
+  let left = current.left && eligibleKeys.includes(current.left) ? current.left : null;
+  let right = current.right && eligibleKeys.includes(current.right) && current.right !== left ? current.right : null;
+  if (!left) left = pickReplacement(eligibleKeys, recency, right);
+  if (!right) right = pickReplacement(eligibleKeys, recency, left);
+  return { left, right };
+}
+
+/**
+ * A tab click while split (design §5.2). Clicking the focused pane's own tab
+ * is a no-op; clicking the unfocused pane's tab just moves focus to it;
+ * clicking a 3rd session's tab replaces the UNFOCUSED pane's content and
+ * takes focus there — a tab click has always meant "attend to this one",
+ * and the unfocused slot is the only one that can change without yanking
+ * the pane the user is actively typing into.
+ */
+export function applyTabClickToSplit(
+  current: PaneAssignment,
+  focusedSide: PaneSide,
+  clickedKey: string,
+): { assignment: PaneAssignment; focusedSide: PaneSide } {
+  if (current.left === clickedKey) return { assignment: current, focusedSide: "left" };
+  if (current.right === clickedKey) return { assignment: current, focusedSide: "right" };
+  const targetSide: PaneSide = focusedSide === "left" ? "right" : "left";
+  const assignment: PaneAssignment =
+    targetSide === "left" ? { ...current, left: clickedKey } : { ...current, right: clickedKey };
+  return { assignment, focusedSide: targetSide };
+}
+
+/**
+ * A drag-to-dock drop on an explicit half (design §6.3). Unlike a tab click,
+ * the user chose the side directly, so this may replace EITHER pane —
+ * including the focused one. `fallbackOtherKey` seeds the other side when
+ * entering split fresh from tabbed mode (the MRA other eligible session).
+ */
+export function applyDropToSplit(
+  current: PaneAssignment,
+  side: PaneSide,
+  droppedKey: string,
+  fallbackOtherKey: string | null,
+): { assignment: PaneAssignment; focusedSide: PaneSide } {
+  const other: PaneSide = side === "left" ? "right" : "left";
+  const otherCurrent = current[other] && current[other] !== droppedKey ? current[other] : null;
+  const filledOther = otherCurrent ?? (fallbackOtherKey !== droppedKey ? fallbackOtherKey : null);
+  const assignment: PaneAssignment =
+    side === "left" ? { left: droppedKey, right: filledOther } : { left: filledOther, right: droppedKey };
+  return { assignment, focusedSide: side };
+}
+
+// ── width floor (design §7 Q3 / §5.8) ───────────────────────────────────────
+
+/** 60 columns at the shipped 12.5px mono metrics (use-terminal-session.ts) + padding/border. */
+export const MIN_PANE_WIDTH_PX = 480;
+/** Two panes + a 1px divider — below this, tabs render instead. */
+export const SPLIT_FALLBACK_BODY_PX = 961;
+/** 20px hysteresis band so a window hovering at the boundary doesn't flap. */
+export const SPLIT_RESTORE_BODY_PX = 981;
+
+/**
+ * Next "below floor" state given a freshly-measured dock body width, with
+ * hysteresis: once below, only restore at the higher `SPLIT_RESTORE_BODY_PX`
+ * threshold. An unmeasured/invalid width (0, NaN — not yet laid out) leaves
+ * the prior state untouched rather than flapping to a guess.
+ */
+export function resolveWidthFloor(bodyWidthPx: number, wasBelowFloor: boolean): boolean {
+  if (!Number.isFinite(bodyWidthPx) || bodyWidthPx <= 0) return wasBelowFloor;
+  return wasBelowFloor ? bodyWidthPx < SPLIT_RESTORE_BODY_PX : bodyWidthPx < SPLIT_FALLBACK_BODY_PX;
+}
+
+// ── mobile gate (Design Review required change 3 / AC14) ──────────────────
+
+/**
+ * Tailwind's `md` breakpoint (768px) is the project's own mobile/desktop
+ * line elsewhere in this feature (tab strip host/session-id text, etc.) —
+ * reused here so "mobile" means the same thing everywhere. The 961px width
+ * floor above would almost always cover this anyway on a real phone, but
+ * Design Review's required change 3 asks for an EXPLICIT, name-checkable
+ * rule rather than a coincidence of the two numbers.
+ */
+export const MOBILE_VIEWPORT_MAX_PX = 767;
+
+export function isMobileViewport(viewportWidthPx: number): boolean {
+  return Number.isFinite(viewportWidthPx) && viewportWidthPx > 0 && viewportWidthPx <= MOBILE_VIEWPORT_MAX_PX;
+}
+
+/** Whether split view may actually render right now, folding every gate together. */
+export function isSplitRenderable(input: {
+  preferred: boolean;
+  eligibleCount: number;
+  belowWidthFloor: boolean;
+  mobileViewport: boolean;
+}): boolean {
+  return input.preferred && input.eligibleCount >= 2 && !input.belowWidthFloor && !input.mobileViewport;
+}
+
+// ── persistence (dock-height.ts's never-throw, clamp-on-read contract) ────
+
+export const SPLIT_VIEW_PREFERENCE_KEY = "vc:term:split-view";
+
+function defaultStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** The stored preference, or `false` when nothing valid was written (or storage throws) — tabs is always the safe default. */
+export function readSplitViewPreference(storage: Storage | null = defaultStorage()): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(SPLIT_VIEW_PREFERENCE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Best-effort write — a failed write (quota, privacy mode) just means the next load defaults to tabs, never a crash. */
+export function writeSplitViewPreference(enabled: boolean, storage: Storage | null = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    if (enabled) storage.setItem(SPLIT_VIEW_PREFERENCE_KEY, "1");
+    else storage.removeItem(SPLIT_VIEW_PREFERENCE_KEY);
+  } catch {
+    /* best-effort only */
+  }
+}
+
+// ── keyboard chord (design §5.4) ───────────────────────────────────────────
+
+/**
+ * Ctrl+Shift+←/→ — absolute (names the destination pane, not a toggle), so
+ * it's idempotent and never needs debouncing against itself. Every closer
+ * chord collides with the browser, macOS, readline, tmux or Claude Code's own
+ * keys per the Design Review's collision audit; this one is clear on all of
+ * them. Callers intercept it via xterm's `attachCustomKeyEventHandler`
+ * (returning `false` so it never reaches the PTY) AND a dock-level keydown
+ * for when DOM focus sits on pane chrome rather than the xterm itself.
+ */
+export function matchFocusMoveChord(e: {
+  key: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+}): PaneSide | null {
+  if (!e.ctrlKey || !e.shiftKey || e.altKey || e.metaKey) return null;
+  if (e.key === "ArrowLeft" || e.key === "Left") return "left";
+  if (e.key === "ArrowRight" || e.key === "Right") return "right";
+  return null;
+}
+
+// ── drag-to-dock gesture geometry (design §6, Design Review required change 1) ──
+
+/** dnd-kit's own MouseSensor activation constraint mirrors this — kept here too so the pure decision is testable without dnd-kit. */
+export const DRAG_ACTIVATION_DISTANCE_PX = 8;
+/** How far below the strip's bottom edge the pointer must go before the drag counts as "in the dock body" — avoids flicker right at the boundary. */
+export const STRIP_GRACE_MARGIN_PX = 8;
+
+export type DropZone = "strip" | "left" | "right" | "none";
+
+/**
+ * Which zone the pointer is currently over, from raw geometry — no DOM
+ * reads, so it's testable with plain numbers. `pointerY <= stripBottom +
+ * grace` is "still over the tab strip" (design §6.1's "gesture undecided
+ * until it crosses down"); outside the dock body's horizontal bounds is
+ * "none" (release-outside cancels, same as Escape).
+ */
+export function classifyDropZone(input: {
+  pointerX: number;
+  pointerY: number;
+  stripBottom: number;
+  bodyLeft: number;
+  bodyWidth: number;
+}): DropZone {
+  if (input.pointerY <= input.stripBottom + STRIP_GRACE_MARGIN_PX) return "strip";
+  if (input.bodyWidth <= 0) return "none";
+  const relativeX = input.pointerX - input.bodyLeft;
+  if (relativeX < 0 || relativeX > input.bodyWidth) return "none";
+  return relativeX < input.bodyWidth / 2 ? "left" : "right";
+}
+
+export type DragDropOutcome = { kind: "cancel" } | { kind: "leave-split" } | { kind: "dock"; side: PaneSide };
+
+/**
+ * Design Review required change 1: tab REORDERING is cut — a drag that
+ * begins and ends within the strip changes nothing, full stop, UNLESS the
+ * dragged tab was already paned, in which case releasing it back on the
+ * strip keeps its designed "leave split" meaning (the return path, §6.3).
+ * Releasing outside the dock entirely also cancels (`"none"`, same as
+ * pressing Escape mid-drag).
+ */
+export function resolveDragOutcome(zone: DropZone, isDraggedTabPaned: boolean): DragDropOutcome {
+  if (zone === "none") return { kind: "cancel" };
+  if (zone === "strip") return isDraggedTabPaned ? { kind: "leave-split" } : { kind: "cancel" };
+  return { kind: "dock", side: zone };
+}
+
+// ── accessible names + live-region announcements (design §8) ───────────────
+
+/** The words half of the focus-clarity signal — never colour alone (Requirements §4 / Design Review §2). */
+export function paneFocusWord(focused: boolean): string {
+  return focused ? "Typing here" : "Watching";
+}
+
+/** A pane's full accessible name — resolves so the a11y tree can never report two "typing" panes (it derives from one caller-supplied `focused` flag). */
+export function paneAccessibleName(label: string, focused: boolean): string {
+  return `${label} — ${focused ? "typing here" : "watching"}`;
+}
+
+export function formatFocusMoveAnnouncement(label: string): string {
+  return `Typing now goes to ${label}`;
+}
+
+export function formatSplitOnAnnouncement(leftLabel: string, rightLabel: string, focusedLabel: string): string {
+  return `Split view on. ${leftLabel} left, ${rightLabel} right. Typing goes to ${focusedLabel}.`;
+}
+
+export function formatSplitOffAnnouncement(remainingLabel: string): string {
+  return `Split view off. Showing ${remainingLabel}.`;
+}
+
+export function formatWidthFloorAnnouncement(kind: "fallback" | "restored"): string {
+  return kind === "fallback"
+    ? "Window too narrow for split view — showing tabs. Split returns when wider."
+    : "Split view restored.";
+}
+
+export function formatDockAnnouncement(label: string, side: PaneSide): string {
+  return `Split view on. ${label} docked ${side}. Typing goes to ${label}.`;
+}
+
+export function formatLeaveSplitAnnouncement(label: string): string {
+  return `Split view off. Showing ${label}.`;
+}


### PR DESCRIPTION
Board card df7a0134. Nick wanted two terminals visible at once instead of flipping between tabs — with one hard requirement: **it must be obvious which one has the cursor, to avoid typing into the wrong box.**

## What this does
- **Split toggle** in the tab strip (2+ sessions only): two sessions side by side, 50/50, at the existing dock height. Tabs stay the default — nothing changes unless you opt in, and the choice persists.
- **Drag-to-dock** (Nick's mid-flight addition): drag a tab onto the left or right half, IDE-style, with a labelled drop zone. 8px activation threshold so a click or a stray wobble can never split the dock; Escape or release-outside cancels; drag a paned tab back to the strip to un-split. The toggle remains the accessible equivalent route.
- **Focus clarity — four redundant signals**, any one of which alone answers "where do my keys go?": accent border + glow; the words "⌨ Typing here" vs "◇ Watching"; header brightness via explicit colour tokens (never opacity, so contrast is provable — 7.4:1 to 16.7:1, all AA); and solid vs hollow cursor from real DOM focus. **Terminal output is never dimmed in either pane** — watching both run is the whole point.
- **Ctrl+Shift+←/→** moves focus between panes, intercepted before it can reach the PTY (full collision audit against browsers, macOS, readline, tmux and Claude Code's own keys in the design doc).
- **Width floor**: 480px per pane (60 columns at the shipped font metrics), so split needs a dock body ≥961px and restores at ≥981px — 20px hysteresis so a window hovering at the boundary doesn't flap. Mobile always renders tabs regardless of stored preference.

## The defect QA caught, and how it was closed
The first implementation shipped a **category-1 bug**: real keyboard focus could diverge from the indicator. xterm sets its hidden textarea's `tabIndex = 0`, both panes were focusable while split, and nothing listened for focus arriving by any route other than a click — so pressing Tab walked into the pane labelled "Watching" while the UI insisted the other was live. A keystroke, including approving a plan, could land in the wrong session. Exactly the accident this feature exists to prevent.

Fixed with two independent guards: the unfocused pane's input is out of the Tab order, **and** native focus/blur on the real input feeds app state, so the indicator follows reality from any route rather than inferring it from clicks. A new `keyboardLive` flag means neither pane claims "Typing here" when focus leaves both.

QA verified the regression tests were genuine by reverting the fix and watching 5 of the 6 new tests fail — the split-view logic had been unit-tested in isolation, which could never have caught a real-DOM wiring gap.

## Deliberately cut
Tab reordering by dragging along the strip — it appeared in the design without being asked for, and adds state, persistence questions and ways for a drag to misfire. A drag beginning and ending in the strip now cancels and changes nothing.

## Known limitations
- Three of the twenty acceptance criteria are unverified: cursor solid-vs-hollow rendering, and terminals refitting on split-open and on resize. They need a live terminal session against a real machine, which no automated step could create.
- No hands-on browser testing — automated suite plus code trace only.

## Checks
`npm run test` 3,122 passed · `npm run typecheck` clean · `npm run lint` 0 errors · `npm run build` succeeds. Front-end only — no server, relay, bridge or database change; rollback is a pure code revert.

Built through the card's six-step workflow, including one QA rejection and rework. Design and release both approved by Nick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)