### PR TITLE
fix(terminal): never resume a conversation that's already live — reconnect to it instead

### DIFF
--- a/src/app/api/terminal/session/route.test.ts
+++ b/src/app/api/terminal/session/route.test.ts
@@ -258,3 +258,57 @@ describe("POST /api/terminal/session — effective auto-accept resolution (task 
     expect(body).not.toHaveProperty("permissionMode");
   });
 });
+
+// Card 0301fe8e (Nick, 2026-08-25): the SAME claude conversation resumed
+// twice at once. The mint route is the server backstop — a resume whose
+// conversation this user already has a LIVE row on is refused, and a
+// permitted resume stamps its conversation id onto the new row at insert
+// time (closing the window in which the row carried null until the bridge
+// announced it).
+describe("POST /api/terminal/session — duplicate-conversation guard (card 0301fe8e)", () => {
+  const CONV = "5a22fd93-0aad-4872-a28f-61c90ff7f25b";
+
+  it("refuses a resume whose conversation is already live — 409 conversation_live, naming the live session, and mints NOTHING", async () => {
+    tableResults.terminal_sessions = { data: { sid: "live-1", idea_id: IDEA_1 }, error: null, count: 0 };
+    const res = await POST(req({ ideaId: IDEA_1, resumeId: CONV }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("conversation_live");
+    expect(body.liveSid).toBe("live-1");
+    expect(body.liveIdeaId).toBe(IDEA_1);
+    expect(insertSpy).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Terminal session mint refused: conversation already live",
+      expect.objectContaining({ resumeId: CONV, liveSid: "live-1" }),
+    );
+  });
+
+  it("mints when no live row matches, stamping claude_session_id from resumeId at insert time", async () => {
+    const res = await POST(req({ ideaId: IDEA_1, resumeId: CONV }));
+    expect(res.status).toBe(200);
+    expect(insertSpy).toHaveBeenCalledWith(expect.objectContaining({ claude_session_id: CONV }));
+  });
+
+  it("a fresh (non-resume) mint never runs the guard — a live row is irrelevant — and inserts claude_session_id null", async () => {
+    tableResults.terminal_sessions = { data: { sid: "live-1", idea_id: IDEA_1 }, error: null, count: 0 };
+    const res = await POST(req({ ideaId: IDEA_1 }));
+    expect(res.status).toBe(200);
+    expect(insertSpy).toHaveBeenCalledWith(expect.objectContaining({ claude_session_id: null }));
+  });
+
+  it("rejects a malformed resumeId at the schema (400) rather than passing it towards the shell", async () => {
+    const res = await POST(req({ ideaId: IDEA_1, resumeId: "not-a-uuid; rm -rf /" }));
+    expect(res.status).toBe(400);
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails open (mints anyway, logs an error) when the live-conversation lookup itself errors", async () => {
+    tableResults.terminal_sessions = { data: null, error: { message: "boom" }, count: 0 };
+    const res = await POST(req({ ideaId: IDEA_1, resumeId: CONV }));
+    expect(res.status).toBe(200);
+    expect(logger.error).toHaveBeenCalledWith(
+      "Terminal session mint: live-conversation lookup failed",
+      expect.objectContaining({ error: "boom", resumeId: CONV }),
+    );
+  });
+});

--- a/src/app/api/terminal/session/route.ts
+++ b/src/app/api/terminal/session/route.ts
@@ -25,6 +25,8 @@ import {
   RATE_LIMIT_CODE,
   DAILY_RELAY_BUDGET_CODE,
   DAILY_RELAY_BUDGET_MESSAGE,
+  CONVERSATION_LIVE_CODE,
+  CONVERSATION_LIVE_MESSAGE,
 } from "@/lib/terminal/session-cap";
 import {
   computeSessionExpiresAt,
@@ -73,6 +75,14 @@ const BodySchema = z.object({
   // string's UTF-16 length without doubling its code-point count) —
   // `normalizeDisplayNameInput` enforces the actual limit below.
   displayName: z.string().max(1000).optional(),
+  // Card 0301fe8e (duplicate-conversation guard): the claude conversation an
+  // exact-conversation Resume is about to `claude --resume`. Sent ONLY by the
+  // resume flow (use-terminal-session.ts forwards the carried payload's
+  // `resumeId`); a fresh launch and the legacy `--continue` resume carry
+  // nothing. Used twice below: to refuse a resume whose conversation this
+  // user already has LIVE, and to stamp the new row's `claude_session_id` at
+  // insert time instead of waiting for the bridge to announce it.
+  resumeId: z.string().uuid().optional(),
 });
 
 export async function POST(req: Request) {
@@ -133,7 +143,7 @@ export async function POST(req: Request) {
     if (!parsed.success) {
       return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
     }
-    const { ideaId, taskId, taskTitle, displayName } = parsed.data;
+    const { ideaId, taskId, taskTitle, displayName, resumeId } = parsed.data;
 
     // Only a member of the idea (author or collaborator) may open a terminal on it.
     const { data: idea } = await supabase
@@ -250,6 +260,52 @@ export async function POST(req: Request) {
     );
     const activeCount = activeBefore - reapedIds.length;
 
+    // ── (a.5) DUPLICATE-CONVERSATION GUARD (card 0301fe8e) ──────────────────
+    // A Resume targeting a claude conversation this user ALREADY has a live
+    // session on must never spawn a second `claude --resume <id>` — two
+    // Claude Code processes on one transcript is the wedge Nick hit on
+    // 2026-08-25. The chooser hides such rows client-side (chooser-data.ts);
+    // this is the server backstop for a second tab, a stale list, or a click
+    // that beat the registry refresh. Runs AFTER the reap so an expired row
+    // never blocks a legitimate resume, and reads `claude_session_id` — which
+    // the insert below now stamps from `resumeId` at mint time, closing the
+    // window in which a freshly-resumed row carried null until the bridge
+    // announced its id. Best-effort read: an error fails OPEN (logged), the
+    // same posture as the task-lookup / cap / budget reads around it.
+    if (resumeId) {
+      const { data: liveRow, error: liveErr } = await supabase
+        .from("terminal_sessions")
+        .select("sid, idea_id")
+        .eq("user_id", user.id)
+        .eq("status", "active")
+        .eq("claude_session_id", resumeId)
+        .limit(1)
+        .maybeSingle();
+      if (liveErr) {
+        logger.error("Terminal session mint: live-conversation lookup failed", {
+          error: liveErr.message,
+          userId: user.id,
+          resumeId,
+        });
+      } else if (liveRow) {
+        logger.warn("Terminal session mint refused: conversation already live", {
+          userId: user.id,
+          ideaId,
+          resumeId,
+          liveSid: liveRow.sid,
+        });
+        return NextResponse.json(
+          {
+            error: CONVERSATION_LIVE_MESSAGE,
+            code: CONVERSATION_LIVE_CODE,
+            liveSid: liveRow.sid,
+            liveIdeaId: liveRow.idea_id,
+          },
+          { status: 409 },
+        );
+      }
+    }
+
     // ── (b) CAP (E1) — refuse before minting anything. ──────────────────────
     const cap = getServerTerminalSessionCap();
     const capDecision = decideCap(activeCount, cap);
@@ -356,6 +412,14 @@ export async function POST(req: Request) {
       task_id: taskId ?? null,
       task_title: taskTitle ?? null,
       display_name: displayName !== undefined ? normalizeDisplayNameInput(displayName) : null,
+      // Card 0301fe8e: an exact-conversation Resume knows its conversation id
+      // from the very first instant — stamp it now so the duplicate guard
+      // above (and the chooser's live-conversation filter) see it immediately,
+      // rather than only once the bridge's announcement PATCH lands seconds
+      // later. The bridge's later announcement writes the same id back over
+      // it (see session/[sid]/route.ts) — harmless, and still authoritative
+      // for the fresh-launch case, where this stays null.
+      claude_session_id: resumeId ?? null,
       status: "active",
       expires_at: computeSessionExpiresAt(nowMs),
     });

--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -102,6 +102,7 @@ import {
   deriveChooserSections,
   chooserHeaderCounts,
   findTaskSessionMatch,
+  findLiveSessionForConversation,
   liveSessionsElsewhereOnThisBoard,
   type ChooserSections,
   type ChooserRegistryRow,
@@ -754,6 +755,15 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   useEffect(() => {
     chooserSectionsRef.current = chooserSections;
   }, [chooserSections]);
+  // Card 0301fe8e: the Resume handlers below need the RAW registry rows (not
+  // `chooserSections` — only the raw layer carries a live row's
+  // `claudeSessionId`) to ask "is this conversation already running?", read
+  // synchronously inside stable callbacks for the same reason as
+  // `chooserSectionsRef` above.
+  const registryRowsRef = useRef(registryRows);
+  useEffect(() => {
+    registryRowsRef.current = registryRows;
+  }, [registryRows]);
 
   // Close every open pop-out hand-off channel if the dock itself unmounts
   // (board navigation away) — the popped windows keep running independently
@@ -1962,6 +1972,35 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // under the wrong one. Declared up here (ahead of the `?resume=` effect
   // that also uses it) so both that effect and the click handlers below
   // share one payload-building rule.
+  //
+  // ── Card 0301fe8e — never resume a conversation that's already live ──────
+  // Nick, 2026-08-25: the SAME claude conversation ended up resumed TWICE at
+  // once (two `claude --resume <id>` processes on one transcript — a plausible
+  // cause of the frozen, un-typeable terminal he hit). Every Resume path in
+  // this file (chooser row, task-choice recent arm, the ended tab's own
+  // button, the `?resume=` landing effect) now asks
+  // `reconnectIfConversationLive` FIRST, and a hit reconnects to the session
+  // already running it — in place on this board, or via `?reconnect=<sid>`
+  // on its own — instead of minting a second copy. `reconnectToLiveSession`
+  // is the shared "go to that live session" step, also handed to the hook as
+  // `onConversationLive` for the server backstop's Reconnect toast action.
+  const reconnectToLiveSession = useCallback(
+    (liveSid: string, liveIdeaId: string) => {
+      if (liveIdeaId === ideaId) void performReattach(liveSid, { focus: true });
+      else router.push(`/ideas/${liveIdeaId}/board?reconnect=${encodeURIComponent(liveSid)}`);
+    },
+    [ideaId, performReattach, router],
+  );
+  const reconnectIfConversationLive = useCallback(
+    (claudeSessionId: string | null | undefined): boolean => {
+      const live = findLiveSessionForConversation(registryRowsRef.current ?? [], claudeSessionId);
+      if (!live) return false;
+      toast.info("That conversation is already running — reconnecting to it instead of starting another copy.");
+      reconnectToLiveSession(live.sid, live.ideaId);
+      return true;
+    },
+    [reconnectToLiveSession],
+  );
   const buildResumePayload = useCallback(
     (row: ChooserRecentRow): BrowserLaunchPayload => ({
       // F4's Resume: the EXISTING (capped) launch flow, carrying the ended
@@ -2031,8 +2070,9 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       toast.error("Couldn't find that session to resume — it may have expired.");
       return;
     }
+    if (reconnectIfConversationLive(row.claudeSessionId)) return;
     mintAndDeliver(buildResumePayload(row), row.sid);
-  }, [resumeParam, registryRows, pathname, mintAndDeliver, buildResumePayload]);
+  }, [resumeParam, registryRows, pathname, mintAndDeliver, buildResumePayload, reconnectIfConversationLive]);
 
   // ── chooser action handlers ─────────────────────────────────────────────────
   // Shared by BOTH the sessions.length === 0 body-swap chooser and the
@@ -2087,6 +2127,10 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       setPendingLaunch(null);
       setChooserOriginKey(null);
       setChooserMode(null);
+      // Card 0301fe8e: checked BEFORE the cross-board navigation below — a
+      // live session on this conversation is reconnected to wherever it is,
+      // never resumed a second time on its "home" board.
+      if (reconnectIfConversationLive(row.claudeSessionId)) return;
       if (row.ideaId !== ideaId) {
         router.push(`/ideas/${row.ideaId}/board?resume=${encodeURIComponent(row.sid)}`);
         return;
@@ -2103,7 +2147,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       // `?resume=` landing effect can build the identical payload.
       mintAndDeliver(buildResumePayload(row), row.sid);
     },
-    [mintAndDeliver, buildResumePayload, ideaId, router],
+    [mintAndDeliver, buildResumePayload, ideaId, router, reconnectIfConversationLive],
   );
 
   // The ended panel's "View my other sessions" link (Nick's field report
@@ -2142,6 +2186,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       // task-launch button was clicked from (chooser-data.ts's Recent isn't
       // idea-scoped), so this arm must navigate-then-mint too, not mint here.
       const row = match.row;
+      if (reconnectIfConversationLive(row.claudeSessionId)) return; // card 0301fe8e
       if (row.ideaId !== ideaId) {
         router.push(`/ideas/${row.ideaId}/board?resume=${encodeURIComponent(row.sid)}`);
         return;
@@ -2154,7 +2199,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     } else {
       router.push(`/ideas/${match.row.ideaId}/board?reconnect=${encodeURIComponent(match.row.sid)}`);
     }
-  }, [pendingLaunch, mintAndDeliver, buildResumePayload, ideaId, performReattach, router]);
+  }, [pendingLaunch, mintAndDeliver, buildResumePayload, ideaId, performReattach, router, reconnectIfConversationLive]);
 
   const handleTaskChoiceStartFresh = useCallback(() => {
     const payload = pendingLaunch;
@@ -2180,6 +2225,10 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
   // existed; see this card's return value for that limitation.
   const handleResumeEndedSession = useCallback(
     (payload: BrowserLaunchPayload, sid: string | null) => {
+      // Card 0301fe8e: the ended tab's own Resume button is the path Nick's
+      // duplicate most likely came through — a tab that ended (or looked
+      // ended) while its conversation was already re-opened elsewhere.
+      if (reconnectIfConversationLive(payload.resumeId)) return;
       if (payload.ideaId && payload.ideaId !== ideaId && sid) {
         router.push(`/ideas/${payload.ideaId}/board?resume=${encodeURIComponent(sid)}`);
         return;
@@ -2190,7 +2239,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
       // and takes over THIS tab rather than opening a new one next to it.
       mintAndDeliver(payload, sid);
     },
-    [ideaId, mintAndDeliver, router],
+    [ideaId, mintAndDeliver, router, reconnectIfConversationLive],
   );
 
   // Back out of the task-scoped choice without launching anything — see the
@@ -2989,6 +3038,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onRegisterActions={registerActions}
             onAnnounce={announce}
             onCapExceeded={openMySessions}
+            onConversationLive={reconnectToLiveSession}
             onBrowseSessions={() => openChooserToBrowse(entry.key)}
             poppedOut={poppedOutKeys.has(entry.key)}
             onPopOut={() => handlePopOut(entry.key)}

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -135,6 +135,8 @@ interface TerminalSessionViewProps {
   onAnnounce: (text: string) => void;
   /** Opens the dock's "My sessions" panel on a cap refusal (E1, design §7b). */
   onCapExceeded?: () => void;
+  /** Card 0301fe8e: reconnects to the live session already running a conversation this tab tried to Resume (the mint route's `conversation_live` refusal). */
+  onConversationLive?: (liveSid: string, liveIdeaId: string) => void;
   /**
    * Multi-session stage 4 (D1-D7): true once the dock has popped this tab's
    * session out into its own window. Renders the "Popped out" placeholder
@@ -269,6 +271,7 @@ export function TerminalSessionView({
   onRegisterActions,
   onAnnounce,
   onCapExceeded,
+  onConversationLive,
   poppedOut = false,
   onPopOut,
   onBringBack,
@@ -291,6 +294,7 @@ export function TerminalSessionView({
     taskTitle: entry.taskTitle,
     displayName: entry.displayName,
     onCapExceeded,
+    onConversationLive,
     // Session entry chooser (card cbe60db5): a Reconnect/instant-continue
     // entry carries a ready-minted `attach` pair instead of a launch to
     // deliver — the hook's own attach-once-per-sid effect handles it below,

--- a/src/components/board/use-terminal-session.ts
+++ b/src/components/board/use-terminal-session.ts
@@ -46,6 +46,8 @@ import {
   getTerminalSessionCap,
   RATE_LIMIT_MESSAGE,
   DAILY_RELAY_BUDGET_MESSAGE,
+  CONVERSATION_LIVE_CODE,
+  CONVERSATION_LIVE_MESSAGE,
 } from "@/lib/terminal/session-cap";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import type { FitAddon as XFitAddon } from "@xterm/addon-fit";
@@ -128,6 +130,9 @@ interface MintErrorBody {
   error?: string;
   code?: string;
   cap?: number;
+  /** Card 0301fe8e — set on a `conversation_live` refusal: the live session already running the conversation, and its board. */
+  liveSid?: string;
+  liveIdeaId?: string;
 }
 
 /**
@@ -143,12 +148,27 @@ function reportMintFailure(
   body: MintErrorBody | null,
   posthog: { capture: (event: string, props?: Record<string, unknown>) => void } | undefined,
   onCapExceeded: (() => void) | undefined,
+  onConversationLive: ((liveSid: string, liveIdeaId: string) => void) | undefined,
 ) {
   logger.error("Terminal session mint refused (client)", {
     status,
     code: body?.code,
     error: body?.error,
   });
+  if (body?.code === CONVERSATION_LIVE_CODE) {
+    // Card 0301fe8e — the server's duplicate-conversation backstop: the
+    // conversation this Resume targeted is ALREADY running in one of the
+    // user's live sessions. Offer the one action that's actually right —
+    // reconnecting to that session — instead of leaving them to hunt for it.
+    const { liveSid, liveIdeaId } = body;
+    toast.error(body.error || CONVERSATION_LIVE_MESSAGE, {
+      action:
+        onConversationLive && liveSid && liveIdeaId
+          ? { label: "Reconnect", onClick: () => onConversationLive(liveSid, liveIdeaId) }
+          : undefined,
+    });
+    return;
+  }
   if (body?.code === "cap_exceeded") {
     const cap = typeof body.cap === "number" ? body.cap : getTerminalSessionCap();
     posthog?.capture("terminal_cap_hit", { cap });
@@ -263,6 +283,14 @@ export interface UseTerminalSessionOptions {
    * toast with no action button.
    */
   onCapExceeded?: () => void;
+  /**
+   * Card 0301fe8e: called when a mint is refused because the conversation a
+   * Resume targeted is already running in one of this user's live sessions
+   * (`conversation_live`). The dock reconnects to that session — in place on
+   * this board, or via `?reconnect=<sid>` on its own. Optional, like
+   * `onCapExceeded`: unwired, the toast simply has no Reconnect action.
+   */
+  onConversationLive?: (liveSid: string, liveIdeaId: string) => void;
   /**
    * Multi-session stage 4 (D1/D2): attach directly to an ALREADY-MINTED
    * session's browser leg — no mint, no first-run/launch flow. Set by the
@@ -532,6 +560,7 @@ export function useTerminalSession(
     taskTitle,
     displayName,
     onCapExceeded,
+    onConversationLive,
     attachExisting = null,
     grabFocus = true,
     dragActiveRef,
@@ -540,8 +569,10 @@ export function useTerminalSession(
   const posthog = usePostHog();
   const posthogRef = useRef(posthog);
   const onCapExceededRef = useRef(onCapExceeded);
+  const onConversationLiveRef = useRef(onConversationLive);
   posthogRef.current = posthog;
   onCapExceededRef.current = onCapExceeded;
+  onConversationLiveRef.current = onConversationLive;
   // Split-view focus-sync defect fix: read fresh inside the stable
   // focus/blur listeners the xterm-init effect attaches below, so a new
   // `onKeyboardFocusChange` identity every render never forces that
@@ -1809,6 +1840,14 @@ export function useTerminalSession(
           ...(taskId ? { taskId } : {}),
           ...(taskTitle ? { taskTitle } : {}),
           ...(displayName ? { displayName } : {}),
+          // Card 0301fe8e: tell the mint route WHICH conversation an
+          // exact-conversation Resume is about to reopen, so it can refuse
+          // one that's already live and stamp the new row's id up front.
+          // `promptPartsRef` is the carried launch intent (set by
+          // launchFromBus before this connect() runs) — a fresh launch or
+          // the legacy `--continue` resume has no `resumeId` and sends
+          // nothing here.
+          ...(promptPartsRef.current?.resumeId ? { resumeId: promptPartsRef.current.resumeId } : {}),
         }),
       });
       if (!res.ok) {
@@ -1817,7 +1856,13 @@ export function useTerminalSession(
         // (a stale refusal toast for an attempt nobody's waiting on anymore).
         if (isConnectSuperseded(gen, connectGenRef.current)) return;
         dispatch({ type: "session-mint-failed" });
-        reportMintFailure(res.status, body, posthogRef.current, onCapExceededRef.current);
+        reportMintFailure(
+          res.status,
+          body,
+          posthogRef.current,
+          onCapExceededRef.current,
+          onConversationLiveRef.current,
+        );
         return;
       }
       data = await res.json();

--- a/src/lib/terminal/chooser-data.test.ts
+++ b/src/lib/terminal/chooser-data.test.ts
@@ -6,6 +6,7 @@ import {
   chooserHeaderCounts,
   findLiveSessionForTask,
   findTaskSessionMatch,
+  findLiveSessionForConversation,
   liveSessionsElsewhereOnThisBoard,
   visibleRecentRows,
   type ChooserRegistryRow,
@@ -756,5 +757,54 @@ describe("liveSessionsElsewhereOnThisBoard", () => {
     ];
     const sections = deriveChooserSections(rows, IDEA_A, NOW, ["own-sid-1", "own-sid-2"]);
     expect(liveSessionsElsewhereOnThisBoard(sections)).toEqual([]);
+  });
+});
+
+// Card 0301fe8e (Nick, 2026-08-25): the SAME claude conversation resumed
+// twice at once — two `claude --resume <id>` processes fighting over one
+// transcript. Recent must drop a row whose conversation is currently live,
+// and the dock's Resume paths must be able to find that live session.
+describe("live-conversation guard (card 0301fe8e)", () => {
+  const CONV = "5a22fd93-0aad-4872-a28f-61c90ff7f25b";
+  const OTHER_CONV = "709cbe62-b9a0-439d-a816-ed7c44d4d677";
+  const endedAt = new Date(NOW - 60_000).toISOString();
+
+  it("hides a Recent row whose conversation is running in a live session — on ANY board", () => {
+    const rows = [
+      row({ sid: "ended-resumed", status: "ended", cwd: "~/p", endedAt, claudeSessionId: CONV }),
+      row({ sid: "live-elsewhere", ideaId: IDEA_B, status: "active", claudeSessionId: CONV }),
+      row({ sid: "ended-other", status: "ended", cwd: "~/p", endedAt, claudeSessionId: OTHER_CONV }),
+    ];
+    const sections = deriveChooserSections(rows, IDEA_A, NOW);
+    expect(sections.recent.map((r) => r.sid)).toEqual(["ended-other"]);
+    // The live row itself is untouched — it's the ONE place the conversation is now reachable.
+    expect(sections.liveElsewhere.map((r) => r.sid)).toEqual(["live-elsewhere"]);
+  });
+
+  it("keeps a Recent row whose conversation is NOT live, and every id-less row (nothing to match on)", () => {
+    const rows = [
+      row({ sid: "live-unrelated", status: "active", claudeSessionId: OTHER_CONV }),
+      row({ sid: "live-unannounced", status: "active", claudeSessionId: null }),
+      row({ sid: "ended-tracked", status: "ended", cwd: "~/p", endedAt, claudeSessionId: CONV }),
+      row({ sid: "ended-idless", status: "ended", cwd: "~/q", endedAt, claudeSessionId: null }),
+    ];
+    const recent = deriveChooserSections(rows, IDEA_A, NOW).recent.map((r) => r.sid);
+    expect(recent).toEqual(["ended-tracked", "ended-idless"]);
+  });
+
+  it("findLiveSessionForConversation returns the live row on any board, never an ended one", () => {
+    const rows = [
+      row({ sid: "ended-same-conv", status: "ended", cwd: "~/p", endedAt, claudeSessionId: CONV }),
+      row({ sid: "live-b", ideaId: IDEA_B, status: "active", claudeSessionId: CONV }),
+    ];
+    expect(findLiveSessionForConversation(rows, CONV)?.sid).toBe("live-b");
+    expect(findLiveSessionForConversation(rows, OTHER_CONV)).toBeNull();
+  });
+
+  it("findLiveSessionForConversation never matches a null/undefined id, even against an unannounced live row", () => {
+    const rows = [row({ sid: "live-unannounced", status: "active", claudeSessionId: null })];
+    expect(findLiveSessionForConversation(rows, null)).toBeNull();
+    expect(findLiveSessionForConversation(rows, undefined)).toBeNull();
+    expect(findLiveSessionForConversation([], CONV)).toBeNull();
   });
 });

--- a/src/lib/terminal/chooser-data.ts
+++ b/src/lib/terminal/chooser-data.ts
@@ -198,10 +198,23 @@ export function deriveChooserSections(
   const live = rows.filter((r) => r.status === "active");
   const liveHere = live.filter((r) => r.ideaId === currentIdeaId).map(toLiveRow);
   const liveElsewhere = live.filter((r) => r.ideaId !== currentIdeaId).map(toLiveRow);
+  // Card 0301fe8e (Nick, 2026-08-25 — the SAME conversation resumed twice at
+  // once, two `claude --resume <id>` processes fighting over one transcript):
+  // once a Resume has spawned a live session on a conversation, that
+  // conversation is reachable ONLY via the live row's Reconnect. The ended
+  // row that described it must drop out of Recent, or a second click (or a
+  // second tab) resumes it again. Keyed on `claudeSessionId` across EVERY
+  // board — a live session is unambiguously reachable regardless of where
+  // it was started (same reasoning as the never-filtered "Running now"
+  // sections above).
+  const liveConversationIds = new Set(
+    live.map((r) => r.claudeSessionId).filter((id): id is string => !!id),
+  );
 
   const recentCandidates = rows
     .filter((r): r is ChooserRegistryRow & { endedAt: string } => {
       if (r.status !== "ended") return false;
+      if (r.claudeSessionId && liveConversationIds.has(r.claudeSessionId)) return false;
       // Null-cwd fix (bug 9fb9fced): no cwd check here any more — a row with
       // no recorded folder still belongs in Recent, just without Resume. See
       // this module's header comment.
@@ -319,6 +332,24 @@ export function findLiveSessionForTask(
     sections.liveElsewhere.find((r) => r.taskId === taskId) ??
     null
   );
+}
+
+/**
+ * Card 0301fe8e — the live session (on ANY board) currently running the given
+ * claude conversation, or null. Every Resume entry point in terminal-dock.tsx
+ * asks this before minting: a hit means "reconnect to that session" (here, or
+ * via `?reconnect=<sid>` on its own board), never a second `claude --resume`.
+ * Takes the RAW registry rows rather than `ChooserSections` because only that
+ * layer carries a live row's `claudeSessionId` (the chooser's live rows don't
+ * need it for display). Ended rows never match — an ended session isn't
+ * running anything — and a null/undefined id never matches anything.
+ */
+export function findLiveSessionForConversation(
+  rows: readonly ChooserRegistryRow[],
+  claudeSessionId: string | null | undefined,
+): ChooserRegistryRow | null {
+  if (!claudeSessionId) return null;
+  return rows.find((r) => r.status === "active" && r.claudeSessionId === claudeSessionId) ?? null;
 }
 
 /**

--- a/src/lib/terminal/session-cap.ts
+++ b/src/lib/terminal/session-cap.ts
@@ -133,6 +133,11 @@ export const RATE_LIMIT_CODE = "rate_limited" as const;
  *  Distinct from both refusals above: this is ACCOUNT-WIDE, not per-user, and
  *  existing sessions are never affected — only NEW mints are refused. */
 export const DAILY_RELAY_BUDGET_CODE = "daily_relay_budget" as const;
+/** Card 0301fe8e — a Resume targeting a claude conversation this user ALREADY
+ *  has a live session on (see the mint route's duplicate-conversation guard).
+ *  Distinct from every refusal above: nothing is "full" or "too fast" — the
+ *  right action is to reconnect to the session that's already running it. */
+export const CONVERSATION_LIVE_CODE = "conversation_live" as const;
 
 /** The mint route's 409 refusal copy (design §7b, cap number always templated). */
 export function capRefusalMessage(cap: number = getServerTerminalSessionCap()): string {
@@ -142,6 +147,10 @@ export function capRefusalMessage(cap: number = getServerTerminalSessionCap()): 
 /** The mint route's 429 refusal copy — distinct state, never suggests ending a session. */
 export const RATE_LIMIT_MESSAGE =
   "You're starting terminals too fast — wait a moment and try again.";
+
+/** Card 0301fe8e — the mint route's 409 refusal copy for `CONVERSATION_LIVE_CODE`. */
+export const CONVERSATION_LIVE_MESSAGE =
+  "That conversation is already open in a live terminal — reconnect to it instead of starting another copy.";
 
 /**
  * MITIGATION 3 — the mint route's 429 refusal copy when the ACCOUNT-WIDE daily


### PR DESCRIPTION
## What broke
Nick, 25 Aug: terminals froze / wouldn't accept typing, and Resume/Reconnect looked dead. `ps` showed the **same** Claude conversation resumed **twice at once** — two bridges 45s apart, each running `claude --resume 5a22fd93…`. Board card 0301fe8e.

## Why
- The chooser's Recent list never cross-references live rows' `claude_session_id`, so an ended row keeps offering **Resume** after Resume has already spawned a live session on it.
- None of the four Resume entry points checked for a live session.
- The mint route never learned it was a resume (no server backstop), and the new row's `claude_session_id` stayed null until the bridge announced it.

## Fix
1. `chooser-data.ts` — hide a Recent row whose conversation is currently live (any board); `findLiveSessionForConversation()`.
2. `terminal-dock.tsx` — every Resume path reconnects to the live session first (here → reattach, elsewhere → `?reconnect=`).
3. `POST /api/terminal/session` — accepts `resumeId`, refuses `409 conversation_live` (+ `liveSid`/`liveIdeaId`) when an active row already carries it, stamps `claude_session_id` at insert time. Client sends `resumeId` on resume mints and shows the refusal with a **Reconnect** action.

## Tests
- 4 new in `chooser-data.test.ts`, 5 new in `session/route.test.ts`
- `npm run typecheck` clean · `npm run lint` 0 errors · full suite 3,400 passed (200 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)