### PR TITLE
fix(terminal): helper download links run the same end-sessions-then-quiesce flow as Update now

### DIFF
--- a/src/components/board/terminal-dock.tsx
+++ b/src/components/board/terminal-dock.tsx
@@ -2351,6 +2351,12 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
     poppedOutKeys.has(key) ? "popped-out" : (summaries[key]?.status ?? "idle");
 
   const statusChips = multi ? summarizeSessionStatuses(sessions.map((s) => displayStatusFor(s.key))) : [];
+  // Helper-update flow (terminal-session-view.tsx): how many sessions its
+  // "End sessions & update" confirm will actually end.
+  const liveSessionCount = sessions.filter((s) => {
+    const st = summaries[s.key]?.status;
+    return st === "connected" || st === "connecting" || st === "waiting-to-pair" || st === "disconnected";
+  }).length;
   const singleView = activeSummary
     ? resolveDockView(activeSummary.status, activeSummary.launchPhase, activeSummary.platformSupported, activeSummary.paired)
     : "setup";
@@ -2990,6 +2996,7 @@ export function TerminalDock({ ideaId, ideaTitle, ideaGithubUrl, recordedProject
             onAnnounce={announce}
             onCapExceeded={openMySessions}
             onBrowseSessions={() => openChooserToBrowse(entry.key)}
+            liveSessionCount={liveSessionCount}
             poppedOut={poppedOutKeys.has(entry.key)}
             onPopOut={() => handlePopOut(entry.key)}
             onBringBack={() => bringBackToDock(entry.key)}

--- a/src/components/board/terminal-helper-update-button.tsx
+++ b/src/components/board/terminal-helper-update-button.tsx
@@ -8,8 +8,18 @@
 // and the session chooser (terminal-session-chooser.tsx) both render this,
 // so they can't drift apart again.
 
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import {
+  UPDATE_CONFIRM_ACCEPT_LABEL,
+  UPDATE_CONFIRM_CANCEL_LABEL,
+  UPDATE_CONFIRM_HEADING,
+  UPDATE_QUIESCE_TIMEOUT_COPY,
+  UPDATE_READY_COPY,
+  updateConfirmBody,
+  type UpdateFlowPhase,
+} from "@/lib/terminal/helper-update-flow";
 
 interface HelperUpdateButtonProps {
   /** My sessions panel: starts the in-app confirm/quiesce/download flow. */
@@ -35,4 +45,61 @@ export function HelperUpdateButton({ onClick, href, className }: HelperUpdateBut
       Update now
     </Button>
   );
+}
+
+/**
+ * The inline notices of the shared quiesce-then-download flow
+ * (helper-update-flow.ts): confirm → "Closing the helper…" → ready /
+ * taking-a-moment. Nick, 2026-08-25: the session banner's bare "Download"
+ * link skipped this flow entirely, so with a session running the DMG
+ * downloaded but the still-running helper could never be replaced. Every
+ * download affordance now renders the same button + these notices.
+ */
+export function HelperUpdateFlowNotice({
+  phase,
+  confirmSessionCount,
+  onConfirm,
+  onCancel,
+}: {
+  phase: UpdateFlowPhase;
+  confirmSessionCount: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  if (phase === "confirming") {
+    return (
+      <div className="border-b border-l-2 border-l-sky-500 bg-sky-500/5 px-3.5 py-2.5" data-testid="helper-update-confirm">
+        <div className="text-[12.5px] font-bold text-sky-300">{UPDATE_CONFIRM_HEADING}</div>
+        <div className="text-[11px] text-zinc-500">{updateConfirmBody(confirmSessionCount)}</div>
+        <div className="mt-2 flex items-center justify-end gap-2">
+          <Button variant="ghost" size="xs" onClick={onCancel}>
+            {UPDATE_CONFIRM_CANCEL_LABEL}
+          </Button>
+          <Button size="xs" className="bg-sky-500 text-sky-950 hover:bg-sky-400" onClick={onConfirm}>
+            {UPDATE_CONFIRM_ACCEPT_LABEL}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+  if (phase === "quiescing") {
+    return (
+      <div className="flex items-center gap-2 border-b border-sky-500/30 bg-sky-500/5 px-3.5 py-1.5 text-[11px] text-sky-300">
+        <Loader2 className="h-3 w-3 flex-none animate-spin" /> Closing the helper…
+      </div>
+    );
+  }
+  if (phase === "ready" || phase === "quiesce-timeout") {
+    return (
+      <div
+        className={cn(
+          "border-b px-3.5 py-2 text-[11px]",
+          phase === "ready" ? "border-sky-500/30 bg-sky-500/5 text-sky-300" : "border-amber-500/30 bg-amber-500/5 text-amber-300",
+        )}
+      >
+        {phase === "ready" ? UPDATE_READY_COPY : UPDATE_QUIESCE_TIMEOUT_COPY}
+      </div>
+    );
+  }
+  return null;
 }

--- a/src/components/board/terminal-session-view.test.tsx
+++ b/src/components/board/terminal-session-view.test.tsx
@@ -788,3 +788,79 @@ describe("TerminalSessionView — idle + paired shows the Ready screen, not the 
     expect(onBrowseSessions).toHaveBeenCalledTimes(1);
   });
 });
+
+// Nick, 2026-08-25: "The download link should behave the same as the Update
+// now button, which also ends the sessions. The download link just downloads
+// the helper but doesn't end the sessions so the helper can never be
+// installed." Every download affordance in this view now runs the shared
+// stand-down-first flow (helper-update-flow.ts) instead of being a bare link.
+describe("TerminalSessionView — helper download affordances run the Update-now flow", () => {
+  function renderWithLiveCount(liveSessionCount: number) {
+    return render(
+      <TerminalSessionView
+        entry={baseEntry()}
+        descriptor={{ ideaId: "idea-1", ideaTitle: "My Idea", ideaGithubUrl: null }}
+        label="Session 1"
+        isActive
+        expanded
+        onRequestExpand={vi.fn()}
+        autoConnectWhenExpanded={false}
+        onReportSummary={vi.fn()}
+        onRegisterActions={vi.fn()}
+        onAnnounce={vi.fn()}
+        liveSessionCount={liveSessionCount}
+      />,
+    );
+  }
+
+  it("the in-session nudge offers 'Update now' (the shared button), never a bare download link", () => {
+    installMockSession(); // connected, helperVersion: null → nudge shows
+    renderWithLiveCount(2);
+    expect(screen.getByRole("button", { name: "Update now" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Download" })).not.toBeInTheDocument();
+  });
+
+  it("with sessions running, the nudge's button asks to end them first — and 'Not now' backs out", () => {
+    installMockSession();
+    renderWithLiveCount(2);
+    fireEvent.click(screen.getByRole("button", { name: "Update now" }));
+    expect(screen.getByTestId("helper-update-confirm")).toBeInTheDocument();
+    expect(screen.getByText(/Your 2 running sessions will end first/)).toBeInTheDocument();
+    // The nudge itself steps aside while the flow is in progress.
+    expect(screen.queryByRole("button", { name: "Update now" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Not now" }));
+    expect(screen.queryByTestId("helper-update-confirm")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update now" })).toBeInTheDocument();
+  });
+
+  it("the one-time-setup wizard's download is a button on the same flow, not a bare link", () => {
+    const actions = mockActions();
+    mockedUseTerminalSession.mockImplementation((): UseTerminalSessionResult => {
+      const containerRef = useRef<HTMLDivElement | null>(null);
+      lastContainerRef = containerRef;
+      return {
+        state: { status: "idle", sessionId: null, errorKind: null, endedReason: null, closeCode: null, closeReason: null },
+        launchPhase: "idle",
+        peerDegraded: false,
+        helperVersion: null,
+        pair: null,
+        cwd: null,
+        claudeSessionId: null,
+        readOnly: false,
+        autoAccept: false,
+        inputEnabled: false,
+        platform: { os: "mac", isAppleSilicon: true, supported: true, downloadLabel: "Download for Mac", downloadUrl: null },
+        paired: false,
+        xtermReady: true,
+        containerRef,
+        pairingTimedOut: false,
+        actions,
+      };
+    });
+    renderWithLiveCount(1);
+    const download = screen.getByRole("button", { name: /Download for Mac/ });
+    expect(screen.queryByRole("link", { name: /Download for Mac/ })).not.toBeInTheDocument();
+    fireEvent.click(download);
+    expect(screen.getByText(/Your 1 running session will end first/)).toBeInTheDocument();
+  });
+});

--- a/src/components/board/terminal-session-view.tsx
+++ b/src/components/board/terminal-session-view.tsx
@@ -61,6 +61,8 @@ import { isSameOwnerPreemptedClose } from "@/lib/terminal/connection";
 import type { TerminalConnectionState, TerminalStatus } from "@/lib/terminal/connection";
 import { type TerminalPlatform, TERMINAL_HELPER_DOWNLOAD_URL } from "@/lib/terminal/platform";
 import { shouldShowHelperUpdateNudge } from "@/lib/terminal/helper-version";
+import { useHelperUpdateFlow } from "@/lib/terminal/use-helper-update-flow";
+import { HelperUpdateButton, HelperUpdateFlowNotice } from "./terminal-helper-update-button";
 import type { BrowserLaunchPayload } from "@/lib/terminal/launch-mode";
 import { FIRST_RUN_COPY } from "@/lib/terminal/first-run-copy";
 import { type DockView, type LaunchPhase, resolveDockView } from "@/lib/terminal/first-run-flow";
@@ -214,6 +216,13 @@ interface TerminalSessionViewProps {
    */
   onBrowseSessions?: () => void;
   /**
+   * Live sessions across the dock (any tab that's connected / connecting /
+   * waiting / reconnecting) — drives the helper-update flow's confirm copy
+   * ("Your N running sessions will end first"). Falls back to this tab's
+   * own liveness when a caller doesn't pass it.
+   */
+  liveSessionCount?: number;
+  /**
    * Split view (task df7a0134, design §3/§9): set (to `true` or `false`)
    * exactly while this view is rendered as one of the split's two panes —
    * `undefined` (the default) means "tabbed mode", rendered exactly as
@@ -276,6 +285,7 @@ export function TerminalSessionView({
   onRetryReconnect,
   onResumeEndedSession,
   onBrowseSessions,
+  liveSessionCount,
   paneFocused,
   onFocusPane,
   grabFocus = true,
@@ -420,7 +430,18 @@ export function TerminalSessionView({
   const showStream = state.status === "connected" || state.status === "disconnected";
   // Only worth showing once there's an actual (live or reconnecting) bridge to
   // update — a setup/coming-soon/idle panel has nothing to nudge about yet.
-  const showHelperNudge = showStream && !dismissedHelperNudge && shouldShowHelperUpdateNudge(helperVersion);
+  // Nick, 2026-08-25: every download affordance in this view goes through
+  // the SAME stand-down-first flow as "Update now" (end sessions → quiesce
+  // the helper → then download) — a bare download while the helper is still
+  // running can never be installed.
+  const thisTabLive =
+    state.status === "connected" ||
+    state.status === "connecting" ||
+    state.status === "waiting-to-pair" ||
+    state.status === "disconnected";
+  const helperUpdate = useHelperUpdateFlow({ sessionCount: liveSessionCount ?? (thisTabLive ? 1 : 0) });
+  const showHelperNudge =
+    showStream && !dismissedHelperNudge && helperUpdate.phase === "idle" && shouldShowHelperUpdateNudge(helperVersion);
   const canLaunch =
     state.status === "idle" ||
     state.status === "error" ||
@@ -674,14 +695,9 @@ export function TerminalSessionView({
           <div className="flex items-center gap-2 border-b border-sky-500/30 bg-sky-500/5 px-3 py-1.5 text-[11px] text-sky-300">
             <Info className="h-3 w-3 shrink-0" />
             <span className="flex-1">
-              Update your terminal helper — faster and lighter on the relay.{" "}
-              <a
-                href={platform.downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL}
-                className="underline hover:text-sky-200"
-              >
-                Download
-              </a>
+              Update your terminal helper — faster and lighter on the relay.
             </span>
+            <HelperUpdateButton onClick={helperUpdate.start} />
             <button
               type="button"
               className="shrink-0 text-sky-400 hover:text-sky-200"
@@ -692,6 +708,12 @@ export function TerminalSessionView({
             </button>
           </div>
         )}
+        <HelperUpdateFlowNotice
+          phase={helperUpdate.phase}
+          confirmSessionCount={helperUpdate.confirmSessionCount}
+          onConfirm={helperUpdate.confirm}
+          onCancel={helperUpdate.cancel}
+        />
 
         {/* Session entry chooser — reconnect with no snapshot to restore
             (common foundations F2): never a silently blank screen. Shown
@@ -737,6 +759,7 @@ export function TerminalSessionView({
               canResume={canResume}
               pairingTimedOut={pairingTimedOut}
               onConnect={() => void actions.connect({ autoLaunch: true })}
+              onDownloadHelper={helperUpdate.start}
               onRetry={() => {
                 // Reconnect-relaunch fix: re-attempt THIS session (a fresh
                 // reattach → fresh deep link) instead of minting an unrelated
@@ -871,6 +894,7 @@ function StateOverlay({
   onCopyBridge,
   onReconnectTakenOver,
   onBrowseSessions,
+  onDownloadHelper,
 }: {
   view: DockView;
   state: TerminalConnectionState;
@@ -900,12 +924,14 @@ function StateOverlay({
   onReconnectTakenOver: () => void;
   /** See TerminalSessionViewProps' same-named prop. */
   onBrowseSessions?: () => void;
+  /** Every download affordance runs the shared stand-down-first flow. */
+  onDownloadHelper: () => void;
 }) {
   return (
     <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 overflow-y-auto bg-[#0c0c0e]/95 px-6 py-6 text-center">
       {view === "coming-soon" && <ComingSoonPanel />}
 
-      {view === "setup" && <SetupPanel platform={platform} onConnect={onConnect} />}
+      {view === "setup" && <SetupPanel platform={platform} onConnect={onConnect} onDownload={onDownloadHelper} />}
 
       {view === "ready" && <ReadyPanel onConnect={onConnect} onBrowseSessions={onBrowseSessions} />}
 
@@ -914,14 +940,14 @@ function StateOverlay({
       )}
 
       {view === "timeout-new" && (
-        <TimeoutPanel variant="new" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
+        <TimeoutPanel variant="new" onRetry={onRetry} onDownload={onDownloadHelper} />
       )}
       {view === "timeout-returning" && (
-        <TimeoutPanel variant="returning" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
+        <TimeoutPanel variant="returning" onRetry={onRetry} onDownload={onDownloadHelper} />
       )}
 
       {view === "legacy-waiting" && pairingTimedOut && (
-        <TimeoutPanel variant="returning" downloadUrl={platform.downloadUrl} onRetry={onRetry} />
+        <TimeoutPanel variant="returning" onRetry={onRetry} onDownload={onDownloadHelper} />
       )}
 
       {view === "legacy-waiting" && !pairingTimedOut && (
@@ -1072,7 +1098,15 @@ function ReadyPanel({ onConnect, onBrowseSessions }: { onConnect: () => void; on
 }
 
 // Screen ① — the numbered one-time setup (unpaired). No deep link has fired here.
-function SetupPanel({ platform, onConnect }: { platform: TerminalPlatform; onConnect: () => void }) {
+function SetupPanel({
+  platform,
+  onConnect,
+  onDownload,
+}: {
+  platform: TerminalPlatform;
+  onConnect: () => void;
+  onDownload: () => void;
+}) {
   const copy = FIRST_RUN_COPY.setup;
   return (
     <div className="flex w-full max-w-lg flex-col text-left">
@@ -1084,14 +1118,13 @@ function SetupPanel({ platform, onConnect }: { platform: TerminalPlatform; onCon
 
       <SetupStep n={1} title={copy.step1Title}>
         <p className="mb-2.5 text-[12.5px] text-zinc-400">{copy.step1Desc}</p>
-        <a
-          href={platform.downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL}
-          target="_blank"
-          rel="noopener noreferrer"
+        <button
+          type="button"
+          onClick={onDownload}
           className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-md bg-emerald-500 px-4 text-sm font-semibold text-emerald-950 hover:bg-emerald-400"
         >
           <Download className="h-4 w-4" /> {platform.downloadLabel}
-        </a>
+        </button>
         {/* We can't reliably tell Apple Silicon from Intel client-side (see
             platform.ts), so the primary button always targets arm64 and Intel
             users self-identify via this opt-in link rather than being silently
@@ -1160,15 +1193,14 @@ function ConnectingPanel({ returning }: { returning: boolean }) {
 // Screen ④ — the calm ~8s fallback. `variant` picks the first-timer vs returning copy.
 function TimeoutPanel({
   variant,
-  downloadUrl,
   onRetry,
+  onDownload,
 }: {
   variant: "new" | "returning";
-  downloadUrl: string | null;
   onRetry: () => void;
+  onDownload: () => void;
 }) {
   const copy = variant === "new" ? FIRST_RUN_COPY.timeoutNew : FIRST_RUN_COPY.timeoutReturning;
-  const href = downloadUrl ?? TERMINAL_HELPER_DOWNLOAD_URL;
   const secondaryLabel = variant === "new" ? FIRST_RUN_COPY.timeoutNew.download : FIRST_RUN_COPY.timeoutReturning.reinstall;
   const footer = variant === "new" ? FIRST_RUN_COPY.timeoutNew.hint : FIRST_RUN_COPY.timeoutReturning.reassure;
   return (
@@ -1183,14 +1215,9 @@ function TimeoutPanel({
         >
           <RotateCw className="h-4 w-4" /> {copy.retry}
         </Button>
-        <a
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-md border border-zinc-700 bg-zinc-800/60 px-4 text-sm font-semibold text-zinc-200 hover:bg-zinc-700"
-        >
+        <button type="button" onClick={onDownload} className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-md border border-zinc-700 bg-zinc-800/60 px-4 text-sm font-semibold text-zinc-200 hover:bg-zinc-700">
           <Download className="h-4 w-4" /> {secondaryLabel}
-        </a>
+        </button>
       </div>
       <p className="text-[11.5px] text-zinc-500">{footer}</p>
     </>


### PR DESCRIPTION
## Summary
- The session banner's "Download" link (and the setup-wizard / timeout-screen download buttons) bypassed the stand-down-first flow, so with a session running the DMG downloaded but the still-running helper could never be replaced (Nick, 25 Aug).
- All of them now use the shared `useHelperUpdateFlow`: confirm ("Your N running sessions will end first") → end all → quiesce → wait for the helper to disconnect → download. Nudge renders the shared "Update now" button + new shared `HelperUpdateFlowNotice`. Dock passes `liveSessionCount` for accurate copy.

## Test plan
- [x] New tests: nudge is a button not a link; confirm/back-out; wizard download is on the flow
- [x] `npm run test` — 3,397 passed / 200 files; `tsc` + eslint clean (one known-flaky dock test, card e4f3bfa2, passed on rerun and in the full run)
- [ ] Nick: with a session running, click "Update now" in the banner → confirm → helper closes → DMG downloads → drag to Applications works

🤖 Generated with [Claude Code](https://claude.com/claude-code)