### PR TITLE
fix(terminal): don't auto-relaunch a session after ending the only open tab

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -122,6 +122,7 @@ vi.mock("./terminal-session-view", () => ({
     paneFocused,
     grabFocus,
     onPaneFocusChange,
+    autoConnectWhenExpanded,
   }: {
     entry: { key: string; taskId?: string; ideaId?: string };
     onResumeEndedSession?: (payload: { cwd?: string; taskId?: string; ideaId?: string }, sid: string | null) => void;
@@ -133,6 +134,14 @@ vi.mock("./terminal-session-view", () => ({
     // .get(key)?.end()` has a real spy to resolve, keyed exactly like the
     // dock keys it. See `registeredActionsByKey` above.
     onRegisterActions: (key: string, actions: MockTerminalSessionActions | null) => void;
+    // Bug fix (last-tab-close auto-relaunch): the real hook's own paired
+    // auto-connect effect (use-terminal-session.ts) lives entirely inside the
+    // component this stub replaces, so it can't be exercised here — surfaced
+    // as a data attribute instead so a test can assert the DOCK computed the
+    // right value for `autoConnectWhenExpanded` (the only thing the dock
+    // itself is responsible for; the hook's own reaction to it is covered by
+    // use-terminal-session.test.ts).
+    autoConnectWhenExpanded?: boolean;
     // Split-view focus-sync defect fix (task df7a0134, QA rework): a real
     // focusable element stands in for xterm's own hidden input, so a test
     // can drive the SAME real focus/blur events the fix listens for (not
@@ -168,7 +177,13 @@ vi.mock("./terminal-session-view", () => ({
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     return (
-      <div data-testid="session-view" data-key={entry.key} data-task-id={entry.taskId ?? ""} data-idea-id={entry.ideaId ?? ""}>
+      <div
+        data-testid="session-view"
+        data-key={entry.key}
+        data-task-id={entry.taskId ?? ""}
+        data-idea-id={entry.ideaId ?? ""}
+        data-auto-connect-when-expanded={autoConnectWhenExpanded ? "true" : "false"}
+      >
         <button
           data-testid={`resume-ended-${entry.key}`}
           onClick={() =>
@@ -1983,6 +1998,56 @@ describe("TerminalDock — wrong-tab-closes-on-confirm fix (task 9f30ae15)", () 
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// Bug fix (last-tab-close auto-relaunch, Nick's field report): closing the
+// dock's LAST remaining tab replaces `sessions` with a fresh pristine entry
+// (B8, "back to the P1 idle state") reusing the exact same shape/launchSeq:0
+// as a genuine page-load pristine entry — which normally auto-connects a
+// paired browser the instant the dock is expanded. Since the user just
+// explicitly ended their only session (the dock is still expanded — that's
+// how they saw the × to click), that replacement entry must NOT also satisfy
+// `autoConnectWhenExpanded`, or ending a session silently reconnects into a
+// brand-new one within the same render pass.
+describe("TerminalDock — ending the last tab does not auto-relaunch a fresh session", () => {
+  function tabContainer(key: string): HTMLElement {
+    const el = document.getElementById(`terminal-tab-${key}`);
+    if (!el) throw new Error(`tab element not found for key ${key}`);
+    return el;
+  }
+
+  it("closing the dock's only live tab returns to the idle pristine slot WITHOUT auto-connecting", async () => {
+    stubFetch(Promise.resolve([]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    // The dock auto-seeds its usual page-load pristine tab (empty-launch
+    // decision) — unchanged P1 behaviour: it DOES want auto-connect.
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    const firstKey = screen.getByTestId("session-view").dataset.key as string;
+    expect(screen.getByTestId("session-view").dataset.autoConnectWhenExpanded).toBe("true");
+
+    // Bring it to a LIVE status so requestClose treats × as "end this
+    // session" (armed confirm) rather than a bare, already-over close.
+    fireEvent.click(screen.getByTestId(`report-connected-${firstKey}`));
+
+    // Expand the dock (clicking the tab does this in the real component) —
+    // the bug only manifests while the dock is visibly open.
+    fireEvent.click(tabContainer(firstKey));
+
+    // First × click arms the confirm; second confirms and actually ends it.
+    fireEvent.click(
+      within(tabContainer(firstKey)).getByRole("button", { name: /^(End session and close tab|Close tab):/ }),
+    );
+    fireEvent.click(within(tabContainer(firstKey)).getByRole("button", { name: /^Confirm end session:/ }));
+
+    // Back to exactly one tab (the pristine slot reused, B8) — but this one
+    // must report `autoConnectWhenExpanded: false`, unlike the very first
+    // pristine entry above.
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(1));
+    const secondEntry = screen.getByTestId("session-view");
+    expect(secondEntry.dataset.key).not.toBe(firstKey); // a genuinely fresh entry, not the same tab
+    expect(secondEntry.dataset.autoConnectWhenExpanded).toBe("false");
   });
 });
 

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -208,7 +208,13 @@ function freshSessionKey(): string {
   return `tab-${Date.now().toString(36)}-${sessionKeySeq}`;
 }
 
-function createPristineEntry(): SessionEntry {
+/**
+ * `suppressAutoConnect` distinguishes the two callers (see `SessionEntry
+ * .autoConnectSuppressed`'s doc): the page-load seeding effect leaves it
+ * unset (unchanged P1 paired auto-connect behaviour), `removeEntry`'s
+ * last-tab-closed replacement passes `true`.
+ */
+function createPristineEntry(suppressAutoConnect = false): SessionEntry {
   return {
     key: freshSessionKey(),
     origin: "toolbar",
@@ -217,6 +223,7 @@ function createPristineEntry(): SessionEntry {
     createdAt: Date.now(),
     launchSeq: 0,
     launchPayload: null,
+    autoConnectSuppressed: suppressAutoConnect,
   };
 }
 
@@ -1421,8 +1428,11 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         const next = prev.filter((s) => s.key !== key);
         if (next.length === 0) {
           // Last tab closed → back to the true P1 idle/resting state (B8), not a
-          // lingering empty strip.
-          const fresh = createPristineEntry();
+          // lingering empty strip. `suppressAutoConnect: true` — the user just
+          // explicitly ended this session, so an expanded dock must NOT
+          // immediately auto-reconnect them into a fresh one (bug fix:
+          // last-tab-close auto-relaunch).
+          const fresh = createPristineEntry(true);
           setActiveKey(fresh.key);
           return [fresh];
         }
@@ -2942,7 +2952,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onPaneFocusChange={inPane ? (focused: boolean) => handlePaneFocusChange(entry.key, focused) : undefined}
             dragActiveRef={dragActiveRef}
             onRequestExpand={requestExpand}
-            autoConnectWhenExpanded={entry.launchSeq === 0 && !entry.attach}
+            autoConnectWhenExpanded={entry.launchSeq === 0 && !entry.attach && !entry.autoConnectSuppressed}
             onReportSummary={reportSummary}
             onRegisterActions={registerActions}
             onAnnounce={announce}

--- a/src/components/board/terminal-tabs.ts
+++ b/src/components/board/terminal-tabs.ts
@@ -88,6 +88,19 @@ export interface SessionEntry {
    * isn't shown here…") instead of a silently blank terminal.
    */
   showReconnectedNoHistoryNote?: boolean;
+  /**
+   * Bug fix (last-tab-close auto-relaunch): `launchSeq === 0` alone used to
+   * mean BOTH "genuinely never launched" (page-load pristine slot, still
+   * wants the paired auto-connect below) AND "just ended my only tab"
+   * (`removeEntry`'s replacement pristine entry — terminal-dock.tsx) — the
+   * second case rendered the same idle screen but, being launchSeq 0 too,
+   * ALSO satisfied `autoConnectWhenExpanded`, so a paired user who explicitly
+   * ended their last session was auto-reconnected into a brand-new one
+   * within the same render pass. Set only on that replacement entry so the
+   * dock's `autoConnectWhenExpanded` expression can tell the two apart
+   * without touching `launchSeq`'s existing "deliver a launch" meaning.
+   */
+  autoConnectSuppressed?: boolean;
 }
 
 // ── shared tone vocabulary (drives both the per-tab glyph and the collapsed

--- a/src/components/board/use-terminal-session.test.ts
+++ b/src/components/board/use-terminal-session.test.ts
@@ -609,6 +609,12 @@ describe("useTerminalSession", () => {
       expect(result.current.state.status).not.toBe("idle");
     });
 
+    // Also the hook-level half of the last-tab-close auto-relaunch fix
+    // (terminal-dock.tsx's `createPristineEntry`/`SessionEntry
+    // .autoConnectSuppressed`): the hook itself doesn't know or care WHY
+    // `autoConnectWhenExpanded` is false — a freshly-minted tab and a
+    // just-ended-my-last-session pristine entry both route through this same
+    // guard, so this generic case is the coverage for both.
     it("does NOT auto-connect when autoConnectWhenExpanded is false (a freshly-minted tab)", async () => {
       const requestExpand = vi.fn();
       const { result } = renderHook(() =>


### PR DESCRIPTION
## Summary
- Ending the terminal dock's last remaining tab (X → confirm) reset state to a fresh "pristine" entry indistinguishable from a genuine page-load entry, which still satisfied the paired-user auto-connect effect — so confirming "end session" minted a brand-new one seconds later. Only reproduced with exactly one tab open.
- Adds `SessionEntry.autoConnectSuppressed`, set only on the post-end replacement pristine entry, so the existing page-load auto-reconnect behavior for paired returning users is preserved while the post-end idle state no longer auto-connects.

## Board task
e00d1ed1-0199-497b-b2f5-2e7e62b64893 — worked through the full Bug Fix workflow (Reproduce & Investigate → Implement Fix → Verify Fix → Regression Check, approved by Nick).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (0 errors)
- [x] Full `npm run test` — 197 files / 3364 tests pass
- [x] New regression test in `terminal-dock.test.tsx` directly asserts ending the last tab does not auto-relaunch
- [ ] Manual click-through in the browser (no dev server was available in this environment during development — worth a quick 30s manual check: open one terminal tab, end it, confirm no new session appears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)