### PR TITLE
fix(sw): return a real Response on failed background fetches

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -76,6 +76,8 @@ self.addEventListener("fetch", (event) => {
 
   // Network-first for everything else
   event.respondWith(
-    fetch(request).catch(() => caches.match(request))
+    fetch(request).catch(() =>
+      caches.match(request).then((cached) => cached || new Response(null, { status: 504, statusText: "Network error" }))
+    )
   );
 });

--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -2062,6 +2062,112 @@ describe("TerminalDock — ending the last tab does not auto-relaunch a fresh se
   });
 });
 
+// Field report (Nick, 2026-08-25): with two tabs open, closing the SECOND
+// (non-last) one collapsed the whole panel — even though the first tab's
+// session was still alive. Reopening the panel showed the first session
+// intact, so nothing was actually torn down server-side; this is purely the
+// dock's local `expanded` state being wrongly cleared on a close that isn't
+// the last tab.
+describe("TerminalDock — closing a non-last tab must not collapse the panel (field report 2026-08-25)", () => {
+  async function mintTwoSessions(): Promise<[string, string]> {
+    await waitFor(() => expect(screen.getByTestId("chooser")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("chooser-start-new"));
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    const firstKey = screen.getByTestId("session-view").dataset.key as string;
+
+    act(() => {
+      requestBrowserLaunch();
+    });
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("chooser-start-new"));
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(2));
+
+    const keys = screen.getAllByTestId("session-view").map((el) => el.dataset.key as string);
+    const secondKey = keys.find((k) => k !== firstKey) as string;
+    return [firstKey, secondKey];
+  }
+
+  function tabContainer(key: string): HTMLElement {
+    const el = document.getElementById(`terminal-tab-${key}`);
+    if (!el) throw new Error(`tab element not found for key ${key}`);
+    return el;
+  }
+
+  it("closing the newer of two tabs leaves the panel expanded on the remaining (original) tab", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+    const [firstKey, secondKey] = await mintTwoSessions();
+
+    expect(screen.getByRole("button", { name: /Collapse terminal panel/ })).toHaveAttribute("aria-expanded", "true");
+
+    // Bring the second tab live so × arms the confirm, matching a real
+    // connected session (mirrors the "ending the last tab" test above).
+    fireEvent.click(screen.getByTestId(`report-connected-${secondKey}`));
+    fireEvent.click(
+      within(tabContainer(secondKey)).getByRole("button", { name: /^(End session and close tab|Close tab):/ }),
+    );
+    fireEvent.click(within(tabContainer(secondKey)).getByRole("button", { name: /^Confirm end session:/ }));
+
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(1));
+    expect(screen.getByTestId("session-view").dataset.key).toBe(firstKey);
+
+    expect(screen.getByRole("button", { name: /(Expand|Collapse) terminal panel/ })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("closing an already-ENDED second tab (single click, no confirm) leaves the panel expanded on the remaining tab", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+    const [firstKey, secondKey] = await mintTwoSessions();
+
+    fireEvent.click(screen.getByTestId(`report-ended-${secondKey}`));
+    fireEvent.click(
+      within(tabContainer(secondKey)).getByRole("button", { name: /^(End session and close tab|Close tab):/ }),
+    );
+
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(1));
+    expect(screen.getByTestId("session-view").dataset.key).toBe(firstKey);
+
+    expect(screen.getByRole("button", { name: /(Expand|Collapse) terminal panel/ })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("real page-load order: auto-seeded first tab (connected) + a '+'-opened second tab — closing the second leaves the first's panel open", async () => {
+    // Empty registry — the FIRST tab comes from the page-load auto-seed
+    // (empty-launch), exactly like Nick's real session, not the chooser.
+    stubFetch(Promise.resolve([]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+
+    await waitFor(() => expect(screen.getByTestId("session-view")).toBeInTheDocument());
+    const firstKey = screen.getByTestId("session-view").dataset.key as string;
+    fireEvent.click(screen.getByTestId(`report-connected-${firstKey}`));
+    fireEvent.click(tabContainer(firstKey)); // expand, as clicking the tab does for real
+
+    fireEvent.click(screen.getByRole("button", { name: "New terminal session" }));
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(2));
+    const secondKey = screen.getAllByTestId("session-view").map((el) => el.dataset.key as string).find((k) => k !== firstKey) as string;
+
+    expect(screen.getByRole("button", { name: /Collapse terminal panel/ })).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(screen.getByTestId(`report-connected-${secondKey}`));
+    fireEvent.click(
+      within(tabContainer(secondKey)).getByRole("button", { name: /^(End session and close tab|Close tab):/ }),
+    );
+    fireEvent.click(within(tabContainer(secondKey)).getByRole("button", { name: /^Confirm end session:/ }));
+
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(1));
+    expect(screen.getByTestId("session-view").dataset.key).toBe(firstKey);
+    expect(screen.getByRole("button", { name: /(Expand|Collapse) terminal panel/ })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+});
+
 // Multi-terminal reload restore (Nick's field report 2026-08-22): two dock
 // tabs open → hard refresh → only one came back, and the orphaned live
 // session was then mislabelled "open in another tab". The tab now remembers

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -1427,6 +1427,17 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         if (idx === -1) return prev;
         const next = prev.filter((s) => s.key !== key);
         if (next.length === 0) {
+          // Temporary diagnostic (Nick's field report 2026-08-25: closing a
+          // non-last tab collapses the panel) — every dock.tsx code path was
+          // traced and none should be able to reach this branch with more
+          // than one tab open. Logging the exact snapshot the moment it
+          // happens, so the next repro tells us what `prev` actually held
+          // instead of us guessing again.
+          logger.warn("Terminal panel collapsing on tab close", {
+            closedKey: key,
+            prevKeys: prev.map((s) => s.key),
+            prevStatuses: prev.map((s) => ({ key: s.key, status: summariesRef.current[s.key]?.status ?? "idle" })),
+          });
           // Last tab closed → back to the true P1 idle/resting state (B8), not a
           // lingering empty strip. `suppressAutoConnect: true` — the user just
           // explicitly ended this session, so an expanded dock must NOT


### PR DESCRIPTION
## Summary
- The offline-caching worker crashed (`Failed to convert value to 'Response'`) whenever a background request failed and wasn't already cached — it handed the browser `undefined` instead of a proper fallback response. Now returns an explicit 504.
- Adds a temporary diagnostic log to the terminal panel's tab-close logic, to help confirm whether this was the cause of a reported bug where closing a second terminal tab collapsed the whole panel even with another session still open.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (terminal-dock.tsx)
- [x] `npx vitest run src/components/board/terminal-dock.test.tsx` — 70 passed
- [ ] Nick to reproduce the panel-collapse bug again in production with this deployed, and check the console for the "Terminal panel collapsing on tab close" log if it still happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)