### PR TITLE
feat(terminal): configurable starting model for terminal sessions

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -157,7 +157,7 @@ jobs:
             SUMMARY="${SUMMARY}\n\n### Warnings\n${WARNINGS}"
           fi
 
-          SUMMARY="${SUMMARY}\n\n---\n*Production migrations require manual trigger via [workflow_dispatch](../actions/workflows/migrations.yml), gated by an approval step. There is no automatic apply on merge.*"
+          SUMMARY="${SUMMARY}\n\n---\n*Migrations are auto-applied to staging when merged to \`develop\`. Production requires manual trigger via [workflow_dispatch](../actions/workflows/migrations.yml).*"
 
           echo "summary<<EOF" >> "$GITHUB_OUTPUT"
           echo -e "$SUMMARY" >> "$GITHUB_OUTPUT"
@@ -171,11 +171,9 @@ jobs:
 
       - name: Comment on PR
         uses: actions/github-script@v7
-        env:
-          SUMMARY: ${{ steps.validate.outputs.summary }}
         with:
           script: |
-            const summary = process.env.SUMMARY;
+            const summary = `${{ steps.validate.outputs.summary }}`;
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
 
@@ -249,14 +247,12 @@ jobs:
         id: create-issue
         if: failure()
         uses: actions/github-script@v7
-        env:
-          MIGRATION_FILES: ${{ needs.detect-migrations.outputs.files }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const sha = context.sha.substring(0, 7);
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
-            const files = process.env.MIGRATION_FILES.split('\n').filter(Boolean);
+            const files = `${{ needs.detect-migrations.outputs.files }}`.split('\n').filter(Boolean);
             const fileList = files.map(f => `- \`${f.split('/').pop()}\``).join('\n');
 
             const issue = await github.rest.issues.create({
@@ -335,13 +331,11 @@ jobs:
       - name: Create production migration reminder
         id: create-reminder
         uses: actions/github-script@v7
-        env:
-          MIGRATION_FILES: ${{ needs.detect-migrations.outputs.files }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const sha = context.sha.substring(0, 7);
-            const files = process.env.MIGRATION_FILES.split('\n').filter(Boolean);
+            const files = `${{ needs.detect-migrations.outputs.files }}`.split('\n').filter(Boolean);
             const fileList = files.map(f => `- \`${f.split('/').pop()}\``).join('\n');
             const workflowUrl = `https://github.com/${owner}/${repo}/actions/workflows/migrations.yml`;
 

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -157,7 +157,7 @@ jobs:
             SUMMARY="${SUMMARY}\n\n### Warnings\n${WARNINGS}"
           fi
 
-          SUMMARY="${SUMMARY}\n\n---\n*Migrations are auto-applied to staging when merged to \`develop\`. Production requires manual trigger via [workflow_dispatch](../actions/workflows/migrations.yml).*"
+          SUMMARY="${SUMMARY}\n\n---\n*Production migrations require manual trigger via [workflow_dispatch](../actions/workflows/migrations.yml), gated by an approval step. There is no automatic apply on merge.*"
 
           echo "summary<<EOF" >> "$GITHUB_OUTPUT"
           echo -e "$SUMMARY" >> "$GITHUB_OUTPUT"
@@ -171,9 +171,11 @@ jobs:
 
       - name: Comment on PR
         uses: actions/github-script@v7
+        env:
+          SUMMARY: ${{ steps.validate.outputs.summary }}
         with:
           script: |
-            const summary = `${{ steps.validate.outputs.summary }}`;
+            const summary = process.env.SUMMARY;
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
 
@@ -247,12 +249,14 @@ jobs:
         id: create-issue
         if: failure()
         uses: actions/github-script@v7
+        env:
+          MIGRATION_FILES: ${{ needs.detect-migrations.outputs.files }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const sha = context.sha.substring(0, 7);
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
-            const files = `${{ needs.detect-migrations.outputs.files }}`.split('\n').filter(Boolean);
+            const files = process.env.MIGRATION_FILES.split('\n').filter(Boolean);
             const fileList = files.map(f => `- \`${f.split('/').pop()}\``).join('\n');
 
             const issue = await github.rest.issues.create({
@@ -331,11 +335,13 @@ jobs:
       - name: Create production migration reminder
         id: create-reminder
         uses: actions/github-script@v7
+        env:
+          MIGRATION_FILES: ${{ needs.detect-migrations.outputs.files }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const sha = context.sha.substring(0, 7);
-            const files = `${{ needs.detect-migrations.outputs.files }}`.split('\n').filter(Boolean);
+            const files = process.env.MIGRATION_FILES.split('\n').filter(Boolean);
             const fileList = files.map(f => `- \`${f.split('/').pop()}\``).join('\n');
             const workflowUrl = `https://github.com/${owner}/${repo}/actions/workflows/migrations.yml`;
 

--- a/src/actions/admin-platform.test.ts
+++ b/src/actions/admin-platform.test.ts
@@ -351,6 +351,30 @@ describe("updatePlatformTerminalModelDefault — super-admin gate", () => {
     await expect(updatePlatformTerminalModelDefault("opus 5!")).rejects.toThrow(/space/i);
   });
 
+  it("rejects a value over the 100-char cap before ever touching the DB (QA Bug 1 — was overflowing the deep link's 2048-char cap platform-wide)", async () => {
+    mockSupabase.auth.getUser.mockReset();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: SUPER_ADMIN_ID } }, error: null });
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { is_super_admin: true }, error: null }) }) }),
+    }));
+
+    await expect(updatePlatformTerminalModelDefault("a".repeat(101))).rejects.toThrow(/100 characters/i);
+  });
+
+  it("boundary: exactly 100 chars is accepted, 101 is rejected (QA Bug 1)", async () => {
+    mockSupabase.auth.getUser.mockReset();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: SUPER_ADMIN_ID } }, error: null });
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "users") {
+        return { select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { is_super_admin: true }, error: null }) }) }) };
+      }
+      return { upsert: () => Promise.resolve({ error: null }) };
+    });
+
+    await expect(updatePlatformTerminalModelDefault("a".repeat(100))).resolves.toBe("a".repeat(100));
+    await expect(updatePlatformTerminalModelDefault("a".repeat(101))).rejects.toThrow(/100 characters/i);
+  });
+
   it("clears the platform default back to unset when passed null (deletes the row, not an error)", async () => {
     mockSupabase.auth.getUser.mockReset();
     mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: SUPER_ADMIN_ID } }, error: null });

--- a/src/actions/admin-platform.test.ts
+++ b/src/actions/admin-platform.test.ts
@@ -24,6 +24,9 @@ import {
   getPlatformModelDefaultsAction,
   getPlatformModelDefaultsForAdmin,
   updatePlatformModelDefaults,
+  getPlatformTerminalModelDefaultAction,
+  getPlatformTerminalModelDefaultForAdmin,
+  updatePlatformTerminalModelDefault,
 } from "./admin-platform";
 import { SEED_PLATFORM_MODEL_DEFAULTS } from "@/lib/platform-model-defaults";
 
@@ -208,6 +211,181 @@ describe("updatePlatformModelDefaults — super-admin gate", () => {
 
     await expect(updatePlatformModelDefaults(validInput)).rejects.toThrow(
       "Failed to save platform model defaults — try again"
+    );
+  });
+});
+
+describe("getPlatformTerminalModelDefaultAction (binding: no seed)", () => {
+  it("returns null when no row is saved yet — never a hardcoded seed", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }),
+    }));
+
+    expect(await getPlatformTerminalModelDefaultAction()).toBeNull();
+  });
+
+  it("returns the live saved value — any authenticated user can read (no admin check)", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { value: { model: "opus" } }, error: null }) }) }),
+    }));
+
+    expect(await getPlatformTerminalModelDefaultAction()).toBe("opus");
+    expect(mockSupabase.auth.getUser).not.toHaveBeenCalled();
+  });
+});
+
+describe("getPlatformTerminalModelDefaultForAdmin", () => {
+  it("reports null value and null audit fields when nothing has been saved", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }),
+    }));
+
+    const result = await getPlatformTerminalModelDefaultForAdmin();
+    expect(result).toEqual({ value: null, updatedBy: null, updatedAt: null });
+  });
+
+  it("surfaces the audit line for a saved row", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({
+              data: {
+                value: { model: "opus" },
+                updated_at: "2026-07-20T00:00:00Z",
+                updated_by: { id: SUPER_ADMIN_ID, full_name: "Nick Ball" },
+              },
+              error: null,
+            }),
+        }),
+      }),
+    }));
+
+    const result = await getPlatformTerminalModelDefaultForAdmin();
+    expect(result.value).toBe("opus");
+    expect(result.updatedBy).toEqual({ id: SUPER_ADMIN_ID, full_name: "Nick Ball" });
+    expect(result.updatedAt).toBe("2026-07-20T00:00:00Z");
+  });
+
+  it("falls back to null when the saved row is structurally invalid", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({ data: { value: { notModel: "opus" }, updated_at: null, updated_by: null }, error: null }),
+        }),
+      }),
+    }));
+
+    const result = await getPlatformTerminalModelDefaultForAdmin();
+    expect(result.value).toBeNull();
+  });
+});
+
+describe("updatePlatformTerminalModelDefault — super-admin gate", () => {
+  it("throws when not authenticated", async () => {
+    mockSupabase.auth.getUser.mockReset();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
+    await expect(updatePlatformTerminalModelDefault("opus")).rejects.toThrow("Not authenticated");
+  });
+
+  it("throws for an authenticated non-super-admin (denied)", async () => {
+    mockSupabase.auth.getUser.mockReset();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: REGULAR_USER_ID } }, error: null });
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { is_super_admin: false }, error: null }) }) }),
+    }));
+
+    await expect(updatePlatformTerminalModelDefault("opus")).rejects.toThrow("Super admin access required");
+  });
+
+  it("saves and returns the trimmed value for a super-admin (allowed)", async () => {
+    mockSupabase.auth.getUser.mockReset();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: SUPER_ADMIN_ID } }, error: null });
+    let upsertedWith: unknown;
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "users") {
+        return { select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { is_super_admin: true }, error: null }) }) }) };
+      }
+      return {
+        upsert: (row: unknown) => {
+          upsertedWith = row;
+          return Promise.resolve({ error: null });
+        },
+      };
+    });
+
+    const result = await updatePlatformTerminalModelDefault("  opus  ");
+    expect(result).toBe("opus");
+    expect(upsertedWith).toMatchObject({
+      key: "terminal_model_default",
+      value: { model: "opus" },
+      updated_by: SUPER_ADMIN_ID,
+    });
+  });
+
+  it("accepts a novel free-text model family (no schema change required)", async () => {
+    mockSupabase.auth.getUser.mockReset();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: SUPER_ADMIN_ID } }, error: null });
+    let upsertedWith: unknown;
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "users") {
+        return { select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { is_super_admin: true }, error: null }) }) }) };
+      }
+      return { upsert: (row: unknown) => { upsertedWith = row; return Promise.resolve({ error: null }); } };
+    });
+
+    const result = await updatePlatformTerminalModelDefault("opus-5.5");
+    expect(result).toBe("opus-5.5");
+    expect((upsertedWith as { value: unknown }).value).toEqual({ model: "opus-5.5" });
+  });
+
+  it("rejects a structurally invalid value before ever touching the DB", async () => {
+    mockSupabase.auth.getUser.mockReset();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: SUPER_ADMIN_ID } }, error: null });
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { is_super_admin: true }, error: null }) }) }),
+    }));
+
+    await expect(updatePlatformTerminalModelDefault("opus 5!")).rejects.toThrow(/space/i);
+  });
+
+  it("clears the platform default back to unset when passed null (deletes the row, not an error)", async () => {
+    mockSupabase.auth.getUser.mockReset();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: SUPER_ADMIN_ID } }, error: null });
+    let deletedKey: string | undefined;
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "users") {
+        return { select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { is_super_admin: true }, error: null }) }) }) };
+      }
+      return {
+        delete: () => ({
+          eq: (col: string, val: string) => {
+            deletedKey = col === "key" ? val : undefined;
+            return Promise.resolve({ error: null });
+          },
+        }),
+      };
+    });
+
+    const result = await updatePlatformTerminalModelDefault(null);
+    expect(result).toBeNull();
+    expect(deletedKey).toBe("terminal_model_default");
+  });
+
+  it("throws a safe message (never the raw DB error) when the upsert fails", async () => {
+    mockSupabase.auth.getUser.mockReset();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: SUPER_ADMIN_ID } }, error: null });
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "users") {
+        return { select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { is_super_admin: true }, error: null }) }) }) };
+      }
+      return { upsert: () => Promise.resolve({ error: { message: "constraint violation on internal_column_xyz" } }) };
+    });
+
+    await expect(updatePlatformTerminalModelDefault("opus")).rejects.toThrow(
+      "Failed to save the terminal starting model — try again"
     );
   });
 });

--- a/src/actions/admin-platform.ts
+++ b/src/actions/admin-platform.ts
@@ -10,6 +10,12 @@ import {
   PLATFORM_MODEL_DEFAULTS_KEY,
   type PlatformModelDefaults,
 } from "@/lib/platform-model-defaults";
+import {
+  getPlatformTerminalModelDefault,
+  isValidPlatformTerminalModelDefault,
+  TERMINAL_MODEL_DEFAULT_KEY,
+} from "@/lib/terminal/platform-terminal-model";
+import { validateTerminalModelValue } from "@/lib/terminal/model-resolution";
 
 // ── Admin-configurable platform model-tier defaults ─────────────────────
 // Super-admin-only read-for-admin / write. Any authenticated user can read
@@ -115,4 +121,89 @@ export async function updatePlatformModelDefaults(
   }
 
   return parsed;
+}
+
+// ── Admin-configurable terminal starting-model default (task c4ca2d95) ─────
+// Same super-admin-only read-for-admin / write posture as the model-tier
+// defaults above, but a SEPARATE platform_settings key (own Save/audit/
+// error boundary — design decision, docs/terminal-starting-model-design.html
+// §0) and, per Nick's binding approval-gate note, NO seed: an admin can
+// clear this back to "unset", at which point resolution omits the model
+// entirely (see resolveEffectiveTerminalModel in
+// src/lib/terminal/model-resolution.ts).
+
+export type PlatformTerminalModelAudit = {
+  /** null = no platform default set — resolution omits the model entirely. */
+  value: string | null;
+  updatedBy: { id: string; full_name: string | null } | null;
+  updatedAt: string | null;
+};
+
+/** Any authenticated user can call this (mirrors getPlatformModelDefaultsAction —
+ *  read is allowed for everyone per RLS; only the write path is super-admin gated).
+ *  Used by the session-mint route and the chooser/launch-dialog launch-surface hooks. */
+export async function getPlatformTerminalModelDefaultAction(): Promise<string | null> {
+  const supabase = await createClient();
+  return getPlatformTerminalModelDefault(supabase);
+}
+
+/** Admin "Platform" tab read — includes the audit line (who/when). Super-admin-only
+ *  surface, but (like the tier-defaults read above) the read itself doesn't need to
+ *  be gated — RLS already allows any authenticated read. */
+export async function getPlatformTerminalModelDefaultForAdmin(): Promise<PlatformTerminalModelAudit> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("platform_settings")
+    .select("value, updated_at, updated_by:users!platform_settings_updated_by_fkey(id, full_name)")
+    .eq("key", TERMINAL_MODEL_DEFAULT_KEY)
+    .maybeSingle();
+
+  if (!data) {
+    return { value: null, updatedBy: null, updatedAt: null };
+  }
+
+  const value = isValidPlatformTerminalModelDefault(data.value) ? data.value.model : null;
+  const updatedBy = Array.isArray(data.updated_by) ? data.updated_by[0] ?? null : data.updated_by ?? null;
+
+  return { value, updatedBy, updatedAt: data.updated_at };
+}
+
+/**
+ * Save (or clear) the platform terminal starting-model default. Super-admin-only
+ * (checked here AND by the platform_settings RLS write policy — defence in depth).
+ * `model: null` clears the platform default back to unset (DELETEs the row) — this
+ * is a legitimate, meaningful choice here (unlike the tier defaults, which always
+ * have a seed to fall back to), not an error case.
+ */
+export async function updatePlatformTerminalModelDefault(model: string | null): Promise<string | null> {
+  const { supabase, userId } = await requireSuperAdmin();
+
+  if (model === null) {
+    const { error } = await supabase.from("platform_settings").delete().eq("key", TERMINAL_MODEL_DEFAULT_KEY);
+    if (error) {
+      logger.error("Failed to clear platform terminal model default", { error: error.message, userId });
+      throw new Error("Failed to clear the terminal starting model — try again");
+    }
+    return null;
+  }
+
+  const trimmed = model.trim();
+  const validation = validateTerminalModelValue(trimmed);
+  if (!validation.ok) {
+    throw new Error(validation.reason);
+  }
+
+  const { error } = await supabase.from("platform_settings").upsert({
+    key: TERMINAL_MODEL_DEFAULT_KEY,
+    value: { model: trimmed },
+    updated_by: userId,
+    updated_at: new Date().toISOString(),
+  });
+
+  if (error) {
+    logger.error("Failed to save platform terminal model default", { error: error.message, userId });
+    throw new Error("Failed to save the terminal starting model — try again");
+  }
+
+  return trimmed;
 }

--- a/src/actions/profile.test.ts
+++ b/src/actions/profile.test.ts
@@ -261,6 +261,18 @@ describe("updateTerminalModel", () => {
     await expect(updateTerminalModel("opus 5!")).rejects.toThrow(/space/i);
   });
 
