### PR TITLE
feat(terminal): real auto mode (helper 0.3.6) + Ready screen instead of the install wizard after ending the last session

### DIFF
--- a/src/actions/profile.ts
+++ b/src/actions/profile.ts
@@ -249,7 +249,7 @@ export async function updateTerminalModel(model: string | null): Promise<string 
 
 // ── Terminal auto-accept mode (task d3de150c "Terminal mode") ──────────────
 // Per-user opt-in: fresh in-app terminal sessions launch with
-// `claude --permission-mode acceptEdits` when true. Self-only, same "lives
+// `claude --permission-mode auto` when true. Self-only, same "lives
 // inside the Model Tiers dialog's Terminal sessions group" posture as the
 // starting-model actions above. Deliberately NO platform-wide default and
 // NO admin action mirroring updatePlatformTerminalModelDefault — a safety

--- a/src/app/api/terminal/session/route.test.ts
+++ b/src/app/api/terminal/session/route.test.ts
@@ -232,16 +232,16 @@ describe("POST /api/terminal/session — effective auto-accept resolution (task 
     expect(body).not.toHaveProperty("permissionMode");
   });
 
-  it("resolves to the literal 'acceptEdits' when the user's own preference is on", async () => {
+  it("resolves to the literal 'auto' when the user's own preference is on", async () => {
     tableResults.users = { data: { terminal_model: null, terminal_auto_accept: true }, error: null };
 
     const res = await POST(req({ ideaId: IDEA_1 }));
     const body = await res.json();
-    expect(body.permissionMode).toBe("acceptEdits");
+    expect(body.permissionMode).toBe("auto");
   });
 
   it("has no platform-wide default input — a platform_settings row never turns this on by itself", async () => {
-    tableResults.platform_settings = { data: { value: { permissionMode: "acceptEdits" } }, error: null };
+    tableResults.platform_settings = { data: { value: { permissionMode: "auto" } }, error: null };
 
     const res = await POST(req({ ideaId: IDEA_1 }));
     const body = await res.json();

--- a/src/app/api/terminal/session/route.ts
+++ b/src/app/api/terminal/session/route.ts
@@ -44,7 +44,7 @@ import {
 } from "@/lib/terminal/relay-budget";
 import { getPlatformTerminalModelDefault } from "@/lib/terminal/platform-terminal-model";
 import { resolveEffectiveTerminalModel } from "@/lib/terminal/model-resolution";
-import { ACCEPT_EDITS_PERMISSION_MODE } from "@/lib/terminal/auto-accept-mode";
+import { AUTO_PERMISSION_MODE } from "@/lib/terminal/auto-accept-mode";
 
 // Pin the runtime: this handler mints per-request, auth-bound tokens and must never
 // be statically optimized or flipped to the Edge runtime. The pin stays as hygiene,
@@ -334,9 +334,9 @@ export async function POST(req: Request) {
     });
     // Task d3de150c: no platform-wide default exists for this by design —
     // the ONLY input is the user's own row. Resolves to the literal
-    // "acceptEdits" or undefined (never any other string) so the deep link
+    // "auto" or undefined (never any other string) so the deep link
     // and the mint response can never carry a forbidden value.
-    const effectivePermissionMode = userAutoAccept ? ACCEPT_EDITS_PERMISSION_MODE : undefined;
+    const effectivePermissionMode = userAutoAccept ? AUTO_PERMISSION_MODE : undefined;
 
     // ── (d) MINT + register. ────────────────────────────────────────────────
     // The bridge/browser pair (per-launch, random sid) and the helper's OWN

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -2397,7 +2397,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
               above it, amber to match the badge/chip elsewhere. Whole-life
               fact, not gated on status, same as the header badge. */}
           {!multi && sessions.length > 0 && activeSummary?.autoAccept && (
-            <Circle className="h-2.5 w-2.5 fill-current text-amber-400" aria-label="Auto-accept" />
+            <Circle className="h-2.5 w-2.5 fill-current text-amber-400" aria-label="Auto mode" />
           )}
           <TerminalIcon className="h-3.5 w-3.5 text-zinc-400" />
           <span className="hidden sm:inline">{multi ? "Terminals" : "Terminal"}</span>

--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -685,33 +685,106 @@ describe("TerminalSessionView — auto-accept badge (task d3de150c)", () => {
   it("shows the Auto-accept badge while connected", () => {
     installMockSessionWithStatus("connected", true);
     renderView(false);
-    expect(screen.getByText("Auto-accept")).toBeInTheDocument();
+    expect(screen.getByText("Auto mode")).toBeInTheDocument();
   });
 
   it("shows the Auto-accept badge while disconnected — NOT gated on status === connected", () => {
     installMockSessionWithStatus("disconnected", true);
     renderView(false);
-    expect(screen.getByText("Auto-accept")).toBeInTheDocument();
+    expect(screen.getByText("Auto mode")).toBeInTheDocument();
   });
 
   it("shows the Auto-accept badge while waiting-to-pair/reconnecting", () => {
     installMockSessionWithStatus("waiting-to-pair", true);
     renderView(false);
-    expect(screen.getByText("Auto-accept")).toBeInTheDocument();
+    expect(screen.getByText("Auto mode")).toBeInTheDocument();
   });
 
   it("never shows the badge when the session was not launched with the flag", () => {
     installMockSessionWithStatus("connected", false);
     renderView(false);
-    expect(screen.queryByText("Auto-accept")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto mode")).not.toBeInTheDocument();
   });
 
   it("renders an accessible title explaining the mode, not just an icon", () => {
     installMockSessionWithStatus("connected", true);
     renderView(false);
-    expect(screen.getByText("Auto-accept").closest("span")).toHaveAttribute(
+    expect(screen.getByText("Auto mode").closest("span")).toHaveAttribute(
       "title",
-      expect.stringContaining("without confirmation"),
+      expect.stringContaining("approves routine edits and commands itself"),
     );
+  });
+});
+
+// Nick, 2026-08-25: "When I close the last terminal, and the panel correctly
+// collapses, when I open it I see [the one-time setup wizard]". The dock
+// replaces the last-closed tab with a pristine entry whose paired
+// auto-connect is deliberately suppressed (ending a session must never
+// relaunch one), so the hook sits at idle + paired — and resolveDockView
+// used to send that straight to the install wizard. It now renders a
+// resting "Ready" screen whose primary button is the same connect the
+// wizard's own Connect fires.
+describe("TerminalSessionView — idle + paired shows the Ready screen, not the install wizard", () => {
+  function installMockIdlePairedSession() {
+    const actions = mockActions();
+    mockedUseTerminalSession.mockImplementation((): UseTerminalSessionResult => {
+      const containerRef = useRef<HTMLDivElement | null>(null);
+      lastContainerRef = containerRef;
+      return {
+        state: { status: "idle", sessionId: null, errorKind: null, endedReason: null, closeCode: null, closeReason: null },
+        launchPhase: "idle",
+        peerDegraded: false,
+        helperVersion: null,
+        pair: null,
+        cwd: null,
+        claudeSessionId: null,
+        readOnly: false,
+        autoAccept: false,
+        inputEnabled: false,
+        platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download", downloadUrl: null },
+        paired: true,
+        xtermReady: true,
+        containerRef,
+        pairingTimedOut: false,
+        actions,
+      };
+    });
+    return actions;
+  }
+
+  function renderIdleView(onBrowseSessions?: () => void) {
+    return render(
+      <TerminalSessionView
+        entry={baseEntry()}
+        descriptor={{ ideaId: "idea-1", ideaTitle: "My Idea", ideaGithubUrl: null }}
+        label="Session 1"
+        isActive
+        expanded
+        onRequestExpand={vi.fn()}
+        autoConnectWhenExpanded={false}
+        onReportSummary={vi.fn()}
+        onRegisterActions={vi.fn()}
+        onAnnounce={vi.fn()}
+        onBrowseSessions={onBrowseSessions}
+      />,
+    );
+  }
+
+  it("renders the Ready screen and NOT the download/setup wizard for a paired Mac", () => {
+    installMockIdlePairedSession();
+    renderIdleView();
+    expect(screen.getByTestId("ready-panel")).toBeInTheDocument();
+    expect(screen.queryByText(/Download for Mac/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/one-time setup/i)).not.toBeInTheDocument();
+  });
+
+  it("'Start new session' fires the same connect the wizard's Connect does; the browse link opens the chooser", () => {
+    const actions = installMockIdlePairedSession();
+    const onBrowseSessions = vi.fn();
+    renderIdleView(onBrowseSessions);
+    fireEvent.click(screen.getByRole("button", { name: "Start new session" }));
+    expect(actions.connect).toHaveBeenCalledWith({ autoLaunch: true });
+    fireEvent.click(screen.getByRole("button", { name: "View my other sessions" }));
+    expect(onBrowseSessions).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -825,6 +825,8 @@ export function dockStatusMeta(
       return { label: FIRST_RUN_COPY.pill.notConnected, Icon: CircleDashed, className: "border-zinc-600 bg-zinc-800/60 text-zinc-300" };
     case "setup":
       return { label: FIRST_RUN_COPY.pill.setup, Icon: Circle, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
+    case "ready":
+      return { label: FIRST_RUN_COPY.pill.ready, Icon: Circle, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
     case "coming-soon":
       return { label: FIRST_RUN_COPY.pill.comingSoon, Icon: Clock, className: "border-zinc-700 bg-zinc-800/60 text-zinc-400" };
     case "disconnected":
@@ -904,6 +906,8 @@ function StateOverlay({
       {view === "coming-soon" && <ComingSoonPanel />}
 
       {view === "setup" && <SetupPanel platform={platform} onConnect={onConnect} />}
+
+      {view === "ready" && <ReadyPanel onConnect={onConnect} onBrowseSessions={onBrowseSessions} />}
 
       {(view === "connecting" || view === "connecting-returning") && (
         <ConnectingPanel returning={view === "connecting-returning"} />
@@ -1040,6 +1044,32 @@ function StateOverlay({
 }
 
 // ── install-first panels ──────────────────────────────────────────────────────
+
+// Resting screen for a PAIRED Mac sitting idle — reached only after the user
+// ended their last session (the dock suppresses the paired auto-connect so an
+// explicit End never relaunches a session). Before this existed the idle
+// branch fell through to the install wizard below, telling an already-set-up
+// Mac to download the helper (Nick, 2026-08-25).
+function ReadyPanel({ onConnect, onBrowseSessions }: { onConnect: () => void; onBrowseSessions?: () => void }) {
+  return (
+    <div className="flex max-w-md flex-col items-center gap-3" data-testid="ready-panel">
+      <p className="text-sm font-semibold text-zinc-100">{FIRST_RUN_COPY.ready.title}</p>
+      <p className="text-xs text-zinc-400">{FIRST_RUN_COPY.ready.body}</p>
+      <button
+        type="button"
+        onClick={onConnect}
+        className="mt-1 rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+      >
+        {FIRST_RUN_COPY.ready.cta}
+      </button>
+      {onBrowseSessions && (
+        <button type="button" onClick={onBrowseSessions} className="text-xs text-zinc-400 underline hover:text-zinc-200">
+          {FIRST_RUN_COPY.ready.browse}
+        </button>
+      )}
+    </div>
+  );
+}
 
 // Screen ① — the numbered one-time setup (unpaired). No deep link has fired here.
 function SetupPanel({ platform, onConnect }: { platform: TerminalPlatform; onConnect: () => void }) {

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -489,7 +489,7 @@ export interface UseTerminalSessionResult {
   /**
    * Task d3de150c ("Terminal mode" auto-accept toggle) — true for the
    * session's WHOLE life once a fresh launch carried
-   * `permissionMode: "acceptEdits"`. See the `autoAccept` state's own doc
+   * `permissionMode: "auto"`. See the `autoAccept` state's own doc
    * comment above for the fresh-launch-only / reset-per-attempt contract.
    */
   autoAccept: boolean;
@@ -554,7 +554,7 @@ export function useTerminalSession(
   /**
    * Task d3de150c ("Terminal mode" auto-accept toggle) — true for the whole
    * life of THIS tab's session once a fresh mint's response carried
-   * `permissionMode: "acceptEdits"` (set in connect() below). Unlike
+   * `permissionMode: "auto"` (set in connect() below). Unlike
    * `readOnly`, there is no user-facing toggle for this — it is a launch-
    * time FACT, not a live control (Shift+Tab inside the terminal is the
    * live control, and the app has no way to observe that — see the design
@@ -1797,7 +1797,7 @@ export function useTerminalSession(
       expiresAt: number;
       /** Task c4ca2d95 — the mint route's resolved effective terminal model, fresh-launch only. */
       model?: string;
-      /** Task d3de150c — the mint route's resolved permission mode ("acceptEdits" or absent), fresh-launch only. */
+      /** Task d3de150c — the mint route's resolved permission mode ("auto" or absent), fresh-launch only. */
       permissionMode?: string;
     };
     try {
@@ -1887,10 +1887,10 @@ export function useTerminalSession(
     }
 
     // Task d3de150c: the mint route only ever returns the literal
-    // "acceptEdits" or omits the field entirely (see session/route.ts) — no
+    // "auto" or omits the field entirely (see session/route.ts) — no
     // further validation needed here, but the exact-literal check stays as
     // defense in depth against a future response shape drifting.
-    setAutoAccept(data.permissionMode === "acceptEdits");
+    setAutoAccept(data.permissionMode === "auto");
 
     // Same-machine: hand the bridge token to the local helper via the deep link.
     if (autoLaunch)

--- a/src/components/profile/model-tier-settings.test.tsx
+++ b/src/components/profile/model-tier-settings.test.tsx
@@ -178,14 +178,14 @@ describe("ModelTierSettings — auto-accept toggle (task d3de150c)", () => {
 
   it("renders as a switch (role=switch), never a select or text input", () => {
     renderDialog();
-    const toggle = screen.getByRole("switch", { name: "Start in auto-accept mode" });
+    const toggle = screen.getByRole("switch", { name: "Start in auto mode" });
     expect(toggle).toBeInTheDocument();
     expect(toggle).toHaveAttribute("aria-checked", "false");
   });
 
   it("defaults to off, with the fresh-launches-only help text", () => {
     renderDialog({ terminalAutoAccept: false });
-    expect(screen.getByRole("switch", { name: "Start in auto-accept mode" })).toHaveAttribute(
+    expect(screen.getByRole("switch", { name: "Start in auto mode" })).toHaveAttribute(
       "aria-checked",
       "false",
     );
@@ -194,16 +194,16 @@ describe("ModelTierSettings — auto-accept toggle (task d3de150c)", () => {
 
   it("reflects an on preference and shows the amber consequence copy", () => {
     renderDialog({ terminalAutoAccept: true });
-    expect(screen.getByRole("switch", { name: "Start in auto-accept mode" })).toHaveAttribute(
+    expect(screen.getByRole("switch", { name: "Start in auto mode" })).toHaveAttribute(
       "aria-checked",
       "true",
     );
-    expect(screen.getByText(/without confirming each change/)).toBeInTheDocument();
+    expect(screen.getByText(/without confirming each one/)).toBeInTheDocument();
   });
 
   it("clicking the switch stages the change and enables Save", () => {
     renderDialog({ terminalAutoAccept: false });
-    const toggle = screen.getByRole("switch", { name: "Start in auto-accept mode" });
+    const toggle = screen.getByRole("switch", { name: "Start in auto mode" });
     const saveButton = screen.getByRole("button", { name: /Save/ });
     expect(saveButton).toBeDisabled();
 
@@ -221,14 +221,14 @@ describe("ModelTierSettings — auto-accept toggle (task d3de150c)", () => {
     render(<ModelTierSettings map={null} terminalModel={null} terminalAutoAccept={false} />);
 
     fireEvent.click(screen.getByRole("button", { name: /Model Tiers/ }));
-    const toggle = screen.getByRole("switch", { name: "Start in auto-accept mode" });
+    const toggle = screen.getByRole("switch", { name: "Start in auto mode" });
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute("aria-checked", "true");
 
     fireEvent.keyDown(toggle, { key: "Escape" });
 
     fireEvent.click(screen.getByRole("button", { name: /Model Tiers/ }));
-    expect(screen.getByRole("switch", { name: "Start in auto-accept mode" })).toHaveAttribute(
+    expect(screen.getByRole("switch", { name: "Start in auto mode" })).toHaveAttribute(
       "aria-checked",
       "false",
     );

--- a/src/components/profile/model-tier-settings.tsx
+++ b/src/components/profile/model-tier-settings.tsx
@@ -369,12 +369,12 @@ export function ModelTierSettings({
 
           {/* Auto-accept toggle (task d3de150c "Terminal mode") — a two-state
               Switch, never a dropdown or free text: the only value this can
-              ever produce is the literal "acceptEdits" or nothing (AC-6).
+              ever produce is the literal "auto" or nothing (AC-6).
               No platform-wide default exists for this — per-user only. */}
           <div className="space-y-1.5">
             <div className="flex items-start justify-between gap-3">
               <Label htmlFor="terminal-auto-accept" className="text-sm font-normal">
-                Start in auto-accept mode
+                Start in auto mode
               </Label>
               <Switch
                 id="terminal-auto-accept"

--- a/src/lib/terminal/auto-accept-mode.test.ts
+++ b/src/lib/terminal/auto-accept-mode.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
-  ACCEPT_EDITS_PERMISSION_MODE,
+  AUTO_PERMISSION_MODE,
   isValidPermissionModeValue,
   terminalLaunchAutoAcceptChip,
 } from "./auto-accept-mode";
 
 describe("isValidPermissionModeValue (task d3de150c)", () => {
-  it("accepts only the exact literal 'acceptEdits'", () => {
-    expect(isValidPermissionModeValue(ACCEPT_EDITS_PERMISSION_MODE)).toBe(true);
-    expect(isValidPermissionModeValue("acceptEdits")).toBe(true);
+  it("accepts only the exact literal 'auto'", () => {
+    expect(isValidPermissionModeValue(AUTO_PERMISSION_MODE)).toBe(true);
+    expect(isValidPermissionModeValue("auto")).toBe(true);
   });
 
   it("rejects the dangerous bypassPermissions mode — hard safety requirement", () => {
@@ -24,8 +24,8 @@ describe("isValidPermissionModeValue (task d3de150c)", () => {
   it("rejects case variants and whitespace", () => {
     expect(isValidPermissionModeValue("AcceptEdits")).toBe(false);
     expect(isValidPermissionModeValue("ACCEPTEDITS")).toBe(false);
-    expect(isValidPermissionModeValue(" acceptEdits")).toBe(false);
-    expect(isValidPermissionModeValue("acceptEdits ")).toBe(false);
+    expect(isValidPermissionModeValue(" auto")).toBe(false);
+    expect(isValidPermissionModeValue("auto ")).toBe(false);
     expect(isValidPermissionModeValue("accept edits")).toBe(false);
   });
 
@@ -40,7 +40,7 @@ describe("isValidPermissionModeValue (task d3de150c)", () => {
 
 describe("terminalLaunchAutoAcceptChip", () => {
   it("returns the chip text when on", () => {
-    expect(terminalLaunchAutoAcceptChip(true)).toBe("⚡ auto-accept on");
+    expect(terminalLaunchAutoAcceptChip(true)).toBe("⚡ auto mode on");
   });
 
   it("returns null when off — nothing renders, byte-identical to today", () => {

--- a/src/lib/terminal/auto-accept-mode.ts
+++ b/src/lib/terminal/auto-accept-mode.ts
@@ -18,7 +18,7 @@
  * this whitelist makes it structurally impossible to transmit or spawn,
  * even if some future caller tried to pass one through.
  */
-export const ACCEPT_EDITS_PERMISSION_MODE = "acceptEdits";
+export const AUTO_PERMISSION_MODE = "auto";
 
 /**
  * Whitelist check used on BOTH the parse side (deep link parsing, in the
@@ -30,32 +30,32 @@ export const ACCEPT_EDITS_PERMISSION_MODE = "acceptEdits";
  * every other real Claude Code permission mode (e.g. `bypassPermissions`,
  * `plan`, `default`).
  */
-export function isValidPermissionModeValue(value: unknown): value is typeof ACCEPT_EDITS_PERMISSION_MODE {
-  return value === ACCEPT_EDITS_PERMISSION_MODE;
+export function isValidPermissionModeValue(value: unknown): value is typeof AUTO_PERMISSION_MODE {
+  return value === AUTO_PERMISSION_MODE;
 }
 
 /**
- * The passive launch-surface chip (design §2): "⚡ auto-accept on" appended
+ * The passive launch-surface chip (design §2): "⚡ auto mode on" appended
  * beside the existing model chip when the toggle is ON. Returns null when
  * OFF — the design's instruction is byte-identical-to-today when the
  * setting is off, so nothing renders, no reserved space.
  */
 export function terminalLaunchAutoAcceptChip(autoAccept: boolean): string | null {
-  return autoAccept ? "⚡ auto-accept on" : null;
+  return autoAccept ? "⚡ auto mode on" : null;
 }
 
 /** Session-header / collapsed-bar badge copy — kept in one place so every
  *  surface (dock panel, split view, pop-out, collapsed bar title) uses the
  *  identical word "Auto-accept" (design review note 3: don't let "requested"
  *  and "Auto-accept" drift apart in the shipped copy). */
-export const AUTO_ACCEPT_BADGE_LABEL = "Auto-accept";
+export const AUTO_ACCEPT_BADGE_LABEL = "Auto mode";
 export const AUTO_ACCEPT_BADGE_TITLE =
-  "Launched in auto-accept mode — file edits proceed without confirmation. Shift+Tab in the terminal changes the live mode.";
+  "Launched in auto mode — Claude Code approves routine edits and commands itself. Shift+Tab in the terminal changes the live mode.";
 
 /** Settings/help copy — fresh-launch-only rule, stated once here so the
  *  Profile dialog, the chooser footer and the per-task dialog can all quote
  *  the same sentence instead of each drifting independently. */
 export const AUTO_ACCEPT_FRESH_ONLY_HELP =
-  "Off = Claude Code asks before each edit (recommended). Applies to fresh sessions only — resumed sessions keep asking, and you can switch any session live with Shift+Tab in the terminal.";
+  "Off = Claude Code asks before each action (recommended). Applies to fresh sessions only — resumed sessions keep asking, and you can switch any session live with Shift+Tab in the terminal.";
 export const AUTO_ACCEPT_ON_CONSEQUENCE =
-  "⚡ New sessions will edit files on your machine without confirming each change. The session header shows an Auto-accept badge whenever this is active.";
+  "⚡ New sessions run in auto mode — Claude Code edits files and runs routine commands on your machine without confirming each one. The session header shows an Auto mode badge whenever this is active.";

--- a/src/lib/terminal/deep-link.test.ts
+++ b/src/lib/terminal/deep-link.test.ts
@@ -213,9 +213,9 @@ describe("buildLaunchDeepLink with model (task c4ca2d95, terminal starting model
 
 describe("buildLaunchDeepLink with permissionMode (task d3de150c, terminal auto-accept mode)", () => {
   it("includes permissionMode, positioned before prompt, and round-trips", () => {
-    const withMode = { ...SAMPLE, permissionMode: "acceptEdits", prompt: "hello" };
+    const withMode = { ...SAMPLE, permissionMode: "auto", prompt: "hello" };
     const url = buildLaunchDeepLink(withMode);
-    expect(url).toContain("permissionMode=acceptEdits");
+    expect(url).toContain("permissionMode=auto");
     expect(url.indexOf("permissionMode=")).toBeLessThan(url.indexOf("prompt="));
     expect(parseLaunchDeepLink(url)).toEqual(withMode);
   });
@@ -226,7 +226,7 @@ describe("buildLaunchDeepLink with permissionMode (task d3de150c, terminal auto-
     expect(parseLaunchDeepLink(url)).toEqual(SAMPLE);
   });
 
-  it("never fires any value other than the literal 'acceptEdits' — hard whitelist, builder side", () => {
+  it("never fires any value other than the literal 'auto' — hard whitelist, builder side", () => {
     const url = buildLaunchDeepLink({ ...SAMPLE, permissionMode: "bypassPermissions" });
     expect(url).not.toContain("permissionMode=");
   });
@@ -239,9 +239,9 @@ describe("buildLaunchDeepLink with permissionMode (task d3de150c, terminal auto-
   });
 
   it("is left untouched by redactDeepLinkToken — not a secret or free-form user content", () => {
-    const url = buildLaunchDeepLink({ ...SAMPLE, permissionMode: "acceptEdits" });
+    const url = buildLaunchDeepLink({ ...SAMPLE, permissionMode: "auto" });
     const redacted = redactDeepLinkToken(url);
-    expect(redacted).toContain("permissionMode=acceptEdits");
+    expect(redacted).toContain("permissionMode=auto");
   });
 });
 

--- a/src/lib/terminal/deep-link.ts
+++ b/src/lib/terminal/deep-link.ts
@@ -107,13 +107,13 @@ export interface LaunchDeepLinkParams {
    * Task d3de150c ("Terminal mode") — set ONLY when the launching user's
    * `terminal_auto_accept` preference is on, resolved server-side at mint
    * time (see src/app/api/terminal/session/route.ts). The single valid
-   * value is the literal "acceptEdits" (isValidPermissionModeValue in
+   * value is the literal "auto" (isValidPermissionModeValue in
    * src/lib/terminal/auto-accept-mode.ts) — anything else is a programmer
    * error and is dropped by buildLaunchDeepLink below rather than sent.
    * Callers must never set this on a resume/resumeId launch (mirrors
    * `model`'s AC-8 constraint exactly) — the fresh-launch call site in
    * use-terminal-session.ts is the only one that threads it through. Rides
-   * as one argv element (`claude --permission-mode acceptEdits`), never
+   * as one argv element (`claude --permission-mode auto`), never
    * shell-split — see terminal/bridge/src/resume-cmd.js. Not a secret or
    * user-free-text like `prompt`: redactDeepLinkToken leaves it untouched.
    */

--- a/src/lib/terminal/first-run-copy.ts
+++ b/src/lib/terminal/first-run-copy.ts
@@ -53,8 +53,15 @@ export const FIRST_RUN_COPY = {
     download: "Download for Windows",
     hint: "The download unlocks automatically when Windows support ships.",
   },
+  ready: {
+    title: "Ready when you are",
+    body: "This Mac is already set up. Start a new session, or pick up one of your other sessions.",
+    cta: "Start new session",
+    browse: "View my other sessions",
+  },
   pill: {
     setup: "One-time setup",
+    ready: "Ready",
     notConnected: "Not connected yet",
     comingSoon: "Coming soon",
   },

--- a/src/lib/terminal/first-run-flow.test.ts
+++ b/src/lib/terminal/first-run-flow.test.ts
@@ -16,6 +16,13 @@ describe("resolveDockView — install-first entry", () => {
     expect(resolveDockView("idle", "idle", true, false)).toBe("setup");
   });
 
+  // Nick, 2026-08-25: after ending his last session (dock suppresses the
+  // paired auto-connect), re-expanding showed the install wizard to an
+  // already-paired Mac — idle+paired used to fall through to "setup".
+  it("idle + supported + PAIRED → ready (resting screen, never the install wizard)", () => {
+    expect(resolveDockView("idle", "idle", true, true)).toBe("ready");
+  });
+
   it("connecting maps to the returning variant when paired", () => {
     expect(resolveDockView("connecting", "opening", true, false)).toBe("connecting");
     expect(resolveDockView("connecting", "opening", true, true)).toBe("connecting-returning");

--- a/src/lib/terminal/first-run-flow.ts
+++ b/src/lib/terminal/first-run-flow.ts
@@ -18,6 +18,7 @@ export type LaunchPhase = "idle" | "opening" | "helper-timeout";
 export type DockView =
   | "coming-soon"
   | "setup"
+  | "ready"
   | "connecting"
   | "connecting-returning"
   | "legacy-waiting"
@@ -33,12 +34,16 @@ export type DockView =
  *
  *  - idle + unsupported            → "coming-soon"  (no deep link)
  *  - idle + supported + unpaired   → "setup"        (numbered setup; no deep link yet)
+ *  - idle + supported + paired     → "ready"        (resting screen: this Mac is set up — start a session)
  *  - connecting/opening            → "connecting"[-returning]
  *  - waiting + helper-timeout      → "timeout-new" | "timeout-returning" (~8s fallback)
  *  - waiting + idle launch phase   → "legacy-waiting" (manual cross-machine pairing)
  *
- * A paired browser auto-connects out of idle immediately, so it never lingers on the
- * "setup" view.
+* A paired browser normally auto-connects out of idle immediately; the one time
+ * it rests there is after the user ends their last session (terminal-dock.tsx
+ * suppresses the auto-connect so ending a session never relaunches one — see
+ * `autoConnectSuppressed`). That resting state used to fall through to "setup"
+ * and show the install wizard to an already-paired Mac (Nick, 2026-08-25).
  */
 export function resolveDockView(
   status: TerminalStatus,
@@ -64,7 +69,7 @@ export function resolveDockView(
     case "idle":
     default:
       if (!supported) return "coming-soon";
-      return "setup";
+      return paired ? "ready" : "setup";
   }
 }
 

--- a/src/lib/terminal/helper-version.ts
+++ b/src/lib/terminal/helper-version.ts
@@ -33,8 +33,12 @@
  *  d3de150c) support — both landed in terminal/bridge on 22–24 Aug WITHOUT a
  *  helper release, so every 0.3.4 install silently ignored them. Lesson: a
  *  bridge/shared change the app relies on is not shipped until the helper is
- *  rebuilt, released, and this constant is bumped. */
-export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.5";
+ *  rebuilt, released, and this constant is bumped. 0.3.6 (same day):
+ *  the auto-accept toggle now launches Claude Code's `auto` permission
+ *  mode — what Nick actually asked for on card d3de150c — instead of the
+ *  narrower `acceptEdits`; the bridge/shared whitelist accepts both for
+ *  deploy skew. */
+export const MINIMUM_RECOMMENDED_HELPER_VERSION = "0.3.6";
 
 export type HelperVersionParts = readonly [number, number, number];
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -48,7 +48,7 @@ export type Database = {
            *  verbatim as `claude --model <value>` on fresh sessions only. */
           terminal_model: string | null;
           /** Task d3de150c ("Terminal mode") — opt-in: fresh in-app terminal
-           *  sessions launch with `claude --permission-mode acceptEdits`
+           *  sessions launch with `claude --permission-mode auto`
            *  when true. Default false. Never applies to a resumed session,
            *  and has no platform-wide default (per-user only, safety
            *  setting) — see src/lib/terminal/auto-accept-mode.ts. */

--- a/terminal/bridge/src/index.js
+++ b/terminal/bridge/src/index.js
@@ -162,7 +162,7 @@ const explicitCmd = args.cmd || process.env.BRIDGE_CMD || null;
 const MODEL = launched?.model || process.env.BRIDGE_MODEL || null;
 // Task d3de150c ("Terminal mode" auto-accept toggle): the deep link's
 // `permissionMode` param, already parse-time whitelisted by the shared
-// module's isPermissionModeSafe (only the literal "acceptEdits" ever
+// module's isPermissionModeSafe (only the literal "auto" ever
 // survives parsing — see deep-link.mjs). Only ever applied by
 // resolveClaudeLaunch on a genuinely fresh session (branch 4) — resume/
 // resumeId/explicitCmd never read it, same as MODEL above.

--- a/terminal/bridge/src/resume-cmd.js
+++ b/terminal/bridge/src/resume-cmd.js
@@ -55,7 +55,7 @@
 // `model` — a resumed/continued conversation keeps whatever permission mode
 // it's already running under; Shift+Tab in the terminal is the live control
 // for that, not this flag. UNLIKE `model`, this is re-validated here with a
-// single-literal WHITELIST (only "acceptEdits" is ever appended), not just a
+// single-literal WHITELIST (only "auto" is ever appended), not just a
 // shell-safety check — a hard requirement, since a wrong value here means
 // Claude Code silently starts with the WRONG permission posture rather than
 // merely picking the wrong model. The value already arrived parse-time
@@ -75,6 +75,6 @@ export function resolveClaudeLaunch({ explicitCmd, resumeId, resume, model, perm
   const modelFlag = model ? ` --model ${model}` : "";
   // Defense-in-depth re-check: only the exact literal is ever appended, no
   // matter what arrives here — see the header comment.
-  const permissionModeFlag = permissionMode === "acceptEdits" ? ` --permission-mode ${permissionMode}` : "";
+  const permissionModeFlag = permissionMode === "auto" || permissionMode === "acceptEdits" ? ` --permission-mode ${permissionMode}` : "";
   return { cmd: `claude --session-id ${conv}${modelFlag}${permissionModeFlag}`, conv };
 }

--- a/terminal/bridge/src/resume-cmd.test.js
+++ b/terminal/bridge/src/resume-cmd.test.js
@@ -97,11 +97,11 @@ test("an explicit --cmd override NEVER receives --model, even if one is somehow 
 
 // ── terminal auto-accept mode (task d3de150c) — permissionMode only ever
 // applies to a fresh mint (branch 4); branches 1-3 must never append
-// --permission-mode, and only the literal "acceptEdits" is ever appended. ──
+// --permission-mode, and only the literal "auto" is ever appended. ──
 
-test("a fresh mint with permissionMode acceptEdits appends --permission-mode acceptEdits", () => {
-  const result = resolveClaudeLaunch({ permissionMode: "acceptEdits", mintId: () => MINTED });
-  assert.deepEqual(result, { cmd: `claude --session-id ${MINTED} --permission-mode acceptEdits`, conv: MINTED });
+test("a fresh mint with permissionMode auto appends --permission-mode auto", () => {
+  const result = resolveClaudeLaunch({ permissionMode: "auto", mintId: () => MINTED });
+  assert.deepEqual(result, { cmd: `claude --session-id ${MINTED} --permission-mode auto`, conv: MINTED });
 });
 
 test("a fresh mint with no permissionMode spawns exactly today's command — no trailing space, no flag", () => {
@@ -110,12 +110,12 @@ test("a fresh mint with no permissionMode spawns exactly today's command — no 
 });
 
 test("model and permissionMode append together, model first, on a fresh mint", () => {
-  const result = resolveClaudeLaunch({ model: "opus", permissionMode: "acceptEdits", mintId: () => MINTED });
-  assert.equal(result.cmd, `claude --session-id ${MINTED} --model opus --permission-mode acceptEdits`);
+  const result = resolveClaudeLaunch({ model: "opus", permissionMode: "auto", mintId: () => MINTED });
+  assert.equal(result.cmd, `claude --session-id ${MINTED} --model opus --permission-mode auto`);
 });
 
-test("hard safety requirement: any permissionMode value other than the literal 'acceptEdits' is dropped, never appended", () => {
-  for (const bad of ["bypassPermissions", "plan", "default", "AcceptEdits", " acceptEdits", ""]) {
+test("hard safety requirement: any permissionMode value other than the literal 'auto' is dropped, never appended", () => {
+  for (const bad of ["bypassPermissions", "plan", "default", "AcceptEdits", " auto", ""]) {
     const result = resolveClaudeLaunch({ permissionMode: bad, mintId: () => MINTED });
     assert.equal(result.cmd, `claude --session-id ${MINTED}`, `permissionMode=${JSON.stringify(bad)} must be dropped`);
     assert.ok(!result.cmd.includes("--permission-mode"));
@@ -123,18 +123,18 @@ test("hard safety requirement: any permissionMode value other than the literal '
 });
 
 test("resumeId NEVER receives --permission-mode, even if one is somehow passed (fresh-launch-only rule)", () => {
-  const result = resolveClaudeLaunch({ resumeId: RESUME_ID, permissionMode: "acceptEdits", mintId: () => MINTED });
+  const result = resolveClaudeLaunch({ resumeId: RESUME_ID, permissionMode: "auto", mintId: () => MINTED });
   assert.equal(result.cmd, `claude --resume ${RESUME_ID}`);
   assert.ok(!result.cmd.includes("--permission-mode"));
 });
 
 test("the legacy --continue resume NEVER receives --permission-mode, even if one is somehow passed", () => {
-  const result = resolveClaudeLaunch({ resume: true, permissionMode: "acceptEdits", mintId: () => MINTED });
+  const result = resolveClaudeLaunch({ resume: true, permissionMode: "auto", mintId: () => MINTED });
   assert.equal(result.cmd, "claude --continue");
   assert.ok(!result.cmd.includes("--permission-mode"));
 });
 
 test("an explicit --cmd override NEVER receives --permission-mode, even if one is somehow passed", () => {
-  const result = resolveClaudeLaunch({ explicitCmd: "bash", permissionMode: "acceptEdits", mintId: () => MINTED });
+  const result = resolveClaudeLaunch({ explicitCmd: "bash", permissionMode: "auto", mintId: () => MINTED });
   assert.deepEqual(result, { cmd: "bash", conv: null });
 });

--- a/terminal/helper/package-lock.json
+++ b/terminal/helper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibecodes-terminal-helper",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "devDependencies": {
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8"

--- a/terminal/helper/package.json
+++ b/terminal/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibecodes-terminal-helper",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "description": "macOS helper app: registers the vibecodes:// URL scheme and runs the terminal bridge (node-pty PTY -> relay) on launch. A thin, installable, signable wrapper around terminal/bridge (no logic duplication).",
   "author": "VibeCodes",

--- a/terminal/shared/deep-link.mjs
+++ b/terminal/shared/deep-link.mjs
@@ -78,11 +78,11 @@
 //   permissionMode — task d3de150c ("Terminal mode"): set ONLY when the
 //             launching user's terminal_auto_accept preference is on,
 //             resolved server-side at mint time. The ONLY legal value is
-//             the literal string "acceptEdits" (isPermissionModeSafe below,
+//             the literal string "auto" (isPermissionModeSafe below,
 //             mirrors src/lib/terminal/auto-accept-mode.ts's
 //             isValidPermissionModeValue) — a hard safety whitelist, not
 //             just a shell-safety check like `model`'s. The bridge appends
-//             `--permission-mode acceptEdits` to the fresh-spawn CMD ONLY
+//             `--permission-mode auto` to the fresh-spawn CMD ONLY
 //             (terminal/bridge/src/resume-cmd.js) — NEVER on a resume/
 //             resumeId launch, same as `model`. An old helper's bundled
 //             copy of this module simply never reads `permissionMode` off
@@ -135,7 +135,7 @@ function isSafeModelValue(v) {
 }
 
 /** Task d3de150c ("Terminal mode") — the ONLY legal `permissionMode` value
- *  is the literal string "acceptEdits". Unlike `isSafeModelValue` above
+ *  is the literal string "auto". Unlike `isSafeModelValue` above
  *  (which accepts arbitrary shell-safe free text), this is a hard
  *  single-literal WHITELIST — the safety requirement is "bypassPermissions
  *  (or anything else) must never be reachable", not just "must not break
@@ -144,7 +144,7 @@ function isSafeModelValue(v) {
  *  @param {unknown} v
  *  @returns {boolean} */
 function isPermissionModeSafe(v) {
-  return v === "acceptEdits";
+  return v === "auto" || v === "acceptEdits";
 }
 
 /**
@@ -254,7 +254,7 @@ export function parseLaunchDeepLink(url) {
   // above — it's about to ride the bridge's shellSplit CMD string as a bare
   // token, so there is no safe partial value. Unlike `model`, this is a
   // single-literal WHITELIST (isPermissionModeSafe), not a shell-safety
-  // check — anything except the exact literal "acceptEdits" is dropped
+  // check — anything except the exact literal "auto" is dropped
   // silently, including a value an attacker or a bug tried to smuggle in.
   // An old helper's bundled copy of this parser simply never reads
   // "permissionMode" at all — no version-skew risk.

--- a/terminal/test/deep-link.test.mjs
+++ b/terminal/test/deep-link.test.mjs
@@ -214,9 +214,9 @@ test("redactDeepLinkToken leaves model untouched — not a secret or free-form u
 // ── terminal auto-accept mode (task d3de150c) ──────────────────────────────
 
 test("build ⇄ parse round-trips permissionMode, positioned before prompt", () => {
-  const withMode = { ...SAMPLE, permissionMode: "acceptEdits", prompt: "hello" };
+  const withMode = { ...SAMPLE, permissionMode: "auto", prompt: "hello" };
   const url = buildLaunchDeepLink(withMode);
-  assert.ok(url.includes("permissionMode=acceptEdits"));
+  assert.ok(url.includes("permissionMode=auto"));
   assert.ok(url.indexOf("permissionMode=") < url.indexOf("prompt="), "permissionMode precedes the LAST param, prompt");
   assert.deepEqual(parseLaunchDeepLink(url), withMode);
 });
@@ -240,9 +240,9 @@ test("a forbidden permissionMode value on the wire (e.g. bypassPermissions) is r
 });
 
 test("redactDeepLinkToken leaves permissionMode untouched — not a secret or free-form user content", () => {
-  const url = buildLaunchDeepLink({ ...SAMPLE, permissionMode: "acceptEdits" });
+  const url = buildLaunchDeepLink({ ...SAMPLE, permissionMode: "auto" });
   const redacted = redactDeepLinkToken(url);
-  assert.ok(redacted.includes("permissionMode=acceptEdits"));
+  assert.ok(redacted.includes("permissionMode=auto"));
 });
 
 test("redactDeepLinkToken elides the prompt (user content) as well as the token", () => {


### PR DESCRIPTION
## Summary
- **Auto mode**: the "Start in auto mode" toggle now launches Claude Code with `--permission-mode auto` (what Nick asked for on card d3de150c) instead of `acceptEdits`. `bypassPermissions` remains structurally unreachable (single-literal whitelist); bridge/shared also accept legacy `acceptEdits` for rollout skew. Copy updated to "auto mode".
- **Helper 0.3.6** built, notarized, published: https://github.com/vibecodes-org/vibe-coding-ideas/releases/tag/terminal-helper-v0.3.6 — `MINIMUM_RECOMMENDED_HELPER_VERSION` → 0.3.6 so 0.3.5 installs get the "Update now" nudge.
- **Ready screen**: after ending your last session and re-expanding the panel, an already-paired Mac saw the one-time-setup wizard (idle + paired resolved to "setup"). New `ready` view with "Start new session" / "View my other sessions".

## Test plan
- [x] `npm run test` — 3,394 passed / 200 files; bridge tests 40/40; `tsc` + eslint clean
- [x] Built helper bundle verified to contain the `auto` whitelist; `spctl`: Notarized Developer ID
- [ ] Nick: Update now → fresh session status line reads "auto mode on"; end last session → expand → Ready screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)