### PR TITLE
fix(terminal): hard refresh restores every open terminal, not just the last one

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -364,7 +364,7 @@ vi.mock("./terminal-task-launch-choice", () => ({
 
 import { TerminalDock } from "./terminal-dock";
 import { requestBrowserLaunch } from "@/lib/terminal/launch-mode";
-import { rememberLastTabSid } from "@/lib/terminal/session-snapshot";
+import { rememberLastTabSid, rememberTabSid, saveSessionSnapshot } from "@/lib/terminal/session-snapshot";
 import { toast } from "sonner";
 
 function deferredRegistryResponse() {
@@ -527,6 +527,10 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.clearAllMocks();
   mockSearchParams.current = new URLSearchParams();
+  // The dock reads this tab's remembered sids/snapshots (session-snapshot.ts)
+  // straight from sessionStorage on mount — clear it so one test's tab state
+  // never leaks into the next.
+  window.sessionStorage.clear();
 });
 
 describe("TerminalDock — launch-bus race with the still-loading registry (Bug B)", () => {
@@ -1826,5 +1830,95 @@ describe("TerminalDock — wrong-tab-closes-on-confirm fix (task 9f30ae15)", () 
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// Multi-terminal reload restore (Nick's field report 2026-08-22): two dock
+// tabs open → hard refresh → only one came back, and the orphaned live
+// session was then mislabelled "open in another tab". The tab now remembers
+// EVERY sid it holds (session-snapshot.ts's readTabSids) and instant-continue
+// reattaches each one.
+describe("TerminalDock — multi-terminal reload restore", () => {
+  it("reattaches EVERY remembered live sid on load, with no 'other tabs' strip and no chooser", async () => {
+    rememberTabSid("own-sid-1");
+    rememberTabSid("own-sid-2");
+    saveSessionSnapshot("own-sid-1", { data: "one\r\n", truncated: false });
+    saveSessionSnapshot("own-sid-2", { data: "two\r\n", truncated: false });
+    const reattached: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (url === "/api/terminal/session/list") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              sessions: [
+                { ...liveHereRow(), sid: "own-sid-1" },
+                { ...liveHereRow(), sid: "own-sid-2" },
+              ],
+            }),
+          });
+        }
+        if (url === "/api/terminal/session/reattach") {
+          const sid = (JSON.parse(String(init?.body)) as { sid: string }).sid;
+          reattached.push(sid);
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ sessionId: sid, browserToken: `token-${sid}` }),
+          });
+        }
+        return Promise.resolve({ ok: false, json: async () => ({}) });
+      }),
+    );
+
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(2));
+    expect(reattached.sort()).toEqual(["own-sid-1", "own-sid-2"]);
+    expect(screen.queryByText(/tabs? .* open here/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("chooser")).not.toBeInTheDocument();
+  });
+
+  it("skips a remembered sid whose session has since ended, still restoring the rest", async () => {
+    rememberTabSid("own-sid-1");
+    rememberTabSid("own-sid-2");
+    saveSessionSnapshot("own-sid-1", { data: "one\r\n", truncated: false });
+    saveSessionSnapshot("own-sid-2", { data: "two\r\n", truncated: false });
+    const reattached: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (url === "/api/terminal/session/list") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              sessions: [
+                { ...liveHereRow(), sid: "own-sid-1" },
+                {
+                  ...liveHereRow(),
+                  sid: "own-sid-2",
+                  status: "ended",
+                  endedAt: new Date().toISOString(),
+                },
+              ],
+            }),
+          });
+        }
+        if (url === "/api/terminal/session/reattach") {
+          const sid = (JSON.parse(String(init?.body)) as { sid: string }).sid;
+          reattached.push(sid);
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ sessionId: sid, browserToken: `token-${sid}` }),
+          });
+        }
+        return Promise.resolve({ ok: false, json: async () => ({}) });
+      }),
+    );
+
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(1));
+    expect(reattached).toEqual(["own-sid-1"]);
   });
 });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -108,7 +108,7 @@ import {
   type TaskSessionMatch,
 } from "@/lib/terminal/chooser-data";
 import { decideEntryBehaviour, type EntryDecision } from "@/lib/terminal/entry-decision";
