### PR TITLE
fix(terminal): resume takes over its own ended tab instead of leaving it behind

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -158,6 +158,32 @@ vi.mock("./terminal-session-view", () => ({
         >
           report ended
         </button>
+        {/* Card df29b85e regression test (ended-tab reclaim): `report-ended`
+            above reports a per-key sid (`sid-for-${entry.key}`), which never
+            lines up with THIS tab's own "Resume this conversation" button —
+            that button always fires the fixed "sid-ended-own-tab" (mirrors
+            the real ended panel's `pair.sessionId`, a single tab's own last
+            session, not derived from its dock key). A dedicated button
+            reports the matching sid so a test can put this tab into the
+            exact state `mintAndDeliver`'s reclaim check needs before
+            clicking Resume. */}
+        <button
+          data-testid={`report-ended-own-sid-${entry.key}`}
+          onClick={() =>
+            onReportSummary(entry.key, {
+              status: "session-ended",
+              sessionId: "sid-ended-own-tab",
+              errorKind: null,
+              launchPhase: "idle",
+              platformSupported: true,
+              paired: true,
+              browserToken: null,
+              readOnly: false,
+            })
+          }
+        >
+          report ended (own sid)
+        </button>
         {/* Lets a test drive this tab to a real MINTED-and-connected status —
             `handlePopOut` (terminal-dock.tsx) bails out silently unless the
             summary carries both a sessionId and a browserToken, so the
@@ -1095,8 +1121,42 @@ describe("TerminalDock — cross-board resume (bug 62e57071)", () => {
 
     expect(mockRouterPush).not.toHaveBeenCalled();
     // A genuine local mint happened (never a silent no-op) — this board's
-    // own dock delivered the resume itself instead of navigating away.
+    // own dock delivered the resume itself instead of navigating away. This
+    // test never puts the tab into a reported "ended" state (see the
+    // dedicated reclaim test just below for that), so mintAndDeliver's
+    // reclaim check can't match and it falls through to appending — the
+    // pristine slot was already used by the `requestBrowserLaunch` above,
+    // so this is a genuine 2nd tab.
     await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(2));
+  });
+
+  // Card df29b85e (field report 22 Aug 2026): "Resuming an ended terminal
+  // session correctly mints a NEW session, but the dock always opens it in a
+  // NEW tab, leaving the dead tab behind." Same setup as the test just
+  // above — same-board resume — but this one first drives the tab into a
+  // reported "session-ended" state with the SAME sid the "Resume this
+  // conversation" button fires (`report-ended-own-sid-${key}`, see the stub's
+  // doc), so `mintAndDeliver`'s ended-tab reclaim (`findReclaimableEndedSlot`)
+  // has what it needs to take this exact tab over instead of appending a
+  // sibling next to it.
+  it("an already-mounted tab's own Resume reclaims that SAME tab in place — never leaves the dead tab behind (card df29b85e)", async () => {
+    stubFetch(Promise.resolve([]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    act(() => {
+      requestBrowserLaunch({ ideaId: "idea-1" });
+    });
+    await waitFor(() => expect(screen.getByTestId("session-view").dataset.ideaId).toBe("idea-1"));
+
+    const key = screen.getByTestId("session-view").dataset.key;
+    fireEvent.click(screen.getByTestId(`report-ended-own-sid-${key}`));
+    fireEvent.click(screen.getByTestId(`resume-ended-${key}`));
+
+    // Still exactly one tab, and it's the SAME tab (same key) — reclaimed in
+    // place, not replaced by a new one leaving the ended tab behind.
+    expect(screen.getAllByTestId("session-view")).toHaveLength(1);
+    expect(screen.getByTestId("session-view").dataset.key).toBe(key);
   });
 });
 

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -154,9 +154,11 @@ import {
   isLiveTabStatus,
   deriveTabLabel,
   findPristineSlot,
+  findReclaimableEndedSlot,
   decideTaskLaunch,
   summarizeSessionStatuses,
   type DedupeCandidate,
+  type ReclaimCandidate,
 } from "./terminal-tabs";
 import {
   TerminalSessionView,
@@ -390,6 +392,15 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // state) because it's read only from inside a native-event callback that
   // must see the CURRENT value without itself triggering a re-render.
   const chooserRenamingActiveRef = useRef(false);
+  // Bug df29b85e (resume opens a new tab, leaves the dead one behind, field
+  // report 22 Aug 2026): `mintAndDeliver`'s ended-tab reclaim path needs a
+  // synchronous read of which tabs are popped out, same reason as the two
+  // refs above — a popped-out tab's OWN reported status is untrustworthy
+  // (see `requestClose`'s identical `poppedOutKeys.has(key) ||
+  // isLiveTabStatus(status)` combined check just below), so reclaim must
+  // never take over one even if its last-known status happens to read
+  // "session-ended".
+  const poppedOutKeysRef = useRef(poppedOutKeys);
   const posthog = usePostHog();
   const posthogRef = useRef(posthog);
   // Session entry chooser (card cbe60db5): mirrors `entryDecision` (declared
@@ -404,8 +415,9 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   useEffect(() => {
     sessionsRef.current = sessions;
     summariesRef.current = summaries;
+    poppedOutKeysRef.current = poppedOutKeys;
     posthogRef.current = posthog;
-  }, [sessions, summaries, posthog]);
+  }, [sessions, summaries, poppedOutKeys, posthog]);
   // Bug B (card cbe60db5 rework 9 — RELEASE-BLOCKING, Nick's field test
   // 2026-08-14): `deliverLaunch` below used to treat `entryDecisionRef.current
   // === null` (the registry fetch is STILL LOADING — genuinely unknown, never
@@ -1340,7 +1352,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // reached either directly (F1's empty-launch state — nothing to choose
   // between) or via the chooser's "Start new session" (see `deliverLaunch`
   // below, which decides which of the two applies).
-  const mintAndDeliver = useCallback((payload: BrowserLaunchPayload | null) => {
+  const mintAndDeliver = useCallback((payload: BrowserLaunchPayload | null, targetSessionId?: string | null) => {
     const currentSessions = sessionsRef.current;
     const currentSummaries = summariesRef.current;
     const candidates: DedupeCandidate[] = currentSessions.map((s) => ({
@@ -1357,6 +1369,48 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     }
 
     setExpanded(true);
+
+    // Ended-tab reclaim (card df29b85e, field report 22 Aug 2026): a resume
+    // that names the sid of a tab already sitting here, already ended, takes
+    // that tab over IN PLACE instead of opening a sibling next to its own
+    // corpse. Checked before the pristine-slot reuse below — the two never
+    // overlap in practice (a reclaimable tab has already connected once, so
+    // its `launchSeq` can't be 0) but reclaim is the more SPECIFIC intent
+    // (an explicit originating sid was named) so it goes first on principle.
+    const reclaimCandidates: ReclaimCandidate[] = currentSessions.map((s) => ({
+      key: s.key,
+      status: currentSummaries[s.key]?.status ?? "idle",
+      sessionId: currentSummaries[s.key]?.sessionId ?? null,
+      poppedOut: poppedOutKeysRef.current.has(s.key),
+    }));
+    const reclaimKey = findReclaimableEndedSlot(reclaimCandidates, targetSessionId);
+    if (reclaimKey) {
+      setSessions((prev) =>
+        prev.map((s) =>
+          s.key === reclaimKey
+            ? {
+                ...s,
+                origin: payload?.resume || payload?.resumeId ? "resume" : payload?.taskId ? "task" : "toolbar",
+                taskId: payload?.taskId,
+                taskTitle: payload?.taskTitle,
+                // Card 3bf262ac (tab rename): match the pristine-slot and
+                // fresh-entry branches below — a reclaimed tab picks up
+                // whatever displayName this launch carries (usually
+                // undefined, falling back to the derived label) rather than
+                // silently keeping a stale custom rename from its dead
+                // session.
+                displayName: payload?.displayName,
+                ideaId: payload?.ideaId ?? ideaId,
+                launchSeq: s.launchSeq + 1,
+                launchPayload: payload ?? null,
+              }
+            : s,
+        ),
+      );
+      setActiveKey(reclaimKey);
+      return;
+    }
+
     const pristineKey = findPristineSlot(
       currentSessions.map((s) => ({ key: s.key, launchSeq: s.launchSeq, hasAttach: !!s.attach })),
     );
@@ -1721,7 +1775,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       toast.error("Couldn't find that session to resume — it may have expired.");
       return;
     }
-    mintAndDeliver(buildResumePayload(row));
+    mintAndDeliver(buildResumePayload(row), row.sid);
   }, [resumeParam, registryRows, pathname, mintAndDeliver, buildResumePayload]);
 
   // ── chooser action handlers ─────────────────────────────────────────────────
@@ -1785,7 +1839,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       // `claude --continue`. Now built by `buildResumePayload` above, which
       // this exact payload shape moved into (cross-board resume fix) so the
       // `?resume=` landing effect can build the identical payload.
-      mintAndDeliver(buildResumePayload(row));
+      mintAndDeliver(buildResumePayload(row), row.sid);
     },
     [mintAndDeliver, buildResumePayload, ideaId, router],
   );
@@ -1829,7 +1883,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         router.push(`/ideas/${row.ideaId}/board?resume=${encodeURIComponent(row.sid)}`);
         return;
       }
-      mintAndDeliver(buildResumePayload(row));
+      mintAndDeliver(buildResumePayload(row), row.sid);
       return;
     }
     if (match.kind === "live-here") {
@@ -1867,7 +1921,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         router.push(`/ideas/${payload.ideaId}/board?resume=${encodeURIComponent(sid)}`);
         return;
       }
-      mintAndDeliver(payload);
+      // The ended panel's own tab is very likely the reclaim target — `sid`
+      // is `pair?.sessionId`, this tab's own last-known session id, so
+      // `mintAndDeliver`'s reclaim check (`findReclaimableEndedSlot`) finds
+      // and takes over THIS tab rather than opening a new one next to it.
+      mintAndDeliver(payload, sid);
     },
     [ideaId, mintAndDeliver, router],
   );

--- a/src/components/board/terminal-tabs.test.ts
+++ b/src/components/board/terminal-tabs.test.ts
@@ -4,12 +4,14 @@ import {
   isLiveTabStatus,
   deriveTabLabel,
   findPristineSlot,
+  findReclaimableEndedSlot,
   decideTaskLaunch,
   summarizeSessionStatuses,
   shouldAnnounceAttention,
   formatAttentionAnnouncement,
   type DedupeCandidate,
   type PristineCandidate,
+  type ReclaimCandidate,
 } from "./terminal-tabs";
 import type { TerminalStatus } from "@/lib/terminal/connection";
 
@@ -160,6 +162,60 @@ describe("findPristineSlot (first-launch reuse)", () => {
   it("never reuses a chooser-attach entry, even at launchSeq 0 (card cbe60db5)", () => {
     const sessions: PristineCandidate[] = [{ key: "s1", launchSeq: 0, hasAttach: true }];
     expect(findPristineSlot(sessions)).toBeNull();
+  });
+});
+
+describe("findReclaimableEndedSlot (ended-tab reclaim, card df29b85e)", () => {
+  it("reclaims the tab whose sessionId matches the resume target, when it's ended", () => {
+    const candidates: ReclaimCandidate[] = [
+      { key: "s1", status: "session-ended", sessionId: "sid-1", poppedOut: false },
+    ];
+    expect(findReclaimableEndedSlot(candidates, "sid-1")).toBe("s1");
+  });
+
+  it("refuses a matching tab that's still live", () => {
+    const candidates: ReclaimCandidate[] = [
+      { key: "s1", status: "connected", sessionId: "sid-1", poppedOut: false },
+    ];
+    expect(findReclaimableEndedSlot(candidates, "sid-1")).toBeNull();
+  });
+
+  it("refuses a matching tab that's popped out, even though its last-known status reads session-ended", () => {
+    const candidates: ReclaimCandidate[] = [
+      { key: "s1", status: "session-ended", sessionId: "sid-1", poppedOut: true },
+    ];
+    expect(findReclaimableEndedSlot(candidates, "sid-1")).toBeNull();
+  });
+
+  it("falls through to append when the target sid matches no local tab", () => {
+    const candidates: ReclaimCandidate[] = [
+      { key: "s1", status: "session-ended", sessionId: "sid-2", poppedOut: false },
+    ];
+    expect(findReclaimableEndedSlot(candidates, "sid-1")).toBeNull();
+  });
+
+  it("never reclaims arbitrarily when no target sid is given — always append", () => {
+    const candidates: ReclaimCandidate[] = [
+      { key: "s1", status: "session-ended", sessionId: "sid-1", poppedOut: false },
+    ];
+    expect(findReclaimableEndedSlot(candidates, undefined)).toBeNull();
+    expect(findReclaimableEndedSlot(candidates, null)).toBeNull();
+  });
+
+  it("refuses a matching tab whose status is error, not session-ended (only a genuinely-ended tab is reclaimable)", () => {
+    const candidates: ReclaimCandidate[] = [
+      { key: "s1", status: "error", sessionId: "sid-1", poppedOut: false },
+    ];
+    expect(findReclaimableEndedSlot(candidates, "sid-1")).toBeNull();
+  });
+
+  it("picks the matching tab out of several others", () => {
+    const candidates: ReclaimCandidate[] = [
+      { key: "s1", status: "connected", sessionId: "sid-other", poppedOut: false },
+      { key: "s2", status: "session-ended", sessionId: "sid-1", poppedOut: false },
+      { key: "s3", status: "session-ended", sessionId: "sid-3", poppedOut: false },
+    ];
+    expect(findReclaimableEndedSlot(candidates, "sid-1")).toBe("s2");
   });
 });
 

--- a/src/components/board/terminal-tabs.ts
+++ b/src/components/board/terminal-tabs.ts
@@ -229,6 +229,61 @@ export function findPristineSlot(sessions: PristineCandidate[]): string | null {
   return only.launchSeq === 0 && !only.hasAttach ? only.key : null;
 }
 
+// ── ended-tab reclaim: resume takes over its own dead tab in place ─────────
+// Card df29b85e (field report 22 Aug 2026): "Resuming an ended terminal
+// session correctly mints a NEW session (`claude --resume`), but the dock
+// always opens it in a NEW tab, leaving the dead tab behind." Root cause was
+// that `mintAndDeliver` only ever had two outcomes — reuse the single
+// PRISTINE slot (`findPristineSlot` above, which an ended tab can never be:
+// its `launchSeq` is never 0) or append a brand-new `SessionEntry`. This is
+// the third outcome: when a resume names the sid of a tab that's sitting
+// right here, already ended, take THAT tab over instead of opening a
+// sibling next to its own corpse.
+
+export interface ReclaimCandidate {
+  key: string;
+  status: TerminalStatus;
+  /** The session id this tab last reported, or null before one's known. */
+  sessionId: string | null;
+  /**
+   * True for a tab the user has popped into its own window. A popped-out
+   * tab's OWN `status` is untrustworthy the moment the pop-out happens (the
+   * relay's 4001 "preempted" close usually lands as "error"/"session-ended"
+   * even though the session is very much alive, just running in the other
+   * window — see terminal-dock.tsx's `poppedOutKeys` and the identical
+   * `poppedOutKeys.has(key) || isLiveTabStatus(status)` guard in
+   * `requestClose`) — reclaiming it here would tear down a live xterm
+   * instance, socket and scrollback out from under the user, so it's
+   * excluded regardless of what `status` says.
+   */
+  poppedOut: boolean;
+}
+
+/**
+ * Is there a tab here safe for a resume to take over IN PLACE, rather than
+ * opening a new one? Only ever reclaims the ONE tab that's the actual
+ * originator of this resume — `targetSessionId` must be given (the resuming
+ * session's own sid, always known at every call site: the registry row's
+ * `sid`, or the ended panel's own `pair.sessionId`) and must match a
+ * candidate's `sessionId` exactly. No `targetSessionId` means "don't guess"
+ * — always append (same conservative default as `findPristineSlot` returning
+ * null for anything but the single obvious case). A `targetSessionId` that
+ * matches nothing local (the tab that ended isn't open on THIS board/tab
+ * strip right now) also falls through to append — there's nothing to
+ * reclaim, not a bug.
+ */
+export function findReclaimableEndedSlot(
+  candidates: ReclaimCandidate[],
+  targetSessionId?: string | null,
+): string | null {
+  if (!targetSessionId) return null;
+  const match = candidates.find((c) => c.sessionId === targetSessionId);
+  if (!match) return null;
+  if (match.poppedOut) return null;
+  if (match.status !== "session-ended") return null;
+  return match.key;
+}
+
 // ── B10: dedupe a task-scoped launch against existing tabs ─────────────────
 
 export interface DedupeCandidate {


### PR DESCRIPTION
Fixes board card df29b85e (Nick's field report, 22 Aug 2026): resuming a timed-out terminal session always opened a brand-new tab, leaving the dead tab in the strip — even in the single-session case via the ended panel's own "Resume this conversation" button.

## What changed
- New pure helper `findReclaimableEndedSlot(candidates, targetSessionId?)` in `terminal-tabs.ts`: returns a tab safe to take over only when an explicit target session id matches a local tab whose status is exactly `session-ended` and which is not popped out. No target / no match / live / error / popped-out → `null` (append exactly as before).
- `mintAndDeliver` (terminal-dock.tsx) takes an optional `targetSessionId`; on a reclaim it updates the ended tab's entry in place (same shape as the pristine-slot branch, incl. the `launchSeq` bump that fires the relaunch) instead of appending. All four resume call sites pass the sid (ended-panel button, chooser Resume, task-choice recent arm, `?resume=` landing effect).
- A reclaimed tab picks up the launch's `displayName` (resume payloads carry the existing/persisted name, so custom renames survive).

## Safety
- Never reclaims a live tab; never reclaims a popped-out tab (its status is untrustworthy mid-preemption — same guard combination as the close-confirm path).
- Every non-resume launch path is byte-for-byte unchanged.

## Verification
- 6 new unit tests for the helper + a dock-level regression test (tab count stays 1, same key reclaimed).
- Full suite: 193 files / 3255 tests pass; typecheck clean; lint 0 errors.
- Independently verified line-by-line against 6 adversarial edge cases (task-dedupe ordering, split view, multiple ended tabs, chooser duplicate, cross-board, pristine overlap) — all safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)