### PR TITLE
fix(ci): stop pasting GitHub Actions expressions into JS script bodies

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -157,7 +157,7 @@ jobs:
             SUMMARY="${SUMMARY}\n\n### Warnings\n${WARNINGS}"
           fi
 
-          SUMMARY="${SUMMARY}\n\n---\n*Migrations are auto-applied to staging when merged to \`develop\`. Production requires manual trigger via [workflow_dispatch](../actions/workflows/migrations.yml).*"
+          SUMMARY="${SUMMARY}\n\n---\n*Production migrations require manual trigger via [workflow_dispatch](../actions/workflows/migrations.yml), gated by an approval step. There is no automatic apply on merge.*"
 
           echo "summary<<EOF" >> "$GITHUB_OUTPUT"
           echo -e "$SUMMARY" >> "$GITHUB_OUTPUT"
@@ -171,9 +171,11 @@ jobs:
 
       - name: Comment on PR
         uses: actions/github-script@v7
+        env:
+          SUMMARY: ${{ steps.validate.outputs.summary }}
         with:
           script: |
-            const summary = `${{ steps.validate.outputs.summary }}`;
+            const summary = process.env.SUMMARY;
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
 
@@ -247,12 +249,14 @@ jobs:
         id: create-issue
         if: failure()
         uses: actions/github-script@v7
+        env:
+          MIGRATION_FILES: ${{ needs.detect-migrations.outputs.files }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const sha = context.sha.substring(0, 7);
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
-            const files = `${{ needs.detect-migrations.outputs.files }}`.split('\n').filter(Boolean);
+            const files = process.env.MIGRATION_FILES.split('\n').filter(Boolean);
             const fileList = files.map(f => `- \`${f.split('/').pop()}\``).join('\n');
 
             const issue = await github.rest.issues.create({
@@ -331,11 +335,13 @@ jobs:
       - name: Create production migration reminder
         id: create-reminder
         uses: actions/github-script@v7
+        env:
+          MIGRATION_FILES: ${{ needs.detect-migrations.outputs.files }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const sha = context.sha.substring(0, 7);
-            const files = `${{ needs.detect-migrations.outputs.files }}`.split('\n').filter(Boolean);
+            const files = process.env.MIGRATION_FILES.split('\n').filter(Boolean);
             const fileList = files.map(f => `- \`${f.split('/').pop()}\``).join('\n');
             const workflowUrl = `https://github.com/${owner}/${repo}/actions/workflows/migrations.yml`;
 

--- a/supabase/migrations/00162_ci_verification_noop.sql
+++ b/supabase/migrations/00162_ci_verification_noop.sql
@@ -1,5 +1,0 @@
--- Throwaway migration used only to trigger the migrations.yml CI workflow
--- for verification of the "Comment on PR" step fix (backtick-collision
--- SyntaxError). Not meant to be applied to any real database and will be
--- removed in a follow-up commit before this PR merges.
-select 1;

--- a/supabase/migrations/00162_ci_verification_noop.sql
+++ b/supabase/migrations/00162_ci_verification_noop.sql
@@ -1,0 +1,5 @@
+-- Throwaway migration used only to trigger the migrations.yml CI workflow
+-- for verification of the "Comment on PR" step fix (backtick-collision
+-- SyntaxError). Not meant to be applied to any real database and will be
+-- removed in a follow-up commit before this PR merges.
+select 1;


### PR DESCRIPTION
## Summary
- `.github/workflows/migrations.yml`'s "Comment on PR" step interpolated `${{ steps.validate.outputs.summary }}` directly into a JS template literal. The summary text is built with literal backticks (backtick-wrapped filenames, a fenced \`\`\`sql block), which collided with the wrapping backticks and produced invalid JavaScript on **every** migration PR — this check has been permanently red since the workflow was written.
- Fixed by routing the value through the job's environment (`env: SUMMARY: ...`) and reading it via `process.env.SUMMARY` in the script, which sidesteps the syntax collision and also closes an injection vector (arbitrary PR-triggered content was previously spliced into executable script text).
- Applied the same treatment to two more spots in the same file with the same risky shape (not live-broken today — plain filenames don't contain backticks in practice).
- Corrected stale copy in the PR comment claiming migrations "auto-apply to staging when merged to `develop`" — develop is dead; production requires the approval-gated manual `workflow_dispatch` trigger, no auto-apply on merge.

**Note:** this PR includes a throwaway migration file (`supabase/migrations/00162_ci_verification_noop.sql`, a single harmless `select 1;`) added **only** to trigger this workflow so the fix can be proven against a real GitHub Actions `pull_request` run — the workflow only fires on changes under `supabase/migrations/*.sql`, so a PR touching only the workflow file would never exercise the broken job. That file will be removed in a follow-up commit on this branch before merge; it is not meant to be applied anywhere.

## Test plan
- [x] Confirmed via reading the `if:` conditions on all 5 jobs that no database-touching job (`apply-staging`, `apply-production`, `apply-staging-manual`, `remind-production`) can fire from a `pull_request` event — only `detect-migrations` and `validate` can run here.
- [ ] Watch CI: "Comment on PR" step succeeds and actually posts a comment containing a backtick-wrapped filename (the exact case that broke it).
- [ ] Remove the throwaway migration file in a follow-up commit once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)