### PR TITLE
fix(terminal): closing the focused split pane no longer blanks the panel

### DIFF
--- a/src/components/board/terminal-dock.test.tsx
+++ b/src/components/board/terminal-dock.test.tsx
@@ -2166,6 +2166,44 @@ describe("TerminalDock — closing a non-last tab must not collapse the panel (f
       "true",
     );
   });
+
+  // The actual root cause, found by reproducing in Nick's own browser: the
+  // panel never collapsed — `expanded` stayed true — its BODY went blank.
+  // Split view was on, the freshly opened 2nd tab held pane focus ("Typing
+  // here"), and closing it left the split's `paneKeys` still naming the
+  // closed key for one commit — long enough for the "keep activeKey on the
+  // focused pane" effect to re-point `activeKey` at the dead session,
+  // overriding `removeEntry`'s neighbor pick. With one tab left nothing in
+  // the body matched `activeKey`, the remaining tab rendered
+  // aria-selected="false", and the status chip fell back to idle
+  // ("One-time setup"). Programmatic/keyboard closes never focused the pane,
+  // which is why the three tests above passed all along.
+  it("closing the FOCUSED pane of a 2-up split leaves the remaining tab selected — the body must not go blank (root cause of the 'panel collapsed' report)", async () => {
+    stubFetch(Promise.resolve([liveElsewhereRow()]));
+    render(<TerminalDock ideaId="idea-1" ideaTitle="My Idea" ideaGithubUrl={null} />);
+    const [firstKey, secondKey] = await mintTwoSessions();
+
+    fireEvent.click(screen.getByRole("button", { name: "Split view: show two sessions side by side" }));
+    await waitFor(() => expect(screen.getByTestId(`pane-indicator-${secondKey}`)).toBeInTheDocument());
+    // Put keyboard focus in the SECOND pane — exactly where a real user is
+    // after opening it (the new tab takes focus) and where a mouse click
+    // on its × leaves it.
+    fireEvent.focus(screen.getByTestId(`pane-input-${secondKey}`));
+    await waitFor(() => expect(screen.getByTestId(`pane-indicator-${secondKey}`).textContent).toBe("Typing here"));
+
+    fireEvent.click(screen.getByTestId(`report-connected-${secondKey}`));
+    fireEvent.click(
+      within(tabContainer(secondKey)).getByRole("button", { name: /^(End session and close tab|Close tab):/ }),
+    );
+    fireEvent.click(within(tabContainer(secondKey)).getByRole("button", { name: /^Confirm end session:/ }));
+
+    await waitFor(() => expect(screen.getAllByTestId("session-view")).toHaveLength(1));
+    expect(screen.getByTestId("session-view").dataset.key).toBe(firstKey);
+    // `aria-selected` is driven straight off `activeKey` — the exact value
+    // that was left dangling on the closed session's key.
+    await waitFor(() => expect(tabContainer(firstKey)).toHaveAttribute("aria-selected", "true"));
+    expect(screen.getByRole("button", { name: /Collapse terminal panel/ })).toHaveAttribute("aria-expanded", "true");
+  });
 });
 
 // Multi-terminal reload restore (Nick's field report 2026-08-22): two dock

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -963,11 +963,26 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // Keep `activeKey` (and so `aria-selected`) pointed at the focused pane's
   // session while split is the standing preference — even if not currently
   // RENDERED as split (width floor / mobile / count, §10.1).
+  //
+  // Bug (Nick's field report 2026-08-25, "closing the 2nd tab collapses the
+  // panel"): the panel wasn't collapsing — `expanded` stayed true — its body
+  // went BLANK. Closing the focused pane of a 2-up split left `paneKeys`
+  // still holding the closed key for one commit (the count-driven effect
+  // above only clears it to [] after this same commit), so this effect
+  // re-pointed `activeKey` at the just-closed session, overriding
+  // `removeEntry`'s neighbor pick. With one tab left, nothing matched
+  // `activeKey` in the body (`isEntryVisible`), the status chip fell back to
+  // idle ("One-time setup"), and the next run of this effect bailed on the
+  // now-empty `paneKeys` — so it never self-healed (3→2 did, by accident, on
+  // the second pass). Only ever follow a pane whose session still exists.
   useEffect(() => {
     if (splitPreferred !== true || paneKeys.length === 0) return;
     const target = paneKeys[focusedPaneIndex] ?? paneKeys[0];
-    if (target && target !== activeKey) setActiveKey(target);
-  }, [splitPreferred, paneKeys, focusedPaneIndex, activeKey]);
+    if (!target || target === activeKey) return;
+    // Closed pane — leave `removeEntry`'s neighbor pick alone.
+    if (!sessions.some((s) => s.key === target)) return;
+    setActiveKey(target);
+  }, [splitPreferred, paneKeys, focusedPaneIndex, activeKey, sessions]);
 
   // Width-shrink fallback WHILE already rendering at the current pane
   // count (as opposed to the count-transition effect above, which handles
@@ -1427,17 +1442,6 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
         if (idx === -1) return prev;
         const next = prev.filter((s) => s.key !== key);
         if (next.length === 0) {
-          // Temporary diagnostic (Nick's field report 2026-08-25: closing a
-          // non-last tab collapses the panel) — every dock.tsx code path was
-          // traced and none should be able to reach this branch with more
-          // than one tab open. Logging the exact snapshot the moment it
-          // happens, so the next repro tells us what `prev` actually held
-          // instead of us guessing again.
-          logger.warn("Terminal panel collapsing on tab close", {
-            closedKey: key,
-            prevKeys: prev.map((s) => s.key),
-            prevStatuses: prev.map((s) => ({ key: s.key, status: summariesRef.current[s.key]?.status ?? "idle" })),
-          });
           // Last tab closed → back to the true P1 idle/resting state (B8), not a
           // lingering empty strip. `suppressAutoConnect: true` — the user just
           // explicitly ended this session, so an expanded dock must NOT


### PR DESCRIPTION
## Summary
- Closing the second of two terminal tabs left the panel "expanded" but with an **empty body** and the remaining tab unselected — it looked collapsed (Nick's report, 25 Aug). Reopening by clicking the tab recovered it.
- Root cause: with split view on, the effect that keeps the active tab pinned to the focused pane still saw the just-closed key in `paneKeys` for one commit, re-pointed `activeKey` at the dead session (overriding `removeEntry`'s neighbor pick), then bailed on the emptied `paneKeys` and never self-healed. Now it only follows a pane whose session still exists.
- Adds a regression test (focus the 2nd pane → close it → remaining tab must be `aria-selected`); fails without the fix with `aria-selected="false"`, the exact state observed live.
- Removes the temporary diagnostic log from #212.

## Test plan
- [x] Reproduced live in production via browser automation; diagnosis matched the DOM state exactly
- [x] New test fails without the fix, passes with it
- [x] `npm run test` — 3,387 passed / 200 files
- [x] `npm run typecheck`, eslint on both files
- [ ] Nick: open a 2nd terminal from "+", close it with × → ✓ — the first terminal should stay on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)