### PR TITLE
chore(terminal): helper 0.3.5 release — starting model + auto-accept actually applied; bump recommended version

### DIFF
--- a/src/lib/terminal/helper-version.ts
+++ b/src/lib/terminal/helper-version.ts
@@ -26,9 +26,15 @@
  *  0.3.4 (Bug B, Nick's field test 2026-08-15) fixes a promptless/Resume
  *  launch's PTY spawning at a hardcoded 80x24 — it now spawns at the
  *  browser's real panel size, carried on the SAME launch deep link (see
- *  terminal/bridge/src/spawn-dims.js). NOT yet built/notarized/published —
- *  bumped here so the recommended-version gate is ready the moment it is. */
-export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.4";
+ *  terminal/bridge/src/spawn-dims.js). 0.3.5 (Nick's field report
+ *  2026-08-25: fresh sessions started on the machine's default model, not
+ *  the configured one) is the first helper that actually ships the bridge's
+ *  `--model` (task c4ca2d95) and `--permission-mode` auto-accept (task
+ *  d3de150c) support — both landed in terminal/bridge on 22–24 Aug WITHOUT a
+ *  helper release, so every 0.3.4 install silently ignored them. Lesson: a
+ *  bridge/shared change the app relies on is not shipped until the helper is
+ *  rebuilt, released, and this constant is bumped. */
+export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.5";
 
 export type HelperVersionParts = readonly [number, number, number];
 

--- a/terminal/helper/package-lock.json
+++ b/terminal/helper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibecodes-terminal-helper",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "devDependencies": {
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8"

--- a/terminal/helper/package.json
+++ b/terminal/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "description": "macOS helper app: registers the vibecodes:// URL scheme and runs the terminal bridge (node-pty PTY -> relay) on launch. A thin, installable, signable wrapper around terminal/bridge (no logic duplication).",
   "author": "VibeCodes",


### PR DESCRIPTION
## Summary
- New browser-terminal sessions ignored the configured starting model (and the Auto-accept toggle): the web app sent them correctly, but the installed helper app (0.3.4, built 16 Aug) predates both bridge features and silently ignored the unknown params. No helper release or version bump ever followed those features, so no one was nudged to update.
- Helper **0.3.5** is built, signed, notarized and published: https://github.com/vibecodes-org/vibe-coding-ideas/releases/tag/terminal-helper-v0.3.5 (verified the bundle contains `BRIDGE_MODEL` / `permissionMode`; download URL returns 200).
- This PR bumps `terminal/helper/package.json` to 0.3.5 and `MINIMUM_RECOMMENDED_HELPER_VERSION` to 0.3.5, so every 0.3.4 install gets the "Update now" nudge and `/download/terminal-helper` serves the new build.

## Test plan
- [x] Bridge tests (40) + helper-version/update-flow/download tests (36) pass; `tsc` clean
- [x] `spctl` / `stapler validate` on the built app: Notarized Developer ID
- [ ] Nick: accept "Update now", start a fresh session — Claude Code banner should say Sonnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)