### PR TITLE
fix(terminal): collapse dock after ending last session

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -2048,6 +2048,17 @@ describe("TerminalDock — ending the last tab does not auto-relaunch a fresh se
     const secondEntry = screen.getByTestId("session-view");
     expect(secondEntry.dataset.key).not.toBe(firstKey); // a genuinely fresh entry, not the same tab
     expect(secondEntry.dataset.autoConnectWhenExpanded).toBe("false");
+
+    // Field report (Nick, 2026-08-24): the dock stayed expanded after ending
+    // the last tab, and — since resolveDockView's idle branch never checks
+    // `paired` (it never had to before this fix; a paired browser used to
+    // always auto-connect instantly out of idle) — rendered the first-time
+    // "one-time setup" install wizard to an already-paired user. Ending the
+    // last tab must collapse the dock, not leave it sitting on that view.
+    expect(screen.getByRole("button", { name: /Expand terminal panel/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
   });
 });
 

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1431,9 +1431,16 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
           // lingering empty strip. `suppressAutoConnect: true` — the user just
           // explicitly ended this session, so an expanded dock must NOT
           // immediately auto-reconnect them into a fresh one (bug fix:
-          // last-tab-close auto-relaunch).
+          // last-tab-close auto-relaunch). Also collapse the dock itself —
+          // left expanded, the fresh pristine entry renders `resolveDockView`'s
+          // idle branch, which (reasonably, since a paired browser used to
+          // always auto-connect out of idle before that fix) never checks
+          // `paired` and shows the first-time "one-time setup" wizard even to
+          // an already-paired user (Nick's field report: panel stayed open
+          // showing the install wizard after ending his only session).
           const fresh = createPristineEntry(true);
           setActiveKey(fresh.key);
+          setExpanded(false);
           return [fresh];
         }
         setActiveKey((cur) => {


### PR DESCRIPTION
## Summary
- Ending the last open terminal tab now correctly stops a new session from auto-starting (prior fix in #207), but left the panel expanded showing the "one-time setup" install wizard to already-paired users.
- The dock's idle view never checked whether the browser had paired before, because a paired browser used to always auto-connect instantly out of idle — that assumption broke once auto-relaunch was suppressed.
- Fix: collapse the dock when the last tab closes, returning to the true idle/resting state instead of lingering on the wrong screen.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx eslint src/components/board/terminal-dock.tsx` clean
- [x] New regression test added asserting the dock collapses (`aria-expanded="false"`) after ending the last live tab
- [x] Full `npm run test` — 3364/3364 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)