### PR TITLE
feat(terminal): split view puts each pane's tab directly above its own terminal

### DIFF
--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -111,6 +111,7 @@ import {
   reconcileSplitAssignment,
   applyTabClickToSplit,
   applyDropToSplit,
+  splitTabGroups,
   resolveWidthFloor,
   isMobileViewport,
   isSplitRenderable,
@@ -2224,11 +2225,15 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
                   : "border-zinc-800",
               )}
             >
-              {/* Tabs shrink then scroll; "+"/toggle (below) stay pinned
-                  OUTSIDE this scroll region so launch + oversight are never
-                  scrolled away (design §4a: "never wrap, never hide the '+'"). */}
-              <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto">
-              {sessions.map((entry, index) => {
+              {/* Tabs shrink then scroll; "+"/toggle (stripControls below)
+                  stay pinned OUTSIDE the scroll region(s) so launch +
+                  oversight are never scrolled away (design §4a: "never wrap,
+                  never hide the '+'"). While split actually renders, the
+                  strip lays out as TWO half-width groups so each pane's tab
+                  sits directly above its own terminal (task c108ae4a) — the
+                  grouping decision is splitTabGroups (split-view.ts). */}
+              {(() => {
+              const renderTab = (entry: SessionEntry, index: number) => {
                 const summary = summaries[entry.key];
                 const status = summary?.status ?? "idle";
                 const poppedOut = poppedOutKeys.has(entry.key);
@@ -2438,14 +2443,16 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
                     )}
                   </DraggableTab>
                 );
-              })}
-              </div>
-              {/* Split view toggle (design §1 "immediately left of the
-                  existing '+'"): visible whenever tabs themselves are —
-                  never a disabled dead button (no trapping dialogs — the
-                  toggle always does something, even below the width floor,
-                  where pressing it stores the preference and shows the
-                  amber notice instead of silently failing). */}
+              };
+              // Split view toggle (design §1 "immediately left of the
+              // existing '+'"): visible whenever tabs themselves are — never
+              // a disabled dead button (no trapping dialogs — the toggle
+              // always does something, even below the width floor, where
+              // pressing it stores the preference and shows the amber notice
+              // instead of silently failing). The "+" rides with it; the
+              // pair pins at the strip's far right in both layouts.
+              const stripControls = (
+                <>
               <button
                 type="button"
                 aria-pressed={splitPreferred === true}
@@ -2472,6 +2479,38 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
               >
                 <Plus className="h-4 w-4" />
               </button>
+                </>
+              );
+              if (!splitActive) {
+                return (
+                  <>
+                    <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto">{sessions.map(renderTab)}</div>
+                    {stripControls}
+                  </>
+                );
+              }
+              const groups = splitTabGroups(
+                sessions.map((s) => s.key),
+                splitAssignment,
+              );
+              return (
+                <>
+                  <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto">
+                    {sessions.map((entry, index) => (groups.left.includes(entry.key) ? renderTab(entry, index) : null))}
+                  </div>
+                  {/* The right half mirrors the pane boundary below exactly:
+                      both halves are flex-1 of the same strip, matching the
+                      two flex-1 panes — the controls live INSIDE this half so
+                      they don't shift the midpoint. */}
+                  <div className="flex min-w-0 flex-1 items-stretch border-l border-zinc-800">
+                    <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto">
+                      {sessions.map((entry, index) => (groups.right.includes(entry.key) ? renderTab(entry, index) : null))}
+                    </div>
+                    {stripControls}
+                  </div>
+                </>
+              );
+              })()}
             </div>
             </>
           )}

--- a/src/lib/terminal/split-view.test.ts
+++ b/src/lib/terminal/split-view.test.ts
@@ -5,6 +5,7 @@ import {
   reconcileSplitAssignment,
   applyTabClickToSplit,
   applyDropToSplit,
+  splitTabGroups,
   resolveWidthFloor,
   isMobileViewport,
   isSplitRenderable,
@@ -134,6 +135,23 @@ describe("applyDropToSplit", () => {
     const result = applyDropToSplit({ left: "a", right: "b" }, "left", "b", null);
     expect(result.assignment.right).not.toBe("b");
     expect(result.assignment).toEqual({ left: "b", right: null });
+  });
+});
+
+describe("splitTabGroups (task c108ae4a — each pane's tab above its own terminal)", () => {
+  it("puts the right pane's tab alone in the right group, everything else left", () => {
+    expect(splitTabGroups(["a", "b"], { left: "a", right: "b" })).toEqual({ left: ["a"], right: ["b"] });
+  });
+
+  it("keeps un-paned tabs (3rd session, popped-out) in the LEFT group, in strip order", () => {
+    expect(splitTabGroups(["a", "b", "c", "d"], { left: "b", right: "d" })).toEqual({
+      left: ["a", "b", "c"],
+      right: ["d"],
+    });
+  });
+
+  it("follows a swapped assignment — strip order does not dictate the side", () => {
+    expect(splitTabGroups(["a", "b"], { left: "b", right: "a" })).toEqual({ left: ["b"], right: ["a"] });
   });
 });
 

--- a/src/lib/terminal/split-view.ts
+++ b/src/lib/terminal/split-view.ts
@@ -133,6 +133,22 @@ export function applyDropToSplit(
   return { assignment, focusedSide: side };
 }
 
+/**
+ * While split is RENDERED, the tab strip lays out as two half-width groups so
+ * each pane's tab sits directly above its own terminal (Nick's feedback, task
+ * c108ae4a — one strip on the left made the right pane's tab look like it
+ * belonged to the left terminal). The right group holds only the right pane's
+ * tab; every other tab — the left pane's, plus any un-paned session (a 3rd
+ * tab, a popped-out one) — stays in the left group in strip order, so
+ * un-paned tabs keep a stable home rather than jumping between halves.
+ */
+export function splitTabGroups(orderedKeys: string[], assignment: PaneAssignment): { left: string[]; right: string[] } {
+  return {
+    left: orderedKeys.filter((k) => k !== assignment.right),
+    right: orderedKeys.filter((k) => k === assignment.right),
+  };
+}
+
 // ── width floor (design §7 Q3 / §5.8) ───────────────────────────────────────
 
 /** 60 columns at the shipped 12.5px mono metrics (use-terminal-session.ts) + padding/border. */


### PR DESCRIPTION
Nick's feedback (screenshot on board card c108ae4a): in side-by-side view, both session tabs sat in one strip at the top-left, so the right pane's tab looked like it belonged to the left terminal.

**Change** (`terminal-dock.tsx`): while split view is actually rendering, the tab strip lays out as two half-width groups that mirror the panes below — each pane's tab sits directly above its own terminal. The right half holds only the right pane's tab; the left pane's tab plus any un-paned tabs (a 3rd session, popped-out ones) stay in the left group in strip order. The split toggle and "+" stay pinned top-right, nested inside the right half so the strip's midpoint aligns exactly with the pane divider. Tabbed (non-split) mode renders byte-for-byte the same DOM as before.

The grouping decision is a new pure helper `splitTabGroups` in `src/lib/terminal/split-view.ts`, unit-tested per the repo's pure-logic-in-lib convention.

**Verification**: typecheck clean, full unit suite 3,110 tests / 186 files green, lint 0 errors.

Board card: c108ae4a (Side-by-side terminals: tab selector should sit above each pane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)