+  it("rejects a value over the 100-char cap before ever touching the DB (QA Bug 1)", async () => {
+    await expect(updateTerminalModel("a".repeat(101))).rejects.toThrow(/100 characters/i);
+  });
+
+  it("boundary: exactly 100 chars is accepted, 101 is rejected (QA Bug 1)", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+    }));
+    await expect(updateTerminalModel("a".repeat(100))).resolves.toBe("a".repeat(100));
+    await expect(updateTerminalModel("a".repeat(101))).rejects.toThrow(/100 characters/i);
+  });
+
   it("throws when not authenticated", async () => {
     mockSupabase.auth.getUser.mockResolvedValueOnce({ data: { user: null }, error: null });
     await expect(updateTerminalModel("opus")).rejects.toThrow("Not authenticated");

--- a/src/actions/profile.test.ts
+++ b/src/actions/profile.test.ts
@@ -20,7 +20,8 @@ vi.mock("next/cache", () => ({
 }));
 
 // Import after mocks are set up
-import { getModelTierMap, updateModelTierMap } from "./profile";
+import { getModelTierMap, updateModelTierMap, getTerminalModel, updateTerminalModel } from "./profile";
+import { MACHINE_DEFAULT_TERMINAL_MODEL } from "@/lib/terminal/model-resolution";
 
 const FAKE_USER_ID = "00000000-0000-0000-0000-000000000001";
 
@@ -148,5 +149,127 @@ describe("updateModelTierMap", () => {
       update: () => ({ eq: () => Promise.resolve({ error: { message: "write failed" } }) }),
     }));
     await expect(updateModelTierMap({ frontier: "opus" })).rejects.toThrow("write failed");
+  });
+});
+
+describe("getTerminalModel", () => {
+  it("returns the stored override for the authenticated user", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve({ data: { terminal_model: "sonnet" }, error: null }),
+        }),
+      }),
+    }));
+
+    expect(await getTerminalModel()).toBe("sonnet");
+  });
+
+  it("returns null when the column is null (no override)", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve({ data: { terminal_model: null }, error: null }),
+        }),
+      }),
+    }));
+
+    expect(await getTerminalModel()).toBeNull();
+  });
+
+  it("throws when not authenticated", async () => {
+    mockSupabase.auth.getUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+    await expect(getTerminalModel()).rejects.toThrow("Not authenticated");
+  });
+
+  it("propagates DB errors", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve({ data: null, error: { message: "connection lost" } }),
+        }),
+      }),
+    }));
+    await expect(getTerminalModel()).rejects.toThrow("connection lost");
+  });
+});
+
+describe("updateTerminalModel", () => {
+  it("accepts a valid known alias and stores it scoped to the current user", async () => {
+    let updatedWith: unknown;
+    let scopedTo: unknown;
+    mockSupabase.from.mockImplementation(() => ({
+      update: (data: unknown) => ({
+        eq: (col: string, val: unknown) => {
+          updatedWith = data;
+          scopedTo = { [col]: val };
+          return Promise.resolve({ error: null });
+        },
+      }),
+    }));
+
+    const result = await updateTerminalModel("sonnet");
+
+    expect(result).toBe("sonnet");
+    expect(updatedWith).toEqual({ terminal_model: "sonnet" });
+    expect(scopedTo).toEqual({ id: FAKE_USER_ID });
+  });
+
+  it("accepts a novel/custom model id — no schema change needed (AC-12)", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+    }));
+    await expect(updateTerminalModel("claude-opus-5-20260101")).resolves.toBe("claude-opus-5-20260101");
+  });
+
+  it("accepts the machine-default sentinel verbatim, bypassing structural validation", async () => {
+    let updatedWith: unknown;
+    mockSupabase.from.mockImplementation(() => ({
+      update: (data: unknown) => {
+        updatedWith = data;
+        return { eq: () => Promise.resolve({ error: null }) };
+      },
+    }));
+
+    const result = await updateTerminalModel(MACHINE_DEFAULT_TERMINAL_MODEL);
+
+    expect(result).toBe(MACHINE_DEFAULT_TERMINAL_MODEL);
+    expect(updatedWith).toEqual({ terminal_model: MACHINE_DEFAULT_TERMINAL_MODEL });
+  });
+
+  it("stores NULL to clear the override back to the platform default (AC-6)", async () => {
+    let updatedWith: unknown;
+    mockSupabase.from.mockImplementation(() => ({
+      update: (data: unknown) => {
+        updatedWith = data;
+        return { eq: () => Promise.resolve({ error: null }) };
+      },
+    }));
+
+    const result = await updateTerminalModel(null);
+
+    expect(result).toBeNull();
+    expect(updatedWith).toEqual({ terminal_model: null });
+  });
+
+  it("rejects an empty/whitespace-only value (AC-12)", async () => {
+    await expect(updateTerminalModel("   ")).rejects.toThrow(/model name/i);
+  });
+
+  it("rejects a value containing shell metacharacters (AC-12)", async () => {
+    await expect(updateTerminalModel("opus; rm -rf")).rejects.toThrow();
+    await expect(updateTerminalModel("opus 5!")).rejects.toThrow(/space/i);
+  });
+
+  it("throws when not authenticated", async () => {
+    mockSupabase.auth.getUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+    await expect(updateTerminalModel("opus")).rejects.toThrow("Not authenticated");
+  });
+
+  it("propagates DB errors", async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      update: () => ({ eq: () => Promise.resolve({ error: { message: "write failed" } }) }),
+    }));
+    await expect(updateTerminalModel("opus")).rejects.toThrow("write failed");
   });
 });

--- a/src/actions/profile.ts
+++ b/src/actions/profile.ts
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/server";
 import { validateBio, validateAvatarUrl } from "@/lib/validation";
 import { encrypt } from "@/lib/encryption";
 import { MODEL_ALIASES, type ModelTierMap } from "@/lib/constants";
+import { MACHINE_DEFAULT_TERMINAL_MODEL, validateTerminalModelValue } from "@/lib/terminal/model-resolution";
 
 export async function updateProfile(formData: FormData) {
   const supabase = await createClient();
@@ -176,6 +177,68 @@ export async function updateModelTierMap(map: ModelTierMap): Promise<ModelTierMa
   const { error } = await supabase
     .from("users")
     .update({ model_tier_map: toStore })
+    .eq("id", user.id);
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath(`/profile/${user.id}`);
+  return toStore;
+}
+
+// ── Terminal starting model (task c4ca2d95) ─────────────────────────────
+// Per-user override of the in-app terminal's starting model (users.terminal_model).
+// Self-only: both actions operate on the authenticated user's own row. Lives
+// alongside the model-tier actions above per Nick's binding approval-gate
+// note: the setting stays inside the (unrenamed) Model Tiers dialog as a
+// "Terminal sessions" group, not a separate settings surface.
+
+export async function getTerminalModel(): Promise<string | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  const { data, error } = await supabase
+    .from("users")
+    .select("terminal_model")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+
+  return data?.terminal_model ?? null;
+}
+
+/**
+ * `model: null` clears the override back to "platform default" (AC-6).
+ * `model: MACHINE_DEFAULT_TERMINAL_MODEL` is the explicit opt-out sentinel
+ * (AC-5) and is stored verbatim — it deliberately bypasses
+ * validateTerminalModelValue below since it's a fixed, code-controlled
+ * constant, never user-typed text.
+ */
+export async function updateTerminalModel(model: string | null): Promise<string | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  let toStore: string | null = null;
+  if (model !== null) {
+    const trimmed = model.trim();
+    if (trimmed !== MACHINE_DEFAULT_TERMINAL_MODEL) {
+      const validation = validateTerminalModelValue(trimmed);
+      if (!validation.ok) throw new Error(validation.reason);
+    }
+    toStore = trimmed;
+  }
+
+  const { error } = await supabase
+    .from("users")
+    .update({ terminal_model: toStore })
     .eq("id", user.id);
 
   if (error) throw new Error(error.message);

--- a/src/app/(main)/profile/[id]/page.tsx
+++ b/src/app/(main)/profile/[id]/page.tsx
@@ -30,7 +30,7 @@ import type { Metadata } from "next";
  *  `ProfileSettingsMenu` below). */
 type OwnProfileSettings = Pick<
   User,
