### PR TITLE
Add quick-add-to-top control on board column headers

### DIFF
--- a/docs/create-task-top-of-column-design.html
+++ b/docs/create-task-top-of-column-design.html
@@ -1,0 +1,288 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Add Task at Top of Column — Design</title>
+<style>
+  /* Zinc dark palette (shadcn New York, Zinc) */
+  :root {
+    --bg: #09090b;          /* zinc-950 */
+    --panel: #18181b;       /* zinc-900 */
+    --panel-50: rgba(39,39,42,.5);
+    --border: #27272a;      /* zinc-800 */
+    --border-2: #3f3f46;    /* zinc-700 */
+    --fg: #fafafa;          /* zinc-50 */
+    --muted: #a1a1aa;       /* zinc-400 */
+    --muted-2: #71717a;     /* zinc-500 */
+    --primary: #fafafa;
+    --primary-fg: #18181b;
+    --destructive: #f87171; /* red-400 — 4.6:1 on zinc-900 */
+    --destructive-dim: rgba(248,113,113,.12);
+    --ring: rgba(250,250,250,.35);
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body {
+    background: var(--bg); color: var(--fg);
+    font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+    padding: 32px 24px 80px;
+  }
+  h1 { font-size: 22px; font-weight: 650; letter-spacing: -.01em; }
+  h2 { font-size: 15px; font-weight: 600; margin: 40px 0 6px; }
+  .sub { color: var(--muted); max-width: 72ch; margin-top: 6px; }
+  .note { color: var(--muted); font-size: 13px; max-width: 72ch; margin: 6px 0 16px; }
+  .note strong { color: var(--fg); font-weight: 600; }
+  kbd {
+    font: 11px/1 ui-monospace, monospace; color: var(--muted);
+    border: 1px solid var(--border-2); border-bottom-width: 2px;
+    border-radius: 4px; padding: 2px 5px; background: var(--panel);
+  }
+
+  .stage { display: flex; gap: 20px; flex-wrap: wrap; align-items: flex-start; margin-top: 16px; }
+
+  /* ---- Column (mirrors board-column.tsx) ---- */
+  .col {
+    width: 300px; background: var(--panel-50);
+    border: 1px solid var(--border); border-radius: 10px;
+    display: flex; flex-direction: column; max-height: 560px;
+  }
+  .col-head {
+    display: flex; align-items: center; justify-content: space-between;
+    border-bottom: 1px solid var(--border); padding: 8px 12px; gap: 8px;
+  }
+  .col-head .left { display: flex; align-items: center; gap: 6px; min-width: 0; }
+  .grip { color: var(--muted-2); flex: none; }
+  .col-title { font-size: 14px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .col-title .count { color: var(--muted); font-weight: 500; }
+  .head-actions { display: flex; align-items: center; gap: 2px; flex: none; }
+  .icon-btn {
+    width: 28px; height: 28px; border-radius: 6px; border: 0; background: transparent;
+    color: var(--muted); display: inline-flex; align-items: center; justify-content: center;
+    cursor: pointer; position: relative;
+  }
+  .icon-btn:hover { background: var(--border); color: var(--fg); }
+  .icon-btn:focus-visible { outline: 2px solid var(--ring); outline-offset: 1px; }
+  /* Invisible touch-target extension to 44x44 on coarse pointers */
+  .icon-btn::after { content: ""; position: absolute; inset: -8px; }
+  .icon-btn svg { width: 16px; height: 16px; }
+
+  .col-body { padding: 8px; display: flex; flex-direction: column; gap: 8px; overflow-y: auto; }
+  .card {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+    padding: 10px 12px; font-size: 13px; box-shadow: 0 1px 2px rgba(0,0,0,.4);
+  }
+  .card .meta { display: flex; gap: 6px; margin-top: 8px; align-items: center; }
+  .chip { font-size: 10px; padding: 2px 7px; border-radius: 999px; border: 1px solid var(--border-2); color: var(--muted); }
+  .chip.violet { color: #c4b5fd; border-color: rgba(196,181,253,.35); }
+  .chip.emerald { color: #6ee7b7; border-color: rgba(110,231,183,.35); }
+  .avatar {
+    width: 18px; height: 18px; border-radius: 999px; margin-left: auto;
+    background: linear-gradient(135deg,#52525b,#27272a);
+    font-size: 9px; display: flex; align-items: center; justify-content: center; color: var(--fg);
+  }
+  .card.faded, .fade-rest { opacity: .55; }
+  .more-tasks { text-align: center; color: var(--muted-2); font-size: 12px; padding: 2px 0 6px; }
+
+  .col-foot { border-top: 1px solid var(--border); padding: 8px; }
+  .add-bottom {
+    width: 100%; display: flex; align-items: center; gap: 8px; border: 0; background: transparent;
+    color: var(--muted); font-size: 13px; padding: 7px 10px; border-radius: 6px; cursor: pointer; text-align: left;
+  }
+  .add-bottom:hover { background: var(--border); color: var(--fg); }
+
+  /* ---- Quick composer ---- */
+  .composer {
+    background: var(--panel); border: 1px solid var(--border-2); border-radius: 8px;
+    padding: 8px; box-shadow: 0 4px 12px rgba(0,0,0,.45);
+  }
+  .composer.focus { border-color: var(--ring); box-shadow: 0 0 0 3px rgba(250,250,250,.08), 0 4px 12px rgba(0,0,0,.45); }
+  .composer label { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); }
+  .composer textarea {
+    width: 100%; resize: none; border: 0; background: transparent; color: var(--fg);
+    font: 13px/1.45 inherit; outline: none; min-height: 38px; padding: 2px 2px 0;
+  }
+  .composer textarea::placeholder { color: var(--muted-2); }
+  .composer .row { display: flex; align-items: center; gap: 8px; margin-top: 6px; }
+  .btn {
+    border: 0; border-radius: 6px; font-size: 13px; font-weight: 600; cursor: pointer;
+    padding: 7px 14px; min-height: 32px;
+  }
+  .btn-primary { background: var(--primary); color: var(--primary-fg); }
+  .btn-primary:hover { background: #e4e4e7; }
+  .btn-ghost { background: transparent; color: var(--muted); padding: 7px 10px; }
+  .btn-ghost:hover { background: var(--border); color: var(--fg); }
+  .hint { margin-left: auto; font-size: 11px; color: var(--muted-2); display: flex; gap: 4px; align-items: center; }
+  .caret { display: inline-block; width: 1px; height: 15px; background: var(--fg); vertical-align: text-bottom; animation: blink 1.1s step-end infinite; }
+  @keyframes blink { 50% { opacity: 0; } }
+
+  /* Error state */
+  .composer.error { border-color: var(--destructive); }
+  .err {
+    display: flex; gap: 7px; align-items: flex-start; margin-top: 8px;
+    background: var(--destructive-dim); border-radius: 6px; padding: 7px 9px;
+    font-size: 12px; color: var(--destructive);
+  }
+  .err svg { width: 14px; height: 14px; flex: none; margin-top: 1px; }
+
+  /* Optimistic (pending) card */
+  .card.pending { border-style: dashed; border-color: var(--border-2); }
+  .card.pending .spin {
+    width: 12px; height: 12px; border: 2px solid var(--border-2); border-top-color: var(--muted);
+    border-radius: 999px; display: inline-block; animation: rot .8s linear infinite; vertical-align: -2px; margin-right: 6px;
+  }
+  @keyframes rot { to { transform: rotate(360deg); } }
+
+  .state-label {
+    font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase;
+    color: var(--muted-2); margin: 0 2px 8px;
+  }
+  .spec {
+    margin-top: 40px; border: 1px solid var(--border); border-radius: 10px; overflow: hidden; max-width: 860px;
+  }
+  .spec table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .spec th, .spec td { text-align: left; padding: 10px 14px; border-top: 1px solid var(--border); vertical-align: top; }
+  .spec th { background: var(--panel); border-top: 0; font-weight: 600; }
+  .spec td:first-child { color: var(--muted); white-space: nowrap; width: 190px; }
+</style>
+</head>
+<body>
+
+<h1>Add task at the top of a column</h1>
+<p class="sub">A quick-add control in every column header. One click opens an inline composer pinned above the first card — no modal, no scrolling. The task appears exactly where the new card will land.</p>
+
+<div class="stage">
+
+  <!-- STATE 1: Default -->
+  <div>
+    <p class="state-label">1 · Default — new “+” beside the column menu</p>
+    <div class="col">
+      <div class="col-head">
+        <div class="left">
+          <svg class="grip" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="9" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="18" r="1"/></svg>
+          <h3 class="col-title">In Progress <span class="count">(7)</span></h3>
+        </div>
+        <div class="head-actions">
+          <button class="icon-btn" title="Add task to top" aria-label="Add task to top of In Progress">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+          </button>
+          <button class="icon-btn" title="Column options" aria-label="Column options">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="5" cy="12" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/></svg>
+          </button>
+        </div>
+      </div>
+      <div class="col-body">
+        <div class="card">Fix relay reconnect flicker on tab switch
+          <div class="meta"><span class="chip violet">terminal</span><span class="avatar">NB</span></div>
+        </div>
+        <div class="card">Persist feed filters per-user across devices
+          <div class="meta"><span class="chip emerald">feed</span><span class="avatar">CW</span></div>
+        </div>
+        <div class="card">Very long task title that wraps onto multiple lines to prove the layout holds up with realistic data</div>
+        <div class="more-tasks">· · · 4 more tasks below the fold · · ·</div>
+      </div>
+      <div class="col-foot">
+        <button class="add-bottom"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg> Add task</button>
+      </div>
+    </div>
+    <p class="note" style="width:300px">The existing bottom “Add task” (full dialog with labels, assignee, etc.) is unchanged. The header “+” is the fast path.</p>
+  </div>
+
+  <!-- STATE 2: Composer open -->
+  <div>
+    <p class="state-label">2 · Open — inline composer pinned above first card</p>
+    <div class="col">
+      <div class="col-head">
+        <div class="left">
+          <svg class="grip" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="9" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="18" r="1"/></svg>
+          <h3 class="col-title">In Progress <span class="count">(7)</span></h3>
+        </div>
+        <div class="head-actions">
+          <button class="icon-btn" title="Close" aria-label="Close quick add" style="background:var(--border);color:var(--fg)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+          </button>
+          <button class="icon-btn" title="Column options" aria-label="Column options">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="5" cy="12" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/></svg>
+          </button>
+        </div>
+      </div>
+      <div class="col-body">
+        <div class="composer focus">
+          <label for="qa-2">Task title</label>
+          <textarea id="qa-2" rows="2" placeholder="Task title…">Wire up header quick-add<span class="caret"></span></textarea>
+          <div class="row">
+            <button class="btn btn-primary">Add task</button>
+            <button class="btn btn-ghost">Cancel</button>
+            <span class="hint"><kbd>↵</kbd> add · <kbd>esc</kbd> cancel</span>
+          </div>
+        </div>
+        <div class="card faded">Fix relay reconnect flicker on tab switch
+          <div class="meta"><span class="chip violet">terminal</span><span class="avatar">NB</span></div>
+        </div>
+        <div class="card faded">Persist feed filters per-user across devices</div>
+        <div class="more-tasks fade-rest">· · ·</div>
+      </div>
+      <div class="col-foot"><button class="add-bottom" style="opacity:.55"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg> Add task</button></div>
+    </div>
+    <p class="note" style="width:300px">The “+” morphs into “×” so the open control is also the close control (Fitts: cancel is where the cursor already is). Enter adds and keeps the composer open for rapid entry; Shift+Enter makes a new line.</p>
+  </div>
+
+  <!-- STATE 3: Error -->
+  <div>
+    <p class="state-label">3 · Error — create failed, nothing lost</p>
+    <div class="col">
+      <div class="col-head">
+        <div class="left">
+          <svg class="grip" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="9" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="18" r="1"/></svg>
+          <h3 class="col-title">In Progress <span class="count">(7)</span></h3>
+        </div>
+        <div class="head-actions">
+          <button class="icon-btn" title="Close" aria-label="Close quick add" style="background:var(--border);color:var(--fg)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+          </button>
+          <button class="icon-btn" title="Column options" aria-label="Column options">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="5" cy="12" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/></svg>
+          </button>
+        </div>
+      </div>
+      <div class="col-body">
+        <div class="composer error">
+          <label for="qa-3">Task title</label>
+          <textarea id="qa-3" rows="2">Wire up header quick-add</textarea>
+          <div class="row">
+            <button class="btn btn-primary">Retry</button>
+            <button class="btn btn-ghost">Cancel</button>
+          </div>
+          <div class="err">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg>
+            <span>Couldn’t create the task. Your text is kept — retry, or cancel to discard.</span>
+          </div>
+        </div>
+        <div class="card pending"><span class="spin"></span>Wire up header quick-add</div>
+        <div class="card faded">Fix relay reconnect flicker on tab switch</div>
+        <div class="more-tasks fade-rest">· · ·</div>
+      </div>
+      <div class="col-foot"><button class="add-bottom" style="opacity:.55"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg> Add task</button></div>
+    </div>
+    <p class="note" style="width:300px">Dashed card = optimistic insert awaiting the server. On failure it rolls back (removed), a toast fires, and the composer re-opens with the title intact and “Add” relabelled “Retry”. Empty or whitespace-only titles disable nothing — pressing Add just shakes the field and shows “Enter a title first”.</p>
+  </div>
+
+</div>
+
+<h2>Interaction spec</h2>
+<div class="spec">
+  <table>
+    <tr><th>Aspect</th><th>Behaviour</th></tr>
+    <tr><td>Placement</td><td>Ghost “+” icon button in the column header, immediately left of the “…” column-options button. Same 28&times;28 visual size and hover treatment; a pseudo-element extends the hit area to 44&times;44 for touch. Header title, count and menu are never obscured.</td></tr>
+    <tr><td>Open</td><td>Click/tap/Enter on “+” renders the composer as the first item of the task list (in normal flow — not a popover or modal), auto-focuses the textarea, and scrolls the column to top if the user had scrolled down. The “+” becomes “×”.</td></tr>
+    <tr><td>Create</td><td><kbd>Enter</kbd> or “Add task” button. Trimmed-empty titles are rejected inline. Optimistic card inserts at position <em>first.position − 1000</em> (existing gap scheme); composer clears and stays open focused for rapid multi-add. Realtime pushes the card to other viewers at the top.</td></tr>
+    <tr><td>Cancel</td><td><kbd>Esc</kbd>, outside-click, the “×” in the header, or the Cancel button — all always work (never trap the user). If text was typed, outside-click keeps the composer open once and shows the hint “Press Esc again to discard”; Esc always closes immediately.</td></tr>
+    <tr><td>Error</td><td>Optimistic card rolls back, <code>toast.error()</code> fires, composer re-opens pre-filled with the failed title, primary button reads “Retry”. No typed text is ever lost.</td></tr>
+    <tr><td>Mobile (375px)</td><td>Identical flow — inline composer, no sheet/modal, so the on-screen keyboard never covers a floating dialog. All targets ≥44px effective. The bottom “Add task” bar remains for users who want the full editor.</td></tr>
+    <tr><td>Keyboard &amp; a11y</td><td>“+” is in the header tab order with <code>aria-label</code> “Add task to top of {column}”. Textarea has a visually-hidden <code>&lt;label&gt;</code>. Focus returns to the “+” button on close. Error message is <code>role="alert"</code>. Contrast: all text ≥4.5:1 on zinc-900 (error red-400 = 4.6:1).</td></tr>
+    <tr><td>Read-only / guest</td><td>Button not rendered at all (mirrors existing <code>isReadOnly</code> handling), never disabled-without-explanation.</td></tr>
+    <tr><td>Unchanged</td><td>Bottom “Add task” full-dialog flow, drag-and-drop, workflow auto-rules (fire identically for top-created tasks), column menu.</td></tr>
+  </table>
+</div>
+
+</body>
+</html>

--- a/src/actions/board.ts
+++ b/src/actions/board.ts
@@ -3,6 +3,7 @@
 import { after } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { DEFAULT_BOARD_COLUMNS, POSITION_GAP } from "@/lib/constants";
+import { computeTopInsertPosition } from "@/lib/board-position";
 import { validateTitle, validateOptionalDescription, validateLabelName, validateLabelColor, validateComment } from "@/lib/validation";
 import { checkAndApplyAutoRules, checkAutoRuleWorkflow, removeAutoRuleWorkflow } from "@/lib/workflow-helpers";
 import { dismissSuggestionsForLabel } from "@/lib/workflow-matching";
@@ -193,6 +194,49 @@ export async function createBoardTask(
       description: description || null,
       assignee_id: assigneeId || null,
       position: maxPos + POSITION_GAP,
+    })
+    .select("id")
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  // No revalidatePath — board is force-dynamic and Realtime subscription handles sync.
+  return data.id;
+}
+
+/**
+ * Creates a task at the top of a column — used by the column header's "+"
+ * quick-add composer. Unlike `createBoardTask` (which appends to the
+ * bottom), this reads the current *lowest* position in the column and
+ * inserts above it via `computeTopInsertPosition`.
+ */
+export async function createBoardTaskAtTop(ideaId: string, columnId: string, title: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  title = validateTitle(title);
+
+  // Get the current first task's position in this column
+  const { data: tasks } = await supabase
+    .from("board_tasks")
+    .select("position")
+    .eq("column_id", columnId)
+    .order("position", { ascending: true })
+    .limit(1);
+
+  const position = computeTopInsertPosition(tasks?.map((t) => t.position) ?? []);
+
+  const { data, error } = await supabase
+    .from("board_tasks")
+    .insert({
+      idea_id: ideaId,
+      column_id: columnId,
+      title,
+      position,
     })
     .select("id")
     .single();

--- a/src/components/board/board-column.tsx
+++ b/src/components/board/board-column.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useMemo, memo } from "react";
+import { useState, useMemo, useRef, memo } from "react";
 import dynamic from "next/dynamic";
 import { toast } from "sonner";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { MoreHorizontal, Plus, Pencil, Trash2, GripVertical, CircleCheckBig, Archive } from "lucide-react";
+import { MoreHorizontal, Plus, X, Pencil, Trash2, GripVertical, CircleCheckBig, Archive } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { BoardTaskCard } from "./board-task-card";
+import { BoardQuickAdd } from "./board-quick-add";
 import { useBoardOps } from "./board-context";
 import { deleteBoardColumn, archiveColumnTasks } from "@/actions/board";
 import { undoableAction } from "@/lib/undo-toast";
@@ -72,7 +73,15 @@ export const BoardColumn = memo(function BoardColumn({
 }: BoardColumnProps) {
   const [addTaskOpen, setAddTaskOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
+  const [quickAddOpen, setQuickAddOpen] = useState(false);
+  const quickAddButtonRef = useRef<HTMLButtonElement>(null);
   const ops = useBoardOps();
+
+  function closeQuickAdd() {
+    setQuickAddOpen(false);
+    // Focus returns to the "+" button that opened it.
+    quickAddButtonRef.current?.focus();
+  }
 
   const sortableData = useMemo(
     () => ({ type: "column" as const, columnId: column.id }),
@@ -172,42 +181,69 @@ export const BoardColumn = memo(function BoardColumn({
             </h3>
           </div>
           {!isReadOnly && (
-            <DropdownMenu>
+            <div className="flex items-center gap-0.5">
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="icon" className="h-7 w-7">
-                      <MoreHorizontal className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
+                  <Button
+                    ref={quickAddButtonRef}
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    aria-label={quickAddOpen ? "Close quick add" : `Add task to top of ${column.title}`}
+                    onClick={() => setQuickAddOpen((open) => !open)}
+                  >
+                    {quickAddOpen ? <X className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
+                  </Button>
                 </TooltipTrigger>
-                <TooltipContent>Column options</TooltipContent>
+                <TooltipContent>{quickAddOpen ? "Close" : "Add task to top"}</TooltipContent>
               </Tooltip>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setRenameOpen(true)}>
-                  <Pencil className="mr-2 h-4 w-4" />
-                  Edit
-                </DropdownMenuItem>
-                {column.is_done_column && column.tasks.length > 0 && (
-                  <DropdownMenuItem onClick={handleArchiveAll}>
-                    <Archive className="mr-2 h-4 w-4" />
-                    Archive all
+              <DropdownMenu>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-7 w-7">
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>Column options</TooltipContent>
+                </Tooltip>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => setRenameOpen(true)}>
+                    <Pencil className="mr-2 h-4 w-4" />
+                    Edit
                   </DropdownMenuItem>
-                )}
-                <DropdownMenuItem
-                  onClick={handleDelete}
-                  className="text-destructive"
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Delete
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                  {column.is_done_column && column.tasks.length > 0 && (
+                    <DropdownMenuItem onClick={handleArchiveAll}>
+                      <Archive className="mr-2 h-4 w-4" />
+                      Archive all
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem
+                    onClick={handleDelete}
+                    className="text-destructive"
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           )}
         </div>
 
         {/* Task list */}
         <div className="min-h-[60px] flex-1 space-y-2 overflow-y-auto p-2">
+          {!isReadOnly && quickAddOpen && (
+            <BoardQuickAdd
+              columnId={column.id}
+              columnTitle={column.title}
+              ideaId={ideaId}
+              currentUserId={currentUserId}
+              existingPositions={columnTaskPositions.map((t) => t.position)}
+              onClose={closeQuickAdd}
+            />
+          )}
           <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
             {column.tasks.length === 0 && (
               <div className="flex items-center justify-center rounded-md border border-dashed border-border py-8 text-center">

--- a/src/components/board/board-context.tsx
+++ b/src/components/board/board-context.tsx
@@ -6,6 +6,8 @@ import type { BoardColumnWithTasks, BoardTaskWithAssignee, BoardColumn } from "@
 export interface BoardOptimisticOps {
   /** Insert a temp task into a column. Returns rollback function. */
   createTask: (columnId: string, tempTask: BoardTaskWithAssignee) => () => void;
+  /** Insert a temp task at the top of a column. Returns rollback function. */
+  createTaskAtTop: (columnId: string, tempTask: BoardTaskWithAssignee) => () => void;
   /** Remove a task from a column. Returns rollback function. */
   deleteTask: (taskId: string, columnId: string) => () => void;
   /** Mark a single task as archived. Returns rollback function. */

--- a/src/components/board/board-quick-add.test.tsx
+++ b/src/components/board/board-quick-add.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+// Deferred promise helper — lets tests control exactly when a "server call"
+// resolves/rejects, so multiple concurrent creates can be interleaved.
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const createTaskAtTop = vi.fn();
+const incrementPendingOps = vi.fn();
+const decrementPendingOps = vi.fn();
+
+vi.mock("./board-context", () => ({
+  useBoardOps: () => ({
+    createTaskAtTop,
+    incrementPendingOps,
+    decrementPendingOps,
+  }),
+}));
+
+const createBoardTaskAtTop = vi.fn();
+vi.mock("@/actions/board", () => ({
+  createBoardTaskAtTop: (...args: unknown[]) => createBoardTaskAtTop(...args),
+}));
+
+const logTaskActivity = vi.fn();
+vi.mock("@/lib/activity", () => ({
+  logTaskActivity: (...args: unknown[]) => logTaskActivity(...args),
+}));
+
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastError(...args) },
+}));
+
+import { BoardQuickAdd } from "./board-quick-add";
+
+afterEach(cleanup);
+beforeEach(() => {
+  vi.clearAllMocks();
+  createTaskAtTop.mockImplementation(() => vi.fn());
+});
+
+function setup(existingPositions: number[] = [1000, 2000], onClose = vi.fn()) {
+  render(
+    <BoardQuickAdd
+      columnId="col-1"
+      columnTitle="In Progress"
+      ideaId="idea-1"
+      currentUserId="user-1"
+      existingPositions={existingPositions}
+      onClose={onClose}
+    />
+  );
+  return { onClose };
+}
+
+function getTextarea() {
+  return screen.getByRole("textbox", { name: /Add task to top of In Progress/i });
+}
+
+describe("BoardQuickAdd", () => {
+  it("creates a task at the top on Enter and clears the field for rapid multi-add", async () => {
+    createBoardTaskAtTop.mockResolvedValue("real-id");
+    setup();
+
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "Fix the flicker" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(createTaskAtTop).toHaveBeenCalledWith(
+      "col-1",
+      expect.objectContaining({ title: "Fix the flicker", position: 1000 - 1000, column_id: "col-1" })
+    );
+
+    await waitFor(() => expect(createBoardTaskAtTop).toHaveBeenCalledWith("idea-1", "col-1", "Fix the flicker"));
+    await waitFor(() => expect(logTaskActivity).toHaveBeenCalledWith("real-id", "idea-1", "user-1", "created"));
+
+    // Composer clears but stays open, ready for another add
+    expect((getTextarea() as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("falls back to position 0 for an empty column", () => {
+    setup([]);
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "First task" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(createTaskAtTop).toHaveBeenCalledWith("col-1", expect.objectContaining({ position: 0 }));
+  });
+
+  it("does not submit on Enter with an empty or whitespace-only title", () => {
+    setup();
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "   " } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(createTaskAtTop).not.toHaveBeenCalled();
+  });
+
+  it("Escape closes immediately and discards typed text, no exceptions", () => {
+    const { onClose } = setup();
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "Some unsaved text" } });
+    fireEvent.keyDown(textarea, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(createTaskAtTop).not.toHaveBeenCalled();
+  });
+
+  it("rolls back, toasts, and re-opens pre-filled with a Retry affordance on failure", async () => {
+    const rollback = vi.fn();
+    createTaskAtTop.mockImplementation(() => rollback);
+    createBoardTaskAtTop.mockRejectedValue(new Error("boom"));
+    setup();
+
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "Will fail" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => expect(rollback).toHaveBeenCalledTimes(1));
+    expect(toastError).toHaveBeenCalledWith("Failed to create task");
+
+    // Text is restored, not lost
+    expect((getTextarea() as HTMLTextAreaElement).value).toBe("Will fail");
+    expect(screen.getByRole("button", { name: /Retry/i })).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(/Couldn.t create the task/);
+  });
+
+  it("only rolls back the failing create when several are in flight at once", async () => {
+    const rollbackA = vi.fn();
+    const rollbackB = vi.fn();
+    const deferredA = deferred<string>();
+    const deferredB = deferred<string>();
+
+    createTaskAtTop.mockImplementationOnce(() => rollbackA).mockImplementationOnce(() => rollbackB);
+    createBoardTaskAtTop.mockImplementationOnce(() => deferredA.promise).mockImplementationOnce(() => deferredB.promise);
+
+    setup();
+    const textarea = getTextarea();
+
+    // Fire off two creates back-to-back before either resolves
+    fireEvent.change(textarea, { target: { value: "Task A" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.change(textarea, { target: { value: "Task B" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(createTaskAtTop).toHaveBeenCalledTimes(2);
+
+    // A fails, B succeeds
+    deferredA.reject(new Error("boom"));
+    deferredB.resolve("task-b-id");
+
+    await waitFor(() => expect(rollbackA).toHaveBeenCalledTimes(1));
+    expect(rollbackB).not.toHaveBeenCalled();
+  });
+
+  it("closes immediately on outside click when there is no unsaved text", () => {
+    const { onClose } = setup();
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the composer open once with a hint on outside click with unsaved text, then discards on the second", () => {
+    const { onClose } = setup();
+    const textarea = getTextarea();
+    fireEvent.change(textarea, { target: { value: "Don't lose me" } });
+
+    fireEvent.mouseDown(document.body);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText(/Press Esc again to discard/i)).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/board/board-quick-add.tsx
+++ b/src/components/board/board-quick-add.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { toast } from "sonner";
+import { AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { useBoardOps } from "./board-context";
+import { createBoardTaskAtTop } from "@/actions/board";
+import { logTaskActivity } from "@/lib/activity";
+import { computeTopInsertPosition } from "@/lib/board-position";
+import type { BoardTaskWithAssignee } from "@/types";
+
+interface BoardQuickAddProps {
+  columnId: string;
+  columnTitle: string;
+  ideaId: string;
+  currentUserId: string;
+  /** Positions of the column's current tasks, used to compute where a new task lands. */
+  existingPositions: number[];
+  /** Called whenever the composer wants to close — Esc, submit-cancel, blur, etc. */
+  onClose: () => void;
+}
+
+/**
+ * Inline "quick add" composer rendered as the first item of a column's task
+ * list (see board-column.tsx). Not a modal or popover — closing it is always
+ * free, per the terminal-dock "never trap the user" rule this project
+ * already applies elsewhere.
+ */
+export function BoardQuickAdd({
+  columnId,
+  columnTitle,
+  ideaId,
+  currentUserId,
+  existingPositions,
+  onClose,
+}: BoardQuickAddProps) {
+  const ops = useBoardOps();
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handleOutsideClick(e: MouseEvent) {
+      if (!containerRef.current || containerRef.current.contains(e.target as Node)) return;
+
+      if (text.trim().length === 0) {
+        onClose();
+        return;
+      }
+
+      // Deliberate deviation from "always close on outside click": unsaved
+      // text survives the first outside click, with a hint, and only
+      // discards on a second one (or Escape, which always discards).
+      if (confirmDiscard) {
+        onClose();
+      } else {
+        setConfirmDiscard(true);
+      }
+    }
+    document.addEventListener("mousedown", handleOutsideClick);
+    return () => document.removeEventListener("mousedown", handleOutsideClick);
+  }, [text, confirmDiscard, onClose]);
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+      return;
+    }
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void handleSubmit();
+    }
+  }
+
+  async function handleSubmit() {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    setError(null);
+    setConfirmDiscard(false);
+
+    const tempId = `temp-${crypto.randomUUID()}`;
+    const position = computeTopInsertPosition(existingPositions);
+    const tempTask: BoardTaskWithAssignee = {
+      id: tempId,
+      idea_id: ideaId,
+      column_id: columnId,
+      title: trimmed,
+      description: null,
+      assignee_id: null,
+      assignee: null,
+      labels: [],
+      position,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      due_date: null,
+      archived: false,
+      workflow_step_total: 0,
+      workflow_step_completed: 0,
+      workflow_step_in_progress: 0,
+      workflow_step_failed: 0,
+      workflow_step_awaiting_approval: 0,
+      workflow_step_started_at: null,
+      workflow_active_step_title: null,
+      workflow_active_agent_name: null,
+      workflow_template_name: null,
+      attachment_count: 0,
+      cover_image_path: null,
+      comment_count: 0,
+      discussion_id: null,
+      working_started_at: null,
+    };
+
+    // Optimistically insert & keep the composer open (cleared) for rapid multi-add.
+    const rollback = ops.createTaskAtTop(columnId, tempTask);
+    ops.incrementPendingOps();
+    setText("");
+
+    try {
+      const taskId = await createBoardTaskAtTop(ideaId, columnId, trimmed);
+      logTaskActivity(taskId, ideaId, currentUserId, "created");
+      textareaRef.current?.focus();
+    } catch {
+      rollback();
+      toast.error("Failed to create task");
+      // Put the failed text back so nothing is lost, and let the user retry.
+      setText(trimmed);
+      setError("Couldn't create the task. Your text is kept — retry, or cancel to discard.");
+    } finally {
+      ops.decrementPendingOps();
+    }
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={`rounded-md border bg-background p-2 shadow-sm ${
+        error ? "border-destructive" : "border-border focus-within:ring-2 focus-within:ring-ring"
+      }`}
+    >
+      <Label htmlFor={`quick-add-${columnId}`} className="sr-only">
+        Task title
+      </Label>
+      <Textarea
+        id={`quick-add-${columnId}`}
+        ref={textareaRef}
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value);
+          if (confirmDiscard) setConfirmDiscard(false);
+        }}
+        onKeyDown={handleKeyDown}
+        placeholder="Task title…"
+        rows={2}
+        className="min-h-[38px] resize-none border-0 p-0 shadow-none focus-visible:ring-0"
+        aria-label={`Add task to top of ${columnTitle}`}
+      />
+      <div className="mt-1.5 flex items-center gap-2">
+        <Button type="button" size="sm" onClick={() => void handleSubmit()} disabled={!text.trim()}>
+          {error ? "Retry" : "Add task"}
+        </Button>
+        <Button type="button" size="sm" variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        {confirmDiscard && !error && (
+          <span className="ml-auto text-xs text-muted-foreground">Press Esc again to discard</span>
+        )}
+      </div>
+      {error && (
+        <div role="alert" className="mt-2 flex items-start gap-1.5 rounded-md bg-destructive/10 p-2 text-xs text-destructive">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -539,6 +539,27 @@ export function KanbanBoard({
     };
   }, []);
 
+  const optimisticCreateTaskAtTop = useCallback((columnId: string, tempTask: BoardTaskWithAssignee) => {
+    setColumns((cols) => {
+      const next = cols.map((col) => (col.id === columnId ? { ...col, tasks: [tempTask, ...col.tasks] } : col));
+      columnsRef.current = next;
+      return next;
+    });
+    // Rollback removes only this temp task by id — rather than reverting to a
+    // captured "prev" snapshot — so rapid multi-add (several quick-adds fired
+    // in quick succession) only undoes the one that actually failed, not
+    // unrelated cards created or still pending alongside it.
+    return () => {
+      setColumns((cols) => {
+        const next = cols.map((col) =>
+          col.id === columnId ? { ...col, tasks: col.tasks.filter((t) => t.id !== tempTask.id) } : col
+        );
+        columnsRef.current = next;
+        return next;
+      });
+    };
+  }, []);
+
   const optimisticDeleteTask = useCallback((taskId: string, columnId: string) => {
     const prev = columnsRef.current;
     setColumns((cols) => {
@@ -699,6 +720,7 @@ export function KanbanBoard({
   const boardOps = useMemo<BoardOptimisticOps>(
     () => ({
       createTask: optimisticCreateTask,
+      createTaskAtTop: optimisticCreateTaskAtTop,
       deleteTask: optimisticDeleteTask,
       archiveTask: optimisticArchiveTask,
       moveTaskWithinColumn: optimisticMoveTaskWithinColumn,
@@ -713,6 +735,7 @@ export function KanbanBoard({
     }),
     [
       optimisticCreateTask,
+      optimisticCreateTaskAtTop,
       optimisticDeleteTask,
       optimisticArchiveTask,
       optimisticMoveTaskWithinColumn,

--- a/src/lib/board-position.test.ts
+++ b/src/lib/board-position.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { computeTopInsertPosition } from "./board-position";
+import { POSITION_GAP } from "@/lib/constants";
+
+describe("computeTopInsertPosition", () => {
+  it("returns 0 for an empty column, matching the bottom Add-task fallback", () => {
+    expect(computeTopInsertPosition([])).toBe(0);
+  });
+
+  it("lands POSITION_GAP below the current lowest position", () => {
+    expect(computeTopInsertPosition([1000, 2000, 3000])).toBe(1000 - POSITION_GAP);
+  });
+
+  it("uses the minimum regardless of array order", () => {
+    expect(computeTopInsertPosition([3000, 500, 2000])).toBe(500 - POSITION_GAP);
+  });
+
+  it("handles negative positions", () => {
+    expect(computeTopInsertPosition([-500])).toBe(-500 - POSITION_GAP);
+  });
+});

--- a/src/lib/board-position.ts
+++ b/src/lib/board-position.ts
@@ -1,0 +1,17 @@
+import { POSITION_GAP } from "@/lib/constants";
+
+/**
+ * Computes the `position` for a task inserted above the current first card
+ * in a column (used by the header "+" quick-add). Mirrors the gap-based
+ * scheme used everywhere else on the board: the new card lands
+ * `POSITION_GAP` below the lowest existing position.
+ *
+ * For an empty column there's nothing to sit above, so it falls back to 0 —
+ * the same value `createBoardTask` produces for the first task added via the
+ * bottom "Add task" dialog (maxPos starts at `-POSITION_GAP`, so
+ * `maxPos + POSITION_GAP === 0`).
+ */
+export function computeTopInsertPosition(existingPositions: number[]): number {
+  if (existingPositions.length === 0) return 0;
+  return Math.min(...existingPositions) - POSITION_GAP;
+}


### PR DESCRIPTION
## Summary
- Adds a "+" button in each column header that opens an inline composer to create a task at the top of the column, without scrolling to the bottom of a long column.
- New tasks land above all existing cards using the existing gap-based position scheme; other cards don't move.
- Existing bottom "Add task" dialog flow is unchanged.
- Failed creates roll back just the failed card (not any other in-flight/succeeded ones during rapid multi-add) and re-open pre-filled for retry.

Full design/requirements background: `docs/create-task-top-of-column-design.html`.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 3,379 tests passing (12 new, covering position calc, empty-column fallback, cancel/escape/outside-click behavior, failure rollback isolation)
- [ ] Manual click-through in a live/deployed environment (not possible locally — no working Docker/Supabase here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)