### PR TITLE
Persist Ideas feed filters (view/status/sort) per-user, cross-device

### DIFF
--- a/src/actions/ideas.ts
+++ b/src/actions/ideas.ts
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { validateTitle, validateDescription, validateGithubUrl, validateTags } from "@/lib/validation";
 import { logger } from "@/lib/logger";
-import type { IdeaStatus } from "@/types";
+import type { IdeaStatus, IdeaFeedPreferences } from "@/types";
 import type { ApplyKitResult } from "./kits";
 
 export type CreateIdeaResult = {
@@ -268,4 +268,24 @@ export async function deleteIdea(ideaId: string) {
   }
 
   redirect("/ideas");
+}
+
+export async function updateFeedPreferences(preferences: IdeaFeedPreferences) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("Not authenticated");
+  }
+
+  const { error } = await supabase
+    .from("users")
+    .update({ feed_preferences: preferences })
+    .eq("id", user.id);
+
+  if (error) {
+    throw new Error(error.message);
+  }
 }

--- a/src/app/(main)/ideas/page.tsx
+++ b/src/app/(main)/ideas/page.tsx
@@ -26,13 +26,30 @@ export default async function FeedPage({
   searchParams: Promise<{ sort?: string; q?: string; tag?: string; status?: string; page?: string; view?: string }>;
 }) {
   const params = await searchParams;
-  const sort = (params.sort as SortOption) || "newest";
+  const { user, supabase } = await requireAuth();
+
+  // Saved per-user feed filter defaults (view/status/sort), used only when
+  // the URL doesn't already specify a value — an explicit link/back-nav
+  // always wins over the saved preference.
+  let savedPreferences: { view?: string; status?: string; sort?: string } = {};
+  if (user) {
+    const { data: prefsRow } = await supabase
+      .from("users")
+      .select("feed_preferences")
+      .eq("id", user.id)
+      .single();
+    savedPreferences = prefsRow?.feed_preferences ?? {};
+  }
+
+  const sort = (params.sort as SortOption) || (savedPreferences.sort as SortOption) || "newest";
   const search = params.q || "";
   const tag = params.tag || "";
-  const status = (params.status as IdeaStatus) || "";
-  const view = (params.view as "all" | "mine" | "collaborating") || "all";
+  const status = (params.status as IdeaStatus) || (savedPreferences.status as IdeaStatus) || "";
+  const view =
+    (params.view as "all" | "mine" | "collaborating") ||
+    (savedPreferences.view as "all" | "mine" | "collaborating") ||
+    "all";
   const page = Math.max(1, parseInt(params.page || "1", 10));
-  const { user, supabase } = await requireAuth();
 
   // For "collaborating" view, fetch idea IDs where user is a collaborator
   let collaboratingIdeaIds: string[] = [];

--- a/src/components/discussions/discussion-thread.test.ts
+++ b/src/components/discussions/discussion-thread.test.ts
@@ -43,6 +43,7 @@ function makeReply(
       model_tier_map: null,
       terminal_model: null,
       terminal_auto_accept: false,
+      feed_preferences: {},
       notification_preferences: {
         comments: true,
         votes: true,

--- a/src/components/ideas/idea-feed.tsx
+++ b/src/components/ideas/idea-feed.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { SORT_OPTIONS, STATUS_CONFIG } from "@/lib/constants";
+import { updateFeedPreferences } from "@/actions/ideas";
 import type { IdeaWithAuthor, IdeaStatus, SortOption } from "@/types";
 
 type FeedView = "all" | "mine" | "collaborating";
@@ -79,6 +80,26 @@ export function IdeaFeed({
     });
   }, [searchParams, router, startTransition]);
 
+  // Same as updateParams, but also remembers the choice on the user's
+  // account (view/status/sort only) so it's the default on their next visit,
+  // on any device.
+  const updateParamsAndSave = useCallback(
+    (updates: { view?: string; status?: string; sort?: string }) => {
+      updateParams(updates);
+      const view = "view" in updates ? updates.view : currentView === "all" ? undefined : currentView;
+      const status = "status" in updates ? updates.status : currentStatus;
+      const sort = "sort" in updates ? updates.sort : currentSort;
+      updateFeedPreferences({
+        view: view || undefined,
+        status: status || undefined,
+        sort: sort || undefined,
+      }).catch(() => {
+        // Best-effort — the URL param is already the source of truth for this visit
+      });
+    },
+    [updateParams, currentView, currentStatus, currentSort]
+  );
+
   // Debounced search on keystroke
   useEffect(() => {
     // Don't trigger on initial render or when input matches current search
@@ -121,7 +142,7 @@ export function IdeaFeed({
         <div className="flex items-center gap-2">
           <Select
             value={currentStatus || "all"}
-            onValueChange={(v) => updateParams({ status: v === "all" ? "" : v })}
+            onValueChange={(v) => updateParamsAndSave({ status: v === "all" ? "" : v })}
           >
             <SelectTrigger className="w-full sm:w-[150px]">
               <SelectValue placeholder="Status" />
@@ -139,7 +160,7 @@ export function IdeaFeed({
           </Select>
           <Select
             value={currentSort}
-            onValueChange={(v) => updateParams({ sort: v })}
+            onValueChange={(v) => updateParamsAndSave({ sort: v })}
           >
             <SelectTrigger className="w-full sm:w-[180px]">
               <SelectValue placeholder="Sort by" />
@@ -165,7 +186,9 @@ export function IdeaFeed({
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground"
             }`}
-            onClick={() => updateParams({ view: option.value === "all" ? "" : option.value })}
+            onClick={() =>
+              updateParamsAndSave({ view: option.value === "all" ? "" : option.value })
+            }
           >
             {option.label}
           </button>
@@ -244,7 +267,7 @@ export function IdeaFeed({
           {currentStatus && (
             <Badge variant="secondary" className="gap-1">
               {STATUS_CONFIG[currentStatus as IdeaStatus]?.label ?? currentStatus}
-              <button className="cursor-pointer" onClick={() => updateParams({ status: "" })}>
+              <button className="cursor-pointer" onClick={() => updateParamsAndSave({ status: "" })}>
                 <X className="h-3 w-3" />
               </button>
             </Badge>
@@ -276,7 +299,7 @@ export function IdeaFeed({
               variant="outline"
               size="sm"
               className="mt-4"
-              onClick={() => updateParams({ view: "" })}
+              onClick={() => updateParamsAndSave({ view: "" })}
             >
               Browse ideas
             </Button>
@@ -296,6 +319,10 @@ export function IdeaFeed({
               onClick={() => {
                 clearSearch();
                 updateParams({ tag: "", status: "", q: "" });
+                updateFeedPreferences({
+                  view: currentView === "all" ? undefined : currentView,
+                  sort: currentSort,
+                }).catch(() => {});
               }}
             >
               Clear filters

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -37,6 +37,10 @@ export type Database = {
             compliance_alerts?: boolean;
           };
           default_board_columns: { title: string; is_done_column: boolean }[] | null;
+          /** Saved Ideas feed filter defaults (view/status/sort), synced across
+           *  devices. Empty object = no saved preference — see IdeaFeedPreferences
+           *  in src/types/index.ts. */
+          feed_preferences: { view?: string; status?: string; sort?: string };
           model_tier_map: { frontier?: string; standard?: string; cheap?: string } | null;
           /** In-app terminal starting-model override. NULL = platform default;
            *  '__machine_default__' = explicit opt-out (see MACHINE_DEFAULT_TERMINAL_MODEL
@@ -90,6 +94,7 @@ export type Database = {
             compliance_alerts?: boolean;
           };
           default_board_columns?: { title: string; is_done_column: boolean }[] | null;
+          feed_preferences?: { view?: string; status?: string; sort?: string };
           model_tier_map?: { frontier?: string; standard?: string; cheap?: string } | null;
           terminal_model?: string | null;
           terminal_auto_accept?: boolean;
@@ -128,6 +133,7 @@ export type Database = {
             compliance_alerts?: boolean;
           };
           default_board_columns?: { title: string; is_done_column: boolean }[] | null;
+          feed_preferences?: { view?: string; status?: string; sort?: string };
           model_tier_map?: { frontier?: string; standard?: string; cheap?: string } | null;
           terminal_model?: string | null;
           terminal_auto_accept?: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,9 @@ export type NotificationWithDetails = Notification & {
 // Notification preferences
 export type NotificationPreferences = User["notification_preferences"];
 
+// Ideas feed filter preferences (view/status/sort), synced across devices
+export type IdeaFeedPreferences = User["feed_preferences"];
+
 // Board types
 export type BoardColumn = Database["public"]["Tables"]["board_columns"]["Row"];
 export type BoardTask = Database["public"]["Tables"]["board_tasks"]["Row"];

--- a/supabase/migrations/00163_user_feed_preferences.sql
+++ b/supabase/migrations/00163_user_feed_preferences.sql
@@ -1,0 +1,15 @@
+-- Per-user, cross-device persistence for the Ideas feed filters (view/status/
+-- sort). Previously these lived only in the URL search params, so every
+-- fresh visit reset to defaults. Mirrors the users.notification_preferences
+-- jsonb pattern (migration 00014): a small settings blob on the user row,
+-- read/written via a server action (src/actions/ideas.ts) rather than a
+-- dedicated preferences table, since this is a single narrow feature.
+--
+-- Keys are all optional — an empty object means "no saved preference, use
+-- the app defaults" (all/newest/no status). See IdeaFeedPreferences in
+-- src/types/index.ts.
+ALTER TABLE users
+  ADD COLUMN feed_preferences jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN users.feed_preferences IS
+  'Saved Ideas feed filter defaults (view/status/sort) — synced across devices. Empty object = no saved preference. See IdeaFeedPreferences in src/types/index.ts.';


### PR DESCRIPTION
## Summary
- Ideas feed filters (view/status/sort) previously lived only in the URL and reset on every fresh visit — nothing was remembered.
- Adds `users.feed_preferences` jsonb column (already applied to production) and saves the user's last choice there whenever they change view/status/sort on the Ideas page.
- The saved preference is used as the default only when the URL doesn't already specify a value — an explicit link/back-nav still wins.

Board task: e1c5d76d-dfb6-4df4-8ea3-3a1870e615ab

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (0 new errors)
- [x] `npm run test` (3364/3364 passing)
- [x] `npm run build`
- [x] Migration applied to production and verified live (`users.feed_preferences` jsonb, default `{}`, not null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)