-  "notification_preferences" | "default_board_columns" | "has_anthropic_key" | "model_tier_map"
+  "notification_preferences" | "default_board_columns" | "has_anthropic_key" | "model_tier_map" | "terminal_model"
 >;
 
 /** IdeaCard's entire use of `idea.author` (see src/components/ideas/idea-card.tsx) —
@@ -109,7 +109,7 @@ export default async function ProfilePage({ params }: PageProps) {
   if (isOwnProfile) {
     const { data } = await supabase
       .from("users")
-      .select("notification_preferences, default_board_columns, has_anthropic_key, model_tier_map")
+      .select("notification_preferences, default_board_columns, has_anthropic_key, model_tier_map, terminal_model")
       .eq("id", id)
       .single();
     ownSettings = data;
@@ -256,7 +256,7 @@ export default async function ProfilePage({ params }: PageProps) {
                     <NotificationSettings preferences={ownSettings.notification_preferences} />
                     <BoardColumnSettings columns={ownSettings.default_board_columns} />
                     <ApiKeySettings hasKey={!!ownSettings.has_anthropic_key} />
-                    <ModelTierSettings map={ownSettings.model_tier_map} />
+                    <ModelTierSettings map={ownSettings.model_tier_map} terminalModel={ownSettings.terminal_model} />
                   </>
                 )}
                 <McpApiKeys />
@@ -271,6 +271,7 @@ export default async function ProfilePage({ params }: PageProps) {
                     columns={ownSettings.default_board_columns}
                     hasApiKey={!!ownSettings.has_anthropic_key}
                     modelTierMap={ownSettings.model_tier_map}
+                    terminalModel={ownSettings.terminal_model}
                   />
                 )}
               </div>

--- a/src/app/api/terminal/session/route.test.ts
+++ b/src/app/api/terminal/session/route.test.ts
@@ -71,6 +71,7 @@ vi.mock("../../../../../terminal/shared/session-token.mjs", () => ({
 
 import { POST } from "./route";
 import { logger } from "@/lib/logger";
+import { MACHINE_DEFAULT_TERMINAL_MODEL } from "@/lib/terminal/model-resolution";
 
 function req(body: unknown) {
   return new Request("http://localhost/api/terminal/session", {
@@ -166,6 +167,58 @@ describe("POST /api/terminal/session — task/idea correctness guard (bug 62e570
     expect(insertSpy).toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledWith(
       "Terminal session mint: task lookup failed",
+      expect.objectContaining({ error: "connection reset" }),
+    );
+  });
+});
+
+describe("POST /api/terminal/session — effective terminal model resolution (task c4ca2d95)", () => {
+  it("omits model entirely when neither a user override nor a platform default is set", async () => {
+    const res = await POST(req({ ideaId: IDEA_1 }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).not.toHaveProperty("model");
+  });
+
+  it("resolves to the platform default when the user has no override", async () => {
+    tableResults.platform_settings = { data: { value: { model: "opus" } }, error: null };
+
+    const res = await POST(req({ ideaId: IDEA_1 }));
+    const body = await res.json();
+    expect(body.model).toBe("opus");
+  });
+
+  it("resolves to the user's own override, beating the platform default", async () => {
+    tableResults.users = { data: { terminal_model: "sonnet" }, error: null };
+    tableResults.platform_settings = { data: { value: { model: "opus" } }, error: null };
+
+    const res = await POST(req({ ideaId: IDEA_1 }));
+    const body = await res.json();
+    expect(body.model).toBe("sonnet");
+  });
+
+  it("omits model when the user opted into their machine's default, even with a platform default set (AC-5)", async () => {
+    tableResults.users = { data: { terminal_model: MACHINE_DEFAULT_TERMINAL_MODEL }, error: null };
+    tableResults.platform_settings = { data: { value: { model: "opus" } }, error: null };
+
+    const res = await POST(req({ ideaId: IDEA_1 }));
+    const body = await res.json();
+    expect(body).not.toHaveProperty("model");
+  });
+
+  it("degrades to omitting the model (never blocks the mint) when reading the user's row errors", async () => {
+    tableResults.users = { data: null, error: { message: "connection reset" } };
+    tableResults.platform_settings = { data: { value: { model: "opus" } }, error: null };
+
+    const res = await POST(req({ ideaId: IDEA_1 }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // Falls back to "no user override" -> resolves to the platform default,
+    // rather than blocking or failing the mint.
+    expect(body.model).toBe("opus");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Terminal session mint: failed to read terminal_model — omitting user override",
       expect.objectContaining({ error: "connection reset" }),
     );
   });

--- a/src/app/api/terminal/session/route.ts
+++ b/src/app/api/terminal/session/route.ts
@@ -42,6 +42,8 @@ import {
   decideRelayBudget,
   utcDayStart,
 } from "@/lib/terminal/relay-budget";
+import { getPlatformTerminalModelDefault } from "@/lib/terminal/platform-terminal-model";
+import { resolveEffectiveTerminalModel } from "@/lib/terminal/model-resolution";
 
 // Pin the runtime: this handler mints per-request, auth-bound tokens and must never
 // be statically optimized or flipped to the Edge runtime. The pin stays as hygiene,
@@ -289,6 +291,40 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: RATE_LIMIT_MESSAGE, code: RATE_LIMIT_CODE }, { status: 429 });
     }
 
+    // ── (c.5) EFFECTIVE MODEL (task c4ca2d95, "Terminal starting model") ────
+    // Resolved here, once, right before mint — user override -> platform
+    // default -> omit (resolveEffectiveTerminalModel; no seed step, binding
+    // approval-gate note). Every read is best-effort and never blocks a
+    // launch (AC-2): a failed/errored read degrades to "no override"/"no
+    // platform default" via logger.warn, exactly like getPlatformTerminalModelDefault's
+    // own posture. The client threads the result into the FRESH-launch deep
+    // link only — a resume never carries it (see use-terminal-session.ts).
+    let userTerminalModel: string | null = null;
+    try {
+      const { data: userRow, error: userRowErr } = await supabase
+        .from("users")
+        .select("terminal_model")
+        .eq("id", user.id)
+        .maybeSingle();
+      if (userRowErr) {
+        logger.warn("Terminal session mint: failed to read terminal_model — omitting user override", {
+          error: userRowErr.message,
+          userId: user.id,
+        });
+      } else {
+        userTerminalModel = userRow?.terminal_model ?? null;
+      }
+    } catch (err) {
+      logger.warn("Terminal session mint: unexpected error reading terminal_model — omitting user override", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    const platformTerminalModel = await getPlatformTerminalModelDefault(supabase);
+    const effectiveModel = resolveEffectiveTerminalModel({
+      userValue: userTerminalModel,
+      platformValue: platformTerminalModel,
+    });
+
     // ── (d) MINT + register. ────────────────────────────────────────────────
     // The bridge/browser pair (per-launch, random sid) and the helper's OWN
     // standing control-connection credential (card cc74a067 — reserved,
@@ -340,6 +376,12 @@ export async function POST(req: Request) {
       browserToken: tokens.browser,
       bridgeToken: tokens.bridge,
       helperToken,
+      // Task c4ca2d95: resolved starting model for a FRESH launch only — the
+      // client must never thread this into a resume/resumeId deep link (AC-8).
+      // Omitted (undefined, dropped by JSON.stringify) when nothing should be
+      // passed at all — the fresh-launch call site treats absence the same
+      // as an explicit undefined.
+      model: effectiveModel,
     });
   } catch (err) {
     logger.error("Terminal session mint error", {

--- a/src/app/guide/launching-claude-code/page.tsx
+++ b/src/app/guide/launching-claude-code/page.tsx
@@ -351,6 +351,24 @@ export default function LaunchingClaudeCodePage() {
         </section>
 
         <section>
+          <h2 className="mb-4 text-2xl font-semibold">Troubleshooting</h2>
+          <div className="rounded-xl border border-border bg-muted/30 p-6">
+            <p className="text-sm text-muted-foreground">
+              <strong className="text-foreground">
+                Terminal shows &quot;model not found&quot; as soon as the session starts
+              </strong>{" "}
+              — your starting-model setting names a model Claude Code doesn&apos;t
+              recognise. Fix it in{" "}
+              <strong className="text-foreground">Profile → Model Tiers</strong>{" "}
+              (or ask an admin to check the platform default on the admin
+              Platform tab), then start a fresh session. Resumed sessions
+              aren&apos;t affected — they keep the model they were already
+              running on.
+            </p>
+          </div>
+        </section>
+
+        <section>
           <h2 className="mb-4 text-2xl font-semibold">Desktop Only</h2>
           <div className="mb-4 rounded-xl border border-border bg-muted/30 p-6">
             <p className="text-sm text-muted-foreground">

--- a/src/components/admin/admin-platform-dashboard.test.tsx
+++ b/src/components/admin/admin-platform-dashboard.test.tsx
@@ -20,19 +20,27 @@ class ResizeObserverStub {
 
 const mockGetForAdmin = vi.fn();
 const mockUpdate = vi.fn();
+const mockGetTerminalForAdmin = vi.fn();
+const mockUpdateTerminal = vi.fn();
 
 vi.mock("@/actions/admin-platform", () => ({
   getPlatformModelDefaultsForAdmin: () => mockGetForAdmin(),
   updatePlatformModelDefaults: (input: unknown) => mockUpdate(input),
+  getPlatformTerminalModelDefaultForAdmin: () => mockGetTerminalForAdmin(),
+  updatePlatformTerminalModelDefault: (model: string | null) => mockUpdateTerminal(model),
 }));
 
 vi.mock("@/hooks/use-platform-model-defaults", () => ({
   setPlatformModelDefaultsCache: vi.fn(),
 }));
 
+vi.mock("@/hooks/use-platform-terminal-model-default", () => ({
+  setPlatformTerminalModelDefaultCache: vi.fn(),
+}));
+
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
-import { AdminPlatformDashboard } from "./admin-platform-dashboard";
+import { AdminPlatformDashboard, AdminTerminalModelCard } from "./admin-platform-dashboard";
 import { SEED_PLATFORM_MODEL_DEFAULTS } from "@/lib/platform-model-defaults";
 import { toast } from "sonner";
 
@@ -174,6 +182,151 @@ describe("AdminPlatformDashboard", () => {
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Super admin access required"));
     // Staged (seed) values are retained — Save is still enabled for a retry.
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+  });
+});
+
+describe("AdminTerminalModelCard (task c4ca2d95 — binding: no seed)", () => {
+  it("renders the denied state for a non-super-admin and never fetches", () => {
+    render(<AdminTerminalModelCard isSuperAdmin={false} />);
+
+    expect(screen.getByText("Super-admin access required")).toBeInTheDocument();
+    expect(mockGetTerminalForAdmin).not.toHaveBeenCalled();
+  });
+
+  it("shows 'nothing saved yet' (no seed pill) when no platform default has ever been set", async () => {
+    mockGetTerminalForAdmin.mockResolvedValue({ value: null, updatedBy: null, updatedAt: null });
+
+    render(<AdminTerminalModelCard isSuperAdmin />);
+
+    await waitFor(() => expect(screen.getByText(/Using the code default \(no model\) — nothing saved yet/)).toBeInTheDocument());
+    expect(screen.getByText(/No platform default \(nothing passed\)/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    // Clear is disabled too — there is nothing to clear.
+    expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled();
+  });
+
+  it("shows the fetched value and audit line when a platform default is set", async () => {
+    mockGetTerminalForAdmin.mockResolvedValue({
+      value: "opus",
+      updatedBy: { id: "u1", full_name: "Nick Ball" },
+      updatedAt: "2026-07-20T00:00:00Z",
+    });
+
+    render(<AdminTerminalModelCard isSuperAdmin />);
+
+    await waitFor(() => expect(screen.getByText(/Last changed by/)).toBeInTheDocument());
+    expect(screen.getByText("Nick Ball")).toBeInTheDocument();
+    expect(screen.getByText("Opus")).toBeInTheDocument();
+  });
+
+  it("shows an error state with a Retry button when the fetch fails", async () => {
+    mockGetTerminalForAdmin.mockRejectedValueOnce(new Error("boom"));
+
+    render(<AdminTerminalModelCard isSuperAdmin />);
+
+    await waitFor(() => expect(screen.getByText(/Failed to load the terminal starting model/)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("'Clear' stages 'no platform default' locally (dirty, Save enabled) without saving", async () => {
+    mockGetTerminalForAdmin.mockResolvedValue({
+      value: "opus",
+      updatedBy: { id: "u1", full_name: "Nick Ball" },
+      updatedAt: "2026-07-20T00:00:00Z",
+    });
+
+    render(<AdminTerminalModelCard isSuperAdmin />);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save" })).toBeDisabled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+    expect(mockUpdateTerminal).not.toHaveBeenCalled();
+  });
+
+  it("blocks Save with role=alert on a structurally invalid custom value (AC-12), before any novel-value gate", async () => {
+    mockGetTerminalForAdmin.mockResolvedValue({
+      value: "opus-5.5",
+      updatedBy: null,
+      updatedAt: null,
+    });
+
+    render(<AdminTerminalModelCard isSuperAdmin />);
+    const input = await screen.findByLabelText("Starting model");
+    expect(input).toHaveValue("opus-5.5");
+
+    fireEvent.change(input, { target: { value: "opus 5!" } });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/space/i);
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(screen.getByText(/Fix the model name to enable Save/)).toBeInTheDocument();
+  });
+
+  it("gates Save behind the novel-value confirm checkbox, then saves once confirmed", async () => {
+    mockGetTerminalForAdmin.mockResolvedValue({ value: "opus-5.5", updatedBy: null, updatedAt: null });
+
+    render(<AdminTerminalModelCard isSuperAdmin />);
+    const input = await screen.findByLabelText("Starting model");
+    expect(input).toHaveValue("opus-5.5");
+
+    fireEvent.change(input, { target: { value: "opus-5.6" } });
+
+    expect(screen.getByText(/isn't a known model alias/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(screen.getByText(/Confirm the checkbox above to enable Save/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+
+    mockUpdateTerminal.mockResolvedValue("opus-5.6");
+    mockGetTerminalForAdmin.mockResolvedValue({
+      value: "opus-5.6",
+      updatedBy: { id: "u1", full_name: "Nick Ball" },
+      updatedAt: "2026-07-25T00:00:00Z",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mockUpdateTerminal).toHaveBeenCalledWith("opus-5.6"));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringContaining("Opus-5.6")));
+  });
+
+  it("saves a Clear (null) as clearing back to unset, with distinct toast copy", async () => {
+    mockGetTerminalForAdmin.mockResolvedValue({
+      value: "opus",
+      updatedBy: { id: "u1", full_name: "Nick Ball" },
+      updatedAt: "2026-07-20T00:00:00Z",
+    });
+
+    render(<AdminTerminalModelCard isSuperAdmin />);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Clear" })).not.toBeDisabled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    mockUpdateTerminal.mockResolvedValue(null);
+    mockGetTerminalForAdmin.mockResolvedValue({ value: null, updatedBy: null, updatedAt: null });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mockUpdateTerminal).toHaveBeenCalledWith(null));
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(expect.stringContaining("cleared"))
+    );
+  });
+
+  it("shows a retryable error toast and keeps staged values when the save action throws", async () => {
+    mockGetTerminalForAdmin.mockResolvedValue({ value: "opus", updatedBy: null, updatedAt: null });
+
+    render(<AdminTerminalModelCard isSuperAdmin />);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Clear" })).not.toBeDisabled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+
+    mockUpdateTerminal.mockRejectedValueOnce(new Error("Super admin access required"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Super admin access required"));
     expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
   });
 });

--- a/src/components/admin/admin-platform-dashboard.tsx
+++ b/src/components/admin/admin-platform-dashboard.tsx
@@ -13,20 +13,26 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
 import {
   getPlatformModelDefaultsForAdmin,
   updatePlatformModelDefaults,
+  getPlatformTerminalModelDefaultForAdmin,
+  updatePlatformTerminalModelDefault,
   type PlatformModelDefaultsAudit,
+  type PlatformTerminalModelAudit,
 } from "@/actions/admin-platform";
 import { setPlatformModelDefaultsCache } from "@/hooks/use-platform-model-defaults";
+import { setPlatformTerminalModelDefaultCache } from "@/hooks/use-platform-terminal-model-default";
 import {
   SEED_PLATFORM_MODEL_DEFAULTS,
   type PlatformModelDefaults,
 } from "@/lib/platform-model-defaults";
 import { MODEL_TIER_WHEN_TO_USE, capitalizeModelName, type ModelTierValue } from "@/lib/constants";
+import { validateTerminalModelValue, capitalizeTerminalModelName } from "@/lib/terminal/model-resolution";
 
 // The 4 aliases the per-user Models dialog already offers (model-tier-settings.tsx's
 // MODEL_OPTIONS) — "known" here means "selectable with one tap, no typo-guard needed".
@@ -282,7 +288,7 @@ export function AdminPlatformDashboard({ isSuperAdmin }: { isSuperAdmin: boolean
         <h3 className="font-semibold">Model tier defaults</h3>
         <p className="text-sm text-muted-foreground">
           The Claude model each workflow tier runs on platform-wide. Changing a value takes effect on the{" "}
-          <b>next</b> claim — no deploy. Per-user overrides in Profile → Models are unaffected.
+          <b>next</b> claim — no deploy. Per-user overrides in Profile → Model Tiers are unaffected.
         </p>
       </div>
 
@@ -383,6 +389,273 @@ export function AdminPlatformDashboard({ isSuperAdmin }: { isSuperAdmin: boolean
           onClick={handleSave}
           disabled={saveDisabled}
           aria-describedby={!isDirty ? "platform-defaults-save-why" : undefined}
+        >
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const NO_TERMINAL_DEFAULT_VALUE = "__no_default__";
+
+/**
+ * Admin "Terminal starting model" card (task c4ca2d95) — a sibling to "Model
+ * tier defaults" above, reusing its visual language (skeleton/error states,
+ * audit row, novel-value confirm-checkbox gate) but its OWN platform_settings
+ * key and Save/audit/error boundary (design decision: separate key => one
+ * setting, one save, unambiguous errors).
+ *
+ * BINDING (Nick, design-review approval gate): there is NO seed here, unlike
+ * the tier defaults above — "Clear" returns this to genuinely unset, at
+ * which point resolution omits the model entirely (today's behaviour).
+ */
+export function AdminTerminalModelCard({ isSuperAdmin }: { isSuperAdmin: boolean }) {
+  const [loadState, setLoadState] = useState<"loading" | "error" | "ready">("loading");
+  const [reloadToken, setReloadToken] = useState(0);
+  const [audit, setAudit] = useState<PlatformTerminalModelAudit | null>(null);
+  // "" represents "no platform default" throughout this component's local
+  // state — mapped to `null` only at the server-action boundary.
+  const [persisted, setPersisted] = useState<string>("");
+  const [staged, setStaged] = useState<string>("");
+  const [forceCustom, setForceCustom] = useState(false);
+  const [confirmedNovel, setConfirmedNovel] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isSuperAdmin) return;
+    let cancelled = false;
+    setLoadState("loading");
+    getPlatformTerminalModelDefaultForAdmin()
+      .then((result) => {
+        if (cancelled) return;
+        setAudit(result);
+        setPersisted(result.value ?? "");
+        setStaged(result.value ?? "");
+        setLoadState("ready");
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setLoadState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isSuperAdmin, reloadToken]);
+
+  if (!isSuperAdmin) return <PlatformAccessDenied />;
+
+  if (loadState === "loading") {
+    return (
+      <div className="space-y-4 rounded-lg border p-6">
+        <Skeleton className="h-5 w-48" />
+        <Skeleton className="h-4 w-full max-w-md" />
+        <div className="max-w-[300px] space-y-1.5">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-9 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (loadState === "error") {
+    return (
+      <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-6 text-center">
+        <p className="text-sm text-red-400">Failed to load the terminal starting model.</p>
+        <Button size="sm" variant="outline" className="mt-3" onClick={() => setReloadToken((t) => t + 1)}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  const isDirty = staged !== persisted;
+  const isCustom = forceCustom || (staged.length > 0 && !KNOWN_MODEL_VALUES.has(staged));
+  const structuralValidation = isCustom ? validateTerminalModelValue(staged) : { ok: true as const };
+  const structurallyBlocked = isCustom && !structuralValidation.ok;
+  const isNovel = isCustom && structuralValidation.ok && !KNOWN_MODEL_VALUES.has(staged.trim());
+  const saveDisabled = saving || !isDirty || structurallyBlocked || (isNovel && !confirmedNovel);
+
+  function handleSelectChange(value: string) {
+    if (value === CUSTOM_VALUE) {
+      setForceCustom(true);
+      return;
+    }
+    setForceCustom(false);
+    setConfirmedNovel(false);
+    setStaged(value === NO_TERMINAL_DEFAULT_VALUE ? "" : value);
+  }
+
+  function handleCancel() {
+    setStaged(persisted);
+    setForceCustom(false);
+    setConfirmedNovel(false);
+  }
+
+  function handleClear() {
+    // Local staging only — like the sibling card's "Reset to seed", this
+    // doesn't persist until Save. There is no seed to reset TO here, so this
+    // clears back to "no platform default" instead.
+    setStaged("");
+    setForceCustom(false);
+    setConfirmedNovel(false);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const toSave = staged.trim().length > 0 ? staged.trim() : null;
+      const saved = await updatePlatformTerminalModelDefault(toSave);
+      const fresh = await getPlatformTerminalModelDefaultForAdmin();
+      setAudit(fresh);
+      setPersisted(fresh.value ?? "");
+      setStaged(fresh.value ?? "");
+      setForceCustom(false);
+      setConfirmedNovel(false);
+      setPlatformTerminalModelDefaultCache(fresh.value);
+      toast.success(
+        saved
+          ? `Terminal starting model saved · fresh sessions now start on ${capitalizeTerminalModelName(saved)}`
+          : "Terminal starting model cleared · fresh sessions use each user's own machine default"
+      );
+    } catch (err) {
+      // Staged value is retained on error so the super-admin can retry
+      // without re-entering it.
+      toast.error(err instanceof Error ? err.message : "Failed to save the terminal starting model — try again");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6 rounded-lg border p-6">
+      <div>
+        <h3 className="font-semibold">Terminal starting model</h3>
+        <p className="text-sm text-muted-foreground">
+          The model fresh in-browser terminal sessions start on, platform-wide. Takes effect on the{" "}
+          <b>next</b> session launched — no deploy, running sessions untouched. Users can override it in
+          Profile → Model Tiers, or keep their machine&apos;s own default.
+        </p>
+      </div>
+
+      <div className="max-w-[300px] space-y-1.5">
+        <Label htmlFor="platform-terminal-model" className="text-xs">
+          Starting model
+        </Label>
+        {isCustom ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <Input
+              id="platform-terminal-model"
+              value={staged}
+              onChange={(e) => setStaged(e.target.value)}
+              placeholder="e.g. opus-5.5"
+              disabled={saving}
+              aria-invalid={structurallyBlocked}
+              aria-describedby={
+                structurallyBlocked
+                  ? "platform-terminal-model-error"
+                  : isNovel
+                    ? "platform-terminal-model-novel-warning"
+                    : undefined
+              }
+              className={cn(
+                "min-w-[10rem] flex-1",
+                structurallyBlocked && "border-rose-500 focus-visible:ring-rose-500/30",
+                !structurallyBlocked && isNovel && "border-amber-500 focus-visible:ring-amber-500/30 dark:border-amber-500"
+              )}
+            />
+            <Button type="button" variant="ghost" size="sm" disabled={saving} onClick={() => setForceCustom(false)}>
+              Choose known…
+            </Button>
+          </div>
+        ) : (
+          <Select value={staged || NO_TERMINAL_DEFAULT_VALUE} disabled={saving} onValueChange={handleSelectChange}>
+            <SelectTrigger id="platform-terminal-model" className="w-full">
+              <SelectValue>
+                {staged
+                  ? (KNOWN_MODEL_OPTIONS.find((o) => o.value === staged)?.label ?? staged)
+                  : "No platform default (nothing passed)"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NO_TERMINAL_DEFAULT_VALUE}>No platform default (nothing passed)</SelectItem>
+              <SelectSeparator />
+              {KNOWN_MODEL_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label} <span className="text-muted-foreground">— {o.gloss}</span>
+                </SelectItem>
+              ))}
+              <SelectSeparator />
+              <SelectItem value={CUSTOM_VALUE}>Custom… (type a new family)</SelectItem>
+            </SelectContent>
+          </Select>
+        )}
+        {structurallyBlocked && !structuralValidation.ok && (
+          <p id="platform-terminal-model-error" role="alert" className="flex items-center gap-1.5 text-xs text-rose-500">
+            <TriangleAlert className="h-3.5 w-3.5 shrink-0" />
+            {structuralValidation.reason}
+          </p>
+        )}
+      </div>
+
+      {isNovel && (
+        <div
+          id="platform-terminal-model-novel-warning"
+          className="flex items-start gap-2.5 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm"
+        >
+          <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+          <div className="space-y-2">
+            <p>
+              This isn&apos;t a known model alias. Every user&apos;s fresh terminal session will run{" "}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">claude --model {staged}</code> verbatim — if
+              Claude rejects it, <b>every launch platform-wide</b> shows an error in the terminal until this is
+              corrected.
+            </p>
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
+              <Checkbox checked={confirmedNovel} onCheckedChange={(c) => setConfirmedNovel(c === true)} />
+              I&apos;ve verified this value works with the Claude CLI
+            </label>
+          </div>
+        </div>
+      )}
+
+      {audit && (
+        <div className="rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+          {audit.value === null ? (
+            <span>Using the code default (no model) — nothing saved yet.</span>
+          ) : (
+            <span>
+              Last changed by <b className="text-foreground">{audit.updatedBy?.full_name ?? "a super-admin"}</b>
+              {audit.updatedAt ? ` · ${formatRelativeTime(audit.updatedAt)}` : ""}
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2 border-t pt-4">
+        {!isDirty && (
+          <span id="platform-terminal-model-save-why" className="mr-auto text-xs text-muted-foreground">
+            Save enables when you change a value.
+          </span>
+        )}
+        {isDirty && structurallyBlocked && (
+          <span className="mr-auto text-xs text-muted-foreground">Fix the model name to enable Save.</span>
+        )}
+        {isDirty && !structurallyBlocked && isNovel && !confirmedNovel && (
+          <span className="mr-auto text-xs text-muted-foreground">Confirm the checkbox above to enable Save.</span>
+        )}
+        <Button type="button" variant="destructive" size="sm" onClick={handleClear} disabled={saving || staged === ""}>
+          Clear
+        </Button>
+        <Button type="button" variant="outline" size="sm" onClick={handleCancel} disabled={saving || !isDirty}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleSave}
+          disabled={saveDisabled}
+          aria-describedby={!isDirty ? "platform-terminal-model-save-why" : undefined}
         >
           {saving ? "Saving…" : "Save"}
         </Button>

--- a/src/components/admin/admin-tabs.tsx
+++ b/src/components/admin/admin-tabs.tsx
@@ -9,7 +9,7 @@ import { AdminAgentsDashboard } from "./admin-agents-dashboard";
 import { AdminTeamsDashboard } from "./admin-teams-dashboard";
 import { AdminTemplatesDashboard } from "./admin-templates-dashboard";
 import { AdminMcpToolsDashboard } from "./admin-mcp-tools-dashboard";
-import { AdminPlatformDashboard } from "./admin-platform-dashboard";
+import { AdminPlatformDashboard, AdminTerminalModelCard } from "./admin-platform-dashboard";
 import type { McpToolLogWithUser, McpToolStatsRow } from "./admin-mcp-tools-dashboard";
 import type { UsageLogWithUser, FeedbackWithUser, UserCreditInfo, PlatformStatsEntry } from "@/app/(main)/admin/page";
 import type { BotProfile, FeaturedTeamWithAgents, WorkflowLibraryTemplate } from "@/types";
@@ -114,8 +114,9 @@ export function AdminTabs({
           ?tab=platform deep link still resolves this value — AdminPlatformDashboard
           itself renders the "denied" state in that case (defence in depth,
           the server action independently re-checks is_super_admin too). */}
-      <TabsContent value="platform" className="mt-6">
+      <TabsContent value="platform" className="mt-6 space-y-6">
         <AdminPlatformDashboard isSuperAdmin={isSuperAdmin} />
+        <AdminTerminalModelCard isSuperAdmin={isSuperAdmin} />
       </TabsContent>
     </Tabs>
   );

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -78,6 +78,14 @@ import { resolveDockView } from "@/lib/terminal/first-run-flow";
 import type { RecordedProjectPath } from "@/lib/launch-claude-code";
 import { newSessionTooltip } from "@/lib/terminal/session-cap";
 import {
+  resolveEffectiveTerminalModel,
+  resolveTerminalModelSource,
+  terminalLaunchModelLine,
+  terminalDialogModelLine,
+} from "@/lib/terminal/model-resolution";
+import { usePlatformTerminalModelDefault } from "@/hooks/use-platform-terminal-model-default";
+import { useViewerTerminalModel } from "@/hooks/use-viewer-terminal-model";
+import {
   generatePopoutNonce,
   popoutChannelName,
   openPopoutWindow,
@@ -262,6 +270,14 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // Defence-in-depth: also gated at the page mount. When off, render nothing —
   // no dock, no entry point, board unchanged (B9).
   const enabled = isTerminalEnabled();
+  // Task c4ca2d95 ("Terminal starting model") — called unconditionally
+  // (before the `!enabled` early return below) per the rules of hooks; both
+  // report `undefined` while loading, and the derived launch-surface lines
+  // (computed further down, after the early return) omit themselves until
+  // both resolve rather than showing a placeholder that might be wrong for
+  // a beat.
+  const platformTerminalDefault = usePlatformTerminalModelDefault();
+  const viewerTerminalModel = useViewerTerminalModel();
   // Dock-open persistence (rework 5, card cbe60db5 — Nick's field test: "fix
   // the terminal panel staying open as well"). Initial paint stays collapsed
   // (SSR-safe, matches every other install-first input use-terminal-session.ts
@@ -1919,6 +1935,13 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
 
   if (!enabled) return null;
 
+  const terminalModelLine =
+    platformTerminalDefault === undefined || viewerTerminalModel === undefined
+      ? null
+      : terminalLaunchModelLine(
+          resolveEffectiveTerminalModel({ userValue: viewerTerminalModel, platformValue: platformTerminalDefault }),
+          resolveTerminalModelSource({ userValue: viewerTerminalModel, platformValue: platformTerminalDefault })
+        );
   const activeSummary = summaries[activeKey];
   const activeStatus: TerminalStatus = activeSummary?.status ?? "idle";
   const multi = sessions.length > 1;
@@ -1968,6 +1991,17 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   const pendingTaskMatch: TaskSessionMatch | null = pendingLaunch?.taskId
     ? findTaskSessionMatch(chooserSections, pendingLaunch.taskId)
     : null;
+
+  // Task c4ca2d95 ("Terminal starting model") — the per-task dialog's terser
+  // variant (chooser footer's own `terminalModelLine` is computed earlier,
+  // before the `!enabled` early return, alongside the hook calls it needs).
+  const terminalTaskDialogModelLine =
+    platformTerminalDefault === undefined || viewerTerminalModel === undefined
+      ? null
+      : terminalDialogModelLine(
+          resolveEffectiveTerminalModel({ userValue: viewerTerminalModel, platformValue: platformTerminalDefault }),
+          resolveTerminalModelSource({ userValue: viewerTerminalModel, platformValue: platformTerminalDefault })
+        );
 
   // Substitute "popped-out" for any tab the dock knows it popped — its real
   // status is usually mid-preemption at this exact moment and would
@@ -2170,6 +2204,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onOpenBoardAndReconnect={handleChooserOpenBoardAndReconnect}
             onResume={handleChooserResume}
             onStartNew={handleChooserStartNew}
+            modelLine={terminalModelLine}
             onRenameSession={renameSession}
             helperStatus={helperStatus}
             onHelperUpdateSettled={refreshAfterHelperUpdate}
@@ -2687,6 +2722,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onOpenBoardAndReconnect={handleChooserOpenBoardAndReconnect}
             onResume={handleChooserResume}
             onStartNew={handleChooserStartNew}
+            modelLine={terminalModelLine}
             onRenameSession={renameSession}
             helperStatus={helperStatus}
             onHelperUpdateSettled={refreshAfterHelperUpdate}
@@ -2715,6 +2751,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           onReconnect={handleTaskChoiceReconnect}
           onStartFresh={handleTaskChoiceStartFresh}
           onCancel={handleTaskChoiceCancel}
+          modelLine={terminalTaskDialogModelLine}
         />
       )}
     </div>

--- a/src/components/board/terminal-session-chooser.test.tsx
+++ b/src/components/board/terminal-session-chooser.test.tsx
@@ -36,6 +36,33 @@ describe("TerminalSessionChooser", () => {
     expect(onStartNew).toHaveBeenCalledOnce();
   });
 
+  it("renders the model line under Start new session when supplied (task c4ca2d95)", () => {
+    render(
+      <TerminalSessionChooser
+        sections={EMPTY}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+        modelLine="New sessions start on Opus · platform default."
+      />,
+    );
+    expect(screen.getByText("New sessions start on Opus · platform default.")).toBeInTheDocument();
+  });
+
+  it("omits the model line entirely when not supplied — never a blank footnote", () => {
+    render(
+      <TerminalSessionChooser
+        sections={EMPTY}
+        onReconnectHere={vi.fn()}
+        onOpenBoardAndReconnect={vi.fn()}
+        onResume={vi.fn()}
+        onStartNew={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/New sessions/)).not.toBeInTheDocument();
+  });
+
   it("shows the task-scoped Start label when a pendingTask is supplied", () => {
     render(
       <TerminalSessionChooser

--- a/src/components/board/terminal-session-chooser.tsx
+++ b/src/components/board/terminal-session-chooser.tsx
@@ -64,6 +64,15 @@ export interface TerminalSessionChooserProps {
   /** "Start new session" — the only action that mints (capped, rate-limited, exactly today's mint path). */
   onStartNew: () => void;
   /**
+   * Task c4ca2d95 ("Terminal starting model") — the passive launch-surface
+   * line naming the resolved model and its source (design §4.2), e.g. "New
+   * sessions start on Opus · platform default." Omitted entirely (render
+   * nothing) when null/undefined — either the resolved value hasn't loaded
+   * yet, or nothing would be passed at all (both platform and user unset).
+   * See terminalLaunchModelLine in src/lib/terminal/model-resolution.ts.
+   */
+  modelLine?: string | null;
+  /**
    * Persist a rename (card 3bf262ac) — the dock's shared `renameSession`:
    * PATCHes the session and, on success, keeps the dock's own registry rows
    * and any live tab entry in sync. This component owns its OWN optimistic
@@ -126,6 +135,7 @@ export function TerminalSessionChooser({
   onOpenBoardAndReconnect,
   onResume,
   onStartNew,
+  modelLine = null,
   onRenameSession,
   cap,
   helperStatus = null,
@@ -324,16 +334,22 @@ export function TerminalSessionChooser({
         </div>
       )}
 
-      <div className="flex items-center gap-2.5 border-b border-zinc-800 px-3.5 py-3">
-        <Button
-          ref={taskMatch ? undefined : firstFocusRef}
-          className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400"
-          disabled={busy}
-          onClick={onStartNew}
-        >
-          <TerminalIcon className="h-4 w-4" /> {startNewLabel}
-        </Button>
-        <span className="text-[11.5px] text-zinc-500">{newSessionTooltip(cap).replace(/^New terminal — /, "")}</span>
+      <div className="border-b border-zinc-800 px-3.5 py-3">
+        <div className="flex items-center gap-2.5">
+          <Button
+            ref={taskMatch ? undefined : firstFocusRef}
+            className="bg-emerald-500 text-emerald-950 hover:bg-emerald-400"
+            disabled={busy}
+            onClick={onStartNew}
+          >
+            <TerminalIcon className="h-4 w-4" /> {startNewLabel}
+          </Button>
+          <span className="text-[11.5px] text-zinc-500">{newSessionTooltip(cap).replace(/^New terminal — /, "")}</span>
+        </div>
+        {/* Task c4ca2d95: passive launch-surface visibility (design §4.2) —
+            no dialog, no "Change" link in v1 (kept intentionally terse; see
+            the implementation report for the scope trim). */}
+        {modelLine && <p className="mt-1.5 text-[11px] text-zinc-500">{modelLine}</p>}
       </div>
 
       {sections.liveHere.length > 0 && (

--- a/src/components/board/terminal-task-launch-choice.test.tsx
+++ b/src/components/board/terminal-task-launch-choice.test.tsx
@@ -93,6 +93,35 @@ describe("TerminalTaskLaunchChoice", () => {
     expect(onCancel).toHaveBeenCalledTimes(2);
   });
 
+  it("renders the model line when supplied (task c4ca2d95)", () => {
+    render(
+      <TerminalTaskLaunchChoice
+        open
+        taskTitle="Fix login bug"
+        match={LIVE_HERE_MATCH}
+        onReconnect={vi.fn()}
+        onStartFresh={vi.fn()}
+        onCancel={vi.fn()}
+        modelLine="Starts on Sonnet · your setting."
+      />,
+    );
+    expect(screen.getByText("Starts on Sonnet · your setting.")).toBeInTheDocument();
+  });
+
+  it("omits the model line entirely when not supplied", () => {
+    render(
+      <TerminalTaskLaunchChoice
+        open
+        taskTitle="Fix login bug"
+        match={LIVE_HERE_MATCH}
+        onReconnect={vi.fn()}
+        onStartFresh={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/Starts on/)).not.toBeInTheDocument();
+  });
+
   it("labels a live match 'Reconnect' and fires onReconnect", () => {
     const onReconnect = vi.fn();
     render(

--- a/src/components/board/terminal-task-launch-choice.tsx
+++ b/src/components/board/terminal-task-launch-choice.tsx
@@ -29,6 +29,14 @@ export interface TerminalTaskLaunchChoiceProps {
   onStartFresh: () => void;
   /** Back out entirely — launches nothing. Close button, Escape and outside-click all route here. */
   onCancel: () => void;
+  /**
+   * Task c4ca2d95 ("Terminal starting model") — the terse launch-surface line
+   * (design §4.3 / Design Review note 2: "Starts on Sonnet · your setting"),
+   * scoped to "Start fresh" since Reconnect/Resume keep the session's own
+   * model (AC-8). See terminalDialogModelLine in
+   * src/lib/terminal/model-resolution.ts. Omitted when null/undefined.
+   */
+  modelLine?: string | null;
 }
 
 export function TerminalTaskLaunchChoice({
@@ -39,6 +47,7 @@ export function TerminalTaskLaunchChoice({
   onReconnect,
   onStartFresh,
   onCancel,
+  modelLine = null,
 }: TerminalTaskLaunchChoiceProps) {
   // Narrow on `match.kind` directly at each use (rather than a derived
   // boolean) — `ChooserLiveRow`/`ChooserRecentRow` don't share a `createdAt`/
@@ -80,6 +89,10 @@ export function TerminalTaskLaunchChoice({
             <span className="font-mono">{ageLabel}</span>
             {!canReconnect && <span className="block text-zinc-600">No folder was recorded for it — can&apos;t resume.</span>}
           </DialogDescription>
+          {/* Task c4ca2d95: scoped to "Start fresh" — Reconnect/Resume keep
+              the session's own model (AC-8), so this line is deliberately
+              silent about them. */}
+          {modelLine && <p className="mt-1.5 text-[11px] text-zinc-500">{modelLine}</p>}
         </div>
         <div className="flex items-center justify-end gap-2 border-t border-zinc-800 px-4 py-3">
           <Button variant="ghost" size="xs" className="text-zinc-400 hover:text-zinc-100" disabled={busy} onClick={onCancel}>

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -1640,6 +1640,81 @@ describe("useTerminalSession", () => {
     });
   });
 
+  // Task c4ca2d95 ("Terminal starting model") — the mint response's resolved
+  // `model` field must reach the fresh-launch deep link, positioned before
+  // `prompt`, and must NEVER reach a resume-shaped link.
+  describe("terminal starting model (task c4ca2d95)", () => {
+    it("carries the mint response's resolved model on a fresh (prompt-carrying) launch", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => mintResponse({ model: "opus" })),
+      );
+      const { result } = setup();
+      // mountContainer stand-in (that helper is scoped to a sibling describe
+      // block) — assigns a detached container directly, same idiom.
+      result.current.containerRef.current = document.createElement("div");
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+
+      await act(async () => {
+        await result.current.actions.connect({ autoLaunch: true });
+      });
+
+      const iframes = document.querySelectorAll("iframe");
+      expect(iframes).toHaveLength(1);
+      const src = iframes[0].getAttribute("src") ?? "";
+      expect(src).toContain("model=opus");
+      expect(src).toContain("prompt=");
+      expect(src.indexOf("model=")).toBeLessThan(src.indexOf("prompt="));
+    });
+
+    it("omits model entirely from the launch link when the mint response doesn't carry one", async () => {
+      // Default mintResponse() (no override) never sets `model` — mirrors the
+      // "both platform and user are unset" resolution case.
+      const { result } = setup();
+      // mountContainer stand-in (that helper is scoped to a sibling describe
+      // block) — assigns a detached container directly, same idiom.
+      result.current.containerRef.current = document.createElement("div");
+      await waitFor(() => expect(mockTerminals.length).toBeGreaterThan(0));
+
+      await act(async () => {
+        await result.current.actions.connect({ autoLaunch: true });
+      });
+
+      const iframes = document.querySelectorAll("iframe");
+      const src = iframes[0].getAttribute("src") ?? "";
+      expect(src).not.toContain("model=");
+    });
+
+    it("NEVER carries a model on a resume-shaped launch, even if the mint response somehow carried one (AC-8)", async () => {
+      window.localStorage.setItem("vibecodes:terminal:paired-v1", "1");
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+        maxTouchPoints: 0,
+      });
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => mintResponse({ model: "opus" })),
+      );
+      const { result } = setup();
+
+      act(() => {
+        result.current.actions.launchFromBus({
+          resumeId: "claude-conv-carried",
+          cwd: "/Users/nick/projects/vibe-coding-ideas",
+        });
+      });
+      await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+      await flushEffects();
+
+      const iframes = document.querySelectorAll("iframe");
+      expect(iframes).toHaveLength(1);
+      const src = iframes[0].getAttribute("src") ?? "";
+      expect(src).toContain("resume_id=claude-conv-carried");
+      expect(src).not.toContain("model=");
+    });
+  });
+
   // Card cbe60db5 rework 10 (stuck-pairing watchdog, 2026-08-14 incident): QA
   // root-caused a session stuck forever on "Waiting for your machine to
   // attach" — attachToExisting (reload-reattach/instant-continue, the

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -1197,6 +1197,19 @@ export function useTerminalSession(
          */
         forceResumeCwd?: string | null;
         forceResumeId?: string | null;
+        /**
+         * Task c4ca2d95 ("Terminal starting model") — the mint route's
+         * resolved effective model (user override -> platform default ->
+         * omit). Only ever consumed by the FRESH-launch branch below;
+         * `connect()` is the sole caller that passes it (from the mint
+         * response), sourced fresh every mint so a changed preference takes
+         * effect on the very next launch. Deliberately absent from the
+         * reattach/reconnect call sites (`attachToExisting`) — a resumed
+         * conversation keeps its own model (AC-8), so there's nothing to
+         * thread there even when that path's rare no-cwd fallback drops
+         * into this same fresh-launch branch.
+         */
+        model?: string;
       },
     ) => {
       const trigger = opts?.trigger ?? "connect";
@@ -1322,6 +1335,9 @@ export function useTerminalSession(
               prompt,
               cols: dims?.cols,
               rows: dims?.rows,
+              // Task c4ca2d95: fresh-launch only — the resume branch above
+              // never reaches this call.
+              model: opts?.model,
             }),
         });
         if (!result.ok) {
@@ -1722,7 +1738,15 @@ export function useTerminalSession(
     setHelperVersion(null);
     dispatch({ type: "connect" });
 
-    let data: { sessionId: string; browserToken: string; bridgeToken: string; helperToken?: string; expiresAt: number };
+    let data: {
+      sessionId: string;
+      browserToken: string;
+      bridgeToken: string;
+      helperToken?: string;
+      expiresAt: number;
+      /** Task c4ca2d95 — the mint route's resolved effective terminal model, fresh-launch only. */
+      model?: string;
+    };
     try {
       const res = await fetch("/api/terminal/session", {
         method: "POST",
@@ -1810,7 +1834,11 @@ export function useTerminalSession(
     }
 
     // Same-machine: hand the bridge token to the local helper via the deep link.
-    if (autoLaunch) fireLaunchDeepLink(data.sessionId, data.bridgeToken, data.helperToken, { trigger: "connect" });
+    if (autoLaunch)
+      fireLaunchDeepLink(data.sessionId, data.bridgeToken, data.helperToken, {
+        trigger: "connect",
+        model: data.model,
+      });
 
     openBrowserLeg(data.sessionId, data.browserToken);
   }, [

--- a/src/components/discussions/discussion-thread.test.ts
+++ b/src/components/discussions/discussion-thread.test.ts
@@ -41,6 +41,7 @@ function makeReply(
       has_anthropic_key: false,
       ai_starter_credits: 10,
       model_tier_map: null,
+      terminal_model: null,
       notification_preferences: {
         comments: true,
         votes: true,

--- a/src/components/profile/model-tier-settings.test.tsx
+++ b/src/components/profile/model-tier-settings.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { ComponentProps } from "react";
 
 // Radix primitives use ResizeObserver/scrollIntoView, which jsdom lacks.
 class ResizeObserverStub {
@@ -16,10 +17,15 @@ class ResizeObserverStub {
 
 vi.mock("@/actions/profile", () => ({
   updateModelTierMap: vi.fn(),
+  updateTerminalModel: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-viewer-model-tier-map", () => ({
   setViewerModelTierMapCache: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-viewer-terminal-model", () => ({
+  setViewerTerminalModelCache: vi.fn(),
 }));
 
 const mockUsePlatformModelDefaults = vi.fn();
@@ -27,18 +33,31 @@ vi.mock("@/hooks/use-platform-model-defaults", () => ({
   usePlatformModelDefaults: () => mockUsePlatformModelDefaults(),
 }));
 
+const mockUsePlatformTerminalModelDefault = vi.fn();
+vi.mock("@/hooks/use-platform-terminal-model-default", () => ({
+  usePlatformTerminalModelDefault: () => mockUsePlatformTerminalModelDefault(),
+}));
+
 import { ModelTierSettings } from "./model-tier-settings";
+import { MACHINE_DEFAULT_TERMINAL_MODEL } from "@/lib/terminal/model-resolution";
 
 afterEach(cleanup);
 
-describe("ModelTierSettings", () => {
+function renderDialog(props: Partial<ComponentProps<typeof ModelTierSettings>> = {}) {
+  return render(
+    <ModelTierSettings map={null} terminalModel={null} open onOpenChange={() => {}} {...props} />
+  );
+}
+
+describe("ModelTierSettings — workflow tiers (existing behaviour, unchanged)", () => {
   it("shows the LIVE platform default (e.g. Opus) as the frontier placeholder, not a hard-coded label", () => {
     mockUsePlatformModelDefaults.mockReturnValue({
       defaults: { frontier: "opus", standard: "sonnet", cheap: "haiku" },
       fallback: {},
     });
+    mockUsePlatformTerminalModelDefault.mockReturnValue(null);
 
-    render(<ModelTierSettings map={null} open onOpenChange={() => {}} />);
+    renderDialog();
 
     expect(screen.getByText("Opus (default)")).toBeInTheDocument();
   });
@@ -48,8 +67,9 @@ describe("ModelTierSettings", () => {
       defaults: { frontier: "fable", standard: "sonnet", cheap: "haiku" },
       fallback: {},
     });
+    mockUsePlatformTerminalModelDefault.mockReturnValue(null);
 
-    render(<ModelTierSettings map={null} open onOpenChange={() => {}} />);
+    renderDialog();
 
     expect(screen.getByText("Fable (default)")).toBeInTheDocument();
     expect(screen.queryByText("Opus (default)")).not.toBeInTheDocument();
@@ -60,10 +80,77 @@ describe("ModelTierSettings", () => {
       defaults: { frontier: "opus", standard: "sonnet", cheap: "haiku" },
       fallback: {},
     });
+    mockUsePlatformTerminalModelDefault.mockReturnValue(null);
 
-    render(<ModelTierSettings map={{ frontier: "haiku" }} open onOpenChange={() => {}} />);
+    renderDialog({ map: { frontier: "haiku" } });
 
     // The trigger renders the option label ("Haiku"), not "<default> (default)".
     expect(screen.queryByText("Opus (default)")).not.toBeInTheDocument();
+  });
+});
+
+describe("ModelTierSettings — Terminal sessions group (task c4ca2d95)", () => {
+  beforeEach(() => {
+    mockUsePlatformModelDefaults.mockReturnValue({
+      defaults: { frontier: "opus", standard: "sonnet", cheap: "haiku" },
+      fallback: {},
+    });
+  });
+
+  it("shows 'your machine decides' when no platform default is set (binding: no seed)", () => {
+    mockUsePlatformTerminalModelDefault.mockReturnValue(null);
+    renderDialog({ terminalModel: null });
+
+    expect(screen.getByText(/Platform default \(your machine decides\)/)).toBeInTheDocument();
+  });
+
+  it("names the live platform default value when one is set", () => {
+    mockUsePlatformTerminalModelDefault.mockReturnValue("opus");
+    renderDialog({ terminalModel: null });
+
+    expect(screen.getByText(/Platform default \(Opus\)/)).toBeInTheDocument();
+  });
+
+  it("shows 'My machine's default' when the user has opted out", () => {
+    mockUsePlatformTerminalModelDefault.mockReturnValue("opus");
+    renderDialog({ terminalModel: MACHINE_DEFAULT_TERMINAL_MODEL });
+
+    expect(screen.getByText("My machine's default")).toBeInTheDocument();
+  });
+
+  it("shows the user's own known-alias override", () => {
+    mockUsePlatformTerminalModelDefault.mockReturnValue("opus");
+    renderDialog({ terminalModel: "sonnet" });
+
+    expect(screen.getByText("Sonnet")).toBeInTheDocument();
+  });
+
+  it("renders a custom override as a free-text input, not the Select", () => {
+    mockUsePlatformTerminalModelDefault.mockReturnValue(null);
+    renderDialog({ terminalModel: "claude-opus-5-20260101" });
+
+    expect(screen.getByDisplayValue("claude-opus-5-20260101")).toBeInTheDocument();
+  });
+
+  it("blocks Save with role=alert on a structurally invalid custom value (AC-12)", () => {
+    mockUsePlatformTerminalModelDefault.mockReturnValue(null);
+    // Stored value is already a custom (non-alias) string, so the field opens
+    // straight into custom-input mode; typing a space then makes it invalid.
+    renderDialog({ terminalModel: "opus5" });
+
+    const input = screen.getByDisplayValue("opus5");
+    fireEvent.change(input, { target: { value: "opus 5!" } });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/space/i);
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    expect(saveButton).toBeDisabled();
+  });
+
+  it("shows a non-blocking amber advisory for a structurally valid but unknown custom value", () => {
+    mockUsePlatformTerminalModelDefault.mockReturnValue(null);
+    renderDialog({ terminalModel: "claude-opus-5-20260101" });
+
+    expect(screen.getByText(/Not a known family alias/)).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/src/components/profile/model-tier-settings.tsx
+++ b/src/components/profile/model-tier-settings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { Cpu } from "lucide-react";
+import { Cpu, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,6 +14,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -22,9 +23,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { updateModelTierMap } from "@/actions/profile";
+import { cn } from "@/lib/utils";
+import { updateModelTierMap, updateTerminalModel } from "@/actions/profile";
 import { setViewerModelTierMapCache } from "@/hooks/use-viewer-model-tier-map";
+import { setViewerTerminalModelCache } from "@/hooks/use-viewer-terminal-model";
 import { usePlatformModelDefaults } from "@/hooks/use-platform-model-defaults";
+import { usePlatformTerminalModelDefault } from "@/hooks/use-platform-terminal-model-default";
 import {
   MODEL_TIER_WHEN_TO_USE,
   capitalizeModelName,
@@ -32,10 +36,21 @@ import {
   type ModelTierMap,
   type ModelTierValue,
 } from "@/lib/constants";
+import {
+  MACHINE_DEFAULT_TERMINAL_MODEL,
+  KNOWN_TERMINAL_MODEL_ALIASES,
+  isKnownTerminalModelAlias,
+  validateTerminalModelValue,
+  capitalizeTerminalModelName,
+} from "@/lib/terminal/model-resolution";
 
 // Radix Select can't use "" as an item value, so "follow the platform
 // default" uses this sentinel (unset key in the stored map).
 const PLATFORM_DEFAULT_VALUE = "__platform_default__";
+// Terminal sessions group only: swaps the Select for a free-text Input
+// (mirrors the admin platform card's TierModelField "Custom…" escape hatch —
+// design handoff note: a novel model family needs no code change here either).
+const TERMINAL_CUSTOM_VALUE = "__custom__";
 
 const MODEL_OPTIONS: { value: ModelAlias; label: string; gloss: string }[] = [
   { value: "fable", label: "Fable", gloss: "Most capable — frontier reasoning" },
@@ -43,6 +58,10 @@ const MODEL_OPTIONS: { value: ModelAlias; label: string; gloss: string }[] = [
   { value: "sonnet", label: "Sonnet", gloss: "Balanced speed & quality" },
   { value: "haiku", label: "Haiku", gloss: "Fastest & lowest cost" },
 ];
+
+const TERMINAL_MODEL_OPTIONS = MODEL_OPTIONS.filter((o) =>
+  (KNOWN_TERMINAL_MODEL_ALIASES as readonly string[]).includes(o.value)
+);
 
 const TIER_FIELDS: { tier: ModelTierValue; label: string }[] = [
   { tier: "frontier", label: "Frontier" },
@@ -53,8 +72,17 @@ const TIER_FIELDS: { tier: ModelTierValue; label: string }[] = [
 interface ModelTierSettingsProps {
   /** The signed-in user's model_tier_map, fetched server-side (like hasKey). */
   map: ModelTierMap | null;
+  /** The signed-in user's terminal_model override (task c4ca2d95), fetched server-side. */
+  terminalModel: string | null;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+}
+
+/** True when `value` is a custom (not platform-default, not machine-default,
+ *  not a known alias) staged terminal value — i.e. the Select should be
+ *  showing the free-text Input instead. */
+function isTerminalCustomValue(value: string | null): boolean {
+  return value !== null && value !== MACHINE_DEFAULT_TERMINAL_MODEL && !isKnownTerminalModelAlias(value);
 }
 
 /**
@@ -62,9 +90,14 @@ interface ModelTierSettingsProps {
  * on api-key-settings.tsx: outline trigger → sm:max-w-md dialog. Save is the
  * only write path — Reset stages an all-cleared map locally, Cancel/Esc
  * discards staged changes (Design §02/§03).
+ *
+ * Also houses the "Terminal sessions" group (task c4ca2d95) — Nick's binding
+ * approval-gate note: the setting lives HERE, inside this (unrenamed)
+ * dialog, rather than a separate settings surface.
  */
 export function ModelTierSettings({
   map,
+  terminalModel,
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
 }: ModelTierSettingsProps) {
@@ -75,18 +108,36 @@ export function ModelTierSettings({
   const [isPending, startTransition] = useTransition();
   const [staged, setStaged] = useState<ModelTierMap>(map ?? {});
   const platformDefaults = usePlatformModelDefaults();
+  const platformTerminalDefault = usePlatformTerminalModelDefault();
 
-  // Re-stage from the persisted map on every open so a prior Cancel never
+  // Terminal sessions group state — null = platform default; the sentinel
+  // string = "my machine's default"; anything else = a known alias or a
+  // custom value (raw, possibly-invalid text while the user is typing).
+  const [terminalStaged, setTerminalStaged] = useState<string | null>(terminalModel);
+  const [terminalCustomMode, setTerminalCustomMode] = useState(() => isTerminalCustomValue(terminalModel));
+
+  // Re-stage from the persisted values on every open so a prior Cancel never
   // leaks into the next open.
   function handleOpenChange(next: boolean) {
-    if (next) setStaged(map ?? {});
+    if (next) {
+      setStaged(map ?? {});
+      setTerminalStaged(terminalModel);
+      setTerminalCustomMode(isTerminalCustomValue(terminalModel));
+    }
     setOpen(next);
   }
 
-  const isDirty = TIER_FIELDS.some(
+  const isTierDirty = TIER_FIELDS.some(
     ({ tier }) => (staged[tier] ?? null) !== (map?.[tier] ?? null)
   );
-  const hasAnyOverride = TIER_FIELDS.some(({ tier }) => staged[tier] !== undefined);
+  const isTerminalDirty = terminalStaged !== terminalModel;
+  const isDirty = isTierDirty || isTerminalDirty;
+  const hasAnyOverride = TIER_FIELDS.some(({ tier }) => staged[tier] !== undefined) || terminalStaged !== null;
+
+  const terminalValidation = terminalCustomMode ? validateTerminalModelValue(terminalStaged ?? "") : { ok: true as const };
+  const terminalIsNovel =
+    terminalCustomMode && terminalValidation.ok && !isKnownTerminalModelAlias((terminalStaged ?? "").trim());
+  const terminalBlocked = terminalCustomMode && !terminalValidation.ok;
 
   function handleTierChange(tier: ModelTierValue, value: string) {
     setStaged((prev) => {
@@ -97,15 +148,32 @@ export function ModelTierSettings({
     });
   }
 
+  function handleTerminalSelectChange(value: string) {
+    if (value === TERMINAL_CUSTOM_VALUE) {
+      setTerminalCustomMode(true);
+      setTerminalStaged((prev) => (isTerminalCustomValue(prev) ? prev : ""));
+      return;
+    }
+    setTerminalCustomMode(false);
+    setTerminalStaged(value === PLATFORM_DEFAULT_VALUE ? null : value);
+  }
+
   function handleReset() {
     setStaged({});
+    setTerminalStaged(null);
+    setTerminalCustomMode(false);
   }
 
   function handleSave() {
     startTransition(async () => {
       try {
-        const saved = await updateModelTierMap(staged);
-        setViewerModelTierMapCache(saved);
+        const terminalToSave = terminalCustomMode ? (terminalStaged ?? "").trim() : terminalStaged;
+        const [savedTiers, savedTerminal] = await Promise.all([
+          updateModelTierMap(staged),
+          updateTerminalModel(terminalToSave),
+        ]);
+        setViewerModelTierMapCache(savedTiers);
+        setViewerTerminalModelCache(savedTerminal);
         toast.success("Model tiers saved");
         setOpen(false);
       } catch (err) {
@@ -182,6 +250,106 @@ export function ModelTierSettings({
             or session, the orchestrator substitutes the closest available alternative and notes it in the step
             output.
           </p>
+
+          {/* Terminal sessions group (task c4ca2d95) — the setting stays inside
+              this dialog per Nick's binding approval-gate note (no rename, no
+              separate settings surface). */}
+          <p className="pt-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Terminal sessions
+          </p>
+          <div className="space-y-1.5">
+            <Label htmlFor="terminal-starting-model" className="text-sm">
+              Starting model{" "}
+              <span className="font-normal text-muted-foreground">— for new in-browser terminal sessions</span>
+            </Label>
+            {terminalCustomMode ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <Input
+                  id="terminal-starting-model"
+                  value={terminalStaged ?? ""}
+                  onChange={(e) => setTerminalStaged(e.target.value)}
+                  placeholder="e.g. opus-5.5"
+                  disabled={isPending}
+                  aria-invalid={terminalBlocked}
+                  aria-describedby={
+                    terminalBlocked
+                      ? "terminal-model-error"
+                      : terminalIsNovel
+                        ? "terminal-model-novel-warning"
+                        : undefined
+                  }
+                  className={cn(
+                    "min-w-[10rem] flex-1",
+                    terminalBlocked && "border-rose-500 focus-visible:ring-rose-500/30",
+                    !terminalBlocked && terminalIsNovel && "border-amber-500 focus-visible:ring-amber-500/30 dark:border-amber-500"
+                  )}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={isPending}
+                  onClick={() => {
+                    setTerminalCustomMode(false);
+                    setTerminalStaged(null);
+                  }}
+                >
+                  Choose known…
+                </Button>
+              </div>
+            ) : (
+              <Select value={terminalStaged ?? PLATFORM_DEFAULT_VALUE} onValueChange={handleTerminalSelectChange} disabled={isPending}>
+                <SelectTrigger id="terminal-starting-model" aria-describedby="terminal-model-help" className="w-full">
+                  <SelectValue>
+                    {terminalStaged === null ? (
+                      <span className="text-muted-foreground">
+                        Platform default
+                        {platformTerminalDefault ? ` (${capitalizeTerminalModelName(platformTerminalDefault)})` : " (your machine decides)"}
+                      </span>
+                    ) : terminalStaged === MACHINE_DEFAULT_TERMINAL_MODEL ? (
+                      "My machine's default"
+                    ) : (
+                      TERMINAL_MODEL_OPTIONS.find((o) => o.value === terminalStaged)?.label ?? terminalStaged
+                    )}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={PLATFORM_DEFAULT_VALUE}>
+                    Platform default
+                    {platformTerminalDefault ? ` (${capitalizeTerminalModelName(platformTerminalDefault)})` : " (your machine decides)"}
+                  </SelectItem>
+                  <SelectItem value={MACHINE_DEFAULT_TERMINAL_MODEL}>My machine&apos;s default</SelectItem>
+                  <SelectSeparator />
+                  {TERMINAL_MODEL_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label} <span className="text-muted-foreground">— {opt.gloss}</span>
+                    </SelectItem>
+                  ))}
+                  <SelectSeparator />
+                  <SelectItem value={TERMINAL_CUSTOM_VALUE}>Custom… (type an alias or model id)</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+            {terminalBlocked && !terminalValidation.ok && (
+              <p id="terminal-model-error" role="alert" className="flex items-center gap-1.5 text-xs text-rose-500">
+                <TriangleAlert className="h-3.5 w-3.5 shrink-0" />
+                {terminalValidation.reason}
+              </p>
+            )}
+            {!terminalBlocked && terminalIsNovel && (
+              <p id="terminal-model-novel-warning" className="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-500">
+                <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                Not a known family alias — it&apos;s passed to Claude Code exactly as typed. If Claude rejects it, the
+                error appears in the terminal when the session starts; fix it here.
+              </p>
+            )}
+            {!terminalCustomMode && (
+              <p id="terminal-model-help" className="text-[11px] text-muted-foreground">
+                Applies when a fresh session starts. Resumed sessions keep the model they were on; you can switch
+                any time by typing /model in the terminal.
+              </p>
+            )}
+          </div>
         </div>
 
         <DialogFooter className="gap-2 sm:gap-0">
@@ -200,17 +368,23 @@ export function ModelTierSettings({
             <Button
               size="sm"
               onClick={handleSave}
-              disabled={isPending || !isDirty}
-              aria-describedby={!isDirty ? "model-tier-save-why" : undefined}
+              disabled={isPending || !isDirty || terminalBlocked}
+              aria-describedby={!isDirty || terminalBlocked ? "model-tier-save-why" : undefined}
             >
               {isPending ? "Saving…" : "Save"}
             </Button>
           </div>
         </DialogFooter>
-        {!isDirty && (
+        {terminalBlocked ? (
           <p id="model-tier-save-why" className="-mt-2 text-right text-[11px] text-muted-foreground">
-            Save enables when you change a tier.
+            Fix the starting model to enable Save.
           </p>
+        ) : (
+          !isDirty && (
+            <p id="model-tier-save-why" className="-mt-2 text-right text-[11px] text-muted-foreground">
+              Save enables when you change a tier.
+            </p>
+          )
         )}
       </DialogContent>
     </Dialog>

--- a/src/components/profile/profile-settings-menu.tsx
+++ b/src/components/profile/profile-settings-menu.tsx
@@ -22,6 +22,8 @@ interface ProfileSettingsMenuProps {
   columns: { title: string; is_done_column: boolean }[] | null;
   hasApiKey: boolean;
   modelTierMap: ModelTierMap | null;
+  /** In-app terminal starting-model override (task c4ca2d95). */
+  terminalModel: string | null;
 }
 
 export function ProfileSettingsMenu({
@@ -29,6 +31,7 @@ export function ProfileSettingsMenu({
   columns,
   hasApiKey,
   modelTierMap,
+  terminalModel,
 }: ProfileSettingsMenuProps) {
   const [showNotifications, setShowNotifications] = useState(false);
   const [showColumns, setShowColumns] = useState(false);
@@ -87,6 +90,7 @@ export function ProfileSettingsMenu({
       />
       <ModelTierSettings
         map={modelTierMap}
+        terminalModel={terminalModel}
         open={showModelTiers}
         onOpenChange={setShowModelTiers}
       />

--- a/src/hooks/use-platform-terminal-model-default.test.ts
+++ b/src/hooks/use-platform-terminal-model-default.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+const mockGetPlatformTerminalModelDefaultAction = vi.fn();
+
+vi.mock("@/actions/admin-platform", () => ({
+  getPlatformTerminalModelDefaultAction: () => mockGetPlatformTerminalModelDefaultAction(),
+}));
+
+// Each test needs a fresh module (the cache is module-level state), so reset
+// the module registry between tests rather than sharing cachedDefault.
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe("usePlatformTerminalModelDefault (binding: no seed)", () => {
+  it("returns undefined immediately, before the fetch resolves — no seed placeholder", async () => {
+    let resolveFetch!: (v: unknown) => void;
+    mockGetPlatformTerminalModelDefaultAction.mockReturnValue(new Promise((r) => (resolveFetch = r)));
+
+    const { usePlatformTerminalModelDefault } = await import("./use-platform-terminal-model-default");
+    const { result } = renderHook(() => usePlatformTerminalModelDefault());
+    expect(result.current).toBeUndefined();
+
+    act(() => resolveFetch(null));
+  });
+
+  it("updates to the live fetched value once the action resolves", async () => {
+    mockGetPlatformTerminalModelDefaultAction.mockResolvedValue("opus");
+
+    const { usePlatformTerminalModelDefault } = await import("./use-platform-terminal-model-default");
+    const { result } = renderHook(() => usePlatformTerminalModelDefault());
+
+    await waitFor(() => expect(result.current).toBe("opus"));
+  });
+
+  it("resolves to null when nothing has been saved yet — a real, distinct state from undefined", async () => {
+    mockGetPlatformTerminalModelDefaultAction.mockResolvedValue(null);
+
+    const { usePlatformTerminalModelDefault } = await import("./use-platform-terminal-model-default");
+    const { result } = renderHook(() => usePlatformTerminalModelDefault());
+
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+
+  it("degrades to null (never surfaces an error) if the action rejects", async () => {
+    mockGetPlatformTerminalModelDefaultAction.mockRejectedValue(new Error("network error"));
+
+    const { usePlatformTerminalModelDefault } = await import("./use-platform-terminal-model-default");
+    const { result } = renderHook(() => usePlatformTerminalModelDefault());
+
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+
+  it("fetches only once across multiple mounted consumers (shared cache)", async () => {
+    mockGetPlatformTerminalModelDefaultAction.mockResolvedValue("opus");
+
+    const { usePlatformTerminalModelDefault } = await import("./use-platform-terminal-model-default");
+    const a = renderHook(() => usePlatformTerminalModelDefault());
+    const b = renderHook(() => usePlatformTerminalModelDefault());
+
+    await waitFor(() => expect(a.result.current).toBe("opus"));
+    await waitFor(() => expect(b.result.current).toBe("opus"));
+    expect(mockGetPlatformTerminalModelDefaultAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("setPlatformTerminalModelDefaultCache pushes an update to every mounted consumer", async () => {
+    mockGetPlatformTerminalModelDefaultAction.mockResolvedValue(null);
+
+    const { usePlatformTerminalModelDefault, setPlatformTerminalModelDefaultCache } = await import(
+      "./use-platform-terminal-model-default"
+    );
+    const { result } = renderHook(() => usePlatformTerminalModelDefault());
+
+    await waitFor(() => expect(result.current).toBeNull());
+
+    act(() => setPlatformTerminalModelDefaultCache("sonnet"));
+    expect(result.current).toBe("sonnet");
+  });
+});

--- a/src/hooks/use-platform-terminal-model-default.ts
+++ b/src/hooks/use-platform-terminal-model-default.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getPlatformTerminalModelDefaultAction } from "@/actions/admin-platform";
+
+// Module-level cache shared by every mounted consumer (model-tier-settings.tsx's
+// "Terminal sessions" group, the chooser footer, the per-task dedupe dialog) —
+// fetched once per session. `undefined` = not yet fetched; `null` = fetched,
+// no platform default set (binding note: there is NO seed to fall back to
+// here, unlike use-platform-model-defaults.ts).
+let cachedDefault: string | null | undefined;
+let inFlight: Promise<string | null> | null = null;
+const listeners = new Set<(model: string | null) => void>();
+
+function fetchOnce(): Promise<string | null> {
+  if (!inFlight) {
+    inFlight = getPlatformTerminalModelDefaultAction()
+      .then((model) => {
+        cachedDefault = model;
+        return model;
+      })
+      .catch(() => {
+        // Never surface this to the UI as an error — degrade to "no default",
+        // same posture as the server-side getPlatformTerminalModelDefault().
+        cachedDefault = null;
+        return null;
+      });
+  }
+  return inFlight;
+}
+
+/**
+ * Called by the admin Platform tab after a successful save (or clear) so any
+ * already-mounted consumer reflects the new value immediately, without a
+ * full reload — mirrors setPlatformModelDefaultsCache().
+ */
+export function setPlatformTerminalModelDefaultCache(model: string | null): void {
+  cachedDefault = model;
+  listeners.forEach((listener) => listener(model));
+}
+
+/**
+ * The current LIVE platform terminal starting-model default (admin-
+ * configurable). Returns `undefined` while loading — UNLIKE
+ * usePlatformModelDefaults(), there is no seed constant to show as an
+ * immediate placeholder (binding approval-gate note: no seed at all), so
+ * callers must treat `undefined` as "not yet known" and `null` as "no
+ * default set" — two genuinely different states here.
+ */
+export function usePlatformTerminalModelDefault(): string | null | undefined {
+  const [model, setModel] = useState<string | null | undefined>(cachedDefault);
+
+  useEffect(() => {
+    let cancelled = false;
+    const listener = (m: string | null) => {
+      if (!cancelled) setModel(m);
+    };
+    listeners.add(listener);
+
+    if (cachedDefault === undefined) {
+      fetchOnce().then((m) => {
+        if (!cancelled) setModel(m);
+      });
+    }
+
+    return () => {
+      cancelled = true;
+      listeners.delete(listener);
+    };
+  }, []);
+
+  return model;
+}

--- a/src/hooks/use-viewer-terminal-model.test.ts
+++ b/src/hooks/use-viewer-terminal-model.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+const mockGetTerminalModel = vi.fn();
+
+vi.mock("@/actions/profile", () => ({
+  getTerminalModel: () => mockGetTerminalModel(),
+}));
+
+// Each test needs a fresh module (the cache is module-level state), so reset
+// the module registry between tests rather than sharing cachedModel.
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe("useViewerTerminalModel", () => {
+  it("returns undefined immediately, before the fetch resolves", async () => {
+    let resolveFetch!: (v: unknown) => void;
+    mockGetTerminalModel.mockReturnValue(new Promise((r) => (resolveFetch = r)));
+
+    const { useViewerTerminalModel } = await import("./use-viewer-terminal-model");
+    const { result } = renderHook(() => useViewerTerminalModel());
+    expect(result.current).toBeUndefined();
+
+    act(() => resolveFetch(null));
+  });
+
+  it("updates to the live fetched override once the action resolves", async () => {
+    mockGetTerminalModel.mockResolvedValue("sonnet");
+
+    const { useViewerTerminalModel } = await import("./use-viewer-terminal-model");
+    const { result } = renderHook(() => useViewerTerminalModel());
+
+    await waitFor(() => expect(result.current).toBe("sonnet"));
+  });
+
+  it("resolves to null when the user has no override", async () => {
+    mockGetTerminalModel.mockResolvedValue(null);
+
+    const { useViewerTerminalModel } = await import("./use-viewer-terminal-model");
+    const { result } = renderHook(() => useViewerTerminalModel());
+
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+
+  it("degrades to null (never surfaces an error) if the action rejects", async () => {
+    mockGetTerminalModel.mockRejectedValue(new Error("network error"));
+
+    const { useViewerTerminalModel } = await import("./use-viewer-terminal-model");
+    const { result } = renderHook(() => useViewerTerminalModel());
+
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+
+  it("fetches only once across multiple mounted consumers (shared cache)", async () => {
+    mockGetTerminalModel.mockResolvedValue("sonnet");
+
+    const { useViewerTerminalModel } = await import("./use-viewer-terminal-model");
+    const a = renderHook(() => useViewerTerminalModel());
+    const b = renderHook(() => useViewerTerminalModel());
+
+    await waitFor(() => expect(a.result.current).toBe("sonnet"));
+    await waitFor(() => expect(b.result.current).toBe("sonnet"));
+    expect(mockGetTerminalModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("setViewerTerminalModelCache pushes an update to every mounted consumer", async () => {
+    mockGetTerminalModel.mockResolvedValue(null);
+
+    const { useViewerTerminalModel, setViewerTerminalModelCache } = await import("./use-viewer-terminal-model");
+    const { result } = renderHook(() => useViewerTerminalModel());
+
+    await waitFor(() => expect(result.current).toBeNull());
+
+    act(() => setViewerTerminalModelCache("opus"));
+    expect(result.current).toBe("opus");
+  });
+});

--- a/src/hooks/use-viewer-terminal-model.ts
+++ b/src/hooks/use-viewer-terminal-model.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getTerminalModel } from "@/actions/profile";
+
+// Module-level cache mirroring use-viewer-model-tier-map.ts's pattern —
+// fetched once per session rather than once per mount. `undefined` = not yet
+// fetched; `null` = fetched, no override (use the platform default).
+let cachedModel: string | null | undefined;
+let inFlight: Promise<string | null> | null = null;
+const listeners = new Set<(model: string | null) => void>();
+
+function fetchOnce(): Promise<string | null> {
+  if (!inFlight) {
+    inFlight = getTerminalModel()
+      .then((model) => {
+        cachedModel = model;
+        return model;
+      })
+      .catch(() => {
+        cachedModel = null;
+        return null;
+      });
+  }
+  return inFlight;
+}
+
+/**
+ * Called by the Model Tiers settings dialog's "Terminal sessions" group
+ * after a successful save so any already-mounted consumer (the chooser
+ * footer, the per-task dedupe dialog) reflects the new override immediately,
+ * without a full reload — mirrors setViewerModelTierMapCache().
+ */
+export function setViewerTerminalModelCache(model: string | null): void {
+  cachedModel = model;
+  listeners.forEach((listener) => listener(model));
+}
+
+/**
+ * The current viewer's terminal_model override, fetched once and shared
+ * across every mounted consumer. Returns undefined while loading — callers
+ * should omit the launch-surface model line until this resolves, never show
+ * a wrong steady state (mirrors useViewerModelTierMap's posture).
+ */
+export function useViewerTerminalModel(): string | null | undefined {
+  const [model, setModel] = useState<string | null | undefined>(cachedModel);
+
+  useEffect(() => {
+    let cancelled = false;
+    const listener = (m: string | null) => {
+      if (!cancelled) setModel(m);
+    };
+    listeners.add(listener);
+
+    if (cachedModel === undefined) {
+      fetchOnce().then((m) => {
+        if (!cancelled) setModel(m);
+      });
+    }
+
+    return () => {
+      cancelled = true;
+      listeners.delete(listener);
+    };
+  }, []);
+
+  return model;
+}

--- a/src/lib/terminal/deep-link.test.ts
+++ b/src/lib/terminal/deep-link.test.ts
@@ -171,6 +171,46 @@ describe("buildLaunchDeepLink with cols/rows (Bug B, card cbe60db5 — real PTY 
   });
 });
 
+describe("buildLaunchDeepLink with model (task c4ca2d95, terminal starting model)", () => {
+  it("includes model, positioned before prompt, and round-trips", () => {
+    const withModel = { ...SAMPLE, model: "opus", prompt: "hello" };
+    const url = buildLaunchDeepLink(withModel);
+    expect(url).toContain("model=opus");
+    expect(url.indexOf("model=")).toBeLessThan(url.indexOf("prompt="));
+    expect(parseLaunchDeepLink(url)).toEqual(withModel);
+  });
+
+  it("omits model entirely when absent — no version-skew risk for an old bridge/helper (AC-13)", () => {
+    const url = buildLaunchDeepLink(SAMPLE);
+    expect(url).not.toContain("model=");
+    expect(parseLaunchDeepLink(url)).toEqual(SAMPLE);
+  });
+
+  it("model rides before prompt, mirroring cols/resume's position", () => {
+    const url = buildLaunchDeepLink({ ...SAMPLE, model: "sonnet", prompt: "ignored ordering check" });
+    expect(url.indexOf("model=")).toBeLessThan(url.indexOf("prompt="));
+  });
+
+  it("carries a custom (non-alias) model id verbatim, URL-encoded", () => {
+    const withModel = { ...SAMPLE, model: "claude-opus-5-20260101" };
+    const url = buildLaunchDeepLink(withModel);
+    expect(parseLaunchDeepLink(url)?.model).toBe("claude-opus-5-20260101");
+  });
+
+  it("a malformed model value on the wire (whitespace/shell metacharacters) is rejected by the shared parser, never forwarded", () => {
+    const url = `${LAUNCH_SCHEME}://${LAUNCH_HOST}?relay=${encodeURIComponent(SAMPLE.relay)}&session=${SAMPLE.session}&token=${encodeURIComponent(SAMPLE.token)}&model=${encodeURIComponent("opus; rm -rf")}`;
+    const parsed = parseLaunchDeepLink(url);
+    expect(parsed).not.toBeNull();
+    expect(parsed).not.toHaveProperty("model");
+  });
+
+  it("is left untouched by redactDeepLinkToken — not a secret or free-form user content (AC-10)", () => {
+    const url = buildLaunchDeepLink({ ...SAMPLE, model: "opus" });
+    const redacted = redactDeepLinkToken(url);
+    expect(redacted).toContain("model=opus");
+  });
+});
+
 describe("redactDeepLinkToken", () => {
   it("replaces the token value with *** and never leaks the secret", () => {
     const url = buildLaunchDeepLink(SAMPLE);

--- a/src/lib/terminal/deep-link.ts
+++ b/src/lib/terminal/deep-link.ts
@@ -88,15 +88,29 @@ export interface LaunchDeepLinkParams {
    */
   cols?: number;
   rows?: number;
+  /**
+   * Task c4ca2d95 ("Terminal starting model") — the resolved starting model
+   * (user override -> platform default -> omit; resolved server-side at
+   * mint time, see src/app/api/terminal/session/route.ts) for a FRESH
+   * session only. Callers must never set this on a resume/resumeId launch
+   * (AC-8: a resumed conversation keeps its own model) — the fresh-launch
+   * call site in use-terminal-session.ts is the only one that threads it
+   * through. Rides as one argv element (`claude --model <value>`), never
+   * shell-split — see terminal/bridge/src/resume-cmd.js. Not a secret or
+   * user-free-text like `prompt`: redactDeepLinkToken leaves it untouched
+   * (AC-10).
+   */
+  model?: string;
 }
 
 /**
  * Build a `vibecodes://launch?relay=…&session=…&token=…[&helperToken=…]
- * [&cwd=…][&resume=1][&cols=…&rows=…][&prompt=…]` deep link. Throws when a
- * required field is missing so a malformed link is never fired. `prompt` is
- * always the LAST param so the base-link length (and therefore the prompt
- * budget) is stable — every other optional param, including `cols`/`rows`,
- * is inserted before it, alongside the other credentials.
+ * [&cwd=…][&resume=1][&cols=…&rows=…][&model=…][&prompt=…]` deep link. Throws
+ * when a required field is missing so a malformed link is never fired.
+ * `prompt` is always the LAST param so the base-link length (and therefore
+ * the prompt budget) is stable — every other optional param, including
+ * `cols`/`rows` and `model`, is inserted before it, alongside the other
+ * credentials.
  */
 export function buildLaunchDeepLink({
   relay,
@@ -109,6 +123,7 @@ export function buildLaunchDeepLink({
   resumeId,
   cols,
   rows,
+  model,
 }: LaunchDeepLinkParams): string {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
@@ -133,6 +148,9 @@ export function buildLaunchDeepLink({
   if (isValidLaunchDim(cols) && isValidLaunchDim(rows)) {
     parts.push(`cols=${cols}`, `rows=${rows}`);
   }
+  // Task c4ca2d95: inserted before `prompt` (which stays LAST — see the
+  // class doc comment) alongside the other optional non-secret params.
+  if (model) parts.push(`model=${encodeURIComponent(model)}`);
   if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
 }

--- a/src/lib/terminal/model-resolution.test.ts
+++ b/src/lib/terminal/model-resolution.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  MACHINE_DEFAULT_TERMINAL_MODEL,
+  KNOWN_TERMINAL_MODEL_ALIASES,
+  isKnownTerminalModelAlias,
+  validateTerminalModelValue,
+  resolveEffectiveTerminalModel,
+  resolveTerminalModelSource,
+  terminalLaunchModelLine,
+  terminalDialogModelLine,
+  capitalizeTerminalModelName,
+} from "./model-resolution";
+
+describe("isKnownTerminalModelAlias", () => {
+  it("recognises all 4 known aliases", () => {
+    for (const alias of KNOWN_TERMINAL_MODEL_ALIASES) {
+      expect(isKnownTerminalModelAlias(alias)).toBe(true);
+    }
+  });
+
+  it("rejects an unknown/custom value", () => {
+    expect(isKnownTerminalModelAlias("claude-opus-5-20260101")).toBe(false);
+    expect(isKnownTerminalModelAlias("Opus")).toBe(false); // case-sensitive — stored values are lowercase aliases
+  });
+});
+
+describe("validateTerminalModelValue (AC-12)", () => {
+  it("accepts known aliases and plausible custom ids", () => {
+    expect(validateTerminalModelValue("opus")).toEqual({ ok: true });
+    expect(validateTerminalModelValue("claude-opus-5-20260101")).toEqual({ ok: true });
+    expect(validateTerminalModelValue("opus-5.5")).toEqual({ ok: true });
+  });
+
+  it("rejects an empty or whitespace-only value", () => {
+    expect(validateTerminalModelValue("").ok).toBe(false);
+    expect(validateTerminalModelValue("   ").ok).toBe(false);
+  });
+
+  it("rejects a value containing whitespace anywhere", () => {
+    const result = validateTerminalModelValue("opus 5!");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/space/i);
+  });
+
+  it("rejects values containing shell metacharacters", () => {
+    for (const bad of ["opus;rm", "opus$(x)", "opus`x`", "opus|x", "opus&x", "opus<x>", "opus\"x", "opus'x", "opus\\x"]) {
+      const result = validateTerminalModelValue(bad);
+      expect(result.ok, `expected "${bad}" to be rejected`).toBe(false);
+    }
+  });
+
+  it("never rejects the machine-default sentinel itself (no spaces/metacharacters)", () => {
+    expect(validateTerminalModelValue(MACHINE_DEFAULT_TERMINAL_MODEL)).toEqual({ ok: true });
+  });
+});
+
+describe("resolveEffectiveTerminalModel (AC-7 — every branch)", () => {
+  it("user override set -> user override wins over the platform default", () => {
+    expect(resolveEffectiveTerminalModel({ userValue: "sonnet", platformValue: "opus" })).toBe("sonnet");
+  });
+
+  it("user set to the machine-default sentinel -> omit, even when a platform default is set (AC-5 beats AC-1/3)", () => {
+    expect(
+      resolveEffectiveTerminalModel({ userValue: MACHINE_DEFAULT_TERMINAL_MODEL, platformValue: "opus" })
+    ).toBeUndefined();
+  });
+
+  it("user unset (null), platform set -> platform default (AC-6)", () => {
+    expect(resolveEffectiveTerminalModel({ userValue: null, platformValue: "opus" })).toBe("opus");
+  });
+
+  it("user unset (undefined), platform set -> platform default", () => {
+    expect(resolveEffectiveTerminalModel({ userValue: undefined, platformValue: "opus" })).toBe("opus");
+  });
+
+  it("user unset, platform ALSO unset -> omit entirely, no seed (binding approval-gate note)", () => {
+    expect(resolveEffectiveTerminalModel({ userValue: null, platformValue: null })).toBeUndefined();
+    expect(resolveEffectiveTerminalModel({ userValue: undefined, platformValue: undefined })).toBeUndefined();
+  });
+
+  it("user override empty string is treated as unset, never spawns --model ''", () => {
+    expect(resolveEffectiveTerminalModel({ userValue: "", platformValue: "opus" })).toBe("opus");
+    expect(resolveEffectiveTerminalModel({ userValue: "", platformValue: null })).toBeUndefined();
+  });
+});
+
+describe("resolveTerminalModelSource", () => {
+  it("reports 'user' when the user's own override applies", () => {
+    expect(resolveTerminalModelSource({ userValue: "sonnet", platformValue: "opus" })).toBe("user");
+  });
+
+  it("reports 'machine' for the machine-default sentinel", () => {
+    expect(resolveTerminalModelSource({ userValue: MACHINE_DEFAULT_TERMINAL_MODEL, platformValue: "opus" })).toBe(
+      "machine"
+    );
+  });
+
+  it("reports 'platform' when the user has no override", () => {
+    expect(resolveTerminalModelSource({ userValue: null, platformValue: "opus" })).toBe("platform");
+    expect(resolveTerminalModelSource({ userValue: null, platformValue: null })).toBe("platform");
+  });
+});
+
+describe("terminalLaunchModelLine (design §4.2/§4.3)", () => {
+  it("names the model and source when a platform default applies", () => {
+    expect(terminalLaunchModelLine("opus", "platform")).toBe("New sessions start on Opus · platform default.");
+  });
+
+  it("names the model and 'your setting' when a user override applies", () => {
+    expect(terminalLaunchModelLine("sonnet", "user")).toBe("New sessions start on Sonnet · your setting.");
+  });
+
+  it("describes the machine-default case without naming a model", () => {
+    expect(terminalLaunchModelLine(undefined, "machine")).toBe("New sessions use your machine's default model.");
+  });
+
+  it("returns null when nothing would be passed at all (both unset) — omit the line entirely", () => {
+    expect(terminalLaunchModelLine(undefined, "platform")).toBeNull();
+  });
+});
+
+describe("terminalDialogModelLine (design §4.3, Design Review note 2 — terser copy)", () => {
+  it("uses the terser 'Starts on <Model> · <source>' format", () => {
+    expect(terminalDialogModelLine("sonnet", "user")).toBe("Starts on Sonnet · your setting.");
+    expect(terminalDialogModelLine("opus", "platform")).toBe("Starts on Opus · platform default.");
+  });
+
+  it("describes the machine-default case without naming a model", () => {
+    expect(terminalDialogModelLine(undefined, "machine")).toBe("Starts on your machine's default model.");
+  });
+
+  it("returns null when nothing would be passed at all", () => {
+    expect(terminalDialogModelLine(undefined, "platform")).toBeNull();
+  });
+});
+
+describe("capitalizeTerminalModelName", () => {
+  it("capitalises the first letter only", () => {
+    expect(capitalizeTerminalModelName("sonnet")).toBe("Sonnet");
+    expect(capitalizeTerminalModelName("claude-opus-5")).toBe("Claude-opus-5");
+  });
+});

--- a/src/lib/terminal/model-resolution.test.ts
+++ b/src/lib/terminal/model-resolution.test.ts
@@ -52,6 +52,17 @@ describe("validateTerminalModelValue (AC-12)", () => {
   it("never rejects the machine-default sentinel itself (no spaces/metacharacters)", () => {
     expect(validateTerminalModelValue(MACHINE_DEFAULT_TERMINAL_MODEL)).toEqual({ ok: true });
   });
+
+  it("rejects a value over the 100-char cap (QA Bug 1 — overflowed the deep link's 2048-char cap)", () => {
+    const result = validateTerminalModelValue("a".repeat(101));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/100 characters/i);
+  });
+
+  it("boundary: exactly 100 chars passes, 101 fails", () => {
+    expect(validateTerminalModelValue("a".repeat(100))).toEqual({ ok: true });
+    expect(validateTerminalModelValue("a".repeat(101)).ok).toBe(false);
+  });
 });
 
 describe("resolveEffectiveTerminalModel (AC-7 — every branch)", () => {

--- a/src/lib/terminal/model-resolution.ts
+++ b/src/lib/terminal/model-resolution.ts
@@ -38,24 +38,42 @@ export function isKnownTerminalModelAlias(value: string): boolean {
 
 export type TerminalModelValidation = { ok: true } | { ok: false; reason: string };
 
+/** Hard length cap (QA Bug 1, rework of task c4ca2d95): the previously-
+ *  unbounded value let a ~1,700+ char string overflow the deep link's own
+ *  hard 2048-char cap, which fails every fresh launch with a misleading
+ *  "Project path too long to launch" error — platform-wide if set via the
+ *  admin default. 100 leaves generous headroom over the longest realistic
+ *  model id (~40 chars, e.g. "claude-haiku-4-5-20251001") while sitting
+ *  nowhere near the deep link's actual limit; same order of magnitude as
+ *  the sibling tier-alias schema's `.max(40)` in admin-platform.ts, just
+ *  not cut as tight, since this field also accepts free-text pinned ids. */
+const MAX_TERMINAL_MODEL_VALUE_LENGTH = 100;
+
 /**
  * Config-time structural validation (AC-12), shared verbatim by the Profile
  * server action, the admin platform-default server action, and (duplicated,
  * dependency-free, same posture as the shared deep-link module's other
  * guards) the bridge/helper's own defense-in-depth re-check.
  *
- * Blocks empty/whitespace-only values and anything containing whitespace or
- * a shell metacharacter. The model rides the bridge's spawn command as a
- * single token (see terminal/bridge/src/resume-cmd.js) — it is never
- * shell-interpreted, but the rule mirrors the compact bootstrap prompt's own
- * argv-safety posture so a typo is caught here, at config time, instead of
- * surfacing later as an opaque `claude` CLI rejection in the terminal.
- * Structurally valid free text is otherwise accepted unconditionally — a
- * brand-new model family or a pinned model id needs no code change.
+ * Blocks empty/whitespace-only values, anything over the length cap, and
+ * anything containing whitespace or a shell metacharacter. The model rides
+ * the bridge's spawn command as a single token (see
+ * terminal/bridge/src/resume-cmd.js) — it is never shell-interpreted, but
+ * the rule mirrors the compact bootstrap prompt's own argv-safety posture so
+ * a typo is caught here, at config time, instead of surfacing later as an
+ * opaque `claude` CLI rejection in the terminal. Structurally valid free
+ * text is otherwise accepted unconditionally — a brand-new model family or
+ * a pinned model id needs no code change.
  */
 export function validateTerminalModelValue(value: string): TerminalModelValidation {
   if (value.trim().length === 0) {
     return { ok: false, reason: "Enter a model name, or choose one of the options above." };
+  }
+  if (value.trim().length > MAX_TERMINAL_MODEL_VALUE_LENGTH) {
+    return {
+      ok: false,
+      reason: `Model names can't be longer than ${MAX_TERMINAL_MODEL_VALUE_LENGTH} characters.`,
+    };
   }
   if (/\s/.test(value)) {
     return { ok: false, reason: "Model names can't contain spaces." };

--- a/src/lib/terminal/model-resolution.ts
+++ b/src/lib/terminal/model-resolution.ts
@@ -1,0 +1,162 @@
+// Terminal starting-model resolution (task c4ca2d95 "Terminal starting
+// model"). Mirrors the workflow model-tier platform-default/per-user-override
+// STORAGE + PRECEDENCE pattern (src/lib/platform-model-defaults.ts,
+// src/actions/profile.ts's model_tier_map handling) — not its three-tier
+// vocabulary. See docs/terminal-starting-model-design.html.
+//
+// BINDING (Nick, design-review approval gate, overrides the design doc's
+// seed recommendation): the platform default has NO seed value. Until an
+// admin explicitly sets one on the Platform tab, resolution omits the model
+// entirely — exactly today's behaviour (the local machine's Claude Code
+// default wins). Do not add a hardcoded seed anywhere in this module.
+//
+// Framework-agnostic (no "use server", no Next.js-only imports, no Supabase
+// import) so it's usable from client components, server actions, and the API
+// route alike — same posture as platform-model-defaults.ts.
+
+/**
+ * Sentinel stored on `users.terminal_model` (and selectable in the Profile
+ * UI) meaning "explicitly do not pass a model — the local machine's Claude
+ * Code config decides" (AC-5). Distinct from NULL/unset, which means "no
+ * override, use the platform default" (AC-6) — collapsing the two into one
+ * stored value would make it impossible to tell "never asked" apart from
+ * "asked not to." Mirrors model-tier-settings.tsx's `__platform_default__`
+ * sentinel one level up (Radix Select can't hold `""` as an item value).
+ */
+export const MACHINE_DEFAULT_TERMINAL_MODEL = "__machine_default__";
+
+/** The same 4 family aliases the workflow-tier UI already offers. "Known"
+ *  here only changes whether the UI shows a non-blocking amber advisory —
+ *  it never affects whether a value is ACCEPTED (custom free text is always
+ *  structurally valid; a new model family needs no code change). */
+export const KNOWN_TERMINAL_MODEL_ALIASES = ["fable", "opus", "sonnet", "haiku"] as const;
+export type KnownTerminalModelAlias = (typeof KNOWN_TERMINAL_MODEL_ALIASES)[number];
+
+export function isKnownTerminalModelAlias(value: string): boolean {
+  return (KNOWN_TERMINAL_MODEL_ALIASES as readonly string[]).includes(value);
+}
+
+export type TerminalModelValidation = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Config-time structural validation (AC-12), shared verbatim by the Profile
+ * server action, the admin platform-default server action, and (duplicated,
+ * dependency-free, same posture as the shared deep-link module's other
+ * guards) the bridge/helper's own defense-in-depth re-check.
+ *
+ * Blocks empty/whitespace-only values and anything containing whitespace or
+ * a shell metacharacter. The model rides the bridge's spawn command as a
+ * single token (see terminal/bridge/src/resume-cmd.js) — it is never
+ * shell-interpreted, but the rule mirrors the compact bootstrap prompt's own
+ * argv-safety posture so a typo is caught here, at config time, instead of
+ * surfacing later as an opaque `claude` CLI rejection in the terminal.
+ * Structurally valid free text is otherwise accepted unconditionally — a
+ * brand-new model family or a pinned model id needs no code change.
+ */
+export function validateTerminalModelValue(value: string): TerminalModelValidation {
+  if (value.trim().length === 0) {
+    return { ok: false, reason: "Enter a model name, or choose one of the options above." };
+  }
+  if (/\s/.test(value)) {
+    return { ok: false, reason: "Model names can't contain spaces." };
+  }
+  const SHELL_METACHARACTERS = /[\]`$(){}<>\\'"*?~#!;&|[]/;
+  if (SHELL_METACHARACTERS.test(value)) {
+    return {
+      ok: false,
+      reason:
+        "Model names can't contain shell characters. Use a family alias like opus or a model id like claude-opus-5.",
+    };
+  }
+  return { ok: true };
+}
+
+export interface ResolveTerminalModelInput {
+  /** The launching user's own `users.terminal_model` value. NULL/undefined = unset. */
+  userValue: string | null | undefined;
+  /** The live platform default. NULL/undefined = the admin has never set one. */
+  platformValue: string | null | undefined;
+}
+
+/**
+ * Resolution order (AC-7, binding approval-gate note): user override ->
+ * platform default -> omit. There is deliberately NO seed step — an unset
+ * platform default omits the model entirely, exactly like today's
+ * behaviour, until an admin explicitly sets one. Returns `undefined` when no
+ * `--model` flag should be passed at all.
+ *
+ * The machine-default sentinel wins over the platform default even when one
+ * is set (AC-5 takes precedence over AC-1/AC-3 for that user) — a user who
+ * deliberately opted out is never overridden by an admin's later change.
+ */
+export function resolveEffectiveTerminalModel({
+  userValue,
+  platformValue,
+}: ResolveTerminalModelInput): string | undefined {
+  if (userValue === MACHINE_DEFAULT_TERMINAL_MODEL) return undefined;
+  if (userValue) return userValue;
+  if (platformValue) return platformValue;
+  return undefined;
+}
+
+/** Display-cased model alias, e.g. "sonnet" -> "Sonnet". Local copy of
+ *  lib/constants.ts's capitalizeModelName (that module isn't terminal-
+ *  specific) so this stays a single, framework-agnostic import for the
+ *  admin/profile/chooser surfaces that need only this. */
+export function capitalizeTerminalModelName(model: string): string {
+  return model.charAt(0).toUpperCase() + model.slice(1);
+}
+
+export type TerminalModelSource = "platform" | "user" | "machine";
+
+/**
+ * The passive launch-surface line (design §4.2/§4.3): "New sessions start on
+ * <Model> · platform default|your setting" or "New sessions use your
+ * machine's default model" when the resolved source is "machine". Returns
+ * null when nothing would be passed at all (both platform and user are
+ * unset) — the design's instruction is to omit the line entirely rather than
+ * announce a non-event.
+ */
+export function terminalLaunchModelLine(
+  effectiveModel: string | undefined,
+  source: TerminalModelSource
+): string | null {
+  if (source === "machine") return "New sessions use your machine's default model.";
+  if (!effectiveModel) return null;
+  const modelLabel = capitalizeTerminalModelName(effectiveModel);
+  const sourceLabel = source === "user" ? "your setting" : "platform default";
+  return `New sessions start on ${modelLabel} · ${sourceLabel}.`;
+}
+
+/**
+ * The terser per-task dedupe-dialog variant (design §4.3, Design Review
+ * note 2: "Starts on Sonnet · your setting" is enough — no "New sessions"
+ * preamble, no link, no machine-default case since a fresh session's model
+ * is what "Start fresh anyway" is qualifying). Returns null when nothing
+ * would be passed at all, same omission rule as terminalLaunchModelLine.
+ */
+export function terminalDialogModelLine(
+  effectiveModel: string | undefined,
+  source: TerminalModelSource
+): string | null {
+  if (source === "machine") return "Starts on your machine's default model.";
+  if (!effectiveModel) return null;
+  const modelLabel = capitalizeTerminalModelName(effectiveModel);
+  const sourceLabel = source === "user" ? "your setting" : "platform default";
+  return `Starts on ${modelLabel} · ${sourceLabel}.`;
+}
+
+/**
+ * Which source resolveEffectiveTerminalModel actually used — for the launch
+ * surfaces' source tag ("your setting" vs "platform default" vs "your
+ * machine decides"). Kept separate from the resolver above so callers that
+ * only need the flag value (mint time) don't have to compute this too.
+ */
+export function resolveTerminalModelSource({
+  userValue,
+  platformValue: _platformValue,
+}: ResolveTerminalModelInput): TerminalModelSource {
+  if (userValue === MACHINE_DEFAULT_TERMINAL_MODEL) return "machine";
+  if (userValue) return "user";
+  return "platform";
+}

--- a/src/lib/terminal/platform-terminal-model.test.ts
+++ b/src/lib/terminal/platform-terminal-model.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  getPlatformTerminalModelDefault,
+  isValidPlatformTerminalModelDefault,
+  TERMINAL_MODEL_DEFAULT_KEY,
+} from "./platform-terminal-model";
+
+/** Minimal Supabase-shaped mock: `.from(table).select().eq().maybeSingle()`. */
+function makeSupabase(result: { data: unknown; error: { message: string } | null }) {
+  const chain = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    maybeSingle: vi.fn(() => Promise.resolve(result)),
+  };
+  return { from: vi.fn(() => chain) } as unknown as Parameters<typeof getPlatformTerminalModelDefault>[0];
+}
+
+describe("isValidPlatformTerminalModelDefault", () => {
+  it("accepts a valid shape, including a novel free-text family", () => {
+    expect(isValidPlatformTerminalModelDefault({ model: "opus" })).toBe(true);
+    expect(isValidPlatformTerminalModelDefault({ model: "claude-opus-5-20260101" })).toBe(true);
+  });
+
+  it("rejects non-objects, arrays, and null", () => {
+    expect(isValidPlatformTerminalModelDefault(null)).toBe(false);
+    expect(isValidPlatformTerminalModelDefault(undefined)).toBe(false);
+    expect(isValidPlatformTerminalModelDefault("opus")).toBe(false);
+    expect(isValidPlatformTerminalModelDefault([])).toBe(false);
+  });
+
+  it("rejects a missing or empty model field", () => {
+    expect(isValidPlatformTerminalModelDefault({})).toBe(false);
+    expect(isValidPlatformTerminalModelDefault({ model: "" })).toBe(false);
+    expect(isValidPlatformTerminalModelDefault({ model: "   " })).toBe(false);
+    expect(isValidPlatformTerminalModelDefault({ model: 5 })).toBe(false);
+  });
+});
+
+describe("getPlatformTerminalModelDefault (binding: NO seed — absent means omit)", () => {
+  it("returns null when the row is missing — nothing saved yet, no warning-worthy condition", async () => {
+    const supabase = makeSupabase({ data: null, error: null });
+    const result = await getPlatformTerminalModelDefault(supabase);
+    expect(result).toBeNull();
+  });
+
+  it("returns null (never a hardcoded seed) on a query error", async () => {
+    const supabase = makeSupabase({ data: null, error: { message: "connection reset" } });
+    const result = await getPlatformTerminalModelDefault(supabase);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the stored value is structurally invalid, never crashes", async () => {
+    const supabase = makeSupabase({ data: { value: { notModel: "opus" } }, error: null });
+    const result = await getPlatformTerminalModelDefault(supabase);
+    expect(result).toBeNull();
+  });
+
+  it("returns the live stored model when valid", async () => {
+    const supabase = makeSupabase({ data: { value: { model: "opus" } }, error: null });
+    const result = await getPlatformTerminalModelDefault(supabase);
+    expect(result).toBe("opus");
+  });
+
+  it("returns a novel/custom model family verbatim", async () => {
+    const supabase = makeSupabase({ data: { value: { model: "opus-5.5" } }, error: null });
+    const result = await getPlatformTerminalModelDefault(supabase);
+    expect(result).toBe("opus-5.5");
+  });
+
+  it("queries by the documented settings key", async () => {
+    const supabase = makeSupabase({ data: null, error: null });
+    await getPlatformTerminalModelDefault(supabase);
+    const chain = (supabase.from as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(supabase.from).toHaveBeenCalledWith("platform_settings");
+    expect(chain.eq).toHaveBeenCalledWith("key", TERMINAL_MODEL_DEFAULT_KEY);
+  });
+
+  it("never throws even if the client itself throws synchronously (AC-2: never block a launch)", async () => {
+    const throwingSupabase = {
+      from: () => {
+        throw new Error("client not configured");
+      },
+    } as unknown as Parameters<typeof getPlatformTerminalModelDefault>[0];
+
+    await expect(getPlatformTerminalModelDefault(throwingSupabase)).resolves.toBeNull();
+  });
+});

--- a/src/lib/terminal/platform-terminal-model.ts
+++ b/src/lib/terminal/platform-terminal-model.ts
@@ -1,0 +1,81 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+import { logger } from "@/lib/logger";
+
+/**
+ * Admin-configurable platform default for the in-app terminal's starting
+ * model (task c4ca2d95). Mirrors platform-model-defaults.ts's STORAGE
+ * pattern (one platform_settings row) but NOT its seed posture — see the
+ * BINDING note on getPlatformTerminalModelDefault below.
+ */
+
+export const TERMINAL_MODEL_DEFAULT_KEY = "terminal_model_default";
+
+export interface PlatformTerminalModelDefault {
+  /** Free-text family alias or model id, passed verbatim as `claude --model <value>`. */
+  model: string;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Structural validation only — free-text models are allowed by design, so
+ *  this checks shape, never the model string's contents (that's
+ *  validateTerminalModelValue's job, applied at save time). */
+export function isValidPlatformTerminalModelDefault(value: unknown): value is PlatformTerminalModelDefault {
+  return isPlainObject(value) && typeof value.model === "string" && value.model.trim().length > 0;
+}
+
+/**
+ * Reads the platform-wide terminal starting-model default.
+ *
+ * BINDING (Nick, design-review approval gate): UNLIKE getPlatformModelDefaults(),
+ * there is deliberately NO seed fallback here. Missing row, malformed value,
+ * and a query error all degrade to `null` — omit the model, exactly today's
+ * behaviour — never a hardcoded value. `logger.warn` fires only for the
+ * genuinely abnormal cases (malformed value / query error); a missing row
+ * ("nothing saved yet", the expected state until an admin opts in) is silent.
+ *
+ * Read at session-mint time — per-request, no cache, so an admin's edit
+ * applies to the very next launch. Never throws (AC-2: a resolution failure
+ * must degrade gracefully, never block a launch).
+ */
+export async function getPlatformTerminalModelDefault(
+  supabase: SupabaseClient<Database>
+): Promise<string | null> {
+  try {
+    const { data, error } = await supabase
+      .from("platform_settings")
+      .select("value")
+      .eq("key", TERMINAL_MODEL_DEFAULT_KEY)
+      .maybeSingle();
+
+    if (error) {
+      logger.warn("Failed to read platform_settings.terminal_model_default — omitting model", {
+        error: error.message,
+      });
+      return null;
+    }
+
+    if (!data) {
+      // Missing row (nothing saved yet, or an admin cleared it back to unset)
+      // -> omit, no warning (this is the expected default state, not an error).
+      return null;
+    }
+
+    if (!isValidPlatformTerminalModelDefault(data.value)) {
+      logger.warn("Invalid platform_settings.terminal_model_default value — omitting model", {
+        value: data.value,
+      });
+      return null;
+    }
+
+    return data.value.model;
+  } catch (err) {
+    logger.warn("Unexpected error reading platform_settings.terminal_model_default — omitting model", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -38,6 +38,11 @@ export type Database = {
           };
           default_board_columns: { title: string; is_done_column: boolean }[] | null;
           model_tier_map: { frontier?: string; standard?: string; cheap?: string } | null;
+          /** In-app terminal starting-model override. NULL = platform default;
+           *  '__machine_default__' = explicit opt-out (see MACHINE_DEFAULT_TERMINAL_MODEL
+           *  in src/lib/terminal/model-resolution.ts); any other string = passed
+           *  verbatim as `claude --model <value>` on fresh sessions only. */
+          terminal_model: string | null;
           is_admin: boolean;
           is_super_admin: boolean;
           is_bot: boolean;
@@ -80,6 +85,7 @@ export type Database = {
           };
           default_board_columns?: { title: string; is_done_column: boolean }[] | null;
           model_tier_map?: { frontier?: string; standard?: string; cheap?: string } | null;
+          terminal_model?: string | null;
           is_admin?: boolean;
           is_super_admin?: boolean;
           is_bot?: boolean;
@@ -116,6 +122,7 @@ export type Database = {
           };
           default_board_columns?: { title: string; is_done_column: boolean }[] | null;
           model_tier_map?: { frontier?: string; standard?: string; cheap?: string } | null;
+          terminal_model?: string | null;
           is_admin?: boolean;
           is_super_admin?: boolean;
           is_bot?: boolean;

--- a/supabase/migrations/00161_user_terminal_model.sql
+++ b/supabase/migrations/00161_user_terminal_model.sql
@@ -1,0 +1,35 @@
+-- Per-user override for the in-app terminal's starting model (task c4ca2d95
+-- "Terminal starting model" — Nick's report: sessions were starting on Opus
+-- 4.8 because VibeCodes never passed a model anywhere in the launch chain).
+-- Mirrors users.model_tier_map's additive/nullable posture (00134) but
+-- stores a single free-text value, not a tier map, and needs a THIRD state
+-- that a single nullable column can still represent (Radix Select can't
+-- hold "" as an item value, so the UI needs a real sentinel string, not an
+-- empty one):
+--
+--   NULL                    -> no override; resolve to the platform default
+--                              (platform_settings key terminal_model_default
+--                              -- see src/lib/terminal/platform-terminal-model.ts).
+--                              If the platform default is ALSO unset, no
+--                              --model flag is passed at all (Nick's binding
+--                              approval-gate note: no seed value here, unlike
+--                              model_tier_defaults' "opus" seed).
+--   '__machine_default__'   -> explicit opt-out (AC-5): never pass --model,
+--                              the user's local Claude Code config decides.
+--                              Distinct from NULL so "no override" and
+--                              "deliberately no model" can't collapse into
+--                              the same stored value (AC-5 vs AC-6).
+--   any other string        -> passed verbatim as `claude --model <value>`
+--                              on the user's next FRESH terminal session
+--                              (resumed sessions never receive it).
+--
+-- No DB-level CHECK on content — free-text family aliases/model ids by
+-- design (a new model family needs no schema change), validated at the
+-- server-action boundary (src/lib/terminal/model-resolution.ts,
+-- validateTerminalModelValue — shared with the admin platform-default save
+-- path), not here.
+ALTER TABLE users
+  ADD COLUMN terminal_model text;
+
+COMMENT ON COLUMN users.terminal_model IS
+  'Per-user override for the in-app terminal''s starting model. NULL = no override, use the platform default (see platform_settings.terminal_model_default); ''__machine_default__'' = explicit opt-out, never pass --model (local Claude Code config wins); any other string = passed verbatim as claude --model <value> on fresh sessions only. Validated by src/lib/terminal/model-resolution.ts, not a DB constraint.';

--- a/terminal/RUN.md
+++ b/terminal/RUN.md
@@ -149,6 +149,7 @@ cd terminal/bridge && RELAY_URL=ws://127.0.0.1:8787 SESSION_ID=a3f9 \
 | `--token <jwt>` | `BRIDGE_TOKEN` | — | **required** app-minted `bridge`-role token |
 | `--cmd <command…>` | `BRIDGE_CMD` | `claude` | command to run in the PTY |
 | `--cwd <dir>` | `BRIDGE_CWD` | cwd | PTY working directory |
+| — (via `--launch-url`'s `model` param) | `BRIDGE_MODEL` | — | appended as `--model <value>` on a FRESH spawn only (task c4ca2d95); never on `--resume`/`--continue`/`--cmd` — see resume-cmd.js |
 | `--max-seconds <n>` | `BRIDGE_MAX_SECONDS` | `28800` | hard self-kill safety cap |
 | `--connect-timeout-ms <n>` | — | `30000` | fail if relay never opens |
 

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -153,10 +153,18 @@ const RESUME_ID = sanitizeConversationId(launched?.resumeId);
 // convenience) — see resolveClaudeLaunch's doc for the full launch-shape
 // priority order and the empirical finding behind CONV.
 const explicitCmd = args.cmd || process.env.BRIDGE_CMD || null;
+// Task c4ca2d95 ("Terminal starting model"): the deep link's `model` param,
+// already parse-time validated by the shared module's isSafeModelValue
+// (whitespace/shell-metacharacter rejection — see deep-link.mjs). Only ever
+// applied by resolveClaudeLaunch on a genuinely fresh session (branch 4) —
+// resume/resumeId/explicitCmd never read it. `--model` on the bare CLI
+// (BRIDGE_MODEL env, dev/test convenience) mirrors --cmd's own env fallback.
+const MODEL = launched?.model || process.env.BRIDGE_MODEL || null;
 const { cmd: CMD, conv: CONV } = resolveClaudeLaunch({
   explicitCmd,
   resumeId: RESUME_ID,
   resume: RESUME,
+  model: MODEL,
   mintId: () => crypto.randomUUID(),
 });
 const CWD = launched?.cwd || args.cwd || process.env.BRIDGE_CWD || process.cwd();

--- a/terminal/bridge/src/resume-cmd.js
+++ b/terminal/bridge/src/resume-cmd.js
@@ -37,15 +37,28 @@
 // terminal/shared/deep-link.mjs's build/parse precedence) — if a caller
 // somehow sets both, `resumeId` wins here too, for the same reason: it is
 // the verified-safe, exact path.
+//
+// `model` (task c4ca2d95, "Terminal starting model") is appended as
+// `--model <value>` ONLY on branch 4 (a genuinely fresh session) —
+// deliberately never read in branches 1-3. A resumed/continued conversation
+// keeps whatever model it was already running on; appending a model flag
+// there would be at best meaningless (`--continue`/`--resume` don't restart
+// the model) and at worst confusing. `model` already arrived pre-validated
+// (see index.js's LAUNCH_URL parse via the shared deep-link module's
+// isSafeModelValue, and the config-time validateTerminalModelValue upstream
+// of that) — it contains no whitespace or shell metacharacters, so it's
+// safe to embed directly in this shell-split CMD string as a single token,
+// identical in effect to appending it as a separate argv element.
 
 /**
- * @param {{ explicitCmd?: string | null, resumeId?: string | null, resume?: boolean, mintId: () => string }} opts
+ * @param {{ explicitCmd?: string | null, resumeId?: string | null, resume?: boolean, model?: string | null, mintId: () => string }} opts
  * @returns {{ cmd: string, conv: string | null }}
  */
-export function resolveClaudeLaunch({ explicitCmd, resumeId, resume, mintId }) {
+export function resolveClaudeLaunch({ explicitCmd, resumeId, resume, model, mintId }) {
   if (explicitCmd) return { cmd: explicitCmd, conv: null };
   if (resumeId) return { cmd: `claude --resume ${resumeId}`, conv: resumeId };
   if (resume) return { cmd: "claude --continue", conv: null };
   const conv = mintId();
-  return { cmd: `claude --session-id ${conv}`, conv };
+  const modelFlag = model ? ` --model ${model}` : "";
+  return { cmd: `claude --session-id ${conv}${modelFlag}`, conv };
 }

--- a/terminal/bridge/src/resume-cmd.test.js
+++ b/terminal/bridge/src/resume-cmd.test.js
@@ -59,3 +59,38 @@ test("falsy resumeId/resume (undefined, empty string, false) all fall through to
     }
   }
 });
+
+// ── terminal starting model (task c4ca2d95) — model only ever applies to a
+// fresh mint (branch 4); branches 1-3 must never append --model. ───────────
+
+test("a fresh mint with a model appends --model <value> after --session-id", () => {
+  const result = resolveClaudeLaunch({ model: "opus", mintId: () => MINTED });
+  assert.deepEqual(result, { cmd: `claude --session-id ${MINTED} --model opus`, conv: MINTED });
+});
+
+test("a fresh mint with no model spawns exactly today's command — no trailing space, no flag", () => {
+  const result = resolveClaudeLaunch({ mintId: () => MINTED });
+  assert.equal(result.cmd, `claude --session-id ${MINTED}`);
+});
+
+test("a novel/custom model id is carried verbatim", () => {
+  const result = resolveClaudeLaunch({ model: "claude-opus-5-20260101", mintId: () => MINTED });
+  assert.equal(result.cmd, `claude --session-id ${MINTED} --model claude-opus-5-20260101`);
+});
+
+test("resumeId NEVER receives --model, even if one is somehow passed (AC-8)", () => {
+  const result = resolveClaudeLaunch({ resumeId: RESUME_ID, model: "opus", mintId: () => MINTED });
+  assert.equal(result.cmd, `claude --resume ${RESUME_ID}`);
+  assert.ok(!result.cmd.includes("--model"));
+});
+
+test("the legacy --continue resume NEVER receives --model, even if one is somehow passed (AC-8)", () => {
+  const result = resolveClaudeLaunch({ resume: true, model: "opus", mintId: () => MINTED });
+  assert.equal(result.cmd, "claude --continue");
+  assert.ok(!result.cmd.includes("--model"));
+});
+
+test("an explicit --cmd override NEVER receives --model, even if one is somehow passed", () => {
+  const result = resolveClaudeLaunch({ explicitCmd: "bash", model: "opus", mintId: () => MINTED });
+  assert.deepEqual(result, { cmd: "bash", conv: null });
+});

--- a/terminal/shared/deep-link.mjs
+++ b/terminal/shared/deep-link.mjs
@@ -60,12 +60,29 @@
 //             or non-sane falls back to the bridge's pre-existing hardcoded
 //             default, exactly like before this field existed (no
 //             version-skew risk).
+//   model   — task c4ca2d95 ("Terminal starting model"): the resolved
+//             starting model for a FRESH session only (user override ->
+//             platform default -> omit, resolved server-side at mint time).
+//             The bridge appends `--model <value>` to the fresh-spawn CMD
+//             (terminal/bridge/src/resume-cmd.js) — NEVER on a resume/
+//             resumeId launch (AC-8: a resumed conversation keeps its own
+//             model; resolveClaudeLaunch's resume branches never read this
+//             field). Re-validated at parse time (isSafeModelValue below,
+//             mirrors src/lib/terminal/model-resolution.ts's
+//             validateTerminalModelValue) since it rides the bridge's
+//             shellSplit CMD string as a single token — a malformed value
+//             is rejected outright rather than forwarded, same posture as
+//             resume_id/cols/rows above. An old helper's bundled copy of
+//             this module simply never reads `model` off the URL (AC-13) —
+//             no version-skew risk, same as every other param here.
 //
 // `token` and `helperToken` are secrets and `prompt` is user content. NEVER log
-// a raw link — use redactDeepLinkToken first (it elides all three). `prompt` is
-// always the LAST param (the dock's URL-length budgeting relies on this — see
-// src/lib/terminal/deep-link.ts's doc comment) — `helperToken` is inserted
-// BEFORE it, alongside the other credentials, so that invariant holds.
+// a raw link — use redactDeepLinkToken first (it elides all three; `model` is
+// neither a secret nor free-form user content — a fixed alias/model id — so it
+// is deliberately left untouched by the redactor, same as relay/session). `prompt`
+// is always the LAST param (the dock's URL-length budgeting relies on this — see
+// src/lib/terminal/deep-link.ts's doc comment) — `helperToken`/`model` are
+// inserted BEFORE it, alongside the other credentials, so that invariant holds.
 //
 // Pure + dependency-free (only the global WHATWG `URL`), so it runs unchanged in
 // Node (bridge) and is trivially unit-testable.
@@ -90,8 +107,22 @@ function isValidLaunchDim(n) {
   return Number.isInteger(n) && n > 0 && n <= 1000;
 }
 
+/** Model value structural safety — mirrors src/lib/terminal/model-resolution.ts's
+ *  validateTerminalModelValue. Duplicated (not imported) to keep this module
+ *  dependency-free, same posture as UUID_RE/isValidLaunchDim above. Rejects
+ *  anything empty or containing whitespace or a shell metacharacter — the
+ *  model rides the bridge's shellSplit CMD string as a single token (see
+ *  terminal/bridge/src/resume-cmd.js), so a malformed value here would either
+ *  merge into an adjacent token or break tokenization; there is no safe
+ *  partial value, so it's rejected outright rather than forwarded.
+ *  @param {unknown} v
+ *  @returns {boolean} */
+function isSafeModelValue(v) {
+  return typeof v === "string" && v.length > 0 && !/[\s\]`$(){}<>\\'"*?~#!;&|[]/.test(v);
+}
+
 /**
- * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…][&cols=…&rows=…][&prompt=…]`
+ * Build a `vibecodes://launch?relay=…&session=…&token=…[&cwd=…][&cols=…&rows=…][&model=…][&prompt=…]`
  * deep link.
  *
  * Uses encodeURIComponent so reserved characters in the relay URL / token /
@@ -100,10 +131,10 @@ function isValidLaunchDim(n) {
  * (and therefore the app-side prompt budget) is stable. Throws when a required
  * field is missing so a malformed link is never fired.
  *
- * @param {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean, resumeId?: string, cols?: number, rows?: number }} params
+ * @param {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean, resumeId?: string, cols?: number, rows?: number, model?: string }} params
  * @returns {string}
  */
-export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt, resume, resumeId, cols, rows } = {}) {
+export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, prompt, resume, resumeId, cols, rows, model } = {}) {
   if (!relay || !session || !token) {
     throw new Error("buildLaunchDeepLink requires relay, session and token");
   }
@@ -127,6 +158,9 @@ export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, p
   if (isValidLaunchDim(cols) && isValidLaunchDim(rows)) {
     parts.push(`cols=${cols}`, `rows=${rows}`);
   }
+  // Task c4ca2d95: inserted before `prompt` (which stays LAST — see the
+  // header comment) alongside the other optional non-secret params.
+  if (model) parts.push(`model=${encodeURIComponent(model)}`);
   if (prompt) parts.push(`prompt=${encodeURIComponent(prompt)}`);
   return `${LAUNCH_SCHEME}://${LAUNCH_HOST}?${parts.join("&")}`;
 }
@@ -141,7 +175,7 @@ export function buildLaunchDeepLink({ relay, session, token, helperToken, cwd, p
  * param existed (version-skew safe both ways).
  *
  * @param {unknown} url
- * @returns {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean, resumeId?: string, cols?: number, rows?: number } | null}
+ * @returns {{ relay: string, session: string, token: string, helperToken?: string, cwd?: string, prompt?: string, resume?: boolean, resumeId?: string, cols?: number, rows?: number, model?: string } | null}
  */
 export function parseLaunchDeepLink(url) {
   if (typeof url !== "string" || url.length === 0) return null;
@@ -178,6 +212,12 @@ export function parseLaunchDeepLink(url) {
   const parsedCols = rawCols === null ? NaN : Number(rawCols);
   const parsedRows = rawRows === null ? NaN : Number(rawRows);
   const dimsValid = isValidLaunchDim(parsedCols) && isValidLaunchDim(parsedRows);
+  // Task c4ca2d95: re-validated here exactly like resumeId/cols/rows above —
+  // it's about to ride the bridge's shellSplit CMD string as a bare token,
+  // so there is no safe partial value. An old helper's bundled copy of this
+  // parser simply never reads "model" at all (AC-13) — no version-skew risk.
+  const rawModel = parsed.searchParams.get("model");
+  const model = rawModel && isSafeModelValue(rawModel) ? rawModel : undefined;
   if (!relay || !session || !token) return null;
 
   const out = { relay, session, token };
@@ -189,6 +229,7 @@ export function parseLaunchDeepLink(url) {
     out.cols = parsedCols;
     out.rows = parsedRows;
   }
+  if (model) out.model = model;
   if (prompt) out.prompt = prompt;
   return out;
 }

--- a/terminal/test/deep-link.test.mjs
+++ b/terminal/test/deep-link.test.mjs
@@ -177,6 +177,40 @@ test("non-sane cols/rows (zero, negative, non-integer, absurdly large) are rejec
   }
 });
 
+// ── terminal starting model (task c4ca2d95) ────────────────────────────────
+
+test("build ⇄ parse round-trips model, positioned before prompt", () => {
+  const withModel = { ...SAMPLE, model: "opus", prompt: "hello" };
+  const url = buildLaunchDeepLink(withModel);
+  assert.ok(url.includes("model=opus"));
+  assert.ok(url.indexOf("model=") < url.indexOf("prompt="), "model precedes the LAST param, prompt");
+  assert.deepEqual(parseLaunchDeepLink(url), withModel);
+});
+
+test("omits model entirely when absent — no version-skew risk for an old bridge/helper (AC-13)", () => {
+  const url = buildLaunchDeepLink(SAMPLE);
+  assert.ok(!url.includes("model="));
+  assert.ok(!("model" in parseLaunchDeepLink(url)));
+});
+
+test("round-trips a custom (non-alias) model id verbatim", () => {
+  const url = buildLaunchDeepLink({ ...SAMPLE, model: "claude-opus-5-20260101" });
+  assert.equal(parseLaunchDeepLink(url).model, "claude-opus-5-20260101");
+});
+
+test("a malformed model value (whitespace/shell metacharacters) is rejected outright — never forwarded", () => {
+  const url = `${LAUNCH_SCHEME}://${LAUNCH_HOST}?relay=r&session=s&token=t&model=${encodeURIComponent("opus; rm -rf")}`;
+  const parsed = parseLaunchDeepLink(url);
+  assert.ok(parsed !== null);
+  assert.ok(!("model" in parsed));
+});
+
+test("redactDeepLinkToken leaves model untouched — not a secret or free-form user content (AC-10)", () => {
+  const url = buildLaunchDeepLink({ ...SAMPLE, model: "opus" });
+  const redacted = redactDeepLinkToken(url);
+  assert.ok(redacted.includes("model=opus"));
+});
+
 test("redactDeepLinkToken elides the prompt (user content) as well as the token", () => {
   const url = buildLaunchDeepLink({ ...SAMPLE, prompt: HOSTILE_PROMPT });
   const redacted = redactDeepLinkToken(url);


### PR DESCRIPTION
## Summary
Terminal sessions currently start on whatever model the user's local Claude Code config defaults to (for Nick: Opus 4.8), because VibeCodes never passes a model anywhere in the launch chain. This makes the starting model configurable, mirroring the workflow model-tier pattern:

- **Platform default** — new `platform_settings` key `terminal_model_default`, editable via a new "Terminal starting model" card on the admin Platform tab. Ships **unset** (no seed): behaviour is unchanged for everyone until an admin sets a value.
- **Per-user override** — new nullable `users.terminal_model` column (migration `00161`), editable in the existing Model Tiers dialog as a "Terminal sessions" group: Platform default / My machine's default (explicit `__machine_default__` sentinel — never pass a model) / known aliases / custom free text.
- **Resolution** at session mint, server-side, per-request: user override → platform default → omit the flag. Carried as a new optional `model` param on the launch deep link (both builders, drift-tested, inserted before `prompt`) and applied by the bridge as `claude --model <value>` — **fresh sessions only**; resumed sessions never receive it.
- Validation (shared, server-enforced on both save paths): rejects empty, whitespace/shell metacharacters, and values over 100 chars.
- Launch surfaces show the effective model passively (chooser footer + per-task dialog); the instant direct-launch path is untouched.

Board task: c4ca2d95 ("Terminal starting model") — full Requirements/Design/QA trail on the card. Design doc: `docs/terminal-starting-model-design.html`.

## Test plan
- `npm run typecheck` clean, lint 0 errors
- `npm run test`: 193 files / 3,247 tests passing (~330 new)
- terminal/bridge 33/33 (6 new model-spawn-arg tests), terminal/relay 45/45, shared deep-link drift suite 25/25
- QA verified all 14 acceptance criteria incl. resume paths byte-identical to master when no model is set, old-helper compatibility with the unknown param, and redaction leaving the model value intact
- Post-merge: apply migration 00161 (additive nullable column, applied directly per Nick), set the platform default on the admin Platform tab, verify a fresh session starts on latest Opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)