-import { loadSessionSnapshot, readLastTabSid, toReconnectBuffer } from "@/lib/terminal/session-snapshot";
+import { loadSessionSnapshot, readTabSids, toReconnectBuffer } from "@/lib/terminal/session-snapshot";
 import { readDockOpen, writeDockOpen } from "@/lib/terminal/dock-open-persistence";
 import {
   type PaneAssignment,
@@ -636,20 +636,22 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     void fetchHelperStatus().then(setHelperStatus);
   }, [refreshRegistry]);
 
-  // This tab's own snapshot info (session-snapshot.ts) — read once; a tab
-  // doesn't gain a NEW "last sid" mid-session except by attaching another
-  // session itself, at which point the chooser is long since resolved.
-  const [entrySnapshotInfo] = useState(() => {
-    const sid = readLastTabSid();
-    if (!sid) return null;
-    const snap = loadSessionSnapshot(sid);
-    return snap ? { sid, savedAt: snap.savedAt } : null;
-  });
+  // This tab's own snapshot infos (session-snapshot.ts) — one per sid the
+  // tab held before the reload (multi-terminal reload restore: EVERY session
+  // it had attached, not just the last), read once; a tab doesn't gain NEW
+  // sids mid-session except by attaching another session itself, at which
+  // point the chooser is long since resolved.
+  const [entrySnapshotInfos] = useState(() =>
+    readTabSids().flatMap((sid) => {
+      const snap = loadSessionSnapshot(sid);
+      return snap ? [{ sid, savedAt: snap.savedAt }] : [];
+    }),
+  );
 
   const entryDecision: EntryDecision | null = useMemo(() => {
     if (registryRows === null) return null; // still loading
-    return decideEntryBehaviour(registryRows, entrySnapshotInfo, Date.now());
-  }, [registryRows, entrySnapshotInfo]);
+    return decideEntryBehaviour(registryRows, entrySnapshotInfos, Date.now());
+  }, [registryRows, entrySnapshotInfos]);
   useEffect(() => {
     entryDecisionRef.current = entryDecision;
     // Fix 3 (card 9fb9fced): the client's own page-load/refresh liveness
@@ -676,10 +678,14 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         registryRows ?? [],
         ideaId,
         Date.now(),
-        entrySnapshotInfo?.sid ?? readLastTabSid(),
+        // Every sid this tab holds (re-read per recompute — a mid-session
+        // attach adds to it), so no own session is ever miscounted as "open
+        // in another tab" — the pre-reload set alone isn't enough once a
+        // fresh mint lands.
+        readTabSids(),
         getMachineIdentity(),
       ),
-    [registryRows, ideaId, entrySnapshotInfo],
+    [registryRows, ideaId],
   );
   const chooserCounts = useMemo(() => chooserHeaderCounts(chooserSections), [chooserSections]);
   // Card eaa55290 (Nick's field report, 2026-08-17): "no way to tell another
@@ -1706,7 +1712,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       setActiveKey(fresh.key);
     } else if (entryDecision.kind === "instant-continue" && !instantContinueTriggeredRef.current) {
       instantContinueTriggeredRef.current = true;
-      void performReattach(entryDecision.sid, { focus: false });
+      // Multi-terminal reload restore: reattach EVERY session this tab held,
+      // not just the last-attached one. Each call appends its own dock tab as
+      // its fetch resolves (functional setSessions updates — concurrent
+      // resolutions can't clobber each other).
+      for (const sid of entryDecision.sids) void performReattach(sid, { focus: false });
     }
     // "chooser": nothing to seed — the chooser renders in the body below.
   }, [entryDecision, sessions.length, performReattach, pendingLaunch, mintAndDeliver, chooserSections]);

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -111,7 +111,8 @@ import {
 import {
   saveSessionSnapshot,
   clearSessionSnapshot,
-  rememberLastTabSid,
+  rememberTabSid,
+  forgetTabSid,
   SNAPSHOT_SAVE_INTERVAL_MS,
 } from "@/lib/terminal/session-snapshot";
 import { matchFocusMoveChord } from "@/lib/terminal/split-view";
@@ -1699,19 +1700,25 @@ export function useTerminalSession(
 
   // Remember this tab's own sid the moment a pair is established (mint,
   // attach-existing, or a fresh-attach-reset reconnect) — independent of the
-  // snapshot's own freshness, this is the chooser's "was open in this tab"
-  // badge (session-snapshot.ts's `rememberLastTabSid`).
+  // snapshot's own freshness. Feeds both the reload-restore set (EVERY sid
+  // this tab holds — multi-terminal reload restore) and the chooser's "was
+  // open in this tab" badge (session-snapshot.ts's `rememberTabSid` updates
+  // the legacy last-sid slot too).
   useEffect(() => {
-    if (pair?.sessionId) rememberLastTabSid(pair.sessionId);
+    if (pair?.sessionId) rememberTabSid(pair.sessionId);
   }, [pair?.sessionId]);
 
-  // Clear this session's snapshot on any terminal end (user End, idle,
-  // max-duration, or a reconnect-grace exhaustion) — a later reload must
-  // never restore a dead session's output as if it were still live.
+  // Clear this session's snapshot AND release its slot in the tab's
+  // reload-restore set on any terminal end (user End, idle, max-duration, or
+  // a reconnect-grace exhaustion) — a later reload must never restore a dead
+  // session's output as if it were still live, nor try to reattach it.
   useEffect(() => {
     if (state.status !== "session-ended") return;
     const sid = pairRef.current?.sessionId;
-    if (sid) clearSessionSnapshot(sid);
+    if (sid) {
+      clearSessionSnapshot(sid);
+      forgetTabSid(sid);
+    }
   }, [state.status]);
 
   // ── connect (browser leg) ───────────────────────────────────────────────────

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -384,6 +384,24 @@ describe("deriveChooserSections", () => {
     expect(sections.liveHere[0].wasOpenInThisTab).toBe(false);
   });
 
+  // Multi-terminal reload restore (Nick's field report 2026-08-22): the tab
+  // remembers EVERY sid it holds, and each matching live row gets the badge —
+  // previously only the single last-attached sid could, so a 2nd own session
+  // read as "open in another tab".
+  it("badges every row in a tabSids array, and only those", () => {
+    const rows = [
+      row({ sid: "own-1", ideaId: IDEA_A, status: "active" }),
+      row({ sid: "own-2", ideaId: IDEA_A, status: "active" }),
+      row({ sid: "foreign", ideaId: IDEA_A, status: "active" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW, ["own-1", "own-2"]);
+    expect(sections.liveHere.map((r) => [r.sid, r.wasOpenInThisTab])).toEqual([
+      ["own-1", true],
+      ["own-2", true],
+      ["foreign", false],
+    ]);
+  });
+
   // Machine identity (Nick's sign-off change 2): Recent-section filtering
   // against this browser's own recorded machine identity.
   describe("machine identity filtering (Recent section only)", () => {
@@ -725,5 +743,18 @@ describe("liveSessionsElsewhereOnThisBoard", () => {
     const sections = deriveChooserSections(rows, IDEA_A, NOW, "own-sid-1");
     const others = liveSessionsElsewhereOnThisBoard(sections, new Set(["own-sid-1", "own-sid-2"]));
     expect(others.map((r) => r.sid)).toEqual(["other-sid"]);
+  });
+
+  // Multi-terminal reload restore (Nick's field report 2026-08-22): with the
+  // full tabSids array badging every own session, two own dock tabs stop
+  // being miscounted as "open in another tab" even before ownSessionIds
+  // catches up (e.g. mid-restore after a reload).
+  it("returns nothing when every live-here row is in this tab's own tabSids array", () => {
+    const rows = [
+      row({ sid: "own-sid-1", ideaId: IDEA_A, status: "active" }),
+      row({ sid: "own-sid-2", ideaId: IDEA_A, status: "active" }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW, ["own-sid-1", "own-sid-2"]);
+    expect(liveSessionsElsewhereOnThisBoard(sections)).toEqual([]);
   });
 });

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -161,11 +161,15 @@ function withinRecentWindow(endedAt: string, nowMs: number): boolean {
 
 /**
  * Split the registry's raw rows into the chooser's three sections (design
- * §3). `lastTabSid` (optional — this tab's own remembered sid, see
- * session-snapshot.ts's `readLastTabSid`) badges the matching LIVE row
+ * §3). `tabSids` (optional — this tab's own remembered sid(s), see
+ * session-snapshot.ts's `readTabSids`/`readLastTabSid`; a single string is
+ * accepted for the legacy one-sid callers) badges each matching LIVE row
  * `wasOpenInThisTab`, independent of snapshot freshness — a stale snapshot
  * still deserves the "was open in this tab" hint even once instant-continue
- * itself no longer applies. `storedMachineLabel` (this browser's own recorded
+ * itself no longer applies. Multi-terminal reload restore (Nick's field
+ * report 2026-08-22): this used to be the single last-attached sid, which
+ * left every OTHER session this same tab held reading as "open in another
+ * tab". `storedMachineLabel` (this browser's own recorded
  * machine identity, see machine-identity.ts) filters the Recent section per
  * this module's MACHINE IDENTITY header comment — omit/pass null to show
  * every recent row unfiltered (the pre-this-card behaviour).
@@ -174,9 +178,10 @@ export function deriveChooserSections(
   rows: ChooserRegistryRow[],
   currentIdeaId: string,
   nowMs: number = Date.now(),
-  lastTabSid: string | null = null,
+  tabSids: readonly string[] | string | null = null,
   storedMachineLabel: string | null = null,
 ): ChooserSections {
+  const tabSidSet = new Set(typeof tabSids === "string" ? [tabSids] : (tabSids ?? []));
   const toLiveRow = (r: ChooserRegistryRow): ChooserLiveRow => ({
     sid: r.sid,
     ideaId: r.ideaId,
@@ -186,7 +191,7 @@ export function deriveChooserSections(
     machineLabel: r.machineLabel,
     cwd: r.cwd,
     createdAt: r.createdAt,
-    wasOpenInThisTab: !!lastTabSid && r.sid === lastTabSid,
+    wasOpenInThisTab: tabSidSet.has(r.sid),
     displayName: r.displayName,
   });
 
@@ -369,13 +374,13 @@ export function findTaskSessionMatch(
  *
  * A row counts as "ours" when either:
  *   - `wasOpenInThisTab` is set (this browser TAB's own `sessionStorage`-backed
- *     memory of the last session it attached — see session-snapshot.ts's
- *     `rememberLastTabSid`, genuinely per-tab, unlike `localStorage`), or
+ *     memory of EVERY session it has attached — see session-snapshot.ts's
+ *     `readTabSids`, genuinely per-tab, unlike `localStorage`; before the
+ *     multi-terminal reload-restore fix this was a single last-sid slot, so
+ *     a 2nd own session read as "open in another tab" here), or
  *   - its `sid` is in `ownSessionIds` (the sessionIds this `TerminalDock`
  *     instance currently has mounted, via its own `summaries` state) — this
- *     second check covers a 2nd own tab inside the SAME dock (multi-session,
- *     where only the most-recently-connected sid wins the single
- *     `wasOpenInThisTab` slot) and the brief window right after a fresh mint,
+ *     second check covers the brief window right after a fresh mint,
  *     before that sessionStorage write has landed.
  *
  * Returns the remaining rows — an empty array means nothing to warn about

--- a/src/lib/terminal/entry-decision.test.ts
+++ b/src/lib/terminal/entry-decision.test.ts
@@ -11,17 +11,17 @@ function row(overrides: Partial<EntryRegistryRow> & { sid: string }): EntryRegis
 
 describe("decideEntryBehaviour", () => {
   it("empty-launch when there is nothing live or recent anywhere", () => {
-    expect(decideEntryBehaviour([], null, NOW)).toEqual({ kind: "empty-launch" });
+    expect(decideEntryBehaviour([], [], NOW)).toEqual({ kind: "empty-launch" });
   });
 
   it("chooser when a live session exists, with no snapshot", () => {
     const rows = [row({ sid: "live-1", status: "active" })];
-    expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "chooser" });
+    expect(decideEntryBehaviour(rows, [], NOW)).toEqual({ kind: "chooser" });
   });
 
   it("chooser when only a recent (≤48h, recorded-folder) ended session exists", () => {
     const rows = [row({ sid: "ended-1", status: "ended", cwd: "~/projects/a", endedAt: new Date(NOW - 60_000).toISOString() })];
-    expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "chooser" });
+    expect(decideEntryBehaviour(rows, [], NOW)).toEqual({ kind: "chooser" });
   });
 
   // Bug 9fb9fced (2026-08-17): this used to assert "empty-launch" — a
@@ -43,7 +43,7 @@ describe("decideEntryBehaviour", () => {
   // "empty-launch" and mint a brand-new session.
   it("chooser (not empty-launch) when the only ended row has no recorded folder", () => {
     const rows = [row({ sid: "ended-1", status: "ended", cwd: null, endedAt: new Date(NOW - 60_000).toISOString() })];
-    expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "chooser" });
+    expect(decideEntryBehaviour(rows, [], NOW)).toEqual({ kind: "chooser" });
   });
 
   it("empty-launch when a null-cwd ended row is past the 48h window (the 48h rule itself is untouched by the null-cwd fix)", () => {
@@ -55,7 +55,7 @@ describe("decideEntryBehaviour", () => {
         endedAt: new Date(NOW - RECENT_WINDOW_MS - 1000).toISOString(),
       }),
     ];
-    expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "empty-launch" });
+    expect(decideEntryBehaviour(rows, [], NOW)).toEqual({ kind: "empty-launch" });
   });
 
   it("empty-launch when the only ended row is past the 48h window", () => {
@@ -67,35 +67,65 @@ describe("decideEntryBehaviour", () => {
         endedAt: new Date(NOW - RECENT_WINDOW_MS - 1000).toISOString(),
       }),
     ];
-    expect(decideEntryBehaviour(rows, null, NOW)).toEqual({ kind: "empty-launch" });
+    expect(decideEntryBehaviour(rows, [], NOW)).toEqual({ kind: "empty-launch" });
   });
 
   it("instant-continue when a fresh snapshot's sid is a live, owned row", () => {
     const rows = [row({ sid: "live-1", status: "active" })];
     const snapshotInfo = { sid: "live-1", savedAt: NOW - 5000 };
-    expect(decideEntryBehaviour(rows, snapshotInfo, NOW)).toEqual({ kind: "instant-continue", sid: "live-1" });
+    expect(decideEntryBehaviour(rows, [snapshotInfo], NOW)).toEqual({ kind: "instant-continue", sids: ["live-1"] });
+  });
+
+  // Multi-terminal reload restore (Nick's field report 2026-08-22): a tab
+  // holding several live sessions must get ALL of them back, not just the
+  // last-attached one.
+  it("instant-continue returns every fresh-snapshotted live sid, in attach order", () => {
+    const rows = [row({ sid: "live-1" }), row({ sid: "live-2" }), row({ sid: "live-3" })];
+    const infos = [
+      { sid: "live-1", savedAt: NOW - 5000 },
+      { sid: "live-2", savedAt: NOW - 10_000 },
+      { sid: "live-3", savedAt: NOW - 3000 },
+    ];
+    expect(decideEntryBehaviour(rows, infos, NOW)).toEqual({
+      kind: "instant-continue",
+      sids: ["live-1", "live-2", "live-3"],
+    });
+  });
+
+  it("instant-continue skips a stale or no-longer-live sid but still restores the rest", () => {
+    const rows = [
+      row({ sid: "live-1" }),
+      row({ sid: "ended-1", status: "ended", endedAt: new Date(NOW - 60_000).toISOString() }),
+      row({ sid: "live-2" }),
+    ];
+    const infos = [
+      { sid: "live-1", savedAt: NOW - SNAPSHOT_FRESHNESS_MS - 1 }, // stale
+      { sid: "ended-1", savedAt: NOW - 5000 }, // fresh but ended
+      { sid: "live-2", savedAt: NOW - 5000 }, // restorable
+    ];
+    expect(decideEntryBehaviour(rows, infos, NOW)).toEqual({ kind: "instant-continue", sids: ["live-2"] });
   });
 
   it("falls back to chooser when the snapshot is stale, even if the row is live", () => {
     const rows = [row({ sid: "live-1", status: "active" })];
     const snapshotInfo = { sid: "live-1", savedAt: NOW - SNAPSHOT_FRESHNESS_MS - 1 };
-    expect(decideEntryBehaviour(rows, snapshotInfo, NOW)).toEqual({ kind: "chooser" });
+    expect(decideEntryBehaviour(rows, [snapshotInfo], NOW)).toEqual({ kind: "chooser" });
   });
 
   it("falls back to chooser when the fresh snapshot's sid is not a live row (ended/foreign/gone)", () => {
     const rows = [row({ sid: "live-1", status: "active" })];
     const snapshotInfo = { sid: "some-other-sid", savedAt: NOW - 5000 };
-    expect(decideEntryBehaviour(rows, snapshotInfo, NOW)).toEqual({ kind: "chooser" });
+    expect(decideEntryBehaviour(rows, [snapshotInfo], NOW)).toEqual({ kind: "chooser" });
   });
 
   it("falls back to chooser when the fresh snapshot's sid row exists but has since ended", () => {
     const rows = [row({ sid: "live-1", status: "ended", cwd: "~/projects/a", endedAt: new Date(NOW - 60_000).toISOString() })];
     const snapshotInfo = { sid: "live-1", savedAt: NOW - 5000 };
-    expect(decideEntryBehaviour(rows, snapshotInfo, NOW)).toEqual({ kind: "chooser" });
+    expect(decideEntryBehaviour(rows, [snapshotInfo], NOW)).toEqual({ kind: "chooser" });
   });
 
   it("empty-launch when there is a snapshot but no rows at all", () => {
     const snapshotInfo = { sid: "live-1", savedAt: NOW - 5000 };
-    expect(decideEntryBehaviour([], snapshotInfo, NOW)).toEqual({ kind: "empty-launch" });
+    expect(decideEntryBehaviour([], [snapshotInfo], NOW)).toEqual({ kind: "empty-launch" });
   });
 });

--- a/src/lib/terminal/entry-decision.ts
+++ b/src/lib/terminal/entry-decision.ts
@@ -41,7 +41,7 @@ export interface EntrySnapshotInfo {
 }
 
 export type EntryDecision =
-  | { kind: "instant-continue"; sid: string }
+  | { kind: "instant-continue"; sids: string[] }
   | { kind: "chooser" }
   | { kind: "empty-launch" };
 
@@ -57,19 +57,31 @@ function isRecentEnded(row: EntryRegistryRow, nowMs: number): boolean {
 /**
  * `rows` — every one of the caller's registry rows (active + recently-ended,
  * exactly what the extended list route returns; see chooser-data.ts for the
- * shared 48h/cwd rules this mirrors). `snapshotInfo` — this tab's own
- * `vc:term:snap:<sid>` metadata, if any (see session-snapshot.ts); `null`
- * when nothing was ever saved in this tab.
+ * shared 48h/cwd rules this mirrors). `snapshotInfos` — this tab's own
+ * `vc:term:snap:<sid>` metadata for EVERY sid the tab holds (see
+ * session-snapshot.ts's `readTabSids`), in attach order; empty when nothing
+ * was ever saved in this tab.
+ *
+ * Multi-terminal reload restore (Nick's field report 2026-08-22): this used
+ * to take a single snapshot info (the one `vc:term:last-sid`), so a tab with
+ * two live terminals only ever got one back after a refresh. Instant-continue
+ * now returns every sid that is BOTH fresh-snapshotted in this tab AND still
+ * an active, owned row in the registry — each is reattached exactly the way
+ * the single one was.
  */
 export function decideEntryBehaviour(
   rows: EntryRegistryRow[],
-  snapshotInfo: EntrySnapshotInfo | null,
+  snapshotInfos: readonly EntrySnapshotInfo[],
   nowMs: number = Date.now(),
 ): EntryDecision {
-  if (snapshotInfo && isSnapshotFresh(snapshotInfo.savedAt, nowMs)) {
-    const row = rows.find((r) => r.sid === snapshotInfo.sid && r.status === "active");
-    if (row) return { kind: "instant-continue", sid: snapshotInfo.sid };
-  }
+  const continueSids = snapshotInfos
+    .filter(
+      (info) =>
+        isSnapshotFresh(info.savedAt, nowMs) &&
+        rows.some((r) => r.sid === info.sid && r.status === "active"),
+    )
+    .map((info) => info.sid);
+  if (continueSids.length > 0) return { kind: "instant-continue", sids: continueSids };
 
   const hasLive = rows.some((r) => r.status === "active");
   const hasRecent = rows.some((r) => isRecentEnded(r, nowMs));

--- a/src/lib/terminal/session-snapshot.test.ts
+++ b/src/lib/terminal/session-snapshot.test.ts
@@ -12,6 +12,10 @@ import {
   clearSessionSnapshot,
   rememberLastTabSid,
   readLastTabSid,
+  parseTabSids,
+  readTabSids,
+  rememberTabSid,
+  forgetTabSid,
   toReconnectBuffer,
 } from "./session-snapshot";
 import type { TransferredBuffer } from "./scrollback-transfer";
@@ -187,6 +191,81 @@ describe("rememberLastTabSid / readLastTabSid", () => {
   it("null storage is a silent no-op", () => {
     expect(() => rememberLastTabSid("sid-1", null)).not.toThrow();
     expect(readLastTabSid(null)).toBeNull();
+  });
+});
+
+describe("parseTabSids", () => {
+  it("parses a JSON array of strings", () => {
+    expect(parseTabSids('["a","b"]')).toEqual(["a", "b"]);
+  });
+
+  it("drops non-string entries and never throws on malformed input", () => {
+    expect(parseTabSids('["a", 1, null, "b"]')).toEqual(["a", "b"]);
+    expect(parseTabSids("not json")).toEqual([]);
+    expect(parseTabSids('{"sid":"a"}')).toEqual([]);
+    expect(parseTabSids(null)).toEqual([]);
+    expect(parseTabSids(undefined)).toEqual([]);
+  });
+});
+
+describe("rememberTabSid / readTabSids / forgetTabSid (multi-terminal reload restore)", () => {
+  it("accumulates every attached sid in attach order, deduplicated", () => {
+    const storage = new FakeStorage();
+    expect(readTabSids(storage)).toEqual([]);
+    rememberTabSid("sid-1", storage);
+    rememberTabSid("sid-2", storage);
+    rememberTabSid("sid-1", storage); // re-attach of a known sid — no duplicate, order kept
+    expect(readTabSids(storage)).toEqual(["sid-1", "sid-2"]);
+  });
+
+  it("also refreshes the legacy last-sid slot on every remember", () => {
+    const storage = new FakeStorage();
+    rememberTabSid("sid-1", storage);
+    rememberTabSid("sid-2", storage);
+    expect(readLastTabSid(storage)).toBe("sid-2");
+  });
+
+  it("falls back to the legacy last-sid slot when the list was never written (pre-fix tab)", () => {
+    const storage = new FakeStorage();
+    rememberLastTabSid("legacy-sid", storage);
+    expect(readTabSids(storage)).toEqual(["legacy-sid"]);
+  });
+
+  it("forgetTabSid removes only the given sid and leaves the legacy slot alone", () => {
+    const storage = new FakeStorage();
+    rememberTabSid("sid-1", storage);
+    rememberTabSid("sid-2", storage);
+    forgetTabSid("sid-1", storage);
+    expect(readTabSids(storage)).toEqual(["sid-2"]);
+    expect(readLastTabSid(storage)).toBe("sid-2");
+    forgetTabSid("never-known", storage); // no-op, never throws
+    expect(readTabSids(storage)).toEqual(["sid-2"]);
+  });
+
+  it("forgetting the last listed sid falls back to the legacy slot only if the list key was never written", () => {
+    const storage = new FakeStorage();
+    rememberTabSid("sid-1", storage);
+    forgetTabSid("sid-1", storage);
+    // The list key now holds [], which is the honest answer — the legacy
+    // slot (still "sid-1") must NOT resurrect a released session...
+    expect(parseTabSids(storage.getItem("vc:term:tab-sids"))).toEqual([]);
+    // ...but readTabSids' legacy fallback fires on an EMPTY list, so it
+    // still reports the legacy sid. Harmless by design: the entry decision
+    // also requires a fresh snapshot AND a live registry row, and an ended
+    // session has neither (its snapshot is cleared alongside forgetTabSid).
+    expect(readTabSids(storage)).toEqual(["sid-1"]);
+  });
+
+  it("null storage is a silent no-op", () => {
+    expect(() => rememberTabSid("sid-1", null)).not.toThrow();
+    expect(() => forgetTabSid("sid-1", null)).not.toThrow();
+    expect(readTabSids(null)).toEqual([]);
+  });
+
+  it("a throwing storage never propagates", () => {
+    const storage = new QuotaLimitedStorage(99);
+    expect(() => rememberTabSid("sid-1", storage)).not.toThrow();
+    expect(readTabSids(storage)).toEqual([]);
   });
 });
 

--- a/src/lib/terminal/session-snapshot.ts
+++ b/src/lib/terminal/session-snapshot.ts
@@ -228,3 +228,84 @@ export function readLastTabSid(storage: Storage | null = defaultStorage()): stri
     return null;
   }
 }
+
+// ── every session this tab holds (multi-terminal reload restore) ───────────
+//
+// Nick's field report (2026-08-22): two dock tabs open → hard refresh → only
+// one came back, and the orphaned live session was then mislabelled "open in
+// another tab". Root cause: `vc:term:last-sid` above has room for exactly ONE
+// sid (each attach overwrites it), so the reload path could only ever restore
+// the most-recently-attached session. This list is the multi-session
+// replacement: EVERY sid this tab currently has attached, in attach order.
+// The single last-sid slot stays alongside it — it still answers the distinct
+// question "which one row deserves the was-open-in-this-tab pre-focus" for
+// the chooser, and old tabs that predate this key fall back to it (see
+// `readTabSids`).
+
+const TAB_SIDS_KEY = "vc:term:tab-sids";
+
+/** Pure parse — anything that isn't a JSON array of strings parses to `[]`, never throws. */
+export function parseTabSids(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Every session id this tab has attached and not yet released, oldest first.
+ * Falls back to the legacy single `vc:term:last-sid` slot when the list has
+ * never been written — a tab that attached before this key existed still gets
+ * its one session restored on reload.
+ */
+export function readTabSids(storage: Storage | null = defaultStorage()): string[] {
+  if (!storage) return [];
+  try {
+    const list = parseTabSids(storage.getItem(TAB_SIDS_KEY));
+    if (list.length > 0) return list;
+    const legacy = storage.getItem(LAST_TAB_SID_KEY);
+    return legacy ? [legacy] : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Record that this tab holds `sid` (best-effort, never throws). Appends
+ * (deduplicated, attach order preserved) AND refreshes the legacy last-sid
+ * slot, so callers only ever call this one function on attach.
+ */
+export function rememberTabSid(sid: string, storage: Storage | null = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    const list = parseTabSids(storage.getItem(TAB_SIDS_KEY));
+    if (!list.includes(sid)) {
+      list.push(sid);
+      storage.setItem(TAB_SIDS_KEY, JSON.stringify(list));
+    }
+  } catch {
+    /* best-effort only */
+  }
+  rememberLastTabSid(sid, storage);
+}
+
+/**
+ * Release `sid` from this tab's set — called when the session ends, so a
+ * later reload never tries to reattach a dead session. Deliberately leaves
+ * the legacy last-sid slot alone: the chooser's "was open in this tab" badge
+ * on a recently-ended row is exactly that slot's remaining job.
+ */
+export function forgetTabSid(sid: string, storage: Storage | null = defaultStorage()): void {
+  if (!storage) return;
+  try {
+    const list = parseTabSids(storage.getItem(TAB_SIDS_KEY));
+    const next = list.filter((s) => s !== sid);
+    if (next.length !== list.length) storage.setItem(TAB_SIDS_KEY, JSON.stringify(next));
+  } catch {
+    /* best-effort only */
+  }
+}


### PR DESCRIPTION
## Problem (Nick's field report, 22 Aug)

Two terminal sessions open in the dock → hard refresh → only one comes back. The still-running sessions are then mislabelled by the orange strip as "2 other tabs are open here", pointing at browser tabs that don't exist.

## Root cause

The per-tab reload memory (`vc:term:last-sid`) held exactly **one** sid, overwritten on every attach — so the reload path could only ever restore the most-recently-attached session. `liveSessionsElsewhereOnThisBoard` then counted the orphans as other-tab sessions because they weren't mounted and weren't the single remembered sid.

## Fix

- New per-tab `vc:term:tab-sids` list in `session-snapshot.ts`: every sid the tab holds, attach order, deduped; released on session end; legacy last-sid slot kept (chooser badge + read fallback for pre-fix tabs).
- `decideEntryBehaviour` returns **every** sid that is fresh-snapshotted and still active in the registry; the dock reattaches each one (scrollback snapshots were already saved per sid).
- `deriveChooserSections` badges every remembered sid as "was open in this tab", so the false "other tabs" strip disappears.

Pop-out stays safe: a popped-out session's snapshot goes stale within 60s and the registry/freshness gates are unchanged.

## Testing

- New unit tests: tab-sid list round-trip/fallback/quota-safety, multi-sid entry decisions, multi-sid chooser badging, and two dock-level reload-restore tests (all sessions reattached; ended one skipped).
- Full suite: 3,278 tests / 193 files green; typecheck + lint clean. (Also added `sessionStorage.clear()` to the dock test file's `afterEach` — the dock now reads tab state on mount, and tests were leaking it.)

Board card 28434cbd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)