### PR TITLE
fix(terminal): End session/rename tab no longer stretches across the whole strip

### DIFF
--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -2283,8 +2283,16 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
                       !isActive && "hover:bg-zinc-800/60 hover:text-zinc-100",
                       // Widen while renaming/confirming — "the tab widens to
                       // its max width while editing so there's room to type"
-                      // (design §3a).
-                      (renaming || confirming) && "max-w-none flex-1",
+                      // (design §3a). Bounded, not unbounded: `max-w-none`
+                      // removed the cap entirely, so with few tabs open the
+                      // confirming/renaming tab grew to fill the ENTIRE
+                      // strip's leftover flex space (bug reported 2026-08-22
+                      // — "End session?" stretching across the screen with
+                      // ✓/✕ pushed to the far edge, and sibling tabs shoved
+                      // out of the visible strip). `flex-1` still lets it
+                      // grow to fit a name when there's room; the explicit
+                      // cap just stops it swallowing the whole row.
+                      (renaming || confirming) && "max-w-[300px] flex-1",
                     )}
                   >
                     {paneSide && (


### PR DESCRIPTION
Reported by Nick with screenshots, 2026-08-22: clicking End on a terminal tab makes it balloon across the entire tab strip, with the ✓/✕ buttons stranded at the far right edge and the other tab's session pushed out of view.

## Root cause
Not caused by the side-by-side feature — this line has been unchanged since the very first multi-session tabbed dock (`597cfce`). It only became visible now because it needs 2+ tabs open with real width to spare, which is a much more common situation since split view landed.

The confirming/renaming tab's class list included `max-w-none flex-1` — removing the tab's normal `max-w-[190px]` cap entirely rather than just letting it grow toward it. With few tabs open, that tab absorbs ALL of the strip's leftover flex space, which on a wide board panel is most of the browser width.

## Fix
Capped at `max-w-[300px]` instead of `max-w-none` — still widens via `flex-1` when there's room (that part of the design intent was correct: "the tab widens to its max width while editing"), it just can't swallow the whole row any more. 300px comfortably fits the confirm text/buttons and a reasonably long session name without truncating hard.

## Checks
`npm run test` 3,110 passed · typecheck clean